### PR TITLE
Add namespaces to tests in System.Runtime.Extensions

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/BitConverter.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverter.cs
@@ -2,248 +2,250 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public static class BitConverterTests
+namespace System.Tests
 {
-    [Fact]
-    public static unsafe void IsLittleEndian()
+    public static class BitConverterTests
     {
-        short s = 1;
-        Assert.Equal(BitConverter.IsLittleEndian, *((byte*)&s) == 1);
-    }
-
-    [Fact]
-    public static void ValueArgumentNull()
-    {
-        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToBoolean(null, 0));
-        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToChar(null, 0));
-        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToDouble(null, 0));
-        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToInt16(null, 0));
-        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToInt32(null, 0));
-        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToInt64(null, 0));
-        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToSingle(null, 0));
-        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToUInt16(null, 0));
-        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToUInt32(null, 0));
-        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToUInt64(null, 0));
-        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToString(null));
-        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToString(null, 0));
-        Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToString(null, 0, 0));
-    }
-
-    [Fact]
-    public static void StartIndexBeyondLength()
-    {
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToBoolean(new byte[1], -1));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToBoolean(new byte[1], 1));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToBoolean(new byte[1], 2));
-
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToChar(new byte[2], -1));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToChar(new byte[2], 2));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToChar(new byte[2], 3));
-
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToDouble(new byte[8], -1));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToDouble(new byte[8], 8));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToDouble(new byte[8], 9));
-
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt16(new byte[2], -1));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt16(new byte[2], 2));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt16(new byte[2], 3));
-
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt32(new byte[4], -1));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt32(new byte[4], 4));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt32(new byte[4], 5));
-
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt64(new byte[8], -1));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt64(new byte[8], 8));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt64(new byte[8], 9));
-
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToSingle(new byte[4], -1));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToSingle(new byte[4], 4));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToSingle(new byte[4], 5));
-
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt16(new byte[2], -1));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt16(new byte[2], 2));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt16(new byte[2], 3));
-
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt32(new byte[4], -1));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt32(new byte[4], 4));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt32(new byte[4], 5));
-
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt64(new byte[8], -1));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt64(new byte[8], 8));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt64(new byte[8], 9));
-
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], -1));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], 1));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], 2));
-
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], -1, 0));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], 1, 0));
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], 2, 0));
-
-        Assert.Throws<ArgumentOutOfRangeException>("length", () => BitConverter.ToString(new byte[1], 0, -1));
-    }
-
-    [Fact]
-    public static void StartIndexPlusNeededLengthTooLong()
-    {
-        Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToBoolean(new byte[0], 0));
-        Assert.Throws<ArgumentException>("value", () => BitConverter.ToChar(new byte[2], 1));
-        Assert.Throws<ArgumentException>("value", () => BitConverter.ToDouble(new byte[8], 1));
-        Assert.Throws<ArgumentException>("value", () => BitConverter.ToInt16(new byte[2], 1));
-        Assert.Throws<ArgumentException>("value", () => BitConverter.ToInt32(new byte[4], 1));
-        Assert.Throws<ArgumentException>("value", () => BitConverter.ToInt64(new byte[8], 1));
-        Assert.Throws<ArgumentException>("value", () => BitConverter.ToSingle(new byte[4], 1));
-        Assert.Throws<ArgumentException>("value", () => BitConverter.ToUInt16(new byte[2], 1));
-        Assert.Throws<ArgumentException>("value", () => BitConverter.ToUInt32(new byte[4], 1));
-        Assert.Throws<ArgumentException>("value", () => BitConverter.ToUInt64(new byte[8], 1));
-        Assert.Throws<ArgumentException>("value", () => BitConverter.ToString(new byte[2], 1, 2));
-    }
-
-    [Fact]
-    public static void DoubleToInt64Bits()
-    {
-        Double input = 123456.3234;
-        Int64 result = BitConverter.DoubleToInt64Bits(input);
-        Assert.Equal(4683220267154373240L, result);
-        Double roundtripped = BitConverter.Int64BitsToDouble(result);
-        Assert.Equal(input, roundtripped);
-    }
-
-    [Fact]
-    public static void RoundtripBoolean()
-    {
-        Byte[] bytes = BitConverter.GetBytes(true);
-        Assert.Equal(1, bytes.Length);
-        Assert.Equal(1, bytes[0]);
-        Assert.True(BitConverter.ToBoolean(bytes, 0));
-
-        bytes = BitConverter.GetBytes(false);
-        Assert.Equal(1, bytes.Length);
-        Assert.Equal(0, bytes[0]);
-        Assert.False(BitConverter.ToBoolean(bytes, 0));
-    }
-
-    [Fact]
-    public static void RoundtripChar()
-    {
-        Char input = 'A';
-        Byte[] expected = { 0x41, 0 };
-        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToChar, input, expected);
-    }
-
-    [Fact]
-    public static void RoundtripDouble()
-    {
-        Double input = 123456.3234;
-        Byte[] expected = { 0x78, 0x7a, 0xa5, 0x2c, 0x05, 0x24, 0xfe, 0x40 };
-        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToDouble, input, expected);
-    }
-
-    [Fact]
-    public static void RoundtripSingle()
-    {
-        Single input = 8392.34f;
-        Byte[] expected = { 0x5c, 0x21, 0x03, 0x46 };
-        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToSingle, input, expected);
-    }
-
-    [Fact]
-    public static void RoundtripInt16()
-    {
-        Int16 input = 0x1234;
-        Byte[] expected = { 0x34, 0x12 };
-        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToInt16, input, expected);
-    }
-
-    [Fact]
-    public static void RoundtripInt32()
-    {
-        Int32 input = 0x12345678;
-        Byte[] expected = { 0x78, 0x56, 0x34, 0x12 };
-        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToInt32, input, expected);
-    }
-
-    [Fact]
-    public static void RoundtripInt64()
-    {
-        Int64 input = 0x0123456789abcdef;
-        Byte[] expected = { 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01 };
-        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToInt64, input, expected);
-    }
-
-    [Fact]
-    public static void RoundtripUInt16()
-    {
-        UInt16 input = 0x1234;
-        Byte[] expected = { 0x34, 0x12 };
-        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToUInt16, input, expected);
-    }
-
-    [Fact]
-    public static void RoundtripUInt32()
-    {
-        UInt32 input = 0x12345678;
-        Byte[] expected = { 0x78, 0x56, 0x34, 0x12 };
-        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToUInt32, input, expected);
-    }
-
-    [Fact]
-    public static void RoundtripUInt64()
-    {
-        UInt64 input = 0x0123456789abcdef;
-        Byte[] expected = { 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01 };
-        VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToUInt64, input, expected);
-    }
-
-    [Fact]
-    public static void RoundtripString()
-    {
-        Byte[] bytes = { 0x12, 0x34, 0x56, 0x78, 0x9a };
-
-        Assert.Equal("12-34-56-78-9A", BitConverter.ToString(bytes));
-        Assert.Equal("56-78-9A", BitConverter.ToString(bytes, 2));
-        Assert.Equal("56", BitConverter.ToString(bytes, 2, 1));
-        Assert.Equal(String.Empty, BitConverter.ToString(new byte[0]));
-    }
-
-    [Fact]
-    public static void ToString_ByteArrayTooLong_Throws()
-    {
-        byte[] arr;
-        try
+        [Fact]
+        public static unsafe void IsLittleEndian()
         {
-            arr = new byte[int.MaxValue / 3 + 1];
-        }
-        catch (OutOfMemoryException)
-        {
-            // Exit out of the test if we don't have an enough contiguous memory
-            // available to create a big enough array.
-            return;
+            short s = 1;
+            Assert.Equal(BitConverter.IsLittleEndian, *((byte*)&s) == 1);
         }
 
-        Assert.Throws<ArgumentOutOfRangeException>("length", () => BitConverter.ToString(arr));
-    }
-
-    private static void VerifyRoundtrip<TInput>(Func<TInput, Byte[]> getBytes, Func<Byte[], int, TInput> convertBack, TInput input, Byte[] expectedBytes)
-    {
-        Byte[] bytes = getBytes(input);
-        Assert.Equal(expectedBytes.Length, bytes.Length);
-
-        if (!BitConverter.IsLittleEndian)
+        [Fact]
+        public static void ValueArgumentNull()
         {
-            Array.Reverse(expectedBytes);
+            Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToBoolean(null, 0));
+            Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToChar(null, 0));
+            Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToDouble(null, 0));
+            Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToInt16(null, 0));
+            Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToInt32(null, 0));
+            Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToInt64(null, 0));
+            Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToSingle(null, 0));
+            Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToUInt16(null, 0));
+            Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToUInt32(null, 0));
+            Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToUInt64(null, 0));
+            Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToString(null));
+            Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToString(null, 0));
+            Assert.Throws<ArgumentNullException>("value", () => BitConverter.ToString(null, 0, 0));
         }
 
-        Assert.Equal(expectedBytes, bytes);
-        Assert.Equal(input, convertBack(bytes, 0));
+        [Fact]
+        public static void StartIndexBeyondLength()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToBoolean(new byte[1], -1));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToBoolean(new byte[1], 1));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToBoolean(new byte[1], 2));
 
-        // Also try unaligned startIndex
-        byte[] longerBytes = new byte[bytes.Length + 1];
-        longerBytes[0] = 0;
-        Array.Copy(bytes, 0, longerBytes, 1, bytes.Length);
-        Assert.Equal(input, convertBack(longerBytes, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToChar(new byte[2], -1));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToChar(new byte[2], 2));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToChar(new byte[2], 3));
+
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToDouble(new byte[8], -1));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToDouble(new byte[8], 8));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToDouble(new byte[8], 9));
+
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt16(new byte[2], -1));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt16(new byte[2], 2));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt16(new byte[2], 3));
+
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt32(new byte[4], -1));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt32(new byte[4], 4));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt32(new byte[4], 5));
+
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt64(new byte[8], -1));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt64(new byte[8], 8));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToInt64(new byte[8], 9));
+
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToSingle(new byte[4], -1));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToSingle(new byte[4], 4));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToSingle(new byte[4], 5));
+
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt16(new byte[2], -1));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt16(new byte[2], 2));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt16(new byte[2], 3));
+
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt32(new byte[4], -1));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt32(new byte[4], 4));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt32(new byte[4], 5));
+
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt64(new byte[8], -1));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt64(new byte[8], 8));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToUInt64(new byte[8], 9));
+
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], -1));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], 1));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], 2));
+
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], -1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], 1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToString(new byte[1], 2, 0));
+
+            Assert.Throws<ArgumentOutOfRangeException>("length", () => BitConverter.ToString(new byte[1], 0, -1));
+        }
+
+        [Fact]
+        public static void StartIndexPlusNeededLengthTooLong()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => BitConverter.ToBoolean(new byte[0], 0));
+            Assert.Throws<ArgumentException>("value", () => BitConverter.ToChar(new byte[2], 1));
+            Assert.Throws<ArgumentException>("value", () => BitConverter.ToDouble(new byte[8], 1));
+            Assert.Throws<ArgumentException>("value", () => BitConverter.ToInt16(new byte[2], 1));
+            Assert.Throws<ArgumentException>("value", () => BitConverter.ToInt32(new byte[4], 1));
+            Assert.Throws<ArgumentException>("value", () => BitConverter.ToInt64(new byte[8], 1));
+            Assert.Throws<ArgumentException>("value", () => BitConverter.ToSingle(new byte[4], 1));
+            Assert.Throws<ArgumentException>("value", () => BitConverter.ToUInt16(new byte[2], 1));
+            Assert.Throws<ArgumentException>("value", () => BitConverter.ToUInt32(new byte[4], 1));
+            Assert.Throws<ArgumentException>("value", () => BitConverter.ToUInt64(new byte[8], 1));
+            Assert.Throws<ArgumentException>("value", () => BitConverter.ToString(new byte[2], 1, 2));
+        }
+
+        [Fact]
+        public static void DoubleToInt64Bits()
+        {
+            Double input = 123456.3234;
+            Int64 result = BitConverter.DoubleToInt64Bits(input);
+            Assert.Equal(4683220267154373240L, result);
+            Double roundtripped = BitConverter.Int64BitsToDouble(result);
+            Assert.Equal(input, roundtripped);
+        }
+
+        [Fact]
+        public static void RoundtripBoolean()
+        {
+            Byte[] bytes = BitConverter.GetBytes(true);
+            Assert.Equal(1, bytes.Length);
+            Assert.Equal(1, bytes[0]);
+            Assert.True(BitConverter.ToBoolean(bytes, 0));
+
+            bytes = BitConverter.GetBytes(false);
+            Assert.Equal(1, bytes.Length);
+            Assert.Equal(0, bytes[0]);
+            Assert.False(BitConverter.ToBoolean(bytes, 0));
+        }
+
+        [Fact]
+        public static void RoundtripChar()
+        {
+            Char input = 'A';
+            Byte[] expected = { 0x41, 0 };
+            VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToChar, input, expected);
+        }
+
+        [Fact]
+        public static void RoundtripDouble()
+        {
+            Double input = 123456.3234;
+            Byte[] expected = { 0x78, 0x7a, 0xa5, 0x2c, 0x05, 0x24, 0xfe, 0x40 };
+            VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToDouble, input, expected);
+        }
+
+        [Fact]
+        public static void RoundtripSingle()
+        {
+            Single input = 8392.34f;
+            Byte[] expected = { 0x5c, 0x21, 0x03, 0x46 };
+            VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToSingle, input, expected);
+        }
+
+        [Fact]
+        public static void RoundtripInt16()
+        {
+            Int16 input = 0x1234;
+            Byte[] expected = { 0x34, 0x12 };
+            VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToInt16, input, expected);
+        }
+
+        [Fact]
+        public static void RoundtripInt32()
+        {
+            Int32 input = 0x12345678;
+            Byte[] expected = { 0x78, 0x56, 0x34, 0x12 };
+            VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToInt32, input, expected);
+        }
+
+        [Fact]
+        public static void RoundtripInt64()
+        {
+            Int64 input = 0x0123456789abcdef;
+            Byte[] expected = { 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01 };
+            VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToInt64, input, expected);
+        }
+
+        [Fact]
+        public static void RoundtripUInt16()
+        {
+            UInt16 input = 0x1234;
+            Byte[] expected = { 0x34, 0x12 };
+            VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToUInt16, input, expected);
+        }
+
+        [Fact]
+        public static void RoundtripUInt32()
+        {
+            UInt32 input = 0x12345678;
+            Byte[] expected = { 0x78, 0x56, 0x34, 0x12 };
+            VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToUInt32, input, expected);
+        }
+
+        [Fact]
+        public static void RoundtripUInt64()
+        {
+            UInt64 input = 0x0123456789abcdef;
+            Byte[] expected = { 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01 };
+            VerifyRoundtrip(BitConverter.GetBytes, BitConverter.ToUInt64, input, expected);
+        }
+
+        [Fact]
+        public static void RoundtripString()
+        {
+            Byte[] bytes = { 0x12, 0x34, 0x56, 0x78, 0x9a };
+
+            Assert.Equal("12-34-56-78-9A", BitConverter.ToString(bytes));
+            Assert.Equal("56-78-9A", BitConverter.ToString(bytes, 2));
+            Assert.Equal("56", BitConverter.ToString(bytes, 2, 1));
+            Assert.Equal(String.Empty, BitConverter.ToString(new byte[0]));
+        }
+
+        [Fact]
+        public static void ToString_ByteArrayTooLong_Throws()
+        {
+            byte[] arr;
+            try
+            {
+                arr = new byte[int.MaxValue / 3 + 1];
+            }
+            catch (OutOfMemoryException)
+            {
+                // Exit out of the test if we don't have an enough contiguous memory
+                // available to create a big enough array.
+                return;
+            }
+
+            Assert.Throws<ArgumentOutOfRangeException>("length", () => BitConverter.ToString(arr));
+        }
+
+        private static void VerifyRoundtrip<TInput>(Func<TInput, Byte[]> getBytes, Func<Byte[], int, TInput> convertBack, TInput input, Byte[] expectedBytes)
+        {
+            Byte[] bytes = getBytes(input);
+            Assert.Equal(expectedBytes.Length, bytes.Length);
+
+            if (!BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(expectedBytes);
+            }
+
+            Assert.Equal(expectedBytes, bytes);
+            Assert.Equal(input, convertBack(bytes, 0));
+
+            // Also try unaligned startIndex
+            byte[] longerBytes = new byte[bytes.Length + 1];
+            longerBytes[0] = 0;
+            Array.Copy(bytes, 0, longerBytes, 1, bytes.Length);
+            Assert.Equal(input, convertBack(longerBytes, 1));
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.BoxedObjectCheck.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.BoxedObjectCheck.cs
@@ -2,17 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.CompilerServices;
 using Xunit;
 
-public class ConvertBoxedObjectCheckTests
+namespace System.Tests
 {
-    [Fact]
-    public static void ChangeTypeIdentity()
+    public class ConvertBoxedObjectCheckTests
     {
-        object[] testValues =
+        [Fact]
+        public static void ChangeTypeIdentity()
         {
+            object[] testValues =
+            {
             true, false,
             Byte.MinValue, Byte.MaxValue,
             SByte.MinValue,SByte.MaxValue, (SByte)0,
@@ -29,49 +30,50 @@ public class ConvertBoxedObjectCheckTests
             DateTime.MinValue, DateTime.Now, DateTime.MaxValue
         };
 
-        foreach (object obj in testValues)
-        {
-            object copy = GetBoxedCopy(obj);
-            Assert.NotSame(obj, copy);
-            Assert.Equal(obj, copy);
+            foreach (object obj in testValues)
+            {
+                object copy = GetBoxedCopy(obj);
+                Assert.NotSame(obj, copy);
+                Assert.Equal(obj, copy);
+            }
         }
-    }
 
-    public static object GetBoxedCopy(object obj)
-    {
-        Type type = obj.GetType();
-        if (type == typeof(Boolean))
-            return Convert.ChangeType(obj, typeof(Boolean));
-        else if (type == typeof(Byte))
-            return Convert.ChangeType(obj, typeof(Byte));
-        else if (type == typeof(SByte))
-            return Convert.ChangeType(obj, typeof(SByte));
-        else if (type == typeof(Int16))
-            return Convert.ChangeType(obj, typeof(Int16));
-        else if (type == typeof(Int32))
-            return Convert.ChangeType(obj, typeof(Int32));
-        else if (type == typeof(Int64))
-            return Convert.ChangeType(obj, typeof(Int64));
-        else if (type == typeof(UInt16))
-            return Convert.ChangeType(obj, typeof(UInt16));
-        else if (type == typeof(UInt32))
-            return Convert.ChangeType(obj, typeof(UInt32));
-        else if (type == typeof(UInt64))
-            return Convert.ChangeType(obj, typeof(UInt64));
-        else if (type == typeof(IntPtr))
-            return Convert.ChangeType(obj, typeof(IntPtr));
-        else if (type == typeof(UIntPtr))
-            return Convert.ChangeType(obj, typeof(UIntPtr));
-        else if (type == typeof(Char))
-            return Convert.ChangeType(obj, typeof(Char));
-        else if (type == typeof(Double))
-            return Convert.ChangeType(obj, typeof(Double));
-        else if (type == typeof(Single))
-            return Convert.ChangeType(obj, typeof(Single));
-        else if (type == typeof(Decimal))
-            return Convert.ChangeType(obj, typeof(Decimal));
-        else
-            // Not a primitive type
-            return RuntimeHelpers.GetObjectValue(obj);
+        public static object GetBoxedCopy(object obj)
+        {
+            Type type = obj.GetType();
+            if (type == typeof(Boolean))
+                return Convert.ChangeType(obj, typeof(Boolean));
+            else if (type == typeof(Byte))
+                return Convert.ChangeType(obj, typeof(Byte));
+            else if (type == typeof(SByte))
+                return Convert.ChangeType(obj, typeof(SByte));
+            else if (type == typeof(Int16))
+                return Convert.ChangeType(obj, typeof(Int16));
+            else if (type == typeof(Int32))
+                return Convert.ChangeType(obj, typeof(Int32));
+            else if (type == typeof(Int64))
+                return Convert.ChangeType(obj, typeof(Int64));
+            else if (type == typeof(UInt16))
+                return Convert.ChangeType(obj, typeof(UInt16));
+            else if (type == typeof(UInt32))
+                return Convert.ChangeType(obj, typeof(UInt32));
+            else if (type == typeof(UInt64))
+                return Convert.ChangeType(obj, typeof(UInt64));
+            else if (type == typeof(IntPtr))
+                return Convert.ChangeType(obj, typeof(IntPtr));
+            else if (type == typeof(UIntPtr))
+                return Convert.ChangeType(obj, typeof(UIntPtr));
+            else if (type == typeof(Char))
+                return Convert.ChangeType(obj, typeof(Char));
+            else if (type == typeof(Double))
+                return Convert.ChangeType(obj, typeof(Double));
+            else if (type == typeof(Single))
+                return Convert.ChangeType(obj, typeof(Single));
+            else if (type == typeof(Decimal))
+                return Convert.ChangeType(obj, typeof(Decimal));
+            else
+                // Not a primitive type
+                return RuntimeHelpers.GetObjectValue(obj);
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.FromBase64.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.FromBase64.cs
@@ -2,258 +2,259 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Text;
 using Xunit;
 
-public class ConvertFromBase64Tests
+namespace System.Tests
 {
-    [Fact]
-    public static void Roundtrip1()
+    public class ConvertFromBase64Tests
     {
-        string input = "test";
-        Verify(input, result =>
+        [Fact]
+        public static void Roundtrip1()
         {
+            string input = "test";
+            Verify(input, result =>
+            {
             // See Freed, N. and N. Borenstein, RFC2045, Section 6.8 for a description of why this check is necessary.
             Assert.Equal(3, result.Length);
 
-            uint triplet = (uint)((result[0] << 16) | (result[1] << 8) | result[2]);
-            Assert.Equal<uint>(45, triplet >> 18); // 't'
+                uint triplet = (uint)((result[0] << 16) | (result[1] << 8) | result[2]);
+                Assert.Equal<uint>(45, triplet >> 18); // 't'
             Assert.Equal<uint>(30, (triplet << 14) >> 26); // 'e'
             Assert.Equal<uint>(44, (triplet << 20) >> 26); // 's'
             Assert.Equal<uint>(45, (triplet << 26) >> 26); // 't'
 
             Assert.Equal(input, Convert.ToBase64String(result));
-        });
-    }
+            });
+        }
 
-    [Fact]
-    public static void Roundtrip2()
-    {
-        VerifyRoundtrip("AAAA");
-    }
-
-    [Fact]
-    public static void Roundtrip3()
-    {
-        VerifyRoundtrip("AAAAAAAA");
-    }
-
-    [Fact]
-    public static void EmptyString()
-    {
-        string input = string.Empty;
-        Verify(input, result =>
+        [Fact]
+        public static void Roundtrip2()
         {
+            VerifyRoundtrip("AAAA");
+        }
+
+        [Fact]
+        public static void Roundtrip3()
+        {
+            VerifyRoundtrip("AAAAAAAA");
+        }
+
+        [Fact]
+        public static void EmptyString()
+        {
+            string input = string.Empty;
+            Verify(input, result =>
+            {
+                Assert.NotNull(result);
+                Assert.Equal(0, result.Length);
+            });
+        }
+
+        [Fact]
+        public static void ZeroLengthArray()
+        {
+            string input = "test";
+            char[] inputChars = input.ToCharArray();
+            byte[] result = Convert.FromBase64CharArray(inputChars, 0, 0);
+
             Assert.NotNull(result);
             Assert.Equal(0, result.Length);
-        });
-    }
-
-    [Fact]
-    public static void ZeroLengthArray()
-    {
-        string input = "test";
-        char[] inputChars = input.ToCharArray();
-        byte[] result = Convert.FromBase64CharArray(inputChars, 0, 0);
-
-        Assert.NotNull(result);
-        Assert.Equal(0, result.Length);
-    }
-
-    [Fact]
-    public static void RoundtripWithPadding1()
-    {
-        VerifyRoundtrip("abc=");
-    }
-
-    [Fact]
-    public static void RoundtripWithPadding2()
-    {
-        VerifyRoundtrip("BQYHCA==");
-    }
-
-    [Fact]
-    public static void PartialRoundtripWithPadding1()
-    {
-        string input = "ab==";
-        Verify(input, result =>
-        {
-            Assert.Equal(1, result.Length);
-
-            string roundtrippedString = Convert.ToBase64String(result);
-            Assert.NotEqual(input, roundtrippedString);
-            Assert.Equal(input[0], roundtrippedString[0]);
-        });
-    }
-
-    [Fact]
-    public static void PartialRoundtripWithPadding2()
-    {
-        string input = "789=";
-        Verify(input, result =>
-        {
-            Assert.Equal(2, result.Length);
-
-            string roundtrippedString = Convert.ToBase64String(result);
-            Assert.NotEqual(input, roundtrippedString);
-            Assert.Equal(input[0], roundtrippedString[0]);
-            Assert.Equal(input[1], roundtrippedString[1]);
-        });
-    }
-
-    [Fact]
-    public static void ParseWithWhitespace()
-    {
-        Verify("abc= \t \r\n =");
-    }
-
-    [Fact]
-    public static void RoundtripWithWhitespace2()
-    {
-        string input = "abc=  \t\n\t\r ";
-        VerifyRoundtrip(input, input.Trim());
-    }
-
-    [Fact]
-    public static void RoundtripWithWhitespace3()
-    {
-        string input = "abc \r\n\t   =  \t\n\t\r ";
-        VerifyRoundtrip(input, "abc=");
-    }
-
-    [Fact]
-    public static void RoundtripWithWhitespace4()
-    {
-        string expected = "test";
-        string input = expected.Insert(1, new string(' ', 17)).PadLeft(31, ' ').PadRight(12, ' ');
-        VerifyRoundtrip(input, expected, expectedLengthBytes: 3);
-    }
-
-    [Fact]
-    public static void RoundtripWithWhitespace5()
-    {
-        string expected = "test";
-        string input = expected.Insert(2, new string('\t', 9)).PadLeft(37, '\t').PadRight(8, '\t');
-        VerifyRoundtrip(input, expected, expectedLengthBytes: 3);
-    }
-
-    [Fact]
-    public static void RoundtripWithWhitespace6()
-    {
-        string expected = "test";
-        string input = expected.Insert(2, new string('\r', 13)).PadLeft(7, '\r').PadRight(29, '\r');
-        VerifyRoundtrip(input, expected, expectedLengthBytes: 3);
-    }
-
-    [Fact]
-    public static void RoundtripWithWhitespace7()
-    {
-        string expected = "test";
-        string input = expected.Insert(2, new string('\n', 23)).PadLeft(17, '\n').PadRight(34, '\n');
-        VerifyRoundtrip(input, expected, expectedLengthBytes: 3);
-    }
-
-    [Fact]
-    public static void RoundtripLargeString()
-    {
-        string input = new string('a', 10000);
-        VerifyRoundtrip(input, input);
-    }
-
-    [Fact]
-    public static void InvalidOffset()
-    {
-        string input = "test";
-        char[] inputChars = input.ToCharArray();
-
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.FromBase64CharArray(inputChars, -1, inputChars.Length));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.FromBase64CharArray(inputChars, inputChars.Length, inputChars.Length));
-    }
-
-    [Fact]
-    public static void InvalidLength()
-    {
-        string input = "test";
-        char[] inputChars = input.ToCharArray();
-
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.FromBase64CharArray(inputChars, 0, -1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.FromBase64CharArray(inputChars, 0, inputChars.Length + 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.FromBase64CharArray(inputChars, 1, inputChars.Length));
-    }
-
-    [Fact]
-    public static void InvalidInput()
-    {
-        Assert.Throws<ArgumentNullException>(() => Convert.FromBase64CharArray(null, 0, 3));
-
-        // Input must be at least 4 characters long
-        VerifyInvalidInput("No");
-
-        // Length of input must be a multiple of 4
-        VerifyInvalidInput("NoMore");
-
-        // Input must not contain invalid characters
-        VerifyInvalidInput("2-34");
-
-        // Input must not contain 3 or more padding characters in a row
-        VerifyInvalidInput("a===");
-        VerifyInvalidInput("abc=====");
-        VerifyInvalidInput("a===\r  \t  \n");
-
-        // Input must not contain padding characters in the middle of the string
-        VerifyInvalidInput("No=n");
-        VerifyInvalidInput("abcdabc=abcd");
-        VerifyInvalidInput("abcdab==abcd");
-        VerifyInvalidInput("abcda===abcd");
-        VerifyInvalidInput("abcd====abcd");
-    }
-
-    [Fact]
-    public static void InvalidCharactersInInput()
-    {
-        ushort[] invalidChars = { 30122, 62608, 13917, 19498, 2473, 40845, 35988, 2281, 51246, 36372 };
-
-        foreach (char ch in invalidChars)
-        {
-            var builder = new StringBuilder("abc");
-            builder.Insert(1, ch);
-            VerifyInvalidInput(builder.ToString());
-        }
-    }
-
-    private static void VerifyRoundtrip(string input, string expected = null, int? expectedLengthBytes = null)
-    {
-        if (expected == null)
-        {
-            expected = input;
         }
 
-        Verify(input, result =>
+        [Fact]
+        public static void RoundtripWithPadding1()
         {
-            if (expectedLengthBytes.HasValue)
+            VerifyRoundtrip("abc=");
+        }
+
+        [Fact]
+        public static void RoundtripWithPadding2()
+        {
+            VerifyRoundtrip("BQYHCA==");
+        }
+
+        [Fact]
+        public static void PartialRoundtripWithPadding1()
+        {
+            string input = "ab==";
+            Verify(input, result =>
             {
-                Assert.Equal(expectedLengthBytes.Value, result.Length);
-            }
-            Assert.Equal(expected, Convert.ToBase64String(result));
-            Assert.Equal(expected, Convert.ToBase64String(result, 0, result.Length));
-        });
-    }
+                Assert.Equal(1, result.Length);
 
-    private static void VerifyInvalidInput(string input)
-    {
-        char[] inputChars = input.ToCharArray();
-        Assert.Throws<FormatException>(() => Convert.FromBase64CharArray(inputChars, 0, inputChars.Length));
-        Assert.Throws<FormatException>(() => Convert.FromBase64String(input));
-    }
+                string roundtrippedString = Convert.ToBase64String(result);
+                Assert.NotEqual(input, roundtrippedString);
+                Assert.Equal(input[0], roundtrippedString[0]);
+            });
+        }
 
-    private static void Verify(string input, Action<byte[]> action = null)
-    {
-        if (action != null)
+        [Fact]
+        public static void PartialRoundtripWithPadding2()
         {
-            action(Convert.FromBase64CharArray(input.ToCharArray(), 0, input.Length));
-            action(Convert.FromBase64String(input));
+            string input = "789=";
+            Verify(input, result =>
+            {
+                Assert.Equal(2, result.Length);
+
+                string roundtrippedString = Convert.ToBase64String(result);
+                Assert.NotEqual(input, roundtrippedString);
+                Assert.Equal(input[0], roundtrippedString[0]);
+                Assert.Equal(input[1], roundtrippedString[1]);
+            });
+        }
+
+        [Fact]
+        public static void ParseWithWhitespace()
+        {
+            Verify("abc= \t \r\n =");
+        }
+
+        [Fact]
+        public static void RoundtripWithWhitespace2()
+        {
+            string input = "abc=  \t\n\t\r ";
+            VerifyRoundtrip(input, input.Trim());
+        }
+
+        [Fact]
+        public static void RoundtripWithWhitespace3()
+        {
+            string input = "abc \r\n\t   =  \t\n\t\r ";
+            VerifyRoundtrip(input, "abc=");
+        }
+
+        [Fact]
+        public static void RoundtripWithWhitespace4()
+        {
+            string expected = "test";
+            string input = expected.Insert(1, new string(' ', 17)).PadLeft(31, ' ').PadRight(12, ' ');
+            VerifyRoundtrip(input, expected, expectedLengthBytes: 3);
+        }
+
+        [Fact]
+        public static void RoundtripWithWhitespace5()
+        {
+            string expected = "test";
+            string input = expected.Insert(2, new string('\t', 9)).PadLeft(37, '\t').PadRight(8, '\t');
+            VerifyRoundtrip(input, expected, expectedLengthBytes: 3);
+        }
+
+        [Fact]
+        public static void RoundtripWithWhitespace6()
+        {
+            string expected = "test";
+            string input = expected.Insert(2, new string('\r', 13)).PadLeft(7, '\r').PadRight(29, '\r');
+            VerifyRoundtrip(input, expected, expectedLengthBytes: 3);
+        }
+
+        [Fact]
+        public static void RoundtripWithWhitespace7()
+        {
+            string expected = "test";
+            string input = expected.Insert(2, new string('\n', 23)).PadLeft(17, '\n').PadRight(34, '\n');
+            VerifyRoundtrip(input, expected, expectedLengthBytes: 3);
+        }
+
+        [Fact]
+        public static void RoundtripLargeString()
+        {
+            string input = new string('a', 10000);
+            VerifyRoundtrip(input, input);
+        }
+
+        [Fact]
+        public static void InvalidOffset()
+        {
+            string input = "test";
+            char[] inputChars = input.ToCharArray();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.FromBase64CharArray(inputChars, -1, inputChars.Length));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.FromBase64CharArray(inputChars, inputChars.Length, inputChars.Length));
+        }
+
+        [Fact]
+        public static void InvalidLength()
+        {
+            string input = "test";
+            char[] inputChars = input.ToCharArray();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.FromBase64CharArray(inputChars, 0, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.FromBase64CharArray(inputChars, 0, inputChars.Length + 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.FromBase64CharArray(inputChars, 1, inputChars.Length));
+        }
+
+        [Fact]
+        public static void InvalidInput()
+        {
+            Assert.Throws<ArgumentNullException>(() => Convert.FromBase64CharArray(null, 0, 3));
+
+            // Input must be at least 4 characters long
+            VerifyInvalidInput("No");
+
+            // Length of input must be a multiple of 4
+            VerifyInvalidInput("NoMore");
+
+            // Input must not contain invalid characters
+            VerifyInvalidInput("2-34");
+
+            // Input must not contain 3 or more padding characters in a row
+            VerifyInvalidInput("a===");
+            VerifyInvalidInput("abc=====");
+            VerifyInvalidInput("a===\r  \t  \n");
+
+            // Input must not contain padding characters in the middle of the string
+            VerifyInvalidInput("No=n");
+            VerifyInvalidInput("abcdabc=abcd");
+            VerifyInvalidInput("abcdab==abcd");
+            VerifyInvalidInput("abcda===abcd");
+            VerifyInvalidInput("abcd====abcd");
+        }
+
+        [Fact]
+        public static void InvalidCharactersInInput()
+        {
+            ushort[] invalidChars = { 30122, 62608, 13917, 19498, 2473, 40845, 35988, 2281, 51246, 36372 };
+
+            foreach (char ch in invalidChars)
+            {
+                var builder = new StringBuilder("abc");
+                builder.Insert(1, ch);
+                VerifyInvalidInput(builder.ToString());
+            }
+        }
+
+        private static void VerifyRoundtrip(string input, string expected = null, int? expectedLengthBytes = null)
+        {
+            if (expected == null)
+            {
+                expected = input;
+            }
+
+            Verify(input, result =>
+            {
+                if (expectedLengthBytes.HasValue)
+                {
+                    Assert.Equal(expectedLengthBytes.Value, result.Length);
+                }
+                Assert.Equal(expected, Convert.ToBase64String(result));
+                Assert.Equal(expected, Convert.ToBase64String(result, 0, result.Length));
+            });
+        }
+
+        private static void VerifyInvalidInput(string input)
+        {
+            char[] inputChars = input.ToCharArray();
+            Assert.Throws<FormatException>(() => Convert.FromBase64CharArray(inputChars, 0, inputChars.Length));
+            Assert.Throws<FormatException>(() => Convert.FromBase64String(input));
+        }
+
+        private static void Verify(string input, Action<byte[]> action = null)
+        {
+            if (action != null)
+            {
+                action(Convert.FromBase64CharArray(input.ToCharArray(), 0, input.Length));
+                action(Convert.FromBase64String(input));
+            }
         }
     }
 }
-

--- a/src/System.Runtime.Extensions/tests/System/Convert.TestBase.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.TestBase.cs
@@ -2,135 +2,135 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Xunit;
-
-public abstract class ConvertTestBase<TOutput>
+namespace System.Tests
 {
-    /// <summary>
-    /// Verify that the provided convert delegate produces expectedValues given testValues.
-    /// </summary>
-    protected void Verify<TInput>(Func<TInput, TOutput> convert, TInput[] testValues, TOutput[] expectedValues)
+    public abstract class ConvertTestBase<TOutput>
     {
-        Assert.Equal(expectedValues.Length, testValues.Length);
-
-        for (int i = 0; i < testValues.Length; i++)
+        /// <summary>
+        /// Verify that the provided convert delegate produces expectedValues given testValues.
+        /// </summary>
+        protected void Verify<TInput>(Func<TInput, TOutput> convert, TInput[] testValues, TOutput[] expectedValues)
         {
-            TOutput result = convert(testValues[i]);
-            Assert.Equal(expectedValues[i], result);
-        }
-    }
+            Assert.Equal(expectedValues.Length, testValues.Length);
 
-    /// <summary>
-    /// Verify that the provided convert delegates produce expectedValues given testValues
-    /// </summary>
-    protected void VerifyFromString(Func<String, TOutput> convert, Func<String, IFormatProvider, TOutput> convertWithFormatProvider, String[] testValues, TOutput[] expectedValues)
-    {
-        Verify<String>(convert, testValues, expectedValues);
-        Verify<String>(input => convertWithFormatProvider(input, TestFormatProvider.s_instance), testValues, expectedValues);
-    }
-
-    /// <summary>
-    /// Verify that the provided convert delegates produce expectedValues given testValues
-    /// </summary>
-    protected void VerifyFromObject(Func<Object, TOutput> convert, Func<Object, IFormatProvider, TOutput> convertWithFormatProvider, Object[] testValues, TOutput[] expectedValues)
-    {
-        Verify<Object>(convert, testValues, expectedValues);
-        Verify<Object>(input => convertWithFormatProvider(input, TestFormatProvider.s_instance), testValues, expectedValues);
-    }
-
-    /// <summary>
-    /// Verify that the provided convert delegate produces expectedValues given testValues and testBases
-    /// </summary>
-    protected void VerifyFromStringWithBase(Func<String, Int32, TOutput> convert, String[] testValues, Int32[] testBases, TOutput[] expectedValues)
-    {
-        Assert.Equal(testValues.Length, testBases.Length);
-        Assert.Equal(testValues.Length, expectedValues.Length);
-
-        for (int i = 0; i < testValues.Length; i++)
-        {
-            TOutput result = convert(testValues[i], testBases[i]);
-            Assert.Equal(expectedValues[i], result);
-        }
-    }
-
-    /// <summary>
-    /// Verify that the provided convert delegate throws an exception of type TException given testValues and testBases
-    /// </summary>
-    protected void VerifyFromStringWithBaseThrows<TException>(Func<String, Int32, TOutput> convert, String[] testValues, Int32[] testBases) where TException : Exception
-    {
-        Assert.Equal(testValues.Length, testBases.Length);
-
-        for (int i = 0; i < testValues.Length; i++)
-        {
-            try
+            for (int i = 0; i < testValues.Length; i++)
             {
-                Assert.Throws<TException>(() => convert(testValues[i], testBases[i]));
-            }
-            catch (Exception e)
-            {
-                String message = String.Format("Expected {0} converting '{1}' (base {2}) to '{3}'", typeof(TException).FullName, testValues[i], testBases[i], typeof(TOutput).FullName);
-                throw new AggregateException(message, e);
+                TOutput result = convert(testValues[i]);
+                Assert.Equal(expectedValues[i], result);
             }
         }
-    }
 
-    /// <summary>
-    /// Verify that the provided convert delegate throws an exception of type TException given testValues
-    /// </summary>
-    protected void VerifyThrows<TException, TInput>(Func<TInput, TOutput> convert, TInput[] testValues) where TException : Exception
-    {
-        for (int i = 0; i < testValues.Length; i++)
+        /// <summary>
+        /// Verify that the provided convert delegates produce expectedValues given testValues
+        /// </summary>
+        protected void VerifyFromString(Func<String, TOutput> convert, Func<String, IFormatProvider, TOutput> convertWithFormatProvider, String[] testValues, TOutput[] expectedValues)
         {
-            try
+            Verify<String>(convert, testValues, expectedValues);
+            Verify<String>(input => convertWithFormatProvider(input, TestFormatProvider.s_instance), testValues, expectedValues);
+        }
+
+        /// <summary>
+        /// Verify that the provided convert delegates produce expectedValues given testValues
+        /// </summary>
+        protected void VerifyFromObject(Func<Object, TOutput> convert, Func<Object, IFormatProvider, TOutput> convertWithFormatProvider, Object[] testValues, TOutput[] expectedValues)
+        {
+            Verify<Object>(convert, testValues, expectedValues);
+            Verify<Object>(input => convertWithFormatProvider(input, TestFormatProvider.s_instance), testValues, expectedValues);
+        }
+
+        /// <summary>
+        /// Verify that the provided convert delegate produces expectedValues given testValues and testBases
+        /// </summary>
+        protected void VerifyFromStringWithBase(Func<String, Int32, TOutput> convert, String[] testValues, Int32[] testBases, TOutput[] expectedValues)
+        {
+            Assert.Equal(testValues.Length, testBases.Length);
+            Assert.Equal(testValues.Length, expectedValues.Length);
+
+            for (int i = 0; i < testValues.Length; i++)
             {
-                Assert.Throws<TException>(() => convert(testValues[i]));
+                TOutput result = convert(testValues[i], testBases[i]);
+                Assert.Equal(expectedValues[i], result);
             }
-            catch (Exception e)
+        }
+
+        /// <summary>
+        /// Verify that the provided convert delegate throws an exception of type TException given testValues and testBases
+        /// </summary>
+        protected void VerifyFromStringWithBaseThrows<TException>(Func<String, Int32, TOutput> convert, String[] testValues, Int32[] testBases) where TException : Exception
+        {
+            Assert.Equal(testValues.Length, testBases.Length);
+
+            for (int i = 0; i < testValues.Length; i++)
             {
-                String message = String.Format("Expected {0} converting '{1}' ({2}) to {3}", typeof(TException).FullName, testValues[i], typeof(TInput).FullName, typeof(TOutput).FullName);
-                throw new AggregateException(message, e);
+                try
+                {
+                    Assert.Throws<TException>(() => convert(testValues[i], testBases[i]));
+                }
+                catch (Exception e)
+                {
+                    String message = String.Format("Expected {0} converting '{1}' (base {2}) to '{3}'", typeof(TException).FullName, testValues[i], testBases[i], typeof(TOutput).FullName);
+                    throw new AggregateException(message, e);
+                }
             }
         }
-    }
 
-    /// <summary>
-    /// Verify that the provided convert delegates throws an exception of type TException given testValues
-    /// </summary>
-    protected void VerifyFromStringThrows<TException>(Func<String, TOutput> convert, Func<String, IFormatProvider, TOutput> convertWithFormatProvider, String[] testValues) where TException : Exception
-    {
-        VerifyThrows<TException, String>(convert, testValues);
-        VerifyThrows<TException, String>(input => convertWithFormatProvider(input, TestFormatProvider.s_instance), testValues);
-    }
-
-    /// <summary>
-    /// Verify that the provided convert delegates throw exception of type TException given testValues
-    /// </summary>
-    protected void VerifyFromObjectThrows<TException>(Func<Object, TOutput> convert, Func<Object, IFormatProvider, TOutput> convertWithFormatProvider, Object[] testValues) where TException : Exception
-    {
-        VerifyThrows<TException, Object>(convert, testValues);
-        VerifyThrows<TException, Object>(input => convertWithFormatProvider(input, TestFormatProvider.s_instance), testValues);
-    }
-
-    /// <summary>
-    /// Helper class to test that the IFormatProvider is being called.
-    /// </summary>
-    protected class TestFormatProvider : IFormatProvider, ICustomFormatter
-    {
-        public static readonly TestFormatProvider s_instance = new TestFormatProvider();
-
-        private TestFormatProvider()
+        /// <summary>
+        /// Verify that the provided convert delegate throws an exception of type TException given testValues
+        /// </summary>
+        protected void VerifyThrows<TException, TInput>(Func<TInput, TOutput> convert, TInput[] testValues) where TException : Exception
         {
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                try
+                {
+                    Assert.Throws<TException>(() => convert(testValues[i]));
+                }
+                catch (Exception e)
+                {
+                    String message = String.Format("Expected {0} converting '{1}' ({2}) to {3}", typeof(TException).FullName, testValues[i], typeof(TInput).FullName, typeof(TOutput).FullName);
+                    throw new AggregateException(message, e);
+                }
+            }
         }
 
-        public Object GetFormat(Type formatType)
+        /// <summary>
+        /// Verify that the provided convert delegates throws an exception of type TException given testValues
+        /// </summary>
+        protected void VerifyFromStringThrows<TException>(Func<String, TOutput> convert, Func<String, IFormatProvider, TOutput> convertWithFormatProvider, String[] testValues) where TException : Exception
         {
-            return this;
+            VerifyThrows<TException, String>(convert, testValues);
+            VerifyThrows<TException, String>(input => convertWithFormatProvider(input, TestFormatProvider.s_instance), testValues);
         }
 
-        public String Format(String format, Object arg, IFormatProvider formatProvider)
+        /// <summary>
+        /// Verify that the provided convert delegates throw exception of type TException given testValues
+        /// </summary>
+        protected void VerifyFromObjectThrows<TException>(Func<Object, TOutput> convert, Func<Object, IFormatProvider, TOutput> convertWithFormatProvider, Object[] testValues) where TException : Exception
         {
-            return arg.ToString();
+            VerifyThrows<TException, Object>(convert, testValues);
+            VerifyThrows<TException, Object>(input => convertWithFormatProvider(input, TestFormatProvider.s_instance), testValues);
+        }
+
+        /// <summary>
+        /// Helper class to test that the IFormatProvider is being called.
+        /// </summary>
+        protected class TestFormatProvider : IFormatProvider, ICustomFormatter
+        {
+            public static readonly TestFormatProvider s_instance = new TestFormatProvider();
+
+            private TestFormatProvider()
+            {
+            }
+
+            public Object GetFormat(Type formatType)
+            {
+                return this;
+            }
+
+            public String Format(String format, Object arg, IFormatProvider formatProvider)
+            {
+                return arg.ToString();
+            }
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToBase64CharArray.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToBase64CharArray.cs
@@ -2,95 +2,97 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public class ConvertToBase64CharArrayTests
+namespace System.Tests
 {
-    [Fact]
-    public static void ValidOffsetIn()
+    public class ConvertToBase64CharArrayTests
     {
-        string input = "test";
-        byte[] inputBytes = Convert.FromBase64String(input);
-        char[] resultChars = new char[4];
-        int fillCharCount = Convert.ToBase64CharArray(inputBytes, 0, inputBytes.Length - 1, resultChars, 0);
-        Assert.Equal(input.Length, fillCharCount);
-    }
+        [Fact]
+        public static void ValidOffsetIn()
+        {
+            string input = "test";
+            byte[] inputBytes = Convert.FromBase64String(input);
+            char[] resultChars = new char[4];
+            int fillCharCount = Convert.ToBase64CharArray(inputBytes, 0, inputBytes.Length - 1, resultChars, 0);
+            Assert.Equal(input.Length, fillCharCount);
+        }
 
-    [Fact]
-    public static void ShortInputArray()
-    {
-        // Regression test for bug where a short input array caused an exception to be thrown
-        byte[] inputBuffer = new byte[] { (byte)'a', (byte)'b', (byte)'c' };
-        char[] ouputBuffer = new char[4];
-        Convert.ToBase64CharArray(inputBuffer, 0, 3, ouputBuffer, 0);
-        Convert.ToBase64CharArray(inputBuffer, 0, 2, ouputBuffer, 0);
-    }
+        [Fact]
+        public static void ShortInputArray()
+        {
+            // Regression test for bug where a short input array caused an exception to be thrown
+            byte[] inputBuffer = new byte[] { (byte)'a', (byte)'b', (byte)'c' };
+            char[] ouputBuffer = new char[4];
+            Convert.ToBase64CharArray(inputBuffer, 0, 3, ouputBuffer, 0);
+            Convert.ToBase64CharArray(inputBuffer, 0, 2, ouputBuffer, 0);
+        }
 
-    [Fact]
-    public static void ValidOffsetOut()
-    {
-        // Regression test for bug where offsetOut parameter was ignored
-        char[] outputBuffer = "........".ToCharArray();
-        byte[] inputBuffer = new byte[6];
-        for (int i = 0; i < inputBuffer.Length; inputBuffer[i] = (byte)i++) ;
+        [Fact]
+        public static void ValidOffsetOut()
+        {
+            // Regression test for bug where offsetOut parameter was ignored
+            char[] outputBuffer = "........".ToCharArray();
+            byte[] inputBuffer = new byte[6];
+            for (int i = 0; i < inputBuffer.Length; inputBuffer[i] = (byte)i++) ;
 
-        // Convert the first half of the byte array, write to the first half of the char array
-        int c = Convert.ToBase64CharArray(inputBuffer, 0, 3, outputBuffer, 0);
-        Assert.Equal(4, c);
-        Assert.Equal("AAEC....", new String(outputBuffer));
+            // Convert the first half of the byte array, write to the first half of the char array
+            int c = Convert.ToBase64CharArray(inputBuffer, 0, 3, outputBuffer, 0);
+            Assert.Equal(4, c);
+            Assert.Equal("AAEC....", new String(outputBuffer));
 
-        // Convert the second half of the byte array, write to the second half of the char array
-        c = Convert.ToBase64CharArray(inputBuffer, 3, 3, outputBuffer, 4);
-        Assert.Equal(4, c);
-        Assert.Equal("AAECAwQF", new String(outputBuffer));
-    }
+            // Convert the second half of the byte array, write to the second half of the char array
+            c = Convert.ToBase64CharArray(inputBuffer, 3, 3, outputBuffer, 4);
+            Assert.Equal(4, c);
+            Assert.Equal("AAECAwQF", new String(outputBuffer));
+        }
 
-    [Fact]
-    public static void InvalidInputBuffer()
-    {
-        Assert.Throws<ArgumentNullException>(() => Convert.ToBase64CharArray(null, 0, 1, new char[1], 0));
-    }
+        [Fact]
+        public static void InvalidInputBuffer()
+        {
+            Assert.Throws<ArgumentNullException>(() => Convert.ToBase64CharArray(null, 0, 1, new char[1], 0));
+        }
 
-    [Fact]
-    public static void InvalidOutputBuffer()
-    {
-        char[] inputChars = "test".ToCharArray();
-        byte[] inputBytes = Convert.FromBase64CharArray(inputChars, 0, inputChars.Length);
-        Assert.Throws<ArgumentNullException>(() => Convert.ToBase64CharArray(inputBytes, 0, inputBytes.Length, null, 0));
-    }
+        [Fact]
+        public static void InvalidOutputBuffer()
+        {
+            char[] inputChars = "test".ToCharArray();
+            byte[] inputBytes = Convert.FromBase64CharArray(inputChars, 0, inputChars.Length);
+            Assert.Throws<ArgumentNullException>(() => Convert.ToBase64CharArray(inputBytes, 0, inputBytes.Length, null, 0));
+        }
 
-    [Fact]
-    public static void InvalidOffsetIn()
-    {
-        char[] inputChars = "test".ToCharArray();
-        byte[] inputBytes = Convert.FromBase64CharArray(inputChars, 0, inputChars.Length);
-        char[] outputBuffer = new char[4];
+        [Fact]
+        public static void InvalidOffsetIn()
+        {
+            char[] inputChars = "test".ToCharArray();
+            byte[] inputBytes = Convert.FromBase64CharArray(inputChars, 0, inputChars.Length);
+            char[] outputBuffer = new char[4];
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64CharArray(inputBytes, -1, inputBytes.Length, outputBuffer, 0));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64CharArray(inputBytes, inputBytes.Length, inputBytes.Length, outputBuffer, 0));
-    }
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64CharArray(inputBytes, -1, inputBytes.Length, outputBuffer, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64CharArray(inputBytes, inputBytes.Length, inputBytes.Length, outputBuffer, 0));
+        }
 
-    [Fact]
-    public static void InvalidOffsetOut()
-    {
-        char[] inputChars = "test".ToCharArray();
-        byte[] inputBytes = Convert.FromBase64CharArray(inputChars, 0, inputChars.Length);
-        char[] outputBuffer = new char[4];
+        [Fact]
+        public static void InvalidOffsetOut()
+        {
+            char[] inputChars = "test".ToCharArray();
+            byte[] inputBytes = Convert.FromBase64CharArray(inputChars, 0, inputChars.Length);
+            char[] outputBuffer = new char[4];
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64CharArray(inputBytes, 0, inputBytes.Length, outputBuffer, -1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64CharArray(inputBytes, 0, inputBytes.Length, outputBuffer, 1));
-    }
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64CharArray(inputBytes, 0, inputBytes.Length, outputBuffer, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64CharArray(inputBytes, 0, inputBytes.Length, outputBuffer, 1));
+        }
 
-    [Fact]
-    public static void InvalidInputLength()
-    {
-        char[] inputChars = "test".ToCharArray();
-        byte[] inputBytes = Convert.FromBase64CharArray(inputChars, 0, inputChars.Length);
-        char[] outputBuffer = new char[4];
+        [Fact]
+        public static void InvalidInputLength()
+        {
+            char[] inputChars = "test".ToCharArray();
+            byte[] inputBytes = Convert.FromBase64CharArray(inputChars, 0, inputChars.Length);
+            char[] outputBuffer = new char[4];
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64CharArray(inputBytes, 0, -1, outputBuffer, 0));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64CharArray(inputBytes, 0, inputBytes.Length + 1, outputBuffer, 0));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64CharArray(inputBytes, 1, inputBytes.Length, outputBuffer, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64CharArray(inputBytes, 0, -1, outputBuffer, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64CharArray(inputBytes, 0, inputBytes.Length + 1, outputBuffer, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64CharArray(inputBytes, 1, inputBytes.Length, outputBuffer, 0));
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToBase64String.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToBase64String.cs
@@ -2,58 +2,60 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public class ConvertToBase64StringTests
+namespace System.Tests
 {
-    [Fact]
-    public static void KnownByteSequence()
+    public class ConvertToBase64StringTests
     {
-        var inputBytes = new byte[4];
-        for (int i = 0; i < 4; i++)
-            inputBytes[i] = (byte)(i + 5);
+        [Fact]
+        public static void KnownByteSequence()
+        {
+            var inputBytes = new byte[4];
+            for (int i = 0; i < 4; i++)
+                inputBytes[i] = (byte)(i + 5);
 
-        // The sequence of bits for this byte array is
-        // 00000101000001100000011100001000
-        // Encoding adds 16 bits of trailing bits to make this a multiple of 24 bits.
-        // |        +         +         +         +    
-        // 000001010000011000000111000010000000000000000000
-        // which is, (Interesting, how do we distinguish between '=' and 'A'?)
-        // 000001 010000 011000 000111 000010 000000 000000 000000
-        // B      Q      Y      H      C      A      =      =
+            // The sequence of bits for this byte array is
+            // 00000101000001100000011100001000
+            // Encoding adds 16 bits of trailing bits to make this a multiple of 24 bits.
+            // |        +         +         +         +    
+            // 000001010000011000000111000010000000000000000000
+            // which is, (Interesting, how do we distinguish between '=' and 'A'?)
+            // 000001 010000 011000 000111 000010 000000 000000 000000
+            // B      Q      Y      H      C      A      =      =
 
-        Assert.Equal("BQYHCA==", Convert.ToBase64String(inputBytes));
-    }
+            Assert.Equal("BQYHCA==", Convert.ToBase64String(inputBytes));
+        }
 
-    [Fact]
-    public static void ZeroLength()
-    {
-        byte[] inputBytes = Convert.FromBase64String("test");
-        Assert.Equal(string.Empty, Convert.ToBase64String(inputBytes, 0, 0));
-    }
+        [Fact]
+        public static void ZeroLength()
+        {
+            byte[] inputBytes = Convert.FromBase64String("test");
+            Assert.Equal(string.Empty, Convert.ToBase64String(inputBytes, 0, 0));
+        }
 
-    [Fact]
-    public static void InvalidInputBuffer()
-    {
-        Assert.Throws<ArgumentNullException>(() => Convert.ToBase64String(null));
-        Assert.Throws<ArgumentNullException>(() => Convert.ToBase64String(null, 0, 0));
-    }
+        [Fact]
+        public static void InvalidInputBuffer()
+        {
+            Assert.Throws<ArgumentNullException>(() => Convert.ToBase64String(null));
+            Assert.Throws<ArgumentNullException>(() => Convert.ToBase64String(null, 0, 0));
+        }
 
-    [Fact]
-    public static void InvalidOffset()
-    {
-        byte[] inputBytes = Convert.FromBase64String("test");
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64String(inputBytes, -1, inputBytes.Length));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64String(inputBytes, inputBytes.Length, inputBytes.Length));
-    }
+        [Fact]
+        public static void InvalidOffset()
+        {
+            byte[] inputBytes = Convert.FromBase64String("test");
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64String(inputBytes, -1, inputBytes.Length));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64String(inputBytes, inputBytes.Length, inputBytes.Length));
+        }
 
-    [Fact]
-    public static void InvalidLength()
-    {
-        byte[] inputBytes = Convert.FromBase64String("test");
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64String(inputBytes, 0, -1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64String(inputBytes, 0, inputBytes.Length + 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64String(inputBytes, 1, inputBytes.Length));
+        [Fact]
+        public static void InvalidLength()
+        {
+            byte[] inputBytes = Convert.FromBase64String("test");
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64String(inputBytes, 0, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64String(inputBytes, 0, inputBytes.Length + 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Convert.ToBase64String(inputBytes, 1, inputBytes.Length));
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToBoolean.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToBoolean.cs
@@ -2,125 +2,127 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public class ConvertToBooleanTests : ConvertTestBase<Boolean>
+namespace System.Tests
 {
-    [Fact]
-    public void FromBoolean()
+    public class ConvertToBooleanTests : ConvertTestBase<Boolean>
     {
-        Boolean[] testValues = { true, false };
-        Verify(Convert.ToBoolean, testValues, testValues);
-    }
+        [Fact]
+        public void FromBoolean()
+        {
+            Boolean[] testValues = { true, false };
+            Verify(Convert.ToBoolean, testValues, testValues);
+        }
 
-    [Fact]
-    public void FromByte()
-    {
-        Byte[] testValues = { Byte.MinValue, Byte.MaxValue, };
-        Boolean[] expectedValues = { false, true };
-        Verify(Convert.ToBoolean, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromByte()
+        {
+            Byte[] testValues = { Byte.MinValue, Byte.MaxValue, };
+            Boolean[] expectedValues = { false, true };
+            Verify(Convert.ToBoolean, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromDecimal()
-    {
-        Decimal[] testValues = { Decimal.MaxValue, Decimal.MinValue, Decimal.One, Decimal.Zero, 0m, 0.0m, 1.5m, -1.5m, 500.00m };
-        Boolean[] expectedValues = { true, true, true, false, false, false, true, true, true };
-        Verify(Convert.ToBoolean, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromDecimal()
+        {
+            Decimal[] testValues = { Decimal.MaxValue, Decimal.MinValue, Decimal.One, Decimal.Zero, 0m, 0.0m, 1.5m, -1.5m, 500.00m };
+            Boolean[] expectedValues = { true, true, true, false, false, false, true, true, true };
+            Verify(Convert.ToBoolean, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromDouble()
-    {
-        Double[] testValues = { Double.Epsilon, Double.MaxValue, Double.MinValue, Double.NaN, Double.NegativeInfinity, Double.PositiveInfinity, 0d, 0.0, 1.5, -1.5, 1.5e300, -1.7e-500, -1.7e300, -1.7e-320 };
-        Boolean[] expectedValues = { true, true, true, true, true, true, false, false, true, true, true, false, true, true };
-        Verify(Convert.ToBoolean, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromDouble()
+        {
+            Double[] testValues = { Double.Epsilon, Double.MaxValue, Double.MinValue, Double.NaN, Double.NegativeInfinity, Double.PositiveInfinity, 0d, 0.0, 1.5, -1.5, 1.5e300, -1.7e-500, -1.7e300, -1.7e-320 };
+            Boolean[] expectedValues = { true, true, true, true, true, true, false, false, true, true, true, false, true, true };
+            Verify(Convert.ToBoolean, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromInt16()
-    {
-        Int16[] testValues = { Int16.MinValue, Int16.MaxValue, 0 };
-        Boolean[] expectedValues = { true, true, false };
-        Verify(Convert.ToBoolean, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt16()
+        {
+            Int16[] testValues = { Int16.MinValue, Int16.MaxValue, 0 };
+            Boolean[] expectedValues = { true, true, false };
+            Verify(Convert.ToBoolean, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromInt32()
-    {
-        Int32[] testValues = { Int32.MinValue, Int32.MaxValue, 0 };
-        Boolean[] expectedValues = { true, true, false };
-        Verify(Convert.ToBoolean, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt32()
+        {
+            Int32[] testValues = { Int32.MinValue, Int32.MaxValue, 0 };
+            Boolean[] expectedValues = { true, true, false };
+            Verify(Convert.ToBoolean, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromInt64()
-    {
-        Int64[] testValues = { Int64.MinValue, Int64.MaxValue, 0 };
-        Boolean[] expectedValues = { true, true, false, };
-        Verify(Convert.ToBoolean, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt64()
+        {
+            Int64[] testValues = { Int64.MinValue, Int64.MaxValue, 0 };
+            Boolean[] expectedValues = { true, true, false, };
+            Verify(Convert.ToBoolean, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromString()
-    {
-        String[] testValues = { null, "True", "true ", " true", " true ", " false ", " false", "false ", "False" };
-        Boolean[] expectedValues = { false, true, true, true, true, false, false, false, false };
-        VerifyFromString(Convert.ToBoolean, Convert.ToBoolean, testValues, expectedValues);
+        [Fact]
+        public void FromString()
+        {
+            String[] testValues = { null, "True", "true ", " true", " true ", " false ", " false", "false ", "False" };
+            Boolean[] expectedValues = { false, true, true, true, true, false, false, false, false };
+            VerifyFromString(Convert.ToBoolean, Convert.ToBoolean, testValues, expectedValues);
 
-        String[] invalidValues = { "Hello" };
-        VerifyFromStringThrows<FormatException>(Convert.ToBoolean, Convert.ToBoolean, invalidValues);
-    }
+            String[] invalidValues = { "Hello" };
+            VerifyFromStringThrows<FormatException>(Convert.ToBoolean, Convert.ToBoolean, invalidValues);
+        }
 
-    [Fact]
-    public void FromObject()
-    {
-        Object[] testValues = { null };
-        Boolean[] expectedValues = { false };
-        VerifyFromObject(Convert.ToBoolean, Convert.ToBoolean, testValues, expectedValues);
+        [Fact]
+        public void FromObject()
+        {
+            Object[] testValues = { null };
+            Boolean[] expectedValues = { false };
+            VerifyFromObject(Convert.ToBoolean, Convert.ToBoolean, testValues, expectedValues);
 
-        Object[] invalidValues = { new Object(), DateTime.Now };
-        VerifyFromObjectThrows<InvalidCastException>(Convert.ToBoolean, Convert.ToBoolean, invalidValues);
-    }
+            Object[] invalidValues = { new Object(), DateTime.Now };
+            VerifyFromObjectThrows<InvalidCastException>(Convert.ToBoolean, Convert.ToBoolean, invalidValues);
+        }
 
-    [Fact]
-    public void FromSByte()
-    {
-        SByte[] testValues = { 0, SByte.MaxValue, SByte.MinValue };
-        Boolean[] expectedValues = { false, true, true };
-        Verify(Convert.ToBoolean, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromSByte()
+        {
+            SByte[] testValues = { 0, SByte.MaxValue, SByte.MinValue };
+            Boolean[] expectedValues = { false, true, true };
+            Verify(Convert.ToBoolean, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromSingle()
-    {
-        Single[] testValues = { Single.Epsilon, Single.MaxValue, Single.MinValue, Single.NaN, Single.NegativeInfinity, Single.PositiveInfinity, 0f, 0.0f, 1.5f, -1.5f, 1.5e30f, -1.7e-100f, -1.7e30f, -1.7e-40f, };
-        Boolean[] expectedValues = { true, true, true, true, true, true, false, false, true, true, true, false, true, true, };
-        Verify(Convert.ToBoolean, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromSingle()
+        {
+            Single[] testValues = { Single.Epsilon, Single.MaxValue, Single.MinValue, Single.NaN, Single.NegativeInfinity, Single.PositiveInfinity, 0f, 0.0f, 1.5f, -1.5f, 1.5e30f, -1.7e-100f, -1.7e30f, -1.7e-40f, };
+            Boolean[] expectedValues = { true, true, true, true, true, true, false, false, true, true, true, false, true, true, };
+            Verify(Convert.ToBoolean, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt16()
-    {
-        UInt16[] testValues = { UInt16.MinValue, UInt16.MaxValue };
-        Boolean[] expectedValues = { false, true };
-        Verify(Convert.ToBoolean, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt16()
+        {
+            UInt16[] testValues = { UInt16.MinValue, UInt16.MaxValue };
+            Boolean[] expectedValues = { false, true };
+            Verify(Convert.ToBoolean, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt32()
-    {
-        UInt32[] testValues = { UInt32.MinValue, UInt32.MaxValue };
-        Boolean[] expectedValues = { false, true };
-        Verify(Convert.ToBoolean, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt32()
+        {
+            UInt32[] testValues = { UInt32.MinValue, UInt32.MaxValue };
+            Boolean[] expectedValues = { false, true };
+            Verify(Convert.ToBoolean, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt64()
-    {
-        UInt64[] testValues = { UInt64.MinValue, UInt64.MaxValue };
-        Boolean[] expectedValues = { false, true };
-        Verify(Convert.ToBoolean, testValues, expectedValues);
+        [Fact]
+        public void FromUInt64()
+        {
+            UInt64[] testValues = { UInt64.MinValue, UInt64.MaxValue };
+            Boolean[] expectedValues = { false, true };
+            Verify(Convert.ToBoolean, testValues, expectedValues);
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToByte.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToByte.cs
@@ -2,183 +2,185 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public class ConvertToByteTests : ConvertTestBase<Byte>
+namespace System.Tests
 {
-    [Fact]
-    public void FromBoolean()
+    public class ConvertToByteTests : ConvertTestBase<Byte>
     {
-        Boolean[] testValues = { true, false };
-        Byte[] expectedValues = { 1, 0 };
-        Verify(Convert.ToByte, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromBoolean()
+        {
+            Boolean[] testValues = { true, false };
+            Byte[] expectedValues = { 1, 0 };
+            Verify(Convert.ToByte, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromChar()
-    {
-        Char[] testValues = { 'A', Char.MinValue };
-        Byte[] expectedValues = { (Byte)'A', (Byte)Char.MinValue };
-        Verify(Convert.ToByte, testValues, expectedValues);
+        [Fact]
+        public void FromChar()
+        {
+            Char[] testValues = { 'A', Char.MinValue };
+            Byte[] expectedValues = { (Byte)'A', (Byte)Char.MinValue };
+            Verify(Convert.ToByte, testValues, expectedValues);
 
-        Char[] overflowValues = { Char.MaxValue };
-        VerifyThrows<OverflowException, Char>(Convert.ToByte, overflowValues);
-    }
+            Char[] overflowValues = { Char.MaxValue };
+            VerifyThrows<OverflowException, Char>(Convert.ToByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromDecimal()
-    {
-        Decimal[] testValues = { Byte.MaxValue, Byte.MinValue, 254.01m, 254.9m };
-        Byte[] expectedValues = { Byte.MaxValue, Byte.MinValue, 254, 255 };
-        Verify(Convert.ToByte, testValues, expectedValues);
+        [Fact]
+        public void FromDecimal()
+        {
+            Decimal[] testValues = { Byte.MaxValue, Byte.MinValue, 254.01m, 254.9m };
+            Byte[] expectedValues = { Byte.MaxValue, Byte.MinValue, 254, 255 };
+            Verify(Convert.ToByte, testValues, expectedValues);
 
-        Decimal[] overflowValues = { Decimal.MinValue, Decimal.MaxValue };
-        VerifyThrows<OverflowException, Decimal>(Convert.ToByte, overflowValues);
-    }
+            Decimal[] overflowValues = { Decimal.MinValue, Decimal.MaxValue };
+            VerifyThrows<OverflowException, Decimal>(Convert.ToByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromDouble()
-    {
-        Double[] testValues = { Byte.MinValue, Byte.MaxValue, 100.0, 254.9, 255.2 };
-        Byte[] expectedValues = { Byte.MinValue, Byte.MaxValue, 100, 255, 255 };
-        Verify(Convert.ToByte, testValues, expectedValues);
+        [Fact]
+        public void FromDouble()
+        {
+            Double[] testValues = { Byte.MinValue, Byte.MaxValue, 100.0, 254.9, 255.2 };
+            Byte[] expectedValues = { Byte.MinValue, Byte.MaxValue, 100, 255, 255 };
+            Verify(Convert.ToByte, testValues, expectedValues);
 
-        Double[] overflowValues = { Double.MinValue, Double.MaxValue };
-        VerifyThrows<OverflowException, Double>(Convert.ToByte, overflowValues);
-    }
+            Double[] overflowValues = { Double.MinValue, Double.MaxValue };
+            VerifyThrows<OverflowException, Double>(Convert.ToByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt16()
-    {
-        Int16[] testValues = { Byte.MinValue, Byte.MaxValue, 10, 2 };
-        Byte[] expectedValues = { Byte.MinValue, Byte.MaxValue, 10, 2 };
-        Verify(Convert.ToByte, testValues, expectedValues);
+        [Fact]
+        public void FromInt16()
+        {
+            Int16[] testValues = { Byte.MinValue, Byte.MaxValue, 10, 2 };
+            Byte[] expectedValues = { Byte.MinValue, Byte.MaxValue, 10, 2 };
+            Verify(Convert.ToByte, testValues, expectedValues);
 
-        Int16[] overflowValues = { Int16.MinValue, Int16.MaxValue };
-        VerifyThrows<OverflowException, Int16>(Convert.ToByte, overflowValues);
-    }
+            Int16[] overflowValues = { Int16.MinValue, Int16.MaxValue };
+            VerifyThrows<OverflowException, Int16>(Convert.ToByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt32()
-    {
-        Int32[] testValues = { Byte.MinValue, Byte.MaxValue, 10 };
-        Byte[] expectedValues = { Byte.MinValue, Byte.MaxValue, 10 };
-        Verify(Convert.ToByte, testValues, expectedValues);
+        [Fact]
+        public void FromInt32()
+        {
+            Int32[] testValues = { Byte.MinValue, Byte.MaxValue, 10 };
+            Byte[] expectedValues = { Byte.MinValue, Byte.MaxValue, 10 };
+            Verify(Convert.ToByte, testValues, expectedValues);
 
-        Int32[] overflowValues = { Int32.MinValue, Int32.MaxValue };
-        VerifyThrows<OverflowException, Int32>(Convert.ToByte, overflowValues);
-    }
+            Int32[] overflowValues = { Int32.MinValue, Int32.MaxValue };
+            VerifyThrows<OverflowException, Int32>(Convert.ToByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt64()
-    {
-        Int64[] testValues = { Byte.MinValue, Byte.MaxValue, 10 };
-        Byte[] expectedValues = { Byte.MinValue, Byte.MaxValue, 10 };
-        Verify(Convert.ToByte, testValues, expectedValues);
+        [Fact]
+        public void FromInt64()
+        {
+            Int64[] testValues = { Byte.MinValue, Byte.MaxValue, 10 };
+            Byte[] expectedValues = { Byte.MinValue, Byte.MaxValue, 10 };
+            Verify(Convert.ToByte, testValues, expectedValues);
 
-        Int64[] overflowValues = { Int64.MinValue, Int64.MaxValue };
-        VerifyThrows<OverflowException, Int64>(Convert.ToByte, overflowValues);
-    }
+            Int64[] overflowValues = { Int64.MinValue, Int64.MaxValue };
+            VerifyThrows<OverflowException, Int64>(Convert.ToByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromObject()
-    {
-        Object[] testValues = { null };
-        Byte[] expectedValues = { 0 };
-        VerifyFromObject(Convert.ToByte, Convert.ToByte, testValues, expectedValues);
+        [Fact]
+        public void FromObject()
+        {
+            Object[] testValues = { null };
+            Byte[] expectedValues = { 0 };
+            VerifyFromObject(Convert.ToByte, Convert.ToByte, testValues, expectedValues);
 
-        Object[] invalidValues = { new Object(), DateTime.Now };
-        VerifyFromObjectThrows<InvalidCastException>(Convert.ToByte, Convert.ToByte, invalidValues);
-    }
+            Object[] invalidValues = { new Object(), DateTime.Now };
+            VerifyFromObjectThrows<InvalidCastException>(Convert.ToByte, Convert.ToByte, invalidValues);
+        }
 
-    [Fact]
-    public void FromSByte()
-    {
-        SByte[] testValues = { 0, 10, SByte.MaxValue };
-        Byte[] expectedValues = { 0, 10, (Byte)SByte.MaxValue };
-        Verify(Convert.ToByte, testValues, expectedValues);
+        [Fact]
+        public void FromSByte()
+        {
+            SByte[] testValues = { 0, 10, SByte.MaxValue };
+            Byte[] expectedValues = { 0, 10, (Byte)SByte.MaxValue };
+            Verify(Convert.ToByte, testValues, expectedValues);
 
-        SByte[] overflowValues = { SByte.MinValue };
-        VerifyThrows<OverflowException, SByte>(Convert.ToByte, overflowValues);
-    }
+            SByte[] overflowValues = { SByte.MinValue };
+            VerifyThrows<OverflowException, SByte>(Convert.ToByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromSingle()
-    {
-        Single[] testValues = { Byte.MaxValue, Byte.MinValue, 254.01f, 254.9f };
-        Byte[] expectedValues = { Byte.MaxValue, Byte.MinValue, 254, 255 };
-        Verify(Convert.ToByte, testValues, expectedValues);
+        [Fact]
+        public void FromSingle()
+        {
+            Single[] testValues = { Byte.MaxValue, Byte.MinValue, 254.01f, 254.9f };
+            Byte[] expectedValues = { Byte.MaxValue, Byte.MinValue, 254, 255 };
+            Verify(Convert.ToByte, testValues, expectedValues);
 
-        Single[] overflowValues = { Single.MinValue, Single.MaxValue };
-        VerifyThrows<OverflowException, Single>(Convert.ToByte, overflowValues);
-    }
+            Single[] overflowValues = { Single.MinValue, Single.MaxValue };
+            VerifyThrows<OverflowException, Single>(Convert.ToByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromString()
-    {
-        String[] testValues = { Byte.MaxValue.ToString(), Byte.MinValue.ToString(), "0", "100", null };
-        Byte[] expectedValues = { Byte.MaxValue, Byte.MinValue, 0, 100, 0 };
-        VerifyFromString(Convert.ToByte, Convert.ToByte, testValues, expectedValues);
+        [Fact]
+        public void FromString()
+        {
+            String[] testValues = { Byte.MaxValue.ToString(), Byte.MinValue.ToString(), "0", "100", null };
+            Byte[] expectedValues = { Byte.MaxValue, Byte.MinValue, 0, 100, 0 };
+            VerifyFromString(Convert.ToByte, Convert.ToByte, testValues, expectedValues);
 
-        String[] overflowValues = { Int32.MinValue.ToString(), Int32.MaxValue.ToString() };
-        VerifyFromStringThrows<OverflowException>(Convert.ToByte, Convert.ToByte, overflowValues);
+            String[] overflowValues = { Int32.MinValue.ToString(), Int32.MaxValue.ToString() };
+            VerifyFromStringThrows<OverflowException>(Convert.ToByte, Convert.ToByte, overflowValues);
 
-        String[] formatExceptionValues = { "abba" };
-        VerifyFromStringThrows<FormatException>(Convert.ToByte, Convert.ToByte, formatExceptionValues);
-    }
+            String[] formatExceptionValues = { "abba" };
+            VerifyFromStringThrows<FormatException>(Convert.ToByte, Convert.ToByte, formatExceptionValues);
+        }
 
-    [Fact]
-    public void FromStringWithBase()
-    {
-        String[] testValues = { null, null, null, null, "10", "100", "1011", "ff", "0xff", "77", "11", "11111111" };
-        Int32[] testBases = { 10, 2, 8, 16, 10, 10, 2, 16, 16, 8, 2, 2 };
-        Byte[] expectedValues = { 0, 0, 0, 0, 10, 100, 11, 255, 255, 63, 3, 255 };
-        VerifyFromStringWithBase(Convert.ToByte, testValues, testBases, expectedValues);
+        [Fact]
+        public void FromStringWithBase()
+        {
+            String[] testValues = { null, null, null, null, "10", "100", "1011", "ff", "0xff", "77", "11", "11111111" };
+            Int32[] testBases = { 10, 2, 8, 16, 10, 10, 2, 16, 16, 8, 2, 2 };
+            Byte[] expectedValues = { 0, 0, 0, 0, 10, 100, 11, 255, 255, 63, 3, 255 };
+            VerifyFromStringWithBase(Convert.ToByte, testValues, testBases, expectedValues);
 
-        String[] overflowValues = { "256", "111111111", "ffffe", "7777777", "-1" };
-        Int32[] overflowBases = { 10, 2, 16, 8, 10 };
-        VerifyFromStringWithBaseThrows<OverflowException>(Convert.ToByte, overflowValues, overflowBases);
+            String[] overflowValues = { "256", "111111111", "ffffe", "7777777", "-1" };
+            Int32[] overflowBases = { 10, 2, 16, 8, 10 };
+            VerifyFromStringWithBaseThrows<OverflowException>(Convert.ToByte, overflowValues, overflowBases);
 
-        String[] formatExceptionValues = { "fffg", "0xxfff", "8", "112", "!56" };
-        Int32[] formatExceptionBases = { 16, 16, 8, 2, 10};
-        VerifyFromStringWithBaseThrows<FormatException>(Convert.ToByte, formatExceptionValues, formatExceptionBases);
+            String[] formatExceptionValues = { "fffg", "0xxfff", "8", "112", "!56" };
+            Int32[] formatExceptionBases = { 16, 16, 8, 2, 10 };
+            VerifyFromStringWithBaseThrows<FormatException>(Convert.ToByte, formatExceptionValues, formatExceptionBases);
 
-        String[] argumentExceptionValues = { null };
-        Int32[] argumentExceptionBases = { 11 };
-        VerifyFromStringWithBaseThrows<ArgumentException>(Convert.ToByte, argumentExceptionValues, argumentExceptionBases);
-    }
+            String[] argumentExceptionValues = { null };
+            Int32[] argumentExceptionBases = { 11 };
+            VerifyFromStringWithBaseThrows<ArgumentException>(Convert.ToByte, argumentExceptionValues, argumentExceptionBases);
+        }
 
-    [Fact]
-    public void FromUInt16()
-    {
-        UInt16[] testValues = { Byte.MinValue, Byte.MaxValue, 10, 100 };
-        Byte[] expectedValues = { Byte.MinValue, Byte.MaxValue, 10, 100 };
-        Verify(Convert.ToByte, testValues, expectedValues);
+        [Fact]
+        public void FromUInt16()
+        {
+            UInt16[] testValues = { Byte.MinValue, Byte.MaxValue, 10, 100 };
+            Byte[] expectedValues = { Byte.MinValue, Byte.MaxValue, 10, 100 };
+            Verify(Convert.ToByte, testValues, expectedValues);
 
-        UInt16[] overflowValues = { UInt16.MaxValue };
-        VerifyThrows<OverflowException, UInt16>(Convert.ToByte, overflowValues);
-    }
+            UInt16[] overflowValues = { UInt16.MaxValue };
+            VerifyThrows<OverflowException, UInt16>(Convert.ToByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromUInt32()
-    {
-        UInt32[] testValues = { Byte.MinValue, Byte.MaxValue, 10, 100 };
-        Byte[] expectedValues = { Byte.MinValue, Byte.MaxValue, 10, 100 };
-        Verify(Convert.ToByte, testValues, expectedValues);
+        [Fact]
+        public void FromUInt32()
+        {
+            UInt32[] testValues = { Byte.MinValue, Byte.MaxValue, 10, 100 };
+            Byte[] expectedValues = { Byte.MinValue, Byte.MaxValue, 10, 100 };
+            Verify(Convert.ToByte, testValues, expectedValues);
 
-        UInt32[] overflowValues = { UInt32.MaxValue };
-        VerifyThrows<OverflowException, UInt32>(Convert.ToByte, overflowValues);
-    }
+            UInt32[] overflowValues = { UInt32.MaxValue };
+            VerifyThrows<OverflowException, UInt32>(Convert.ToByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromUInt64()
-    {
-        UInt64[] testValues = { Byte.MinValue, Byte.MaxValue, 10, 100 };
-        Byte[] expectedValues = { Byte.MinValue, Byte.MaxValue, 10, 100 };
-        Verify(Convert.ToByte, testValues, expectedValues);
+        [Fact]
+        public void FromUInt64()
+        {
+            UInt64[] testValues = { Byte.MinValue, Byte.MaxValue, 10, 100 };
+            Byte[] expectedValues = { Byte.MinValue, Byte.MaxValue, 10, 100 };
+            Verify(Convert.ToByte, testValues, expectedValues);
 
-        UInt64[] overflowValues = { UInt64.MaxValue };
-        VerifyThrows<OverflowException, UInt64>(Convert.ToByte, overflowValues);
+            UInt64[] overflowValues = { UInt64.MaxValue };
+            VerifyThrows<OverflowException, UInt64>(Convert.ToByte, overflowValues);
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToChar.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToChar.cs
@@ -2,142 +2,144 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public class ConvertToCharTests : ConvertTestBase<Char>
+namespace System.Tests
 {
-    [Fact]
-    public void FromByte()
+    public class ConvertToCharTests : ConvertTestBase<Char>
     {
-        Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
-        Char[] expectedValues = { (Char)Byte.MaxValue, (Char)Byte.MinValue };
-        Verify(Convert.ToChar, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromByte()
+        {
+            Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
+            Char[] expectedValues = { (Char)Byte.MaxValue, (Char)Byte.MinValue };
+            Verify(Convert.ToChar, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromChar()
-    {
-        Object[] testValues = { Char.MaxValue, Char.MinValue, 'b' };
-        Char[] expectedValues = { Char.MaxValue, Char.MinValue, 'b' };
-        Verify<Object>(Convert.ToChar, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromChar()
+        {
+            Object[] testValues = { Char.MaxValue, Char.MinValue, 'b' };
+            Char[] expectedValues = { Char.MaxValue, Char.MinValue, 'b' };
+            Verify<Object>(Convert.ToChar, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromDecimal()
-    {
-        Object[] invalidValues = { 0m, Decimal.MinValue, Decimal.MaxValue };
-        VerifyFromObjectThrows<InvalidCastException>(Convert.ToChar, Convert.ToChar, invalidValues);
-    }
+        [Fact]
+        public void FromDecimal()
+        {
+            Object[] invalidValues = { 0m, Decimal.MinValue, Decimal.MaxValue };
+            VerifyFromObjectThrows<InvalidCastException>(Convert.ToChar, Convert.ToChar, invalidValues);
+        }
 
-    [Fact]
-    public void FromDouble()
-    {
-        Object[] invalidValues = { 0.0, Double.MinValue, Double.MaxValue };
-        VerifyFromObjectThrows<InvalidCastException>(Convert.ToChar, Convert.ToChar, invalidValues);
-    }
+        [Fact]
+        public void FromDouble()
+        {
+            Object[] invalidValues = { 0.0, Double.MinValue, Double.MaxValue };
+            VerifyFromObjectThrows<InvalidCastException>(Convert.ToChar, Convert.ToChar, invalidValues);
+        }
 
-    [Fact]
-    public void FromInt16()
-    {
-        Int16[] testValues = { Int16.MaxValue, 0 };
-        Char[] expectedValues = { (Char)Int16.MaxValue, '\0' };
-        Verify(Convert.ToChar, testValues, expectedValues);
+        [Fact]
+        public void FromInt16()
+        {
+            Int16[] testValues = { Int16.MaxValue, 0 };
+            Char[] expectedValues = { (Char)Int16.MaxValue, '\0' };
+            Verify(Convert.ToChar, testValues, expectedValues);
 
-        Int16[] overflowValues = { Int16.MinValue, -1000 };
-        VerifyThrows<OverflowException, Int16>(Convert.ToChar, overflowValues);
-    }
+            Int16[] overflowValues = { Int16.MinValue, -1000 };
+            VerifyThrows<OverflowException, Int16>(Convert.ToChar, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt32()
-    {
-        Int32[] testValues = { Char.MaxValue, Char.MinValue };
-        Char[] expectedValues = { Char.MaxValue, Char.MinValue };
-        Verify(Convert.ToChar, testValues, expectedValues);
+        [Fact]
+        public void FromInt32()
+        {
+            Int32[] testValues = { Char.MaxValue, Char.MinValue };
+            Char[] expectedValues = { Char.MaxValue, Char.MinValue };
+            Verify(Convert.ToChar, testValues, expectedValues);
 
-        Int32[] overflowValues = { Int32.MinValue, Int32.MaxValue, (Int32)UInt16.MaxValue + 1, -1000 };
-        VerifyThrows<OverflowException, Int32>(Convert.ToChar, overflowValues);
-    }
+            Int32[] overflowValues = { Int32.MinValue, Int32.MaxValue, (Int32)UInt16.MaxValue + 1, -1000 };
+            VerifyThrows<OverflowException, Int32>(Convert.ToChar, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt64()
-    {
-        Int64[] testValues = { 0, 98, UInt16.MaxValue };
-        Char[] expectedValues = { '\0', 'b', Char.MaxValue };
-        Verify(Convert.ToChar, testValues, expectedValues);
+        [Fact]
+        public void FromInt64()
+        {
+            Int64[] testValues = { 0, 98, UInt16.MaxValue };
+            Char[] expectedValues = { '\0', 'b', Char.MaxValue };
+            Verify(Convert.ToChar, testValues, expectedValues);
 
-        Int64[] overflowValues = { Int64.MinValue, Int64.MaxValue, -1 };
-        VerifyThrows<OverflowException, Int64>(Convert.ToChar, overflowValues);
-    }
+            Int64[] overflowValues = { Int64.MinValue, Int64.MaxValue, -1 };
+            VerifyThrows<OverflowException, Int64>(Convert.ToChar, overflowValues);
+        }
 
-    [Fact]
-    public void FromObject()
-    {
-        Object[] testValues = { null };
-        Char[] expectedValues = { '\0' };
-        Verify(Convert.ToChar, testValues, expectedValues);
+        [Fact]
+        public void FromObject()
+        {
+            Object[] testValues = { null };
+            Char[] expectedValues = { '\0' };
+            Verify(Convert.ToChar, testValues, expectedValues);
 
-        Object[] invalidValues = { new Object(), DateTime.Now };
-        VerifyThrows<InvalidCastException, Object>(Convert.ToChar, invalidValues);
-    }
+            Object[] invalidValues = { new Object(), DateTime.Now };
+            VerifyThrows<InvalidCastException, Object>(Convert.ToChar, invalidValues);
+        }
 
-    [Fact]
-    public void FromSByte()
-    {
-        SByte[] testValues = { SByte.MaxValue, 0 };
-        Char[] expectedValues = { (Char)SByte.MaxValue, '\0' };
-        Verify(Convert.ToChar, testValues, expectedValues);
+        [Fact]
+        public void FromSByte()
+        {
+            SByte[] testValues = { SByte.MaxValue, 0 };
+            Char[] expectedValues = { (Char)SByte.MaxValue, '\0' };
+            Verify(Convert.ToChar, testValues, expectedValues);
 
-        SByte[] overflowValues = { SByte.MinValue, -100, -1 };
-        VerifyThrows<OverflowException, SByte>(Convert.ToChar, overflowValues);
-    }
+            SByte[] overflowValues = { SByte.MinValue, -100, -1 };
+            VerifyThrows<OverflowException, SByte>(Convert.ToChar, overflowValues);
+        }
 
-    [Fact]
-    public void FromSingle()
-    {
-        Object[] invalidValues = { 0f, Single.MinValue, Single.MaxValue };
-        VerifyFromObjectThrows<InvalidCastException>(Convert.ToChar, Convert.ToChar, invalidValues);
-    }
+        [Fact]
+        public void FromSingle()
+        {
+            Object[] invalidValues = { 0f, Single.MinValue, Single.MaxValue };
+            VerifyFromObjectThrows<InvalidCastException>(Convert.ToChar, Convert.ToChar, invalidValues);
+        }
 
-    [Fact]
-    public void FromString()
-    {
-        String[] testValues = { "a", "T", "z", "a" };
-        Char[] expectedValues = { 'a', 'T', 'z', 'a' };
-        VerifyFromString(Convert.ToChar, Convert.ToChar, testValues, expectedValues);
+        [Fact]
+        public void FromString()
+        {
+            String[] testValues = { "a", "T", "z", "a" };
+            Char[] expectedValues = { 'a', 'T', 'z', 'a' };
+            VerifyFromString(Convert.ToChar, Convert.ToChar, testValues, expectedValues);
 
-        String[] formatExceptionValues = { String.Empty, "ab" };
-        VerifyFromStringThrows<FormatException>(Convert.ToChar, Convert.ToChar, formatExceptionValues);
-        VerifyFromStringThrows<ArgumentNullException>(Convert.ToChar, Convert.ToChar, new String[] { null });
-    }
+            String[] formatExceptionValues = { String.Empty, "ab" };
+            VerifyFromStringThrows<FormatException>(Convert.ToChar, Convert.ToChar, formatExceptionValues);
+            VerifyFromStringThrows<ArgumentNullException>(Convert.ToChar, Convert.ToChar, new String[] { null });
+        }
 
-    [Fact]
-    public void FromUInt16()
-    {
-        UInt16[] testValues = { 0, 98, UInt16.MaxValue };
-        Char[] expectedValues = { '\0', 'b', Char.MaxValue };
-        Verify(Convert.ToChar, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt16()
+        {
+            UInt16[] testValues = { 0, 98, UInt16.MaxValue };
+            Char[] expectedValues = { '\0', 'b', Char.MaxValue };
+            Verify(Convert.ToChar, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt32()
-    {
-        UInt32[] testValues = { UInt16.MaxValue, 0 };
-        Char[] expectedValues = { (Char)UInt16.MaxValue, '\0' };
-        Verify(Convert.ToChar, testValues, expectedValues);
+        [Fact]
+        public void FromUInt32()
+        {
+            UInt32[] testValues = { UInt16.MaxValue, 0 };
+            Char[] expectedValues = { (Char)UInt16.MaxValue, '\0' };
+            Verify(Convert.ToChar, testValues, expectedValues);
 
-        UInt32[] overflowValues = { UInt32.MaxValue };
-        VerifyThrows<OverflowException, UInt32>(Convert.ToChar, overflowValues);
-    }
+            UInt32[] overflowValues = { UInt32.MaxValue };
+            VerifyThrows<OverflowException, UInt32>(Convert.ToChar, overflowValues);
+        }
 
-    [Fact]
-    public void FromUInt64()
-    {
-        UInt64[] testValues = { 0, 98, UInt16.MaxValue };
-        Char[] expectedValues = { '\0', 'b', Char.MaxValue };
-        Verify(Convert.ToChar, testValues, expectedValues);
+        [Fact]
+        public void FromUInt64()
+        {
+            UInt64[] testValues = { 0, 98, UInt16.MaxValue };
+            Char[] expectedValues = { '\0', 'b', Char.MaxValue };
+            Verify(Convert.ToChar, testValues, expectedValues);
 
-        UInt64[] overflowValues = { UInt64.MaxValue, (UInt64)UInt16.MaxValue + 1 };
-        VerifyThrows<OverflowException, UInt64>(Convert.ToChar, overflowValues);
+            UInt64[] overflowValues = { UInt64.MaxValue, (UInt64)UInt16.MaxValue + 1 };
+            VerifyThrows<OverflowException, UInt64>(Convert.ToChar, overflowValues);
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToDateTime.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToDateTime.cs
@@ -2,145 +2,147 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Globalization;
 using Xunit;
 
-public class ConvertToDateTimeTests : ConvertTestBase<DateTime>
+namespace System.Tests
 {
-    private static readonly DateTimeFormatInfo s_dateTimeFormatInfo = new DateTimeFormatInfo();
-
-    [Fact]
-    public void FromString()
+    public class ConvertToDateTimeTests : ConvertTestBase<DateTime>
     {
-        DateTime[] expectedValues = { new DateTime(1999, 12, 31, 23, 59, 59), new DateTime(100, 1, 1, 0, 0, 0), new DateTime(2216, 2, 29, 0, 0, 0), new DateTime(1, 1, 1, 0, 0, 0) };
+        private static readonly DateTimeFormatInfo s_dateTimeFormatInfo = new DateTimeFormatInfo();
 
-        // Generate test values. Note that some calendars have very restricted date ranges.
-        var dateTimeFormat = CultureInfo.CurrentCulture.DateTimeFormat;
-        if (expectedValues[1] < dateTimeFormat.Calendar.MinSupportedDateTime)
-            expectedValues[1] = dateTimeFormat.Calendar.MinSupportedDateTime.AddYears(100);
-        if (expectedValues[2] > dateTimeFormat.Calendar.MaxSupportedDateTime)
-            expectedValues[2] = dateTimeFormat.Calendar.MaxSupportedDateTime.Date;
-        if (expectedValues[3] < dateTimeFormat.Calendar.MinSupportedDateTime)
-            expectedValues[3] = dateTimeFormat.Calendar.MinSupportedDateTime;
-
-        string pattern = dateTimeFormat.LongDatePattern + ' ' + dateTimeFormat.LongTimePattern;
-        String[] testValues = new String[expectedValues.Length];
-        for (int i = 0; i < expectedValues.Length; i++)
+        [Fact]
+        public void FromString()
         {
-            testValues[i] = expectedValues[i].ToString(pattern, dateTimeFormat);
-        }
+            DateTime[] expectedValues = { new DateTime(1999, 12, 31, 23, 59, 59), new DateTime(100, 1, 1, 0, 0, 0), new DateTime(2216, 2, 29, 0, 0, 0), new DateTime(1, 1, 1, 0, 0, 0) };
 
-        VerifyFromString(Convert.ToDateTime, Convert.ToDateTime, testValues, expectedValues);
-        VerifyFromObject(Convert.ToDateTime, Convert.ToDateTime, testValues, expectedValues);
+            // Generate test values. Note that some calendars have very restricted date ranges.
+            var dateTimeFormat = CultureInfo.CurrentCulture.DateTimeFormat;
+            if (expectedValues[1] < dateTimeFormat.Calendar.MinSupportedDateTime)
+                expectedValues[1] = dateTimeFormat.Calendar.MinSupportedDateTime.AddYears(100);
+            if (expectedValues[2] > dateTimeFormat.Calendar.MaxSupportedDateTime)
+                expectedValues[2] = dateTimeFormat.Calendar.MaxSupportedDateTime.Date;
+            if (expectedValues[3] < dateTimeFormat.Calendar.MinSupportedDateTime)
+                expectedValues[3] = dateTimeFormat.Calendar.MinSupportedDateTime;
 
-        String[] formatExceptionValues =
-        {
+            string pattern = dateTimeFormat.LongDatePattern + ' ' + dateTimeFormat.LongTimePattern;
+            String[] testValues = new String[expectedValues.Length];
+            for (int i = 0; i < expectedValues.Length; i++)
+            {
+                testValues[i] = expectedValues[i].ToString(pattern, dateTimeFormat);
+            }
+
+            VerifyFromString(Convert.ToDateTime, Convert.ToDateTime, testValues, expectedValues);
+            VerifyFromObject(Convert.ToDateTime, Convert.ToDateTime, testValues, expectedValues);
+
+            String[] formatExceptionValues =
+            {
             "null",
             // Regression test for case which was throwing IndexOutOfRangeException
             "20-5-14T00:00:00"
         };
 
-        VerifyFromStringThrows<FormatException>(Convert.ToDateTime, Convert.ToDateTime, formatExceptionValues);
-    }
-
-    [Fact]
-    public void FromStringWithCustomFormatProvider()
-    {
-        String[] testValues = { null, "12/31/1999 11:59:59 PM", "0100/01/01 12:00:00 AM", "1492/02/29 12:00:00 AM", "0001/01/01 12:00:00 AM" };
-        DateTime[] expectedValues = { DateTime.MinValue, new DateTime(1999, 12, 31, 23, 59, 59), new DateTime(100, 1, 1, 0, 0, 0), new DateTime(1492, 2, 29, 0, 0, 0), new DateTime(1, 1, 1, 0, 0, 0) };
-        Assert.Equal(testValues.Length, expectedValues.Length);
-
-        for (int i = 0; i < testValues.Length; i++)
-        {
-            DateTime result = Convert.ToDateTime(testValues[i], s_dateTimeFormatInfo);
-            Assert.Equal(expectedValues[i], result);
-            result = Convert.ToDateTime((object)testValues[i], s_dateTimeFormatInfo);
-            Assert.Equal(expectedValues[i], result);
+            VerifyFromStringThrows<FormatException>(Convert.ToDateTime, Convert.ToDateTime, formatExceptionValues);
         }
-    }
 
-    [Fact]
-    public void FromDateTime()
-    {
-        DateTime[] expectedValues = { new DateTime(1999, 12, 31, 23, 59, 59), new DateTime(100, 1, 1, 0, 0, 0), new DateTime(1492, 2, 29, 0, 0, 0), new DateTime(1, 1, 1, 0, 0, 0) };
-        for (int i = 0; i < expectedValues.Length; i++)
+        [Fact]
+        public void FromStringWithCustomFormatProvider()
         {
-            DateTime result = Convert.ToDateTime(expectedValues[i]);
-            Assert.Equal(expectedValues[i], result);
+            String[] testValues = { null, "12/31/1999 11:59:59 PM", "0100/01/01 12:00:00 AM", "1492/02/29 12:00:00 AM", "0001/01/01 12:00:00 AM" };
+            DateTime[] expectedValues = { DateTime.MinValue, new DateTime(1999, 12, 31, 23, 59, 59), new DateTime(100, 1, 1, 0, 0, 0), new DateTime(1492, 2, 29, 0, 0, 0), new DateTime(1, 1, 1, 0, 0, 0) };
+            Assert.Equal(testValues.Length, expectedValues.Length);
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                DateTime result = Convert.ToDateTime(testValues[i], s_dateTimeFormatInfo);
+                Assert.Equal(expectedValues[i], result);
+                result = Convert.ToDateTime((object)testValues[i], s_dateTimeFormatInfo);
+                Assert.Equal(expectedValues[i], result);
+            }
         }
-    }
 
-    [Fact]
-    public void FromObject()
-    {
-        Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(new Object()));
-        Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(new Object(), s_dateTimeFormatInfo));
-    }
+        [Fact]
+        public void FromDateTime()
+        {
+            DateTime[] expectedValues = { new DateTime(1999, 12, 31, 23, 59, 59), new DateTime(100, 1, 1, 0, 0, 0), new DateTime(1492, 2, 29, 0, 0, 0), new DateTime(1, 1, 1, 0, 0, 0) };
+            for (int i = 0; i < expectedValues.Length; i++)
+            {
+                DateTime result = Convert.ToDateTime(expectedValues[i]);
+                Assert.Equal(expectedValues[i], result);
+            }
+        }
 
-    [Fact]
-    public void FromBoolean()
-    {
-        Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(false));
-    }
+        [Fact]
+        public void FromObject()
+        {
+            Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(new Object()));
+            Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(new Object(), s_dateTimeFormatInfo));
+        }
 
-    [Fact]
-    public void FromChar()
-    {
-        Assert.Throws<InvalidCastException>(() => Convert.ToDateTime('a'));
-    }
+        [Fact]
+        public void FromBoolean()
+        {
+            Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(false));
+        }
 
-    [Fact]
-    public void FromInt16()
-    {
-        Assert.Throws<InvalidCastException>(() => Convert.ToDateTime((Int16)5));
-    }
+        [Fact]
+        public void FromChar()
+        {
+            Assert.Throws<InvalidCastException>(() => Convert.ToDateTime('a'));
+        }
 
-    [Fact]
-    public void FromInt32()
-    {
-        Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(6));
-    }
+        [Fact]
+        public void FromInt16()
+        {
+            Assert.Throws<InvalidCastException>(() => Convert.ToDateTime((Int16)5));
+        }
 
-    [Fact]
-    public void FromInt64()
-    {
-        Assert.Throws<InvalidCastException>(() => Convert.ToDateTime((Int64)5));
-    }
+        [Fact]
+        public void FromInt32()
+        {
+            Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(6));
+        }
 
-    [Fact]
-    public void FromUInt16()
-    {
-        Assert.Throws<InvalidCastException>(() => Convert.ToDateTime((UInt16)5));
-    }
+        [Fact]
+        public void FromInt64()
+        {
+            Assert.Throws<InvalidCastException>(() => Convert.ToDateTime((Int64)5));
+        }
 
-    [Fact]
-    public void FromUInt32()
-    {
-        Assert.Throws<InvalidCastException>(() => Convert.ToDateTime((UInt32)5));
-    }
+        [Fact]
+        public void FromUInt16()
+        {
+            Assert.Throws<InvalidCastException>(() => Convert.ToDateTime((UInt16)5));
+        }
 
-    [Fact]
-    public void FromUInt64()
-    {
-        Assert.Throws<InvalidCastException>(() => Convert.ToDateTime((UInt64)5));
-    }
+        [Fact]
+        public void FromUInt32()
+        {
+            Assert.Throws<InvalidCastException>(() => Convert.ToDateTime((UInt32)5));
+        }
 
-    [Fact]
-    public void FromSingle()
-    {
-        Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(1.0f));
-    }
+        [Fact]
+        public void FromUInt64()
+        {
+            Assert.Throws<InvalidCastException>(() => Convert.ToDateTime((UInt64)5));
+        }
 
-    [Fact]
-    public void FromDouble()
-    {
-        Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(1.1));
-    }
+        [Fact]
+        public void FromSingle()
+        {
+            Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(1.0f));
+        }
 
-    [Fact]
-    public void FromDecimal()
-    {
-        Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(1.0m));
+        [Fact]
+        public void FromDouble()
+        {
+            Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(1.1));
+        }
+
+        [Fact]
+        public void FromDecimal()
+        {
+            Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(1.0m));
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToDecimal.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToDecimal.cs
@@ -2,135 +2,137 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public class ConvertToDecimalTests : ConvertTestBase<Decimal>
+namespace System.Tests
 {
-    [Fact]
-    public void FromBoolean()
+    public class ConvertToDecimalTests : ConvertTestBase<Decimal>
     {
-        Boolean[] testValues = { true, false };
-        Decimal[] expectedValues = { 1.0m, Decimal.Zero };
-        Verify(Convert.ToDecimal, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromBoolean()
+        {
+            Boolean[] testValues = { true, false };
+            Decimal[] expectedValues = { 1.0m, Decimal.Zero };
+            Verify(Convert.ToDecimal, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromByte()
-    {
-        Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
-        Decimal[] expectedValues = { Byte.MaxValue, Byte.MinValue };
-        Verify(Convert.ToDecimal, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromByte()
+        {
+            Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
+            Decimal[] expectedValues = { Byte.MaxValue, Byte.MinValue };
+            Verify(Convert.ToDecimal, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromDecimal()
-    {
-        Decimal[] testValues = { Decimal.MaxValue, Decimal.MinValue, 0 };
-        Decimal[] expectedValues = { Decimal.MaxValue, Decimal.MinValue, 0 };
-        Verify(Convert.ToDecimal, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromDecimal()
+        {
+            Decimal[] testValues = { Decimal.MaxValue, Decimal.MinValue, 0 };
+            Decimal[] expectedValues = { Decimal.MaxValue, Decimal.MinValue, 0 };
+            Verify(Convert.ToDecimal, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromDouble()
-    {
-        Double[] testValues = { 1000.0, 100.0, 0.0, 0.001, -1000.0, -100.0, };
-        Decimal[] expectedValues = { 1000.0m, 100.0m, 0.0m, 0.001m, -1000.0m, -100.0m };
-        Verify(Convert.ToDecimal, testValues, expectedValues);
+        [Fact]
+        public void FromDouble()
+        {
+            Double[] testValues = { 1000.0, 100.0, 0.0, 0.001, -1000.0, -100.0, };
+            Decimal[] expectedValues = { 1000.0m, 100.0m, 0.0m, 0.001m, -1000.0m, -100.0m };
+            Verify(Convert.ToDecimal, testValues, expectedValues);
 
-        Double[] overflowValues = { Double.MaxValue, Double.MinValue };
-        VerifyThrows<OverflowException, Double>(Convert.ToDecimal, overflowValues);
-    }
+            Double[] overflowValues = { Double.MaxValue, Double.MinValue };
+            VerifyThrows<OverflowException, Double>(Convert.ToDecimal, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt16()
-    {
-        Int16[] testValues = { Int16.MaxValue, Int16.MinValue, 0 };
-        Decimal[] expectedValues = { Int16.MaxValue, Int16.MinValue, 0 };
-        Verify(Convert.ToDecimal, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt16()
+        {
+            Int16[] testValues = { Int16.MaxValue, Int16.MinValue, 0 };
+            Decimal[] expectedValues = { Int16.MaxValue, Int16.MinValue, 0 };
+            Verify(Convert.ToDecimal, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromInt32()
-    {
-        Int32[] testValues = { Int32.MaxValue, Int32.MinValue, 0 };
-        Decimal[] expectedValues = { Int32.MaxValue, Int32.MinValue, 0 };
-        Verify(Convert.ToDecimal, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt32()
+        {
+            Int32[] testValues = { Int32.MaxValue, Int32.MinValue, 0 };
+            Decimal[] expectedValues = { Int32.MaxValue, Int32.MinValue, 0 };
+            Verify(Convert.ToDecimal, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromInt64()
-    {
-        Int64[] testValues = { Int64.MaxValue, Int64.MinValue, 0 };
-        Decimal[] expectedValues = { Int64.MaxValue, Int64.MinValue, 0 };
-        Verify(Convert.ToDecimal, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt64()
+        {
+            Int64[] testValues = { Int64.MaxValue, Int64.MinValue, 0 };
+            Decimal[] expectedValues = { Int64.MaxValue, Int64.MinValue, 0 };
+            Verify(Convert.ToDecimal, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromObject()
-    {
-        Object[] testValues = { null };
-        Decimal[] expectedValues = { 0 };
-        VerifyFromObject(Convert.ToDecimal, Convert.ToDecimal, testValues, expectedValues);
+        [Fact]
+        public void FromObject()
+        {
+            Object[] testValues = { null };
+            Decimal[] expectedValues = { 0 };
+            VerifyFromObject(Convert.ToDecimal, Convert.ToDecimal, testValues, expectedValues);
 
-        Object[] invalidValues = { new Object(), DateTime.Now };
-        VerifyFromObjectThrows<InvalidCastException>(Convert.ToDecimal, Convert.ToDecimal, invalidValues);
-    }
+            Object[] invalidValues = { new Object(), DateTime.Now };
+            VerifyFromObjectThrows<InvalidCastException>(Convert.ToDecimal, Convert.ToDecimal, invalidValues);
+        }
 
-    [Fact]
-    public void FromSByte()
-    {
-        SByte[] testValues = { SByte.MinValue, SByte.MaxValue, 0 };
-        Decimal[] expectedValues = { SByte.MinValue, SByte.MaxValue, 0 };
-        Verify(Convert.ToDecimal, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromSByte()
+        {
+            SByte[] testValues = { SByte.MinValue, SByte.MaxValue, 0 };
+            Decimal[] expectedValues = { SByte.MinValue, SByte.MaxValue, 0 };
+            Verify(Convert.ToDecimal, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromSingle()
-    {
-        Single[] testValues = { 1000.0f, 100.0f, 0.0f, -1.0f, -100.0f };
-        Decimal[] expectedValues = { 1000.0m, 100.0m, 0.0m, -1.0m, -100.0m };
-        Verify(Convert.ToDecimal, testValues, expectedValues);
+        [Fact]
+        public void FromSingle()
+        {
+            Single[] testValues = { 1000.0f, 100.0f, 0.0f, -1.0f, -100.0f };
+            Decimal[] expectedValues = { 1000.0m, 100.0m, 0.0m, -1.0m, -100.0m };
+            Verify(Convert.ToDecimal, testValues, expectedValues);
 
-        Single[] overflowValues = { Single.MaxValue, Single.MinValue };
-        VerifyThrows<OverflowException, Single>(Convert.ToDecimal, overflowValues);
-    }
+            Single[] overflowValues = { Single.MaxValue, Single.MinValue };
+            VerifyThrows<OverflowException, Single>(Convert.ToDecimal, overflowValues);
+        }
 
-    [Fact]
-    public void FromString()
-    {
-        String[] testValues = { Int32.MaxValue.ToString(), Int64.MaxValue.ToString(), Decimal.MaxValue.ToString(), Decimal.MinValue.ToString(), "0", null };
-        Decimal[] expectedValues = { Int32.MaxValue, Int64.MaxValue, Decimal.MaxValue, Decimal.MinValue, 0, 0 };
-        VerifyFromString(Convert.ToDecimal, Convert.ToDecimal, testValues, expectedValues);
+        [Fact]
+        public void FromString()
+        {
+            String[] testValues = { Int32.MaxValue.ToString(), Int64.MaxValue.ToString(), Decimal.MaxValue.ToString(), Decimal.MinValue.ToString(), "0", null };
+            Decimal[] expectedValues = { Int32.MaxValue, Int64.MaxValue, Decimal.MaxValue, Decimal.MinValue, 0, 0 };
+            VerifyFromString(Convert.ToDecimal, Convert.ToDecimal, testValues, expectedValues);
 
-        String[] overflowValues = { "1" + Decimal.MaxValue.ToString(), Decimal.MinValue.ToString() + "1" };
-        VerifyFromStringThrows<OverflowException>(Convert.ToDecimal, Convert.ToDecimal, overflowValues);
+            String[] overflowValues = { "1" + Decimal.MaxValue.ToString(), Decimal.MinValue.ToString() + "1" };
+            VerifyFromStringThrows<OverflowException>(Convert.ToDecimal, Convert.ToDecimal, overflowValues);
 
-        String[] formatExceptionValues = { "100E12" };
-        VerifyFromStringThrows<FormatException>(Convert.ToDecimal, Convert.ToDecimal, formatExceptionValues);
-    }
+            String[] formatExceptionValues = { "100E12" };
+            VerifyFromStringThrows<FormatException>(Convert.ToDecimal, Convert.ToDecimal, formatExceptionValues);
+        }
 
-    [Fact]
-    public void FromUInt16()
-    {
-        UInt16[] testValues = { UInt16.MaxValue, UInt16.MinValue };
-        Decimal[] expectedValues = { UInt16.MaxValue, UInt16.MinValue };
-        Verify(Convert.ToDecimal, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt16()
+        {
+            UInt16[] testValues = { UInt16.MaxValue, UInt16.MinValue };
+            Decimal[] expectedValues = { UInt16.MaxValue, UInt16.MinValue };
+            Verify(Convert.ToDecimal, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt32()
-    {
-        UInt32[] testValues = { UInt32.MaxValue, UInt32.MinValue };
-        Decimal[] expectedValues = { UInt32.MaxValue, UInt32.MinValue };
-        Verify(Convert.ToDecimal, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt32()
+        {
+            UInt32[] testValues = { UInt32.MaxValue, UInt32.MinValue };
+            Decimal[] expectedValues = { UInt32.MaxValue, UInt32.MinValue };
+            Verify(Convert.ToDecimal, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt64()
-    {
-        UInt64[] testValues = { UInt64.MaxValue, UInt64.MinValue };
-        Decimal[] expectedValues = { UInt64.MaxValue, UInt64.MinValue };
-        Verify(Convert.ToDecimal, testValues, expectedValues);
+        [Fact]
+        public void FromUInt64()
+        {
+            UInt64[] testValues = { UInt64.MaxValue, UInt64.MinValue };
+            Decimal[] expectedValues = { UInt64.MaxValue, UInt64.MinValue };
+            Verify(Convert.ToDecimal, testValues, expectedValues);
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToDouble.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToDouble.cs
@@ -2,129 +2,131 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public class ConvertToDoubleTests : ConvertTestBase<Double>
+namespace System.Tests
 {
-    [Fact]
-    public void FromBoolean()
+    public class ConvertToDoubleTests : ConvertTestBase<Double>
     {
-        Boolean[] testValues = { true, false };
-        Double[] expectedValues = { 1.0, 0.0 };
-        Verify(Convert.ToDouble, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromBoolean()
+        {
+            Boolean[] testValues = { true, false };
+            Double[] expectedValues = { 1.0, 0.0 };
+            Verify(Convert.ToDouble, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromByte()
-    {
-        Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
-        Double[] expectedValues = { Byte.MaxValue, Byte.MinValue };
-        Verify(Convert.ToDouble, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromByte()
+        {
+            Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
+            Double[] expectedValues = { Byte.MaxValue, Byte.MinValue };
+            Verify(Convert.ToDouble, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromDecimal()
-    {
-        Decimal[] testValues = { Decimal.MaxValue, Decimal.MinValue, 0.0m };
-        Double[] expectedValues = { (Double)Decimal.MaxValue, (Double)Decimal.MinValue, 0.0};
-        Verify(Convert.ToDouble, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromDecimal()
+        {
+            Decimal[] testValues = { Decimal.MaxValue, Decimal.MinValue, 0.0m };
+            Double[] expectedValues = { (Double)Decimal.MaxValue, (Double)Decimal.MinValue, 0.0 };
+            Verify(Convert.ToDouble, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromDouble()
-    {
-        Double[] testValues = { Double.MaxValue, Double.MinValue, Double.NegativeInfinity, Double.PositiveInfinity, Double.Epsilon };
-        Double[] expectedValues = { Double.MaxValue, Double.MinValue, Double.NegativeInfinity, Double.PositiveInfinity, Double.Epsilon };
-        Verify(Convert.ToDouble, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromDouble()
+        {
+            Double[] testValues = { Double.MaxValue, Double.MinValue, Double.NegativeInfinity, Double.PositiveInfinity, Double.Epsilon };
+            Double[] expectedValues = { Double.MaxValue, Double.MinValue, Double.NegativeInfinity, Double.PositiveInfinity, Double.Epsilon };
+            Verify(Convert.ToDouble, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromInt16()
-    {
-        Int16[] testValues = { Int16.MaxValue, Int16.MinValue, 0 };
-        Double[] expectedValues = { Int16.MaxValue, Int16.MinValue, 0 };
-        Verify(Convert.ToDouble, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt16()
+        {
+            Int16[] testValues = { Int16.MaxValue, Int16.MinValue, 0 };
+            Double[] expectedValues = { Int16.MaxValue, Int16.MinValue, 0 };
+            Verify(Convert.ToDouble, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromInt32()
-    {
-        Int32[] testValues = { Int32.MaxValue, Int32.MinValue, 0 };
-        Double[] expectedValues = { Int32.MaxValue, Int32.MinValue, 0 };
-        Verify(Convert.ToDouble, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt32()
+        {
+            Int32[] testValues = { Int32.MaxValue, Int32.MinValue, 0 };
+            Double[] expectedValues = { Int32.MaxValue, Int32.MinValue, 0 };
+            Verify(Convert.ToDouble, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromInt64()
-    {
-        Int64[] testValues = { Int64.MaxValue, Int64.MinValue, 0 };
-        Double[] expectedValues = { (Double)Int64.MaxValue, (Double)Int64.MinValue, 0 };
-        Verify(Convert.ToDouble, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt64()
+        {
+            Int64[] testValues = { Int64.MaxValue, Int64.MinValue, 0 };
+            Double[] expectedValues = { (Double)Int64.MaxValue, (Double)Int64.MinValue, 0 };
+            Verify(Convert.ToDouble, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromObject()
-    {
-        Object[] testValues = { null };
-        Double[] expectedValues = { 0.0 };
-        VerifyFromObject(Convert.ToDouble, Convert.ToDouble, testValues, expectedValues);
+        [Fact]
+        public void FromObject()
+        {
+            Object[] testValues = { null };
+            Double[] expectedValues = { 0.0 };
+            VerifyFromObject(Convert.ToDouble, Convert.ToDouble, testValues, expectedValues);
 
-        Object[] invalidValues = { new Object(), DateTime.Now };
-        VerifyFromObjectThrows<InvalidCastException>(Convert.ToDouble, Convert.ToDouble, invalidValues);
-    }
+            Object[] invalidValues = { new Object(), DateTime.Now };
+            VerifyFromObjectThrows<InvalidCastException>(Convert.ToDouble, Convert.ToDouble, invalidValues);
+        }
 
-    [Fact]
-    public void FromSByte()
-    {
-        SByte[] testValues = { SByte.MaxValue, SByte.MinValue };
-        Double[] expectedValues = { SByte.MaxValue, SByte.MinValue };
-        Verify(Convert.ToDouble, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromSByte()
+        {
+            SByte[] testValues = { SByte.MaxValue, SByte.MinValue };
+            Double[] expectedValues = { SByte.MaxValue, SByte.MinValue };
+            Verify(Convert.ToDouble, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromSingle()
-    {
-        Single[] testValues = { Single.MaxValue, Single.MinValue, 0.0f };
-        Double[] expectedValues = { Single.MaxValue, Single.MinValue, 0.0 };
-        Verify(Convert.ToDouble, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromSingle()
+        {
+            Single[] testValues = { Single.MaxValue, Single.MinValue, 0.0f };
+            Double[] expectedValues = { Single.MaxValue, Single.MinValue, 0.0 };
+            Verify(Convert.ToDouble, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromString()
-    {
-        String[] testValues = { Double.MinValue.ToString("R"), Double.MaxValue.ToString("R"), (0.0).ToString(), (10.0).ToString(), (-10.0).ToString(), null };
-        Double[] expectedValues = { Double.MinValue, Double.MaxValue, 0.0, 10.0, -10.0, 0.0 };
-        VerifyFromString(Convert.ToDouble, Convert.ToDouble, testValues, expectedValues);
+        [Fact]
+        public void FromString()
+        {
+            String[] testValues = { Double.MinValue.ToString("R"), Double.MaxValue.ToString("R"), (0.0).ToString(), (10.0).ToString(), (-10.0).ToString(), null };
+            Double[] expectedValues = { Double.MinValue, Double.MaxValue, 0.0, 10.0, -10.0, 0.0 };
+            VerifyFromString(Convert.ToDouble, Convert.ToDouble, testValues, expectedValues);
 
-        String[] overflowValues = { Double.MaxValue.ToString(), Double.MinValue.ToString() };
-        VerifyFromStringThrows<OverflowException>(Convert.ToDouble, Convert.ToDouble, overflowValues);
+            String[] overflowValues = { Double.MaxValue.ToString(), Double.MinValue.ToString() };
+            VerifyFromStringThrows<OverflowException>(Convert.ToDouble, Convert.ToDouble, overflowValues);
 
-        String[] formatExceptionValues = { "123xyz" };
-        VerifyFromStringThrows<FormatException>(Convert.ToDouble, Convert.ToDouble, formatExceptionValues);
-    }
+            String[] formatExceptionValues = { "123xyz" };
+            VerifyFromStringThrows<FormatException>(Convert.ToDouble, Convert.ToDouble, formatExceptionValues);
+        }
 
-    [Fact]
-    public void FromUInt16()
-    {
-        UInt16[] testValues = { UInt16.MaxValue, UInt16.MinValue };
-        Double[] expectedValues = { UInt16.MaxValue, UInt16.MinValue };
-        Verify(Convert.ToDouble, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt16()
+        {
+            UInt16[] testValues = { UInt16.MaxValue, UInt16.MinValue };
+            Double[] expectedValues = { UInt16.MaxValue, UInt16.MinValue };
+            Verify(Convert.ToDouble, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt32()
-    {
-        UInt32[] testValues = { UInt32.MaxValue, UInt32.MinValue };
-        Double[] expectedValues = { UInt32.MaxValue, UInt32.MinValue };
-        Verify(Convert.ToDouble, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt32()
+        {
+            UInt32[] testValues = { UInt32.MaxValue, UInt32.MinValue };
+            Double[] expectedValues = { UInt32.MaxValue, UInt32.MinValue };
+            Verify(Convert.ToDouble, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt64()
-    {
-        UInt64[] testValues = { UInt64.MaxValue, UInt64.MinValue };
-        Double[] expectedValues = { (Double)UInt64.MaxValue, (Double)UInt64.MinValue };
-        Verify(Convert.ToDouble, testValues, expectedValues);
+        [Fact]
+        public void FromUInt64()
+        {
+            UInt64[] testValues = { UInt64.MaxValue, UInt64.MinValue };
+            Double[] expectedValues = { (Double)UInt64.MaxValue, (Double)UInt64.MinValue };
+            Verify(Convert.ToDouble, testValues, expectedValues);
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToInt16.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToInt16.cs
@@ -2,182 +2,184 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public class ConvertToInt16Tests : ConvertTestBase<Int16>
+namespace System.Tests
 {
-    [Fact]
-    public void FromBoolean()
+    public class ConvertToInt16Tests : ConvertTestBase<Int16>
     {
-        Boolean[] testValues = { true, false };
-        Int16[] expectedValues = { 1, 0 };
-        Verify(Convert.ToInt16, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromBoolean()
+        {
+            Boolean[] testValues = { true, false };
+            Int16[] expectedValues = { 1, 0 };
+            Verify(Convert.ToInt16, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromByte()
-    {
-        Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
-        Int16[] expectedValues = { 255, 0 };
-        Verify(Convert.ToInt16, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromByte()
+        {
+            Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
+            Int16[] expectedValues = { 255, 0 };
+            Verify(Convert.ToInt16, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromChar()
-    {
-        Char[] testValues = { 'A', Char.MinValue, };
-        Int16[] expectedValues = { 65, (Int16)Char.MinValue };
-        Verify(Convert.ToInt16, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromChar()
+        {
+            Char[] testValues = { 'A', Char.MinValue, };
+            Int16[] expectedValues = { 65, (Int16)Char.MinValue };
+            Verify(Convert.ToInt16, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromDecimal()
-    {
-        Decimal[] testValues = { 100m, -100m, 0m };
-        Int16[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToInt16, testValues, expectedValues);
+        [Fact]
+        public void FromDecimal()
+        {
+            Decimal[] testValues = { 100m, -100m, 0m };
+            Int16[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToInt16, testValues, expectedValues);
 
-        Decimal[] overflowValues = { Decimal.MaxValue, Decimal.MinValue };
-        VerifyThrows<OverflowException, Decimal>(Convert.ToInt16, overflowValues);
-    }
+            Decimal[] overflowValues = { Decimal.MaxValue, Decimal.MinValue };
+            VerifyThrows<OverflowException, Decimal>(Convert.ToInt16, overflowValues);
+        }
 
-    [Fact]
-    public void FromDouble()
-    {
-        Double[] testValues = { 100.0, -100.0, 0 };
-        Int16[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToInt16, testValues, expectedValues);
+        [Fact]
+        public void FromDouble()
+        {
+            Double[] testValues = { 100.0, -100.0, 0 };
+            Int16[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToInt16, testValues, expectedValues);
 
-        Double[] overflowValues = { Double.MaxValue, Double.MinValue };
-        VerifyThrows<OverflowException, Double>(Convert.ToInt16, overflowValues);
-    }
+            Double[] overflowValues = { Double.MaxValue, Double.MinValue };
+            VerifyThrows<OverflowException, Double>(Convert.ToInt16, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt16()
-    {
-        Int16[] testValues = { Int16.MaxValue, Int16.MinValue, 0 };
-        Int16[] expectedValues = { Int16.MaxValue, Int16.MinValue, 0 };
-        Verify(Convert.ToInt16, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt16()
+        {
+            Int16[] testValues = { Int16.MaxValue, Int16.MinValue, 0 };
+            Int16[] expectedValues = { Int16.MaxValue, Int16.MinValue, 0 };
+            Verify(Convert.ToInt16, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromInt32()
-    {
-        Int32[] testValues = { 100, -100, 0 };
-        Int16[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToInt16, testValues, expectedValues);
+        [Fact]
+        public void FromInt32()
+        {
+            Int32[] testValues = { 100, -100, 0 };
+            Int16[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToInt16, testValues, expectedValues);
 
-        Int32[] overflowValues = { Int32.MaxValue, Int32.MinValue };
-        VerifyThrows<OverflowException, Int32>(Convert.ToInt16, overflowValues);
-    }
+            Int32[] overflowValues = { Int32.MaxValue, Int32.MinValue };
+            VerifyThrows<OverflowException, Int32>(Convert.ToInt16, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt64()
-    {
-        Int64[] testValues = { 100, -100, 0 };
-        Int16[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToInt16, testValues, expectedValues);
+        [Fact]
+        public void FromInt64()
+        {
+            Int64[] testValues = { 100, -100, 0 };
+            Int16[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToInt16, testValues, expectedValues);
 
-        Int64[] overflowValues = { Int64.MaxValue, Int64.MinValue };
-        VerifyThrows<OverflowException, Int64>(Convert.ToInt16, overflowValues);
-    }
+            Int64[] overflowValues = { Int64.MaxValue, Int64.MinValue };
+            VerifyThrows<OverflowException, Int64>(Convert.ToInt16, overflowValues);
+        }
 
-    [Fact]
-    public void FromObject()
-    {
-        Object[] testValues = { null };
-        Int16[] expectedValues = { 0 };
-        VerifyFromObject(Convert.ToInt16, Convert.ToInt16, testValues, expectedValues);
+        [Fact]
+        public void FromObject()
+        {
+            Object[] testValues = { null };
+            Int16[] expectedValues = { 0 };
+            VerifyFromObject(Convert.ToInt16, Convert.ToInt16, testValues, expectedValues);
 
-        Object[] invalidValues = { new Object(), DateTime.Now };
-        VerifyFromObjectThrows<InvalidCastException>(Convert.ToInt16, Convert.ToInt16, invalidValues);
-    }
+            Object[] invalidValues = { new Object(), DateTime.Now };
+            VerifyFromObjectThrows<InvalidCastException>(Convert.ToInt16, Convert.ToInt16, invalidValues);
+        }
 
-    [Fact]
-    public void FromSByte()
-    {
-        SByte[] testValues = { 100, -100, 0 };
-        Int16[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToInt16, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromSByte()
+        {
+            SByte[] testValues = { 100, -100, 0 };
+            Int16[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToInt16, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromSingle()
-    {
-        Single[] testValues = { 100.0f, -100.0f, 0.0f, };
-        Int16[] expectedValues = { 100, -100, 0, };
-        Verify(Convert.ToInt16, testValues, expectedValues);
+        [Fact]
+        public void FromSingle()
+        {
+            Single[] testValues = { 100.0f, -100.0f, 0.0f, };
+            Int16[] expectedValues = { 100, -100, 0, };
+            Verify(Convert.ToInt16, testValues, expectedValues);
 
-        Single[] overflowValues = { Single.MaxValue, Single.MinValue };
-        VerifyThrows<OverflowException, Single>(Convert.ToInt16, overflowValues);
-    }
+            Single[] overflowValues = { Single.MaxValue, Single.MinValue };
+            VerifyThrows<OverflowException, Single>(Convert.ToInt16, overflowValues);
+        }
 
-    [Fact]
-    public void FromString()
-    {
-        String[] testValues = { "100", "-100", "0", Int16.MinValue.ToString(), Int16.MaxValue.ToString(), null };
-        Int16[] expectedValues = { 100, -100, 0, Int16.MinValue, Int16.MaxValue, 0 };
-        VerifyFromString(Convert.ToInt16, Convert.ToInt16, testValues, expectedValues);
+        [Fact]
+        public void FromString()
+        {
+            String[] testValues = { "100", "-100", "0", Int16.MinValue.ToString(), Int16.MaxValue.ToString(), null };
+            Int16[] expectedValues = { 100, -100, 0, Int16.MinValue, Int16.MaxValue, 0 };
+            VerifyFromString(Convert.ToInt16, Convert.ToInt16, testValues, expectedValues);
 
-        String[] overflowValues = { Int32.MinValue.ToString(), Int32.MaxValue.ToString() };
-        VerifyFromStringThrows<OverflowException>(Convert.ToInt16, Convert.ToInt16, overflowValues);
+            String[] overflowValues = { Int32.MinValue.ToString(), Int32.MaxValue.ToString() };
+            VerifyFromStringThrows<OverflowException>(Convert.ToInt16, Convert.ToInt16, overflowValues);
 
-        String[] formatExceptionValues = { "abba" };
-        VerifyFromStringThrows<FormatException>(Convert.ToInt16, Convert.ToInt16, formatExceptionValues);
-    }
+            String[] formatExceptionValues = { "abba" };
+            VerifyFromStringThrows<FormatException>(Convert.ToInt16, Convert.ToInt16, formatExceptionValues);
+        }
 
-    [Fact]
-    public void FromStringWithBase()
-    {
-        String[] testValues = { null, null, null, null, "7fff", "32767", "77777", "111111111111111", "8000", "-32768", "100000", "1000000000000000" };
-        Int32[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2 };
-        Int16[] expectedValues = { 0, 0, 0, 0, Int16.MaxValue, Int16.MaxValue, Int16.MaxValue, Int16.MaxValue, Int16.MinValue, Int16.MinValue, Int16.MinValue, Int16.MinValue };
-        VerifyFromStringWithBase(Convert.ToInt16, testValues, testBases, expectedValues);
+        [Fact]
+        public void FromStringWithBase()
+        {
+            String[] testValues = { null, null, null, null, "7fff", "32767", "77777", "111111111111111", "8000", "-32768", "100000", "1000000000000000" };
+            Int32[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2 };
+            Int16[] expectedValues = { 0, 0, 0, 0, Int16.MaxValue, Int16.MaxValue, Int16.MaxValue, Int16.MaxValue, Int16.MinValue, Int16.MinValue, Int16.MinValue, Int16.MinValue };
+            VerifyFromStringWithBase(Convert.ToInt16, testValues, testBases, expectedValues);
 
-        String[] overflowValues = { "32768", "-32769", "11111111111111111", "1FFFF", "777777" };
-        Int32[] overflowBases = { 10, 10, 2, 16, 8 };
-        VerifyFromStringWithBaseThrows<OverflowException>(Convert.ToInt16, overflowValues, overflowBases);
+            String[] overflowValues = { "32768", "-32769", "11111111111111111", "1FFFF", "777777" };
+            Int32[] overflowBases = { 10, 10, 2, 16, 8 };
+            VerifyFromStringWithBaseThrows<OverflowException>(Convert.ToInt16, overflowValues, overflowBases);
 
-        String[] formatExceptionValues = { "12", "ffffffffffffffffffff" };
-        Int32[] formatExceptionBases = { 2, 8 };
-        VerifyFromStringWithBaseThrows<FormatException>(Convert.ToInt16, formatExceptionValues, formatExceptionBases);
+            String[] formatExceptionValues = { "12", "ffffffffffffffffffff" };
+            Int32[] formatExceptionBases = { 2, 8 };
+            VerifyFromStringWithBaseThrows<FormatException>(Convert.ToInt16, formatExceptionValues, formatExceptionBases);
 
-        String[] argumentExceptionValues = { "10", "11", "abba", "-ab" };
-        Int32[] argumentExceptionBases = { -1, 3, 0, 16 };
-        VerifyFromStringWithBaseThrows<ArgumentException>(Convert.ToInt16, argumentExceptionValues, argumentExceptionBases);
-    }
+            String[] argumentExceptionValues = { "10", "11", "abba", "-ab" };
+            Int32[] argumentExceptionBases = { -1, 3, 0, 16 };
+            VerifyFromStringWithBaseThrows<ArgumentException>(Convert.ToInt16, argumentExceptionValues, argumentExceptionBases);
+        }
 
-    [Fact]
-    public void FromUInt16()
-    {
-        UInt16[] testValues = { 100, 0 };
-        Int16[] expectedValues = { 100, 0 };
-        Verify(Convert.ToInt16, testValues, expectedValues);
+        [Fact]
+        public void FromUInt16()
+        {
+            UInt16[] testValues = { 100, 0 };
+            Int16[] expectedValues = { 100, 0 };
+            Verify(Convert.ToInt16, testValues, expectedValues);
 
-        UInt16[] overflowValues = { UInt16.MaxValue };
-        VerifyThrows<OverflowException, UInt16>(Convert.ToInt16, overflowValues);
-    }
+            UInt16[] overflowValues = { UInt16.MaxValue };
+            VerifyThrows<OverflowException, UInt16>(Convert.ToInt16, overflowValues);
+        }
 
-    [Fact]
-    public void FromUInt32()
-    {
-        UInt32[] testValues = { 100, 0 };
-        Int16[] expectedValues = { 100, 0 };
-        Verify(Convert.ToInt16, testValues, expectedValues);
+        [Fact]
+        public void FromUInt32()
+        {
+            UInt32[] testValues = { 100, 0 };
+            Int16[] expectedValues = { 100, 0 };
+            Verify(Convert.ToInt16, testValues, expectedValues);
 
-        UInt32[] overflowValues = { UInt32.MaxValue };
-        VerifyThrows<OverflowException, UInt32>(Convert.ToInt16, overflowValues);
-    }
+            UInt32[] overflowValues = { UInt32.MaxValue };
+            VerifyThrows<OverflowException, UInt32>(Convert.ToInt16, overflowValues);
+        }
 
-    [Fact]
-    public void FromUInt64()
-    {
-        UInt64[] testValues = { 100, 0 };
-        Int16[] expectedValues = { 100, 0 };
-        Verify(Convert.ToInt16, testValues, expectedValues);
+        [Fact]
+        public void FromUInt64()
+        {
+            UInt64[] testValues = { 100, 0 };
+            Int16[] expectedValues = { 100, 0 };
+            Verify(Convert.ToInt16, testValues, expectedValues);
 
-        UInt64[] overflowValues = { UInt64.MaxValue };
-        VerifyThrows<OverflowException, UInt64>(Convert.ToInt16, overflowValues);
+            UInt64[] overflowValues = { UInt64.MaxValue };
+            VerifyThrows<OverflowException, UInt64>(Convert.ToInt16, overflowValues);
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToInt32.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToInt32.cs
@@ -2,176 +2,178 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public class ConvertToInt32Tests : ConvertTestBase<Int32>
+namespace System.Tests
 {
-    [Fact]
-    public void FromBoolean()
+    public class ConvertToInt32Tests : ConvertTestBase<Int32>
     {
-        Boolean[] testValues = { true, false };
-        Int32[] expectedValues = { 1, 0 };
-        Verify(Convert.ToInt32, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromBoolean()
+        {
+            Boolean[] testValues = { true, false };
+            Int32[] expectedValues = { 1, 0 };
+            Verify(Convert.ToInt32, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromByte()
-    {
-        Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
-        Int32[] expectedValues = { 255, 0 };
-        Verify(Convert.ToInt32, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromByte()
+        {
+            Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
+            Int32[] expectedValues = { 255, 0 };
+            Verify(Convert.ToInt32, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromChar()
-    {
-        Char[] testValues = { Char.MinValue, Char.MaxValue, 'b' };
-        Int32[] expectedValues = { Char.MinValue, Char.MaxValue, 98 };
-        Verify(Convert.ToInt32, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromChar()
+        {
+            Char[] testValues = { Char.MinValue, Char.MaxValue, 'b' };
+            Int32[] expectedValues = { Char.MinValue, Char.MaxValue, 98 };
+            Verify(Convert.ToInt32, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromDecimal()
-    {
-        Decimal[] testValues = { 100m, -100m, 0m };
-        Int32[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToInt32, testValues, expectedValues);
+        [Fact]
+        public void FromDecimal()
+        {
+            Decimal[] testValues = { 100m, -100m, 0m };
+            Int32[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToInt32, testValues, expectedValues);
 
-        Decimal[] overflowValues = { Decimal.MaxValue, Decimal.MinValue };
-        VerifyThrows<OverflowException, Decimal>(Convert.ToInt32, overflowValues);
-    }
+            Decimal[] overflowValues = { Decimal.MaxValue, Decimal.MinValue };
+            VerifyThrows<OverflowException, Decimal>(Convert.ToInt32, overflowValues);
+        }
 
-    [Fact]
-    public void FromDouble()
-    {
-        Double[] testValues = { 100.0, -100.0, 0 };
-        Int32[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToInt32, testValues, expectedValues);
+        [Fact]
+        public void FromDouble()
+        {
+            Double[] testValues = { 100.0, -100.0, 0 };
+            Int32[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToInt32, testValues, expectedValues);
 
-        Double[] overflowValues = { Double.MaxValue, Double.MinValue };
-        VerifyThrows<OverflowException, Double>(Convert.ToInt32, overflowValues);
-    }
+            Double[] overflowValues = { Double.MaxValue, Double.MinValue };
+            VerifyThrows<OverflowException, Double>(Convert.ToInt32, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt16()
-    {
-        Int16[] testValues = { 100, -100, 0, };
-        Int32[] expectedValues = { 100, -100, 0, };
-        Verify(Convert.ToInt32, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt16()
+        {
+            Int16[] testValues = { 100, -100, 0, };
+            Int32[] expectedValues = { 100, -100, 0, };
+            Verify(Convert.ToInt32, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromInt32()
-    {
-        Int32[] testValues = { Int32.MaxValue, Int32.MinValue, 0 };
-        Int32[] expectedValues = { Int32.MaxValue, Int32.MinValue, 0 };
-        Verify(Convert.ToInt32, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt32()
+        {
+            Int32[] testValues = { Int32.MaxValue, Int32.MinValue, 0 };
+            Int32[] expectedValues = { Int32.MaxValue, Int32.MinValue, 0 };
+            Verify(Convert.ToInt32, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromInt64()
-    {
-        Int64[] testValues = { 100, -100, 0 };
-        Int32[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToInt32, testValues, expectedValues);
+        [Fact]
+        public void FromInt64()
+        {
+            Int64[] testValues = { 100, -100, 0 };
+            Int32[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToInt32, testValues, expectedValues);
 
-        Int64[] overflowValues = { Int64.MaxValue, Int64.MinValue };
-        VerifyThrows<OverflowException, Int64>(Convert.ToInt32, overflowValues);
-    }
+            Int64[] overflowValues = { Int64.MaxValue, Int64.MinValue };
+            VerifyThrows<OverflowException, Int64>(Convert.ToInt32, overflowValues);
+        }
 
-    [Fact]
-    public void FromObject()
-    {
-        Object[] testValues = { null };
-        Int32[] expectedValues = { 0 };
-        VerifyFromObject(Convert.ToInt32, Convert.ToInt32, testValues, expectedValues);
+        [Fact]
+        public void FromObject()
+        {
+            Object[] testValues = { null };
+            Int32[] expectedValues = { 0 };
+            VerifyFromObject(Convert.ToInt32, Convert.ToInt32, testValues, expectedValues);
 
-        Object[] invalidValues = { new Object() };
-        VerifyFromObjectThrows<InvalidCastException>(Convert.ToInt32, Convert.ToInt32, invalidValues);
-    }
+            Object[] invalidValues = { new Object() };
+            VerifyFromObjectThrows<InvalidCastException>(Convert.ToInt32, Convert.ToInt32, invalidValues);
+        }
 
-    [Fact]
-    public void FromSByte()
-    {
-        SByte[] testValues = { 100, -100, 0 };
-        Int32[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToInt32, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromSByte()
+        {
+            SByte[] testValues = { 100, -100, 0 };
+            Int32[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToInt32, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromSingle()
-    {
-        Single[] testValues = { 100.0f, -100.0f, 0.0f, };
-        Int32[] expectedValues = { 100, -100, 0, };
-        Verify(Convert.ToInt32, testValues, expectedValues);
+        [Fact]
+        public void FromSingle()
+        {
+            Single[] testValues = { 100.0f, -100.0f, 0.0f, };
+            Int32[] expectedValues = { 100, -100, 0, };
+            Verify(Convert.ToInt32, testValues, expectedValues);
 
-        Single[] overflowValues = { Single.MaxValue, Single.MinValue };
-        VerifyThrows<OverflowException, Single>(Convert.ToInt32, overflowValues);
-    }
+            Single[] overflowValues = { Single.MaxValue, Single.MinValue };
+            VerifyThrows<OverflowException, Single>(Convert.ToInt32, overflowValues);
+        }
 
-    [Fact]
-    public void FromString()
-    {
-        String[] testValues = { "100", "-100", "0", Int32.MinValue.ToString(), Int32.MaxValue.ToString(), null };
-        Int32[] expectedValues = { 100, -100, 0, Int32.MinValue, Int32.MaxValue, 0 };
-        VerifyFromString(Convert.ToInt32, Convert.ToInt32, testValues, expectedValues);
+        [Fact]
+        public void FromString()
+        {
+            String[] testValues = { "100", "-100", "0", Int32.MinValue.ToString(), Int32.MaxValue.ToString(), null };
+            Int32[] expectedValues = { 100, -100, 0, Int32.MinValue, Int32.MaxValue, 0 };
+            VerifyFromString(Convert.ToInt32, Convert.ToInt32, testValues, expectedValues);
 
-        String[] overflowValues = { Int64.MinValue.ToString(), Int64.MaxValue.ToString() };
-        VerifyFromStringThrows<OverflowException>(Convert.ToInt32, Convert.ToInt32, overflowValues);
+            String[] overflowValues = { Int64.MinValue.ToString(), Int64.MaxValue.ToString() };
+            VerifyFromStringThrows<OverflowException>(Convert.ToInt32, Convert.ToInt32, overflowValues);
 
-        String[] formatExceptionValues = { "abba" };
-        VerifyFromStringThrows<FormatException>(Convert.ToInt32, Convert.ToInt32, formatExceptionValues);
-    }
+            String[] formatExceptionValues = { "abba" };
+            VerifyFromStringThrows<FormatException>(Convert.ToInt32, Convert.ToInt32, formatExceptionValues);
+        }
 
-    [Fact]
-    public void FromStringWithBase()
-    {
-        String[] testValues = { null, null, null, null, "7FFFFFFF", "2147483647", "17777777777", "1111111111111111111111111111111", "80000000", "-2147483648", "20000000000", "10000000000000000000000000000000", };
-        Int32[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2, };
-        Int32[] expectedValues = { 0, 0, 0, 0, Int32.MaxValue, Int32.MaxValue, Int32.MaxValue, Int32.MaxValue, Int32.MinValue, Int32.MinValue, Int32.MinValue, Int32.MinValue, };
-        VerifyFromStringWithBase(Convert.ToInt32, testValues, testBases, expectedValues);
+        [Fact]
+        public void FromStringWithBase()
+        {
+            String[] testValues = { null, null, null, null, "7FFFFFFF", "2147483647", "17777777777", "1111111111111111111111111111111", "80000000", "-2147483648", "20000000000", "10000000000000000000000000000000", };
+            Int32[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2, };
+            Int32[] expectedValues = { 0, 0, 0, 0, Int32.MaxValue, Int32.MaxValue, Int32.MaxValue, Int32.MaxValue, Int32.MinValue, Int32.MinValue, Int32.MinValue, Int32.MinValue, };
+            VerifyFromStringWithBase(Convert.ToInt32, testValues, testBases, expectedValues);
 
-        String[] overflowValues = { "2147483648", "-2147483649", "111111111111111111111111111111111", "1FFFFffff", "777777777777" };
-        Int32[] overflowBases = { 10, 10, 2, 16, 8 };
-        VerifyFromStringWithBaseThrows<OverflowException>(Convert.ToInt32, overflowValues, overflowBases);
+            String[] overflowValues = { "2147483648", "-2147483649", "111111111111111111111111111111111", "1FFFFffff", "777777777777" };
+            Int32[] overflowBases = { 10, 10, 2, 16, 8 };
+            VerifyFromStringWithBaseThrows<OverflowException>(Convert.ToInt32, overflowValues, overflowBases);
 
-        String[] formatExceptionValues = { "12", "ffffffffffffffffffff" };
-        Int32[] formatExceptionBases = { 2, 8 };
-        VerifyFromStringWithBaseThrows<FormatException>(Convert.ToInt32, formatExceptionValues, formatExceptionBases);
+            String[] formatExceptionValues = { "12", "ffffffffffffffffffff" };
+            Int32[] formatExceptionBases = { 2, 8 };
+            VerifyFromStringWithBaseThrows<FormatException>(Convert.ToInt32, formatExceptionValues, formatExceptionBases);
 
-        String[] argumentExceptionValues = { "10", "11", "abba", "-ab" };
-        Int32[] argumentExceptionBases = { -1, 3, 0, 16 };
-        VerifyFromStringWithBaseThrows<ArgumentException>(Convert.ToInt32, argumentExceptionValues, argumentExceptionBases);
-    }
+            String[] argumentExceptionValues = { "10", "11", "abba", "-ab" };
+            Int32[] argumentExceptionBases = { -1, 3, 0, 16 };
+            VerifyFromStringWithBaseThrows<ArgumentException>(Convert.ToInt32, argumentExceptionValues, argumentExceptionBases);
+        }
 
-    [Fact]
-    public void FromUInt16()
-    {
-        UInt16[] testValues = { 100, 0 };
-        Int32[] expectedValues = { 100, 0 };
-        Verify(Convert.ToInt32, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt16()
+        {
+            UInt16[] testValues = { 100, 0 };
+            Int32[] expectedValues = { 100, 0 };
+            Verify(Convert.ToInt32, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt32()
-    {
-        UInt32[] testValues = { 100, 0 };
-        Int32[] expectedValues = { 100, 0 };
-        Verify(Convert.ToInt32, testValues, expectedValues);
+        [Fact]
+        public void FromUInt32()
+        {
+            UInt32[] testValues = { 100, 0 };
+            Int32[] expectedValues = { 100, 0 };
+            Verify(Convert.ToInt32, testValues, expectedValues);
 
-        UInt32[] overflowValues = { UInt32.MaxValue };
-        VerifyThrows<OverflowException, UInt32>(Convert.ToInt32, overflowValues);
-    }
+            UInt32[] overflowValues = { UInt32.MaxValue };
+            VerifyThrows<OverflowException, UInt32>(Convert.ToInt32, overflowValues);
+        }
 
-    [Fact]
-    public void FromUInt64()
-    {
-        UInt64[] testValues = { 100, 0 };
-        Int32[] expectedValues = { 100, 0 };
-        Verify(Convert.ToInt32, testValues, expectedValues);
+        [Fact]
+        public void FromUInt64()
+        {
+            UInt64[] testValues = { 100, 0 };
+            Int32[] expectedValues = { 100, 0 };
+            Verify(Convert.ToInt32, testValues, expectedValues);
 
-        UInt64[] overflowValues = { UInt64.MaxValue };
-        VerifyThrows<OverflowException, UInt64>(Convert.ToInt32, overflowValues);
+            UInt64[] overflowValues = { UInt64.MaxValue };
+            VerifyThrows<OverflowException, UInt64>(Convert.ToInt32, overflowValues);
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToInt64.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToInt64.cs
@@ -2,170 +2,172 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public class ConvertToInt64Tests : ConvertTestBase<Int64>
+namespace System.Tests
 {
-    [Fact]
-    public void FromBoolean()
+    public class ConvertToInt64Tests : ConvertTestBase<Int64>
     {
-        Boolean[] testValues = { true, false };
-        Int64[] expectedValues = { 1, 0 };
-        Verify(Convert.ToInt64, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromBoolean()
+        {
+            Boolean[] testValues = { true, false };
+            Int64[] expectedValues = { 1, 0 };
+            Verify(Convert.ToInt64, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromByte()
-    {
-        Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
-        Int64[] expectedValues = { 255, 0 };
-        Verify(Convert.ToInt64, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromByte()
+        {
+            Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
+            Int64[] expectedValues = { 255, 0 };
+            Verify(Convert.ToInt64, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromChar()
-    {
-        Char[] testValues = { Char.MaxValue, Char.MinValue, 'b' };
-        Int64[] expectedValues = { Char.MaxValue, Char.MinValue, 98 };
-        Verify(Convert.ToInt64, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromChar()
+        {
+            Char[] testValues = { Char.MaxValue, Char.MinValue, 'b' };
+            Int64[] expectedValues = { Char.MaxValue, Char.MinValue, 98 };
+            Verify(Convert.ToInt64, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromDecimal()
-    {
-        Decimal[] testValues = { 100m, -100m, 0m };
-        Int64[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToInt64, testValues, expectedValues);
+        [Fact]
+        public void FromDecimal()
+        {
+            Decimal[] testValues = { 100m, -100m, 0m };
+            Int64[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToInt64, testValues, expectedValues);
 
-        Decimal[] overflowValues = { Decimal.MaxValue, Decimal.MinValue };
-        VerifyThrows<OverflowException, Decimal>(Convert.ToInt64, overflowValues);
-    }
+            Decimal[] overflowValues = { Decimal.MaxValue, Decimal.MinValue };
+            VerifyThrows<OverflowException, Decimal>(Convert.ToInt64, overflowValues);
+        }
 
-    [Fact]
-    public void FromDouble()
-    {
-        Double[] testValues = { 100.0, -100.0, 0 };
-        Int64[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToInt64, testValues, expectedValues);
+        [Fact]
+        public void FromDouble()
+        {
+            Double[] testValues = { 100.0, -100.0, 0 };
+            Int64[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToInt64, testValues, expectedValues);
 
-        Double[] overflowValues = { Double.MaxValue, Double.MinValue };
-        VerifyThrows<OverflowException, Double>(Convert.ToInt64, overflowValues);
-    }
+            Double[] overflowValues = { Double.MaxValue, Double.MinValue };
+            VerifyThrows<OverflowException, Double>(Convert.ToInt64, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt16()
-    {
-        Int16[] testValues = { 100, -100, 0, };
-        Int64[] expectedValues = { 100, -100, 0, };
-        Verify(Convert.ToInt64, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt16()
+        {
+            Int16[] testValues = { 100, -100, 0, };
+            Int64[] expectedValues = { 100, -100, 0, };
+            Verify(Convert.ToInt64, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromInt32()
-    {
-        Int32[] testValues = { Int32.MaxValue, Int32.MinValue, 0 };
-        Int64[] expectedValues = { Int32.MaxValue, Int32.MinValue, 0 };
-        Verify(Convert.ToInt64, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt32()
+        {
+            Int32[] testValues = { Int32.MaxValue, Int32.MinValue, 0 };
+            Int64[] expectedValues = { Int32.MaxValue, Int32.MinValue, 0 };
+            Verify(Convert.ToInt64, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromInt64()
-    {
-        Int64[] testValues = { Int64.MaxValue, Int64.MinValue, 0 };
-        Int64[] expectedValues = { Int64.MaxValue, Int64.MinValue, 0 };
-        Verify(Convert.ToInt64, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt64()
+        {
+            Int64[] testValues = { Int64.MaxValue, Int64.MinValue, 0 };
+            Int64[] expectedValues = { Int64.MaxValue, Int64.MinValue, 0 };
+            Verify(Convert.ToInt64, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromObject()
-    {
-        Object[] testValues = { null };
-        Int64[] expectedValues = { 0 };
-        VerifyFromObject(Convert.ToInt64, Convert.ToInt64, testValues, expectedValues);
+        [Fact]
+        public void FromObject()
+        {
+            Object[] testValues = { null };
+            Int64[] expectedValues = { 0 };
+            VerifyFromObject(Convert.ToInt64, Convert.ToInt64, testValues, expectedValues);
 
-        Object[] invalidValues = { new Object(), DateTime.Now };
-        VerifyFromObjectThrows<InvalidCastException>(Convert.ToInt64, Convert.ToInt64, invalidValues);
-    }
+            Object[] invalidValues = { new Object(), DateTime.Now };
+            VerifyFromObjectThrows<InvalidCastException>(Convert.ToInt64, Convert.ToInt64, invalidValues);
+        }
 
-    [Fact]
-    public void FromSByte()
-    {
-        SByte[] testValues = { 100, -100, 0 };
-        Int64[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToInt64, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromSByte()
+        {
+            SByte[] testValues = { 100, -100, 0 };
+            Int64[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToInt64, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromSingle()
-    {
-        Single[] testValues = { 100.0f, -100.0f, 0.0f, };
-        Int64[] expectedValues = { 100, -100, 0, };
-        Verify(Convert.ToInt64, testValues, expectedValues);
+        [Fact]
+        public void FromSingle()
+        {
+            Single[] testValues = { 100.0f, -100.0f, 0.0f, };
+            Int64[] expectedValues = { 100, -100, 0, };
+            Verify(Convert.ToInt64, testValues, expectedValues);
 
-        Single[] overflowValues = { Single.MaxValue, Single.MinValue };
-        VerifyThrows<OverflowException, Single>(Convert.ToInt64, overflowValues);
-    }
+            Single[] overflowValues = { Single.MaxValue, Single.MinValue };
+            VerifyThrows<OverflowException, Single>(Convert.ToInt64, overflowValues);
+        }
 
-    [Fact]
-    public void FromString()
-    {
-        String[] testValues = { "100", "-100", "0", Int64.MinValue.ToString(), Int64.MaxValue.ToString(), null };
-        Int64[] expectedValues = { 100, -100, 0, Int64.MinValue, Int64.MaxValue, 0 };
-        VerifyFromString(Convert.ToInt64, Convert.ToInt64, testValues, expectedValues);
+        [Fact]
+        public void FromString()
+        {
+            String[] testValues = { "100", "-100", "0", Int64.MinValue.ToString(), Int64.MaxValue.ToString(), null };
+            Int64[] expectedValues = { 100, -100, 0, Int64.MinValue, Int64.MaxValue, 0 };
+            VerifyFromString(Convert.ToInt64, Convert.ToInt64, testValues, expectedValues);
 
-        String[] overflowValues = { "1" + Int64.MaxValue.ToString(), Int64.MinValue.ToString() + "1" };
-        VerifyFromStringThrows<OverflowException>(Convert.ToInt64, Convert.ToInt64, overflowValues);
+            String[] overflowValues = { "1" + Int64.MaxValue.ToString(), Int64.MinValue.ToString() + "1" };
+            VerifyFromStringThrows<OverflowException>(Convert.ToInt64, Convert.ToInt64, overflowValues);
 
-        String[] formatExceptionValues = { "abba" };
-        VerifyFromStringThrows<FormatException>(Convert.ToInt64, Convert.ToInt64, formatExceptionValues);
-    }
+            String[] formatExceptionValues = { "abba" };
+            VerifyFromStringThrows<FormatException>(Convert.ToInt64, Convert.ToInt64, formatExceptionValues);
+        }
 
-    [Fact]
-    public void FromStringWithBase()
-    {
-        String[] testValues = { null, null, null, null, "7FFFFFFFFFFFFFFF", "9223372036854775807", "777777777777777777777", "111111111111111111111111111111111111111111111111111111111111111", "8000000000000000", "-9223372036854775808", "1000000000000000000000", "1000000000000000000000000000000000000000000000000000000000000000" };
-        Int32[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2 };
-        Int64[] expectedValues = { 0, 0, 0, 0, Int64.MaxValue, Int64.MaxValue, Int64.MaxValue, Int64.MaxValue, Int64.MinValue, Int64.MinValue, Int64.MinValue, Int64.MinValue };
-        VerifyFromStringWithBase(Convert.ToInt64, testValues, testBases, expectedValues);
+        [Fact]
+        public void FromStringWithBase()
+        {
+            String[] testValues = { null, null, null, null, "7FFFFFFFFFFFFFFF", "9223372036854775807", "777777777777777777777", "111111111111111111111111111111111111111111111111111111111111111", "8000000000000000", "-9223372036854775808", "1000000000000000000000", "1000000000000000000000000000000000000000000000000000000000000000" };
+            Int32[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2 };
+            Int64[] expectedValues = { 0, 0, 0, 0, Int64.MaxValue, Int64.MaxValue, Int64.MaxValue, Int64.MaxValue, Int64.MinValue, Int64.MinValue, Int64.MinValue, Int64.MinValue };
+            VerifyFromStringWithBase(Convert.ToInt64, testValues, testBases, expectedValues);
 
-        String[] overflowValues = { "9223372036854775808", "-9223372036854775809", "11111111111111111111111111111111111111111111111111111111111111111", "1FFFFffffFFFFffff", "7777777777777777777777777" };
-        Int32[] overflowBases = { 10, 10, 2, 16, 8 };
-        VerifyFromStringWithBaseThrows<OverflowException>(Convert.ToInt64, overflowValues, overflowBases);
+            String[] overflowValues = { "9223372036854775808", "-9223372036854775809", "11111111111111111111111111111111111111111111111111111111111111111", "1FFFFffffFFFFffff", "7777777777777777777777777" };
+            Int32[] overflowBases = { 10, 10, 2, 16, 8 };
+            VerifyFromStringWithBaseThrows<OverflowException>(Convert.ToInt64, overflowValues, overflowBases);
 
-        String[] formatExceptionValues = { "12", "ffffffffffffffffffff" };
-        Int32[] formatExceptionBases = { 2, 8 };
-        VerifyFromStringWithBaseThrows<FormatException>(Convert.ToInt64, formatExceptionValues, formatExceptionBases);
+            String[] formatExceptionValues = { "12", "ffffffffffffffffffff" };
+            Int32[] formatExceptionBases = { 2, 8 };
+            VerifyFromStringWithBaseThrows<FormatException>(Convert.ToInt64, formatExceptionValues, formatExceptionBases);
 
-        String[] argumentExceptionValues = { "10", "11", "abba", "-ab" };
-        Int32[] argumentExceptionBases = { -1, 3, 0, 16 };
-        VerifyFromStringWithBaseThrows<ArgumentException>(Convert.ToInt64, argumentExceptionValues, argumentExceptionBases);
-    }
+            String[] argumentExceptionValues = { "10", "11", "abba", "-ab" };
+            Int32[] argumentExceptionBases = { -1, 3, 0, 16 };
+            VerifyFromStringWithBaseThrows<ArgumentException>(Convert.ToInt64, argumentExceptionValues, argumentExceptionBases);
+        }
 
-    [Fact]
-    public void FromUInt16()
-    {
-        UInt16[] testValues = { 100, 0 };
-        Int64[] expectedValues = { 100, 0 };
-        Verify(Convert.ToInt64, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt16()
+        {
+            UInt16[] testValues = { 100, 0 };
+            Int64[] expectedValues = { 100, 0 };
+            Verify(Convert.ToInt64, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt32()
-    {
-        UInt32[] testValues = { 100, 0 };
-        Int64[] expectedValues = { 100, 0 };
-        Verify(Convert.ToInt64, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt32()
+        {
+            UInt32[] testValues = { 100, 0 };
+            Int64[] expectedValues = { 100, 0 };
+            Verify(Convert.ToInt64, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt64()
-    {
-        UInt64[] testValues = { 100, 0 };
-        Int64[] expectedValues = { 100, 0 };
-        Verify(Convert.ToInt64, testValues, expectedValues);
+        [Fact]
+        public void FromUInt64()
+        {
+            UInt64[] testValues = { 100, 0 };
+            Int64[] expectedValues = { 100, 0 };
+            Verify(Convert.ToInt64, testValues, expectedValues);
 
-        UInt64[] overflowValues = { UInt64.MaxValue };
-        VerifyThrows<OverflowException, UInt64>(Convert.ToInt64, overflowValues);
+            UInt64[] overflowValues = { UInt64.MaxValue };
+            VerifyThrows<OverflowException, UInt64>(Convert.ToInt64, overflowValues);
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToSByte.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToSByte.cs
@@ -2,193 +2,195 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public class ConvertToSByteTests : ConvertTestBase<SByte>
+namespace System.Tests
 {
-    [Fact]
-    public void FromBoolean()
+    public class ConvertToSByteTests : ConvertTestBase<SByte>
     {
-        Boolean[] testValues = { true, false };
-        SByte[] expectedValues = { 1, 0 };
-        Verify(Convert.ToSByte, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromBoolean()
+        {
+            Boolean[] testValues = { true, false };
+            SByte[] expectedValues = { 1, 0 };
+            Verify(Convert.ToSByte, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromByte()
-    {
-        Byte[] testValues = { 100, 0 };
-        SByte[] expectedValues = { 100, 0 };
-        Verify(Convert.ToSByte, testValues, expectedValues);
+        [Fact]
+        public void FromByte()
+        {
+            Byte[] testValues = { 100, 0 };
+            SByte[] expectedValues = { 100, 0 };
+            Verify(Convert.ToSByte, testValues, expectedValues);
 
-        Byte[] overflowValues = { Byte.MaxValue };
-        VerifyThrows<OverflowException, Byte>(Convert.ToSByte, overflowValues);
-    }
+            Byte[] overflowValues = { Byte.MaxValue };
+            VerifyThrows<OverflowException, Byte>(Convert.ToSByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromChar()
-    {
-        Char[] testValues = { 'A', Char.MinValue, };
-        SByte[] expectedValues = { 65, (SByte)Char.MinValue };
-        Verify(Convert.ToSByte, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromChar()
+        {
+            Char[] testValues = { 'A', Char.MinValue, };
+            SByte[] expectedValues = { 65, (SByte)Char.MinValue };
+            Verify(Convert.ToSByte, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromDecimal()
-    {
-        Decimal[] testValues = { 100m, -100m, 0m };
-        SByte[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToSByte, testValues, expectedValues);
+        [Fact]
+        public void FromDecimal()
+        {
+            Decimal[] testValues = { 100m, -100m, 0m };
+            SByte[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToSByte, testValues, expectedValues);
 
-        Decimal[] overflowValues = { Decimal.MaxValue, Decimal.MinValue };
-        VerifyThrows<OverflowException, Decimal>(Convert.ToSByte, overflowValues);
-    }
+            Decimal[] overflowValues = { Decimal.MaxValue, Decimal.MinValue };
+            VerifyThrows<OverflowException, Decimal>(Convert.ToSByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromDouble()
-    {
-        Double[] testValues = { 100.0, -100.0, 0 };
-        SByte[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToSByte, testValues, expectedValues);
+        [Fact]
+        public void FromDouble()
+        {
+            Double[] testValues = { 100.0, -100.0, 0 };
+            SByte[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToSByte, testValues, expectedValues);
 
-        Double[] overflowValues = { Double.MaxValue, Double.MinValue };
-        VerifyThrows<OverflowException, Double>(Convert.ToSByte, overflowValues);
-    }
+            Double[] overflowValues = { Double.MaxValue, Double.MinValue };
+            VerifyThrows<OverflowException, Double>(Convert.ToSByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt16()
-    {
-        Int16[] testValues = { 100, -100, 0 };
-        SByte[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToSByte, testValues, expectedValues);
+        [Fact]
+        public void FromInt16()
+        {
+            Int16[] testValues = { 100, -100, 0 };
+            SByte[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToSByte, testValues, expectedValues);
 
-        Int64[] overflowValues = { Int64.MaxValue, Int64.MinValue };
-        VerifyThrows<OverflowException, Int64>(Convert.ToSByte, overflowValues);
-    }
+            Int64[] overflowValues = { Int64.MaxValue, Int64.MinValue };
+            VerifyThrows<OverflowException, Int64>(Convert.ToSByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt32()
-    {
-        Int32[] testValues = { 100, -100, 0 };
-        SByte[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToSByte, testValues, expectedValues);
+        [Fact]
+        public void FromInt32()
+        {
+            Int32[] testValues = { 100, -100, 0 };
+            SByte[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToSByte, testValues, expectedValues);
 
-        Int32[] overflowValues = { Int32.MaxValue, Int32.MinValue };
-        VerifyThrows<OverflowException, Int32>(Convert.ToSByte, overflowValues);
-    }
+            Int32[] overflowValues = { Int32.MaxValue, Int32.MinValue };
+            VerifyThrows<OverflowException, Int32>(Convert.ToSByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt64()
-    {
-        Int64[] testValues = { 100, -100, 0 };
-        SByte[] expectedValues = { 100, -100, 0 };
-        Verify(Convert.ToSByte, testValues, expectedValues);
+        [Fact]
+        public void FromInt64()
+        {
+            Int64[] testValues = { 100, -100, 0 };
+            SByte[] expectedValues = { 100, -100, 0 };
+            Verify(Convert.ToSByte, testValues, expectedValues);
 
-        Int64[] overflowValues = { Int64.MaxValue, Int64.MinValue };
-        VerifyThrows<OverflowException, Int64>(Convert.ToSByte, overflowValues);
-    }
+            Int64[] overflowValues = { Int64.MaxValue, Int64.MinValue };
+            VerifyThrows<OverflowException, Int64>(Convert.ToSByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromObject()
-    {
-        Object[] testValues = { null };
-        SByte[] expectedValues = { 0 };
-        VerifyFromObject(Convert.ToSByte, Convert.ToSByte, testValues, expectedValues);
+        [Fact]
+        public void FromObject()
+        {
+            Object[] testValues = { null };
+            SByte[] expectedValues = { 0 };
+            VerifyFromObject(Convert.ToSByte, Convert.ToSByte, testValues, expectedValues);
 
-        Object[] invalidValues = { new Object(), DateTime.Now };
-        VerifyFromObjectThrows<InvalidCastException>(Convert.ToSByte, Convert.ToSByte, invalidValues);
-    }
+            Object[] invalidValues = { new Object(), DateTime.Now };
+            VerifyFromObjectThrows<InvalidCastException>(Convert.ToSByte, Convert.ToSByte, invalidValues);
+        }
 
-    [Fact]
-    public void FromSByte()
-    {
-        SByte[] testValues = { SByte.MaxValue, SByte.MinValue };
-        SByte[] expectedValues = { SByte.MaxValue, SByte.MinValue };
-        Verify(Convert.ToSByte, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromSByte()
+        {
+            SByte[] testValues = { SByte.MaxValue, SByte.MinValue };
+            SByte[] expectedValues = { SByte.MaxValue, SByte.MinValue };
+            Verify(Convert.ToSByte, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromSingle()
-    {
-        Single[] testValues = { 100.0f, -100.0f, 0.0f, };
-        SByte[] expectedValues = { 100, -100, 0, };
-        Verify(Convert.ToSByte, testValues, expectedValues);
+        [Fact]
+        public void FromSingle()
+        {
+            Single[] testValues = { 100.0f, -100.0f, 0.0f, };
+            SByte[] expectedValues = { 100, -100, 0, };
+            Verify(Convert.ToSByte, testValues, expectedValues);
 
-        Single[] overflowValues = { Single.MaxValue, Single.MinValue };
-        VerifyThrows<OverflowException, Single>(Convert.ToSByte, overflowValues);
-    }
+            Single[] overflowValues = { Single.MaxValue, Single.MinValue };
+            VerifyThrows<OverflowException, Single>(Convert.ToSByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromString()
-    {
-        String[] testValues = { "100", "-100", "0", SByte.MinValue.ToString(), SByte.MaxValue.ToString() };
-        SByte[] expectedValues = { 100, -100, 0, SByte.MinValue, SByte.MaxValue };
-        VerifyFromString(Convert.ToSByte, Convert.ToSByte, testValues, expectedValues);
+        [Fact]
+        public void FromString()
+        {
+            String[] testValues = { "100", "-100", "0", SByte.MinValue.ToString(), SByte.MaxValue.ToString() };
+            SByte[] expectedValues = { 100, -100, 0, SByte.MinValue, SByte.MaxValue };
+            VerifyFromString(Convert.ToSByte, Convert.ToSByte, testValues, expectedValues);
 
-        String[] overflowValues = { Int16.MinValue.ToString(), Int16.MaxValue.ToString() };
-        VerifyFromStringThrows<OverflowException>(Convert.ToSByte, Convert.ToSByte, overflowValues);
+            String[] overflowValues = { Int16.MinValue.ToString(), Int16.MaxValue.ToString() };
+            VerifyFromStringThrows<OverflowException>(Convert.ToSByte, Convert.ToSByte, overflowValues);
 
-        String[] formatExceptionValues = { "abba" };
-        VerifyFromStringThrows<FormatException>(Convert.ToSByte, Convert.ToSByte, formatExceptionValues);
+            String[] formatExceptionValues = { "abba" };
+            VerifyFromStringThrows<FormatException>(Convert.ToSByte, Convert.ToSByte, formatExceptionValues);
 
-        // Note: Only the Convert.ToSByte(String, IFormatProvider) overload throws an ArgumentNullException.
-        // This is inconsistent with the other numeric conversions, but fixing this behavior is not worth making
-        // a breaking change which will affect the desktop CLR.
-        Assert.Throws<ArgumentNullException>(() => Convert.ToSByte((String)null, TestFormatProvider.s_instance));
-    }
+            // Note: Only the Convert.ToSByte(String, IFormatProvider) overload throws an ArgumentNullException.
+            // This is inconsistent with the other numeric conversions, but fixing this behavior is not worth making
+            // a breaking change which will affect the desktop CLR.
+            Assert.Throws<ArgumentNullException>(() => Convert.ToSByte((String)null, TestFormatProvider.s_instance));
+        }
 
-    [Fact]
-    public void FromStringWithBase()
-    {
-        String[] testValues = { null, null, null, null, "7f", "127", "177", "1111111", "80", "-128", "200", "10000000" };
-        Int32[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2 };
-        SByte[] expectedValues = { 0, 0, 0, 0, SByte.MaxValue, SByte.MaxValue, SByte.MaxValue, SByte.MaxValue, SByte.MinValue, SByte.MinValue, SByte.MinValue, SByte.MinValue };
-        VerifyFromStringWithBase(Convert.ToSByte, testValues, testBases, expectedValues);
+        [Fact]
+        public void FromStringWithBase()
+        {
+            String[] testValues = { null, null, null, null, "7f", "127", "177", "1111111", "80", "-128", "200", "10000000" };
+            Int32[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2 };
+            SByte[] expectedValues = { 0, 0, 0, 0, SByte.MaxValue, SByte.MaxValue, SByte.MaxValue, SByte.MaxValue, SByte.MinValue, SByte.MinValue, SByte.MinValue, SByte.MinValue };
+            VerifyFromStringWithBase(Convert.ToSByte, testValues, testBases, expectedValues);
 
-        String[] overflowValues = { "128", "-129", "111111111", "1FF", "777" };
-        Int32[] overflowBases = { 10, 10, 2, 16, 8 };
-        VerifyFromStringWithBaseThrows<OverflowException>(Convert.ToSByte, overflowValues, overflowBases);
+            String[] overflowValues = { "128", "-129", "111111111", "1FF", "777" };
+            Int32[] overflowBases = { 10, 10, 2, 16, 8 };
+            VerifyFromStringWithBaseThrows<OverflowException>(Convert.ToSByte, overflowValues, overflowBases);
 
-        String[] formatExceptionValues = { "12", "ffffffffffffffffffff" };
-        Int32[] formatExceptionBases = { 2, 8 };
-        VerifyFromStringWithBaseThrows<FormatException>(Convert.ToSByte, formatExceptionValues, formatExceptionBases);
+            String[] formatExceptionValues = { "12", "ffffffffffffffffffff" };
+            Int32[] formatExceptionBases = { 2, 8 };
+            VerifyFromStringWithBaseThrows<FormatException>(Convert.ToSByte, formatExceptionValues, formatExceptionBases);
 
-        String[] argumentExceptionValues = { "10", "11", "abba", "-ab" };
-        Int32[] argumentExceptionBases = { -1, 3, 0, 16 };
-        VerifyFromStringWithBaseThrows<ArgumentException>(Convert.ToSByte, argumentExceptionValues, argumentExceptionBases);
-    }
+            String[] argumentExceptionValues = { "10", "11", "abba", "-ab" };
+            Int32[] argumentExceptionBases = { -1, 3, 0, 16 };
+            VerifyFromStringWithBaseThrows<ArgumentException>(Convert.ToSByte, argumentExceptionValues, argumentExceptionBases);
+        }
 
-    [Fact]
-    public void FromUInt16()
-    {
-        UInt16[] testValues = { 100, 0 };
-        SByte[] expectedValues = { 100, 0 };
-        Verify(Convert.ToSByte, testValues, expectedValues);
+        [Fact]
+        public void FromUInt16()
+        {
+            UInt16[] testValues = { 100, 0 };
+            SByte[] expectedValues = { 100, 0 };
+            Verify(Convert.ToSByte, testValues, expectedValues);
 
-        UInt16[] overflowValues = { UInt16.MaxValue };
-        VerifyThrows<OverflowException, UInt16>(Convert.ToSByte, overflowValues);
-    }
+            UInt16[] overflowValues = { UInt16.MaxValue };
+            VerifyThrows<OverflowException, UInt16>(Convert.ToSByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromUInt32()
-    {
-        UInt32[] testValues = { 100, 0 };
-        SByte[] expectedValues = { 100, 0 };
-        Verify(Convert.ToSByte, testValues, expectedValues);
+        [Fact]
+        public void FromUInt32()
+        {
+            UInt32[] testValues = { 100, 0 };
+            SByte[] expectedValues = { 100, 0 };
+            Verify(Convert.ToSByte, testValues, expectedValues);
 
-        UInt32[] overflowValues = { UInt32.MaxValue };
-        VerifyThrows<OverflowException, UInt32>(Convert.ToSByte, overflowValues);
-    }
+            UInt32[] overflowValues = { UInt32.MaxValue };
+            VerifyThrows<OverflowException, UInt32>(Convert.ToSByte, overflowValues);
+        }
 
-    [Fact]
-    public void FromUInt64()
-    {
-        UInt64[] testValues = { 100, 0 };
-        SByte[] expectedValues = { 100, 0 };
-        Verify(Convert.ToSByte, testValues, expectedValues);
+        [Fact]
+        public void FromUInt64()
+        {
+            UInt64[] testValues = { 100, 0 };
+            SByte[] expectedValues = { 100, 0 };
+            Verify(Convert.ToSByte, testValues, expectedValues);
 
-        UInt64[] overflowValues = { UInt64.MaxValue };
-        VerifyThrows<OverflowException, UInt64>(Convert.ToSByte, overflowValues);
+            UInt64[] overflowValues = { UInt64.MaxValue };
+            VerifyThrows<OverflowException, UInt64>(Convert.ToSByte, overflowValues);
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToSingle.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToSingle.cs
@@ -2,129 +2,131 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public class ConvertToSingleTests : ConvertTestBase<Single>
+namespace System.Tests
 {
-    [Fact]
-    public void FromBoolean()
+    public class ConvertToSingleTests : ConvertTestBase<Single>
     {
-        Boolean[] testValues = { false, true };
-        Single[] expectedValues = { 0.0f, 1.0f };
-        Verify(Convert.ToSingle, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromBoolean()
+        {
+            Boolean[] testValues = { false, true };
+            Single[] expectedValues = { 0.0f, 1.0f };
+            Verify(Convert.ToSingle, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromByte()
-    {
-        Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
-        Single[] expectedValues = { Byte.MaxValue, Byte.MinValue };
-        Verify(Convert.ToSingle, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromByte()
+        {
+            Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
+            Single[] expectedValues = { Byte.MaxValue, Byte.MinValue };
+            Verify(Convert.ToSingle, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromDecimal()
-    {
-        Decimal[] testValues = { 1000m, 0m, -1000m, Decimal.MaxValue, Decimal.MinValue };
-        Single[] expectedValues = { 1000f, 0.0f, -1000f, (Single)Decimal.MaxValue, (Single)Decimal.MinValue };
-        Verify(Convert.ToSingle, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromDecimal()
+        {
+            Decimal[] testValues = { 1000m, 0m, -1000m, Decimal.MaxValue, Decimal.MinValue };
+            Single[] expectedValues = { 1000f, 0.0f, -1000f, (Single)Decimal.MaxValue, (Single)Decimal.MinValue };
+            Verify(Convert.ToSingle, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromDouble()
-    {
-        Double[] testValues = { 1000.0, 100.0, 0.0, -100.0, -1000.0, Double.MaxValue, Double.MinValue };
-        Single[] expectedValues = { 1000.0f, 100.0f, 0.0f, -100.0f, -1000.0f, Single.PositiveInfinity, Single.NegativeInfinity };
-        Verify(Convert.ToSingle, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromDouble()
+        {
+            Double[] testValues = { 1000.0, 100.0, 0.0, -100.0, -1000.0, Double.MaxValue, Double.MinValue };
+            Single[] expectedValues = { 1000.0f, 100.0f, 0.0f, -100.0f, -1000.0f, Single.PositiveInfinity, Single.NegativeInfinity };
+            Verify(Convert.ToSingle, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromInt16()
-    {
-        Int16[] testValues = { Int16.MaxValue, Int16.MinValue, 0 };
-        Single[] expectedValues = { Int16.MaxValue, Int16.MinValue, 0f };
-        Verify(Convert.ToSingle, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt16()
+        {
+            Int16[] testValues = { Int16.MaxValue, Int16.MinValue, 0 };
+            Single[] expectedValues = { Int16.MaxValue, Int16.MinValue, 0f };
+            Verify(Convert.ToSingle, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromInt32()
-    {
-        Int32[] testValues = { Int32.MaxValue, Int32.MinValue, 0 };
-        Single[] expectedValues = { Int32.MaxValue, Int32.MinValue, 0f };
-        Verify(Convert.ToSingle, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt32()
+        {
+            Int32[] testValues = { Int32.MaxValue, Int32.MinValue, 0 };
+            Single[] expectedValues = { Int32.MaxValue, Int32.MinValue, 0f };
+            Verify(Convert.ToSingle, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromInt64()
-    {
-        Int64[] testValues = { Int64.MaxValue, Int64.MinValue, 0 };
-        Single[] expectedValues = { Int64.MaxValue, Int64.MinValue, 0f };
-        Verify(Convert.ToSingle, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromInt64()
+        {
+            Int64[] testValues = { Int64.MaxValue, Int64.MinValue, 0 };
+            Single[] expectedValues = { Int64.MaxValue, Int64.MinValue, 0f };
+            Verify(Convert.ToSingle, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromObject()
-    {
-        Object[] testValues = { null };
-        Single[] expectedValues = { 0f };
-        VerifyFromObject(Convert.ToSingle, Convert.ToSingle, testValues, expectedValues);
+        [Fact]
+        public void FromObject()
+        {
+            Object[] testValues = { null };
+            Single[] expectedValues = { 0f };
+            VerifyFromObject(Convert.ToSingle, Convert.ToSingle, testValues, expectedValues);
 
-        Object[] invalidValues = { new Object(), DateTime.Now };
-        VerifyFromObjectThrows<InvalidCastException>(Convert.ToSingle, Convert.ToSingle, invalidValues);
-    }
+            Object[] invalidValues = { new Object(), DateTime.Now };
+            VerifyFromObjectThrows<InvalidCastException>(Convert.ToSingle, Convert.ToSingle, invalidValues);
+        }
 
-    [Fact]
-    public void FromSByte()
-    {
-        SByte[] testValues = { 100, -100, 0 };
-        Single[] expectedValues = { 100f, -100f, 0f };
-        Verify(Convert.ToSingle, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromSByte()
+        {
+            SByte[] testValues = { 100, -100, 0 };
+            Single[] expectedValues = { 100f, -100f, 0f };
+            Verify(Convert.ToSingle, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromSingle()
-    {
-        Single[] testValues = { Single.MaxValue, Single.MinValue, new Single(), Single.NegativeInfinity, Single.PositiveInfinity, Single.Epsilon };
-        Single[] expectedValues = { Single.MaxValue, Single.MinValue, new Single(), Single.NegativeInfinity, Single.PositiveInfinity, Single.Epsilon };
-        Verify(Convert.ToSingle, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromSingle()
+        {
+            Single[] testValues = { Single.MaxValue, Single.MinValue, new Single(), Single.NegativeInfinity, Single.PositiveInfinity, Single.Epsilon };
+            Single[] expectedValues = { Single.MaxValue, Single.MinValue, new Single(), Single.NegativeInfinity, Single.PositiveInfinity, Single.Epsilon };
+            Verify(Convert.ToSingle, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromString()
-    {
-        String[] testValues = { Single.MaxValue.ToString("R"), (0f).ToString(), Single.MinValue.ToString("R"), null };
-        Single[] expectedValues = { Single.MaxValue, 0f, Single.MinValue, 0f };
-        VerifyFromString(Convert.ToSingle, Convert.ToSingle, testValues, expectedValues);
+        [Fact]
+        public void FromString()
+        {
+            String[] testValues = { Single.MaxValue.ToString("R"), (0f).ToString(), Single.MinValue.ToString("R"), null };
+            Single[] expectedValues = { Single.MaxValue, 0f, Single.MinValue, 0f };
+            VerifyFromString(Convert.ToSingle, Convert.ToSingle, testValues, expectedValues);
 
-        String[] overflowValues = { Double.MinValue.ToString(), Double.MaxValue.ToString() };
-        VerifyFromStringThrows<OverflowException>(Convert.ToSingle, Convert.ToSingle, overflowValues);
+            String[] overflowValues = { Double.MinValue.ToString(), Double.MaxValue.ToString() };
+            VerifyFromStringThrows<OverflowException>(Convert.ToSingle, Convert.ToSingle, overflowValues);
 
-        String[] formatExceptionValues = { "1f2d" };
-        VerifyFromStringThrows<FormatException>(Convert.ToSingle, Convert.ToSingle, formatExceptionValues);
-    }
+            String[] formatExceptionValues = { "1f2d" };
+            VerifyFromStringThrows<FormatException>(Convert.ToSingle, Convert.ToSingle, formatExceptionValues);
+        }
 
-    [Fact]
-    public void FromUInt16()
-    {
-        UInt16[] testValues = { UInt16.MaxValue, UInt16.MinValue, };
-        Single[] expectedValues = { UInt16.MaxValue, UInt16.MinValue };
-        Verify(Convert.ToSingle, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt16()
+        {
+            UInt16[] testValues = { UInt16.MaxValue, UInt16.MinValue, };
+            Single[] expectedValues = { UInt16.MaxValue, UInt16.MinValue };
+            Verify(Convert.ToSingle, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt32()
-    {
-        UInt32[] testValues = { UInt32.MaxValue, UInt32.MinValue };
-        Single[] expectedValues = { UInt32.MaxValue, UInt32.MinValue };
-        Verify(Convert.ToSingle, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt32()
+        {
+            UInt32[] testValues = { UInt32.MaxValue, UInt32.MinValue };
+            Single[] expectedValues = { UInt32.MaxValue, UInt32.MinValue };
+            Verify(Convert.ToSingle, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt64()
-    {
-        UInt64[] testValues = { UInt64.MaxValue, UInt64.MinValue };
-        Single[] expectedValues = { UInt64.MaxValue, UInt64.MinValue };
-        Verify(Convert.ToSingle, testValues, expectedValues);
+        [Fact]
+        public void FromUInt64()
+        {
+            UInt64[] testValues = { UInt64.MaxValue, UInt64.MinValue };
+            Single[] expectedValues = { UInt64.MaxValue, UInt64.MinValue };
+            Verify(Convert.ToSingle, testValues, expectedValues);
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToString.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToString.cs
@@ -2,17 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Globalization;
 using Xunit;
 
-public class ConvertToStringTests
+namespace System.Tests
 {
-    [Fact]
-    public static void FromBoxedObject()
+    public class ConvertToStringTests
     {
-        Object[] testValues =
+        [Fact]
+        public static void FromBoxedObject()
         {
+            Object[] testValues =
+            {
             // Boolean
             true,
             false,
@@ -95,8 +96,8 @@ public class ConvertToStringTests
             UInt64.MaxValue
         };
 
-        String[] expectedValues =
-        {
+            String[] expectedValues =
+            {
             // Boolean
             "True",
             "False",
@@ -179,539 +180,540 @@ public class ConvertToStringTests
             "18446744073709551615",
         };
 
-        for (int i = 0; i < testValues.Length; i++)
-        {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], NumberFormatInfo.InvariantInfo));
-        }
-    }
-
-    [Fact]
-    public static void FromObject()
-    {
-        Assert.Equal("ConvertToStringTests", Convert.ToString(new ConvertToStringTests()));
-    }
-
-    [Fact]
-    public static void FromDateTime()
-    {
-        DateTime[] testValues = { new DateTime(2000, 8, 15, 16, 59, 59), new DateTime(1, 1, 1, 1, 1, 1) };
-        string[] expectedValues = { "08/15/2000 16:59:59", "01/01/0001 01:01:01" };
-
-        for (int i = 0; i < testValues.Length; i++)
-        {
-            Assert.Equal(testValues[i].ToString(), Convert.ToString(testValues[i]));
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], DateTimeFormatInfo.InvariantInfo));
-        }
-    }
-
-    [Fact]
-    public static void FromChar()
-    {
-        Char[] testValues = { 'a', 'A', '@', '\n' };
-        String[] expectedValues = { "a", "A", "@", "\n" };
-
-        for (int i = 0; i < testValues.Length; i++)
-        {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i]));
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], CultureInfo.InvariantCulture));
-        }
-    }
-
-    private static void Verify<TInput>(Func<TInput, String> convert, Func<TInput, IFormatProvider, String> convertWithFormatProvider, TInput[] testValues, String[] expectedValues, IFormatProvider formatProvider = null)
-    {
-        Assert.Equal(expectedValues.Length, testValues.Length);
-
-        if (formatProvider == null)
-        {
-            formatProvider = CultureInfo.InvariantCulture;
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], NumberFormatInfo.InvariantInfo));
+            }
         }
 
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromObject()
         {
-            Assert.Equal(expectedValues[i], convert(testValues[i]));
-            Assert.Equal(expectedValues[i], convertWithFormatProvider(testValues[i], formatProvider));
+            Assert.Equal("System.Tests.ConvertToStringTests", Convert.ToString(new ConvertToStringTests()));
         }
-    }
 
-    [Fact]
-    public static void FromByteBase2()
-    {
-        Byte[] testValues = { Byte.MinValue, 100, Byte.MaxValue };
-        String[] expectedValues = { "0", "1100100", "11111111" };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromDateTime()
         {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 2));
+            DateTime[] testValues = { new DateTime(2000, 8, 15, 16, 59, 59), new DateTime(1, 1, 1, 1, 1, 1) };
+            string[] expectedValues = { "08/15/2000 16:59:59", "01/01/0001 01:01:01" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(testValues[i].ToString(), Convert.ToString(testValues[i]));
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], DateTimeFormatInfo.InvariantInfo));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromByteBase8()
-    {
-        Byte[] testValues = { Byte.MinValue, 100, Byte.MaxValue };
-        String[] expectedValues = { "0", "144", "377" };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromChar()
         {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 8));
+            Char[] testValues = { 'a', 'A', '@', '\n' };
+            String[] expectedValues = { "a", "A", "@", "\n" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i]));
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], CultureInfo.InvariantCulture));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromByteBase10()
-    {
-        Byte[] testValues = { Byte.MinValue, 100, Byte.MaxValue };
-        String[] expectedValues = { "0", "100", "255" };
-
-        for (int i = 0; i < testValues.Length; i++)
+        private static void Verify<TInput>(Func<TInput, String> convert, Func<TInput, IFormatProvider, String> convertWithFormatProvider, TInput[] testValues, String[] expectedValues, IFormatProvider formatProvider = null)
         {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 10));
+            Assert.Equal(expectedValues.Length, testValues.Length);
+
+            if (formatProvider == null)
+            {
+                formatProvider = CultureInfo.InvariantCulture;
+            }
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], convert(testValues[i]));
+                Assert.Equal(expectedValues[i], convertWithFormatProvider(testValues[i], formatProvider));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromByteBase16()
-    {
-        Byte[] testValues = { Byte.MinValue, 100, Byte.MaxValue };
-        String[] expectedValues = { "0", "64", "ff" };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromByteBase2()
         {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 16));
+            Byte[] testValues = { Byte.MinValue, 100, Byte.MaxValue };
+            String[] expectedValues = { "0", "1100100", "11111111" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 2));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromByteInvalidBase()
-    {
-        Assert.Throws<ArgumentException>(() => Convert.ToString(Byte.MaxValue, 13));
-    }
-
-    [Fact]
-    public static void FromInt16Base2()
-    {
-        Int16[] testValues = { Int16.MinValue, 0, Int16.MaxValue };
-        String[] expectedValues = { "1000000000000000", "0", "111111111111111" };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromByteBase8()
         {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 2));
+            Byte[] testValues = { Byte.MinValue, 100, Byte.MaxValue };
+            String[] expectedValues = { "0", "144", "377" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 8));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromInt16Base8()
-    {
-        Int16[] testValues = { Int16.MinValue, 0, Int16.MaxValue };
-        String[] expectedValues = { "100000", "0", "77777" };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromByteBase10()
         {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 8));
+            Byte[] testValues = { Byte.MinValue, 100, Byte.MaxValue };
+            String[] expectedValues = { "0", "100", "255" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 10));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromInt16Base10()
-    {
-        Int16[] testValues = { Int16.MinValue, 0, Int16.MaxValue };
-        String[] expectedValues = { "-32768", "0", "32767" };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromByteBase16()
         {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 10));
+            Byte[] testValues = { Byte.MinValue, 100, Byte.MaxValue };
+            String[] expectedValues = { "0", "64", "ff" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 16));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromInt16Base16()
-    {
-        Int16[] testValues = { Int16.MinValue, 0, Int16.MaxValue };
-        String[] expectedValues = { "8000", "0", "7fff" };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromByteInvalidBase()
         {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 16));
+            Assert.Throws<ArgumentException>(() => Convert.ToString(Byte.MaxValue, 13));
         }
-    }
 
-    [Fact]
-    public static void FromInt16InvalidBase()
-    {
-        Assert.Throws<ArgumentException>(() => Convert.ToString(Int16.MaxValue, 0));
-    }
-
-    [Fact]
-    public static void FromInt32Base2()
-    {
-        Int32[] testValues = { Int32.MinValue, 0, Int32.MaxValue };
-        String[] expectedValues = { "10000000000000000000000000000000", "0", "1111111111111111111111111111111" };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromInt16Base2()
         {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 2));
+            Int16[] testValues = { Int16.MinValue, 0, Int16.MaxValue };
+            String[] expectedValues = { "1000000000000000", "0", "111111111111111" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 2));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromInt32Base8()
-    {
-        Int32[] testValues = { Int32.MinValue, 0, Int32.MaxValue };
-        String[] expectedValues = { "20000000000", "0", "17777777777" };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromInt16Base8()
         {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 8));
+            Int16[] testValues = { Int16.MinValue, 0, Int16.MaxValue };
+            String[] expectedValues = { "100000", "0", "77777" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 8));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromInt32Base10()
-    {
-        Int32[] testValues = { Int32.MinValue, 0, Int32.MaxValue };
-        String[] expectedValues = { "-2147483648", "0", "2147483647" };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromInt16Base10()
         {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 10));
+            Int16[] testValues = { Int16.MinValue, 0, Int16.MaxValue };
+            String[] expectedValues = { "-32768", "0", "32767" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 10));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromInt32Base16()
-    {
-        Int32[] testValues = { Int32.MinValue, 0, Int32.MaxValue };
-        String[] expectedValues = { "80000000", "0", "7fffffff" };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromInt16Base16()
         {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 16));
+            Int16[] testValues = { Int16.MinValue, 0, Int16.MaxValue };
+            String[] expectedValues = { "8000", "0", "7fff" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 16));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromInt32InvalidBase()
-    {
-        Assert.Throws<ArgumentException>(() => Convert.ToString(Int32.MaxValue, 9));
-    }
-
-    [Fact]
-    public static void FromInt64Base2()
-    {
-        Int64[] testValues = { Int64.MinValue, 0, Int64.MaxValue };
-        String[] expectedValues = { "1000000000000000000000000000000000000000000000000000000000000000", "0", "111111111111111111111111111111111111111111111111111111111111111" };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromInt16InvalidBase()
         {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 2));
+            Assert.Throws<ArgumentException>(() => Convert.ToString(Int16.MaxValue, 0));
         }
-    }
 
-    [Fact]
-    public static void FromInt64Base8()
-    {
-        Int64[] testValues = { Int64.MinValue, 0, Int64.MaxValue };
-        String[] expectedValues = { "1000000000000000000000", "0", "777777777777777777777" };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromInt32Base2()
         {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 8));
+            Int32[] testValues = { Int32.MinValue, 0, Int32.MaxValue };
+            String[] expectedValues = { "10000000000000000000000000000000", "0", "1111111111111111111111111111111" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 2));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromInt64Base10()
-    {
-        Int64[] testValues = { Int64.MinValue, 0, Int64.MaxValue };
-        String[] expectedValues = { "-9223372036854775808", "0", "9223372036854775807" };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromInt32Base8()
         {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 10));
+            Int32[] testValues = { Int32.MinValue, 0, Int32.MaxValue };
+            String[] expectedValues = { "20000000000", "0", "17777777777" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 8));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromInt64Base16()
-    {
-        Int64[] testValues = { Int64.MinValue, 0, Int64.MaxValue };
-        String[] expectedValues = { "8000000000000000", "0", "7fffffffffffffff" };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromInt32Base10()
         {
-            Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 16));
+            Int32[] testValues = { Int32.MinValue, 0, Int32.MaxValue };
+            String[] expectedValues = { "-2147483648", "0", "2147483647" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 10));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromInt64InvalidBase()
-    {
-        Assert.Throws<ArgumentException>(() => Convert.ToString(Int64.MaxValue, 1));
-    }
-
-    [Fact]
-    public static void FromBoolean()
-    {
-        Boolean[] testValues = new[] { true, false };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromInt32Base16()
         {
-            string expected = testValues[i].ToString();
-            string actual = Convert.ToString(testValues[i]);
-            Assert.Equal(expected, actual);
-            actual = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
-            Assert.Equal(expected, actual);
+            Int32[] testValues = { Int32.MinValue, 0, Int32.MaxValue };
+            String[] expectedValues = { "80000000", "0", "7fffffff" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 16));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromSByte()
-    {
-        SByte[] testValues = new SByte[] { SByte.MinValue, -1, 0, 1, SByte.MaxValue };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromInt32InvalidBase()
         {
-            String result = Convert.ToString(testValues[i]);
-            Assert.Equal(testValues[i].ToString(), result);
-            result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
-            Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            Assert.Throws<ArgumentException>(() => Convert.ToString(Int32.MaxValue, 9));
         }
-    }
 
-    [Fact]
-    public static void FromByte()
-    {
-        Byte[] testValues = new Byte[] { Byte.MinValue, 0, 1, 100, Byte.MaxValue };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromInt64Base2()
         {
-            String result = Convert.ToString(testValues[i]);
-            Assert.Equal(testValues[i].ToString(), result);
-            result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
-            Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            Int64[] testValues = { Int64.MinValue, 0, Int64.MaxValue };
+            String[] expectedValues = { "1000000000000000000000000000000000000000000000000000000000000000", "0", "111111111111111111111111111111111111111111111111111111111111111" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 2));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromInt16Array()
-    {
-        Int16[] testValues = new Int16[] { Int16.MinValue, -1000, -1, 0, 1, 1000, Int16.MaxValue };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromInt64Base8()
         {
-            String result = Convert.ToString(testValues[i]);
-            Assert.Equal(testValues[i].ToString(), result);
-            result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
-            Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            Int64[] testValues = { Int64.MinValue, 0, Int64.MaxValue };
+            String[] expectedValues = { "1000000000000000000000", "0", "777777777777777777777" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 8));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromUInt16Array()
-    {
-        UInt16[] testValues = new UInt16[] { UInt16.MinValue, 0, 1, 1000, UInt16.MaxValue };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromInt64Base10()
         {
-            String result = Convert.ToString(testValues[i]);
-            Assert.Equal(testValues[i].ToString(), result);
-            result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
-            Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            Int64[] testValues = { Int64.MinValue, 0, Int64.MaxValue };
+            String[] expectedValues = { "-9223372036854775808", "0", "9223372036854775807" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 10));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromInt32Array()
-    {
-        Int32[] testValues = new Int32[] { Int32.MinValue, -1000, -1, 0, 1, 1000, Int32.MaxValue };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromInt64Base16()
         {
-            String result = Convert.ToString(testValues[i]);
-            Assert.Equal(testValues[i].ToString(), result);
-            result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
-            Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            Int64[] testValues = { Int64.MinValue, 0, Int64.MaxValue };
+            String[] expectedValues = { "8000000000000000", "0", "7fffffffffffffff" };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], Convert.ToString(testValues[i], 16));
+            }
         }
-    }
 
-    [Fact]
-    public static void FromUInt32Array()
-    {
-        UInt32[] testValues = new UInt32[] { UInt32.MinValue, 0, 1, 1000, UInt32.MaxValue };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromInt64InvalidBase()
         {
-            String result = Convert.ToString(testValues[i]);
-            Assert.Equal(testValues[i].ToString(), result);
-            result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
-            Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            Assert.Throws<ArgumentException>(() => Convert.ToString(Int64.MaxValue, 1));
         }
-    }
 
-    [Fact]
-    public static void FromInt64Array()
-    {
-        Int64[] testValues = new Int64[] { Int64.MinValue, -1000, -1, 0, 1, 1000, Int64.MaxValue };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromBoolean()
         {
-            String result = Convert.ToString(testValues[i]);
-            Assert.Equal(testValues[i].ToString(), result);
-            result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
-            Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            Boolean[] testValues = new[] { true, false };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                string expected = testValues[i].ToString();
+                string actual = Convert.ToString(testValues[i]);
+                Assert.Equal(expected, actual);
+                actual = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
+                Assert.Equal(expected, actual);
+            }
         }
-    }
 
-    [Fact]
-    public static void FromUInt64Array()
-    {
-        UInt64[] testValues = new UInt64[] { UInt64.MinValue, 0, 1, 1000, UInt64.MaxValue };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromSByte()
         {
-            String result = Convert.ToString(testValues[i]);
-            Assert.Equal(testValues[i].ToString(), result);
-            result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
-            Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            SByte[] testValues = new SByte[] { SByte.MinValue, -1, 0, 1, SByte.MaxValue };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                String result = Convert.ToString(testValues[i]);
+                Assert.Equal(testValues[i].ToString(), result);
+                result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
+                Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            }
         }
-    }
 
-    [Fact]
-    public static void FromSingleArray()
-    {
-        Single[] testValues = new Single[] { Single.MinValue, 0.0f, 1.0f, 1000.0f, Single.MaxValue, Single.NegativeInfinity, Single.PositiveInfinity, Single.Epsilon, Single.NaN };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromByte()
         {
-            String result = Convert.ToString(testValues[i]);
-            Assert.Equal(testValues[i].ToString(), result);
-            result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
-            Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            Byte[] testValues = new Byte[] { Byte.MinValue, 0, 1, 100, Byte.MaxValue };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                String result = Convert.ToString(testValues[i]);
+                Assert.Equal(testValues[i].ToString(), result);
+                result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
+                Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            }
         }
-    }
 
-    [Fact]
-    public static void FromDoubleArray()
-    {
-        Double[] testValues = new Double[] { Double.MinValue, 0.0, 1.0, 1000.0, Double.MaxValue, Double.NegativeInfinity, Double.PositiveInfinity, Double.Epsilon, Double.NaN };
-
-        // Vanila Test Cases
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromInt16Array()
         {
-            String result = Convert.ToString(testValues[i]);
-            Assert.Equal(testValues[i].ToString(), result);
-            result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
-            Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            Int16[] testValues = new Int16[] { Int16.MinValue, -1000, -1, 0, 1, 1000, Int16.MaxValue };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                String result = Convert.ToString(testValues[i]);
+                Assert.Equal(testValues[i].ToString(), result);
+                result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
+                Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            }
         }
-    }
 
-    [Fact]
-    public static void FromDecimalArray()
-    {
-        Decimal[] testValues = new Decimal[] { Decimal.MinValue, Decimal.Parse("-1.234567890123456789012345678", NumberFormatInfo.InvariantInfo), (Decimal)0.0, (Decimal)1.0, (Decimal)1000.0, Decimal.MaxValue, Decimal.One, Decimal.Zero, Decimal.MinusOne };
-
-        for (int i = 0; i < testValues.Length; i++)
+        [Fact]
+        public static void FromUInt16Array()
         {
-            String result = Convert.ToString(testValues[i]);
-            Assert.Equal(testValues[i].ToString(), result);
-            result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
-            Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
-        }
-    }
+            UInt16[] testValues = new UInt16[] { UInt16.MinValue, 0, 1, 1000, UInt16.MaxValue };
 
-    [Fact]
-    public static void FromDateTimeArray()
-    {
-        DateTime[] testValues = new DateTime[] {
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                String result = Convert.ToString(testValues[i]);
+                Assert.Equal(testValues[i].ToString(), result);
+                result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
+                Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            }
+        }
+
+        [Fact]
+        public static void FromInt32Array()
+        {
+            Int32[] testValues = new Int32[] { Int32.MinValue, -1000, -1, 0, 1, 1000, Int32.MaxValue };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                String result = Convert.ToString(testValues[i]);
+                Assert.Equal(testValues[i].ToString(), result);
+                result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
+                Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            }
+        }
+
+        [Fact]
+        public static void FromUInt32Array()
+        {
+            UInt32[] testValues = new UInt32[] { UInt32.MinValue, 0, 1, 1000, UInt32.MaxValue };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                String result = Convert.ToString(testValues[i]);
+                Assert.Equal(testValues[i].ToString(), result);
+                result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
+                Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            }
+        }
+
+        [Fact]
+        public static void FromInt64Array()
+        {
+            Int64[] testValues = new Int64[] { Int64.MinValue, -1000, -1, 0, 1, 1000, Int64.MaxValue };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                String result = Convert.ToString(testValues[i]);
+                Assert.Equal(testValues[i].ToString(), result);
+                result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
+                Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            }
+        }
+
+        [Fact]
+        public static void FromUInt64Array()
+        {
+            UInt64[] testValues = new UInt64[] { UInt64.MinValue, 0, 1, 1000, UInt64.MaxValue };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                String result = Convert.ToString(testValues[i]);
+                Assert.Equal(testValues[i].ToString(), result);
+                result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
+                Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            }
+        }
+
+        [Fact]
+        public static void FromSingleArray()
+        {
+            Single[] testValues = new Single[] { Single.MinValue, 0.0f, 1.0f, 1000.0f, Single.MaxValue, Single.NegativeInfinity, Single.PositiveInfinity, Single.Epsilon, Single.NaN };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                String result = Convert.ToString(testValues[i]);
+                Assert.Equal(testValues[i].ToString(), result);
+                result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
+                Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            }
+        }
+
+        [Fact]
+        public static void FromDoubleArray()
+        {
+            Double[] testValues = new Double[] { Double.MinValue, 0.0, 1.0, 1000.0, Double.MaxValue, Double.NegativeInfinity, Double.PositiveInfinity, Double.Epsilon, Double.NaN };
+
+            // Vanila Test Cases
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                String result = Convert.ToString(testValues[i]);
+                Assert.Equal(testValues[i].ToString(), result);
+                result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
+                Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            }
+        }
+
+        [Fact]
+        public static void FromDecimalArray()
+        {
+            Decimal[] testValues = new Decimal[] { Decimal.MinValue, Decimal.Parse("-1.234567890123456789012345678", NumberFormatInfo.InvariantInfo), (Decimal)0.0, (Decimal)1.0, (Decimal)1000.0, Decimal.MaxValue, Decimal.One, Decimal.Zero, Decimal.MinusOne };
+
+            for (int i = 0; i < testValues.Length; i++)
+            {
+                String result = Convert.ToString(testValues[i]);
+                Assert.Equal(testValues[i].ToString(), result);
+                result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
+                Assert.Equal(testValues[i].ToString(NumberFormatInfo.CurrentInfo), result);
+            }
+        }
+
+        [Fact]
+        public static void FromDateTimeArray()
+        {
+            DateTime[] testValues = new DateTime[] {
             DateTime.Parse("08/15/2000 16:59:59", DateTimeFormatInfo.InvariantInfo),
             DateTime.Parse("01/01/0001 01:01:01", DateTimeFormatInfo.InvariantInfo) };
 
-        IFormatProvider formatProvider = DateTimeFormatInfo.GetInstance(new CultureInfo("en-US"));
+            IFormatProvider formatProvider = DateTimeFormatInfo.GetInstance(new CultureInfo("en-US"));
 
-        for (int i = 0; i < testValues.Length; i++)
-        {
-            String result = Convert.ToString(testValues[i]);
-            Assert.Equal(testValues[i].ToString(), result);
-            result = Convert.ToString(testValues[i], formatProvider);
-            String expected = testValues[i].ToString(formatProvider);
-            Assert.Equal(expected, result);
-        }
-    }
-
-    [Fact]
-    public static void FromString()
-    {
-        String[] testValues = new String[] { "Hello", " ", "", "\0" };
-
-        for (int i = 0; i < testValues.Length; i++)
-        {
-            String result = Convert.ToString(testValues[i]);
-            Assert.Equal(testValues[i].ToString(), result);
-            result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
-            Assert.Equal(testValues[i].ToString(), result);
-        }
-    }
-
-    [Fact]
-    public static void FromIFormattable()
-    {
-        FooFormattable foo = new FooFormattable(3);
-        String result = Convert.ToString(foo);
-        Assert.Equal("FooFormattable: 3", result);
-        result = Convert.ToString(foo, NumberFormatInfo.CurrentInfo);
-        Assert.Equal("System.Globalization.NumberFormatInfo: 3", result);
-
-        foo = null;
-        result = Convert.ToString(foo, NumberFormatInfo.CurrentInfo);
-        Assert.Equal("", result);
-    }
-
-    [Fact]
-    public static void FromNonIConvertible()
-    {
-        Foo foo = new Foo(3);
-        String result = Convert.ToString(foo);
-        Assert.Equal("ConvertToStringTests+Foo", result);
-        result = Convert.ToString(foo, NumberFormatInfo.CurrentInfo);
-        Assert.Equal("ConvertToStringTests+Foo", result);
-
-        foo = null;
-        result = Convert.ToString(foo, NumberFormatInfo.CurrentInfo);
-        Assert.Equal("", result);
-    }
-
-    private class FooFormattable : IFormattable
-    {
-        private int _value;
-        public FooFormattable(int value) { _value = value; }
-
-        public String ToString(String format, IFormatProvider formatProvider)
-        {
-            if (formatProvider != null)
+            for (int i = 0; i < testValues.Length; i++)
             {
-                return String.Format("{0}: {1}", formatProvider, _value);
-            }
-            else
-            {
-                return String.Format("FooFormattable: {0}", (_value));
+                String result = Convert.ToString(testValues[i]);
+                Assert.Equal(testValues[i].ToString(), result);
+                result = Convert.ToString(testValues[i], formatProvider);
+                String expected = testValues[i].ToString(formatProvider);
+                Assert.Equal(expected, result);
             }
         }
-    }
 
-    private class Foo
-    {
-        private int _value;
-        public Foo(int value) { _value = value; }
-
-        public String ToString(IFormatProvider provider)
+        [Fact]
+        public static void FromString()
         {
-            if (provider != null)
+            String[] testValues = new String[] { "Hello", " ", "", "\0" };
+
+            for (int i = 0; i < testValues.Length; i++)
             {
-                return String.Format("{0}: {1}", provider, _value);
+                String result = Convert.ToString(testValues[i]);
+                Assert.Equal(testValues[i].ToString(), result);
+                result = Convert.ToString(testValues[i], NumberFormatInfo.CurrentInfo);
+                Assert.Equal(testValues[i].ToString(), result);
             }
-            else
+        }
+
+        [Fact]
+        public static void FromIFormattable()
+        {
+            FooFormattable foo = new FooFormattable(3);
+            String result = Convert.ToString(foo);
+            Assert.Equal("FooFormattable: 3", result);
+            result = Convert.ToString(foo, NumberFormatInfo.CurrentInfo);
+            Assert.Equal("System.Globalization.NumberFormatInfo: 3", result);
+
+            foo = null;
+            result = Convert.ToString(foo, NumberFormatInfo.CurrentInfo);
+            Assert.Equal("", result);
+        }
+
+        [Fact]
+        public static void FromNonIConvertible()
+        {
+            Foo foo = new Foo(3);
+            String result = Convert.ToString(foo);
+            Assert.Equal("System.Tests.ConvertToStringTests+Foo", result);
+            result = Convert.ToString(foo, NumberFormatInfo.CurrentInfo);
+            Assert.Equal("System.Tests.ConvertToStringTests+Foo", result);
+
+            foo = null;
+            result = Convert.ToString(foo, NumberFormatInfo.CurrentInfo);
+            Assert.Equal("", result);
+        }
+
+        private class FooFormattable : IFormattable
+        {
+            private int _value;
+            public FooFormattable(int value) { _value = value; }
+
+            public String ToString(String format, IFormatProvider formatProvider)
             {
-                return String.Format("Foo: {0}", _value);
+                if (formatProvider != null)
+                {
+                    return String.Format("{0}: {1}", formatProvider, _value);
+                }
+                else
+                {
+                    return String.Format("FooFormattable: {0}", (_value));
+                }
+            }
+        }
+
+        private class Foo
+        {
+            private int _value;
+            public Foo(int value) { _value = value; }
+
+            public String ToString(IFormatProvider provider)
+            {
+                if (provider != null)
+                {
+                    return String.Format("{0}: {1}", provider, _value);
+                }
+                else
+                {
+                    return String.Format("Foo: {0}", _value);
+                }
             }
         }
     }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToUInt16.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToUInt16.cs
@@ -2,185 +2,187 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public class ConvertToUInt16Tests : ConvertTestBase<UInt16>
+namespace System.Tests
 {
-    [Fact]
-    public void FromBoolean()
+    public class ConvertToUInt16Tests : ConvertTestBase<UInt16>
     {
-        Boolean[] testValues = { true, false };
-        UInt16[] expectedValues = { 1, 0 };
-        Verify(Convert.ToUInt16, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromBoolean()
+        {
+            Boolean[] testValues = { true, false };
+            UInt16[] expectedValues = { 1, 0 };
+            Verify(Convert.ToUInt16, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromByte()
-    {
-        Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
-        UInt16[] expectedValues = { 255, 0 };
-        Verify(Convert.ToUInt16, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromByte()
+        {
+            Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
+            UInt16[] expectedValues = { 255, 0 };
+            Verify(Convert.ToUInt16, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromChar()
-    {
-        Char[] testValues = { Char.MaxValue, Char.MinValue, 'b' };
-        UInt16[] expectedValues = { Char.MaxValue, Char.MinValue, 98 };
-        Verify(Convert.ToUInt16, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromChar()
+        {
+            Char[] testValues = { Char.MaxValue, Char.MinValue, 'b' };
+            UInt16[] expectedValues = { Char.MaxValue, Char.MinValue, 98 };
+            Verify(Convert.ToUInt16, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromDecimal()
-    {
-        Decimal[] testValues = { 1000m, 0m };
-        UInt16[] expectedValues = { 1000, 0 };
-        Verify(Convert.ToUInt16, testValues, expectedValues);
+        [Fact]
+        public void FromDecimal()
+        {
+            Decimal[] testValues = { 1000m, 0m };
+            UInt16[] expectedValues = { 1000, 0 };
+            Verify(Convert.ToUInt16, testValues, expectedValues);
 
-        Decimal[] overflowValues = { Decimal.MaxValue, Decimal.MinValue };
-        VerifyThrows<OverflowException, Decimal>(Convert.ToUInt16, overflowValues);
-    }
+            Decimal[] overflowValues = { Decimal.MaxValue, Decimal.MinValue };
+            VerifyThrows<OverflowException, Decimal>(Convert.ToUInt16, overflowValues);
+        }
 
-    [Fact]
-    public void FromDouble()
-    {
-        Double[] testValues = { 1000.0, 0.0 };
-        UInt16[] expectedValues = { 1000, 0 };
-        Verify(Convert.ToUInt16, testValues, expectedValues);
+        [Fact]
+        public void FromDouble()
+        {
+            Double[] testValues = { 1000.0, 0.0 };
+            UInt16[] expectedValues = { 1000, 0 };
+            Verify(Convert.ToUInt16, testValues, expectedValues);
 
-        Double[] overflowValues = { Double.MaxValue, -100.0 };
-        VerifyThrows<OverflowException, Double>(Convert.ToUInt16, overflowValues);
-    }
+            Double[] overflowValues = { Double.MaxValue, -100.0 };
+            VerifyThrows<OverflowException, Double>(Convert.ToUInt16, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt16()
-    {
-        Int16[] testValues = { 1000, 0, Int16.MaxValue };
-        UInt16[] expectedValues = { 1000, 0, (UInt16)Int16.MaxValue };
-        Verify(Convert.ToUInt16, testValues, expectedValues);
+        [Fact]
+        public void FromInt16()
+        {
+            Int16[] testValues = { 1000, 0, Int16.MaxValue };
+            UInt16[] expectedValues = { 1000, 0, (UInt16)Int16.MaxValue };
+            Verify(Convert.ToUInt16, testValues, expectedValues);
 
-        Int16[] overflowValues = { Int16.MinValue };
-        VerifyThrows<OverflowException, Int16>(Convert.ToUInt16, overflowValues);
-    }
+            Int16[] overflowValues = { Int16.MinValue };
+            VerifyThrows<OverflowException, Int16>(Convert.ToUInt16, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt32()
-    {
-        Int32[] testValues = { 1000, 0 };
-        UInt16[] expectedValues = { 1000, 0 };
-        Verify(Convert.ToUInt16, testValues, expectedValues);
+        [Fact]
+        public void FromInt32()
+        {
+            Int32[] testValues = { 1000, 0 };
+            UInt16[] expectedValues = { 1000, 0 };
+            Verify(Convert.ToUInt16, testValues, expectedValues);
 
-        Int32[] overflowValues = { Int32.MinValue, Int32.MaxValue };
-        VerifyThrows<OverflowException, Int32>(Convert.ToUInt16, overflowValues);
-    }
+            Int32[] overflowValues = { Int32.MinValue, Int32.MaxValue };
+            VerifyThrows<OverflowException, Int32>(Convert.ToUInt16, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt64()
-    {
-        Int64[] testValues = { 1000, 0 };
-        UInt16[] expectedValues = { 1000, 0 };
-        Verify(Convert.ToUInt16, testValues, expectedValues);
+        [Fact]
+        public void FromInt64()
+        {
+            Int64[] testValues = { 1000, 0 };
+            UInt16[] expectedValues = { 1000, 0 };
+            Verify(Convert.ToUInt16, testValues, expectedValues);
 
-        Int64[] overflowValues = { Int64.MinValue, Int64.MaxValue };
-        VerifyThrows<OverflowException, Int64>(Convert.ToUInt16, overflowValues);
-    }
+            Int64[] overflowValues = { Int64.MinValue, Int64.MaxValue };
+            VerifyThrows<OverflowException, Int64>(Convert.ToUInt16, overflowValues);
+        }
 
-    [Fact]
-    public void FromObject()
-    {
-        Object[] testValues = { null };
-        UInt16[] expectedValues = { 0 };
-        VerifyFromObject(Convert.ToUInt16, Convert.ToUInt16, testValues, expectedValues);
+        [Fact]
+        public void FromObject()
+        {
+            Object[] testValues = { null };
+            UInt16[] expectedValues = { 0 };
+            VerifyFromObject(Convert.ToUInt16, Convert.ToUInt16, testValues, expectedValues);
 
-        Object[] invalidValues = { new Object(), DateTime.Now };
-        VerifyFromObjectThrows<InvalidCastException>(Convert.ToUInt16, Convert.ToUInt16, invalidValues);
-    }
+            Object[] invalidValues = { new Object(), DateTime.Now };
+            VerifyFromObjectThrows<InvalidCastException>(Convert.ToUInt16, Convert.ToUInt16, invalidValues);
+        }
 
-    [Fact]
-    public void FromSByte()
-    {
-        SByte[] testValues = { 100, 0 };
-        UInt16[] expectedValues = { 100, 0 };
-        Verify(Convert.ToUInt16, testValues, expectedValues);
+        [Fact]
+        public void FromSByte()
+        {
+            SByte[] testValues = { 100, 0 };
+            UInt16[] expectedValues = { 100, 0 };
+            Verify(Convert.ToUInt16, testValues, expectedValues);
 
-        SByte[] values = { SByte.MinValue };
-        VerifyThrows<OverflowException, SByte>(Convert.ToUInt16, values);
-    }
+            SByte[] values = { SByte.MinValue };
+            VerifyThrows<OverflowException, SByte>(Convert.ToUInt16, values);
+        }
 
-    [Fact]
-    public void FromSingle()
-    {
-        Single[] testValues = { 1000.0f, 0.0f };
-        UInt16[] expectedValues = { 1000, 0 };
-        Verify(Convert.ToUInt16, testValues, expectedValues);
+        [Fact]
+        public void FromSingle()
+        {
+            Single[] testValues = { 1000.0f, 0.0f };
+            UInt16[] expectedValues = { 1000, 0 };
+            Verify(Convert.ToUInt16, testValues, expectedValues);
 
-        Single[] values = { Single.MaxValue, -100.0f };
-        VerifyThrows<OverflowException, Single>(Convert.ToUInt16, values);
-    }
+            Single[] values = { Single.MaxValue, -100.0f };
+            VerifyThrows<OverflowException, Single>(Convert.ToUInt16, values);
+        }
 
-    [Fact]
-    public void FromString()
-    {
-        String[] testValues = { "1000", "0", UInt16.MaxValue.ToString(), null };
-        UInt16[] expectedValues = { 1000, 0, UInt16.MaxValue, 0 };
-        VerifyFromString(Convert.ToUInt16, Convert.ToUInt16, testValues, expectedValues);
+        [Fact]
+        public void FromString()
+        {
+            String[] testValues = { "1000", "0", UInt16.MaxValue.ToString(), null };
+            UInt16[] expectedValues = { 1000, 0, UInt16.MaxValue, 0 };
+            VerifyFromString(Convert.ToUInt16, Convert.ToUInt16, testValues, expectedValues);
 
-        String[] overflowValues = { "-1", Decimal.MaxValue.ToString() };
-        VerifyFromStringThrows<OverflowException>(Convert.ToUInt16, Convert.ToUInt16, overflowValues);
+            String[] overflowValues = { "-1", Decimal.MaxValue.ToString() };
+            VerifyFromStringThrows<OverflowException>(Convert.ToUInt16, Convert.ToUInt16, overflowValues);
 
-        String[] formatExceptionValues = { "abba" };
-        VerifyFromStringThrows<FormatException>(Convert.ToUInt16, Convert.ToUInt16, formatExceptionValues);
-    }
+            String[] formatExceptionValues = { "abba" };
+            VerifyFromStringThrows<FormatException>(Convert.ToUInt16, Convert.ToUInt16, formatExceptionValues);
+        }
 
-    [Fact]
-    public void FromStringWithBase()
-    {
-        String[] testValues = { null, null, null, null, "ffff", "65535", "177777", "1111111111111111", "0", "0", "0", "0" };
-        Int32[] testBases =   { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2 };
-        UInt16[] expectedValues = { 0, 0, 0, 0, UInt16.MaxValue, UInt16.MaxValue, UInt16.MaxValue, UInt16.MaxValue, UInt16.MinValue, UInt16.MinValue, UInt16.MinValue, UInt16.MinValue };
-        VerifyFromStringWithBase(Convert.ToUInt16, testValues, testBases, expectedValues);
+        [Fact]
+        public void FromStringWithBase()
+        {
+            String[] testValues = { null, null, null, null, "ffff", "65535", "177777", "1111111111111111", "0", "0", "0", "0" };
+            Int32[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2 };
+            UInt16[] expectedValues = { 0, 0, 0, 0, UInt16.MaxValue, UInt16.MaxValue, UInt16.MaxValue, UInt16.MaxValue, UInt16.MinValue, UInt16.MinValue, UInt16.MinValue, UInt16.MinValue };
+            VerifyFromStringWithBase(Convert.ToUInt16, testValues, testBases, expectedValues);
 
-        String[] overflowValues = { "65536", "-1", "11111111111111111", "1FFFF", "777777" };
-        Int32[] overflowBases = { 10, 10, 2, 16, 8 };
-        VerifyFromStringWithBaseThrows<OverflowException>(Convert.ToUInt16, overflowValues, overflowBases);
+            String[] overflowValues = { "65536", "-1", "11111111111111111", "1FFFF", "777777" };
+            Int32[] overflowBases = { 10, 10, 2, 16, 8 };
+            VerifyFromStringWithBaseThrows<OverflowException>(Convert.ToUInt16, overflowValues, overflowBases);
 
-        String[] formatExceptionValues = { "12", "ffffffffffffffffffff" };
-        Int32[] formatExceptionBases = { 2, 8 };
-        VerifyFromStringWithBaseThrows<FormatException>(Convert.ToUInt16, formatExceptionValues, formatExceptionBases);
+            String[] formatExceptionValues = { "12", "ffffffffffffffffffff" };
+            Int32[] formatExceptionBases = { 2, 8 };
+            VerifyFromStringWithBaseThrows<FormatException>(Convert.ToUInt16, formatExceptionValues, formatExceptionBases);
 
-        String[] argumentExceptionValues = { "10", "11", "abba", "-ab" };
-        Int32[] argumentExceptionBases = { -1, 3, 0, 16 };
-        VerifyFromStringWithBaseThrows<ArgumentException>(Convert.ToUInt16, argumentExceptionValues, argumentExceptionBases);
-    }
+            String[] argumentExceptionValues = { "10", "11", "abba", "-ab" };
+            Int32[] argumentExceptionBases = { -1, 3, 0, 16 };
+            VerifyFromStringWithBaseThrows<ArgumentException>(Convert.ToUInt16, argumentExceptionValues, argumentExceptionBases);
+        }
 
-    [Fact]
-    public void FromUInt16()
-    {
-        UInt16[] testValues = { UInt16.MaxValue, UInt16.MinValue };
-        UInt16[] expectedValues = { UInt16.MaxValue, UInt16.MinValue };
-        Verify(Convert.ToUInt16, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt16()
+        {
+            UInt16[] testValues = { UInt16.MaxValue, UInt16.MinValue };
+            UInt16[] expectedValues = { UInt16.MaxValue, UInt16.MinValue };
+            Verify(Convert.ToUInt16, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt32()
-    {
-        UInt32[] testValues = { 100, 0 };
-        UInt16[] expectedValues = { 100, 0 };
-        Verify(Convert.ToUInt16, testValues, expectedValues);
+        [Fact]
+        public void FromUInt32()
+        {
+            UInt32[] testValues = { 100, 0 };
+            UInt16[] expectedValues = { 100, 0 };
+            Verify(Convert.ToUInt16, testValues, expectedValues);
 
-        UInt32[] overflowValues = { UInt32.MaxValue };
-        VerifyThrows<OverflowException, UInt32>(Convert.ToUInt16, overflowValues);
-    }
+            UInt32[] overflowValues = { UInt32.MaxValue };
+            VerifyThrows<OverflowException, UInt32>(Convert.ToUInt16, overflowValues);
+        }
 
-    [Fact]
-    public void FromUInt64()
-    {
-        UInt64[] testValues = { 100, 0 };
-        UInt16[] expectedValues = { 100, 0 };
-        Verify(Convert.ToUInt16, testValues, expectedValues);
+        [Fact]
+        public void FromUInt64()
+        {
+            UInt64[] testValues = { 100, 0 };
+            UInt16[] expectedValues = { 100, 0 };
+            Verify(Convert.ToUInt16, testValues, expectedValues);
 
-        UInt64[] overflowValues = { UInt64.MaxValue };
-        VerifyThrows<OverflowException, UInt64>(Convert.ToUInt16, overflowValues);
+            UInt64[] overflowValues = { UInt64.MaxValue };
+            VerifyThrows<OverflowException, UInt64>(Convert.ToUInt16, overflowValues);
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToUInt32.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToUInt32.cs
@@ -2,182 +2,184 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public class ConvertToUInt32Tests : ConvertTestBase<UInt32>
+namespace System.Tests
 {
-    [Fact]
-    public void FromBoolean()
+    public class ConvertToUInt32Tests : ConvertTestBase<UInt32>
     {
-        Boolean[] testValues = { true, false };
-        UInt32[] expectedValues = { 1, 0 };
-        Verify(Convert.ToUInt32, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromBoolean()
+        {
+            Boolean[] testValues = { true, false };
+            UInt32[] expectedValues = { 1, 0 };
+            Verify(Convert.ToUInt32, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromByte()
-    {
-        Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
-        UInt32[] expectedValues = { 255, 0 };
-        Verify(Convert.ToUInt32, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromByte()
+        {
+            Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
+            UInt32[] expectedValues = { 255, 0 };
+            Verify(Convert.ToUInt32, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromChar()
-    {
-        Char[] testValues = { Char.MinValue, Char.MaxValue, 'b' };
-        UInt32[] expectedValues = { Char.MinValue, Char.MaxValue, 98 };
-        Verify(Convert.ToUInt32, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromChar()
+        {
+            Char[] testValues = { Char.MinValue, Char.MaxValue, 'b' };
+            UInt32[] expectedValues = { Char.MinValue, Char.MaxValue, 98 };
+            Verify(Convert.ToUInt32, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromDecimal()
-    {
-        Decimal[] testValues = { 1000m, 0m };
-        UInt32[] expectedValues = { 1000, 0 };
-        Verify(Convert.ToUInt32, testValues, expectedValues);
+        [Fact]
+        public void FromDecimal()
+        {
+            Decimal[] testValues = { 1000m, 0m };
+            UInt32[] expectedValues = { 1000, 0 };
+            Verify(Convert.ToUInt32, testValues, expectedValues);
 
-        Decimal[] overflowValues = { Decimal.MaxValue, Decimal.MinValue };
-        VerifyThrows<OverflowException, Decimal>(Convert.ToUInt32, overflowValues);
-    }
+            Decimal[] overflowValues = { Decimal.MaxValue, Decimal.MinValue };
+            VerifyThrows<OverflowException, Decimal>(Convert.ToUInt32, overflowValues);
+        }
 
-    [Fact]
-    public void FromDouble()
-    {
-        Double[] testValues = { 1000.0, 0.0, -0.5, 4294967295.49999, 472.2, 472.6, 472.5, 471.5 };
-        UInt32[] expectedValues = { 1000, 0, 0, 4294967295, 472, 473, 472, 472 };
-        Verify(Convert.ToUInt32, testValues, expectedValues);
+        [Fact]
+        public void FromDouble()
+        {
+            Double[] testValues = { 1000.0, 0.0, -0.5, 4294967295.49999, 472.2, 472.6, 472.5, 471.5 };
+            UInt32[] expectedValues = { 1000, 0, 0, 4294967295, 472, 473, 472, 472 };
+            Verify(Convert.ToUInt32, testValues, expectedValues);
 
-        Double[] overflowValues = { Double.MaxValue, -0.500000000001, -100.0, 4294967296, 4294967295.5 };
-        VerifyThrows<OverflowException, Double>(Convert.ToUInt32, overflowValues);
-    }
+            Double[] overflowValues = { Double.MaxValue, -0.500000000001, -100.0, 4294967296, 4294967295.5 };
+            VerifyThrows<OverflowException, Double>(Convert.ToUInt32, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt16()
-    {
-        Int16[] testValues = { 1000, 0, Int16.MaxValue };
-        UInt32[] expectedValues = { 1000, 0, (UInt32)Int16.MaxValue };
-        Verify(Convert.ToUInt32, testValues, expectedValues);
+        [Fact]
+        public void FromInt16()
+        {
+            Int16[] testValues = { 1000, 0, Int16.MaxValue };
+            UInt32[] expectedValues = { 1000, 0, (UInt32)Int16.MaxValue };
+            Verify(Convert.ToUInt32, testValues, expectedValues);
 
-        Int16[] overflowValues = { Int16.MinValue };
-        VerifyThrows<OverflowException, Int16>(Convert.ToUInt32, overflowValues);
-    }
+            Int16[] overflowValues = { Int16.MinValue };
+            VerifyThrows<OverflowException, Int16>(Convert.ToUInt32, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt32()
-    {
-        Int32[] testValues = { 1000, 0, Int32.MaxValue };
-        UInt32[] expectedValues = { 1000, 0, Int32.MaxValue };
-        Verify(Convert.ToUInt32, testValues, expectedValues);
+        [Fact]
+        public void FromInt32()
+        {
+            Int32[] testValues = { 1000, 0, Int32.MaxValue };
+            UInt32[] expectedValues = { 1000, 0, Int32.MaxValue };
+            Verify(Convert.ToUInt32, testValues, expectedValues);
 
-        Int32[] overflowValues = { Int32.MinValue };
-        VerifyThrows<OverflowException, Int32>(Convert.ToUInt32, overflowValues);
-    }
+            Int32[] overflowValues = { Int32.MinValue };
+            VerifyThrows<OverflowException, Int32>(Convert.ToUInt32, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt64()
-    {
-        Int64[] testValues = { 1000, 0 };
-        UInt32[] expectedValues = { 1000, 0 };
-        Verify(Convert.ToUInt32, testValues, expectedValues);
+        [Fact]
+        public void FromInt64()
+        {
+            Int64[] testValues = { 1000, 0 };
+            UInt32[] expectedValues = { 1000, 0 };
+            Verify(Convert.ToUInt32, testValues, expectedValues);
 
-        Int64[] overflowValues = { Int64.MaxValue, Int64.MinValue };
-        VerifyThrows<OverflowException, Int64>(Convert.ToUInt32, overflowValues);
-    }
+            Int64[] overflowValues = { Int64.MaxValue, Int64.MinValue };
+            VerifyThrows<OverflowException, Int64>(Convert.ToUInt32, overflowValues);
+        }
 
-    [Fact]
-    public void FromObject()
-    {
-        Object[] testValues = { null };
-        UInt32[] expectedValues = { 0 };
-        VerifyFromObject(Convert.ToUInt32, Convert.ToUInt32, testValues, expectedValues);
+        [Fact]
+        public void FromObject()
+        {
+            Object[] testValues = { null };
+            UInt32[] expectedValues = { 0 };
+            VerifyFromObject(Convert.ToUInt32, Convert.ToUInt32, testValues, expectedValues);
 
-        Object[] invalidValues = { new Object(), DateTime.Now };
-        VerifyFromObjectThrows<InvalidCastException>(Convert.ToUInt32, Convert.ToUInt32, invalidValues);
-    }
+            Object[] invalidValues = { new Object(), DateTime.Now };
+            VerifyFromObjectThrows<InvalidCastException>(Convert.ToUInt32, Convert.ToUInt32, invalidValues);
+        }
 
-    [Fact]
-    public void FromSByte()
-    {
-        SByte[] testValues = { 100, 0 };
-        UInt32[] expectedValues = { 100, 0 };
-        Verify(Convert.ToUInt32, testValues, expectedValues);
+        [Fact]
+        public void FromSByte()
+        {
+            SByte[] testValues = { 100, 0 };
+            UInt32[] expectedValues = { 100, 0 };
+            Verify(Convert.ToUInt32, testValues, expectedValues);
 
-        SByte[] overflowValues = { SByte.MinValue };
-        VerifyThrows<OverflowException, SByte>(Convert.ToUInt32, overflowValues);
-    }
+            SByte[] overflowValues = { SByte.MinValue };
+            VerifyThrows<OverflowException, SByte>(Convert.ToUInt32, overflowValues);
+        }
 
-    [Fact]
-    public void FromSingle()
-    {
-        Single[] testValues = { 1000.0f, 0.0f };
-        UInt32[] expectedValues = { 1000, 0 };
-        Verify(Convert.ToUInt32, testValues, expectedValues);
+        [Fact]
+        public void FromSingle()
+        {
+            Single[] testValues = { 1000.0f, 0.0f };
+            UInt32[] expectedValues = { 1000, 0 };
+            Verify(Convert.ToUInt32, testValues, expectedValues);
 
-        Single[] overflowValues = { Single.MaxValue, -100.0f };
-        VerifyThrows<OverflowException, Single>(Convert.ToUInt32, overflowValues);
-    }
+            Single[] overflowValues = { Single.MaxValue, -100.0f };
+            VerifyThrows<OverflowException, Single>(Convert.ToUInt32, overflowValues);
+        }
 
-    [Fact]
-    public void FromString()
-    {
-        String[] testValues = { "1000", "0", UInt16.MaxValue.ToString(), UInt32.MaxValue.ToString(), Int32.MaxValue.ToString(), "2147483648", "2147483649", null };
-        UInt32[] expectedValues = { 1000, 0, UInt16.MaxValue, UInt32.MaxValue, Int32.MaxValue, (UInt32)Int32.MaxValue + 1, (UInt32)Int32.MaxValue + 2, 0 };
-        VerifyFromString(Convert.ToUInt32, Convert.ToUInt32, testValues, expectedValues);
+        [Fact]
+        public void FromString()
+        {
+            String[] testValues = { "1000", "0", UInt16.MaxValue.ToString(), UInt32.MaxValue.ToString(), Int32.MaxValue.ToString(), "2147483648", "2147483649", null };
+            UInt32[] expectedValues = { 1000, 0, UInt16.MaxValue, UInt32.MaxValue, Int32.MaxValue, (UInt32)Int32.MaxValue + 1, (UInt32)Int32.MaxValue + 2, 0 };
+            VerifyFromString(Convert.ToUInt32, Convert.ToUInt32, testValues, expectedValues);
 
-        String[] overflowValues = { "-1", Decimal.MaxValue.ToString() };
-        VerifyFromStringThrows<OverflowException>(Convert.ToUInt32, Convert.ToUInt32, overflowValues);
+            String[] overflowValues = { "-1", Decimal.MaxValue.ToString() };
+            VerifyFromStringThrows<OverflowException>(Convert.ToUInt32, Convert.ToUInt32, overflowValues);
 
-        String[] formatExceptionValues = { "abba" };
-        VerifyFromStringThrows<FormatException>(Convert.ToUInt32, Convert.ToUInt32, formatExceptionValues);
-    }
+            String[] formatExceptionValues = { "abba" };
+            VerifyFromStringThrows<FormatException>(Convert.ToUInt32, Convert.ToUInt32, formatExceptionValues);
+        }
 
-    [Fact]
-    public void FromStringWithBase()
-    {
-        String[] testValues = { null, null, null, null, "ffffffff", "4294967295", "37777777777", "11111111111111111111111111111111", "0", "0", "0", "0", "2147483647", "2147483648", "2147483649" };
-        Int32[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2, 10, 10, 10 };
-        UInt32[] expectedValues = { 0, 0, 0, 0, UInt32.MaxValue, UInt32.MaxValue, UInt32.MaxValue, UInt32.MaxValue, UInt32.MinValue, UInt32.MinValue, UInt32.MinValue, UInt32.MinValue, (UInt32)Int32.MaxValue, (UInt32)Int32.MaxValue + 1, (UInt32)Int32.MaxValue + 2 };
-        VerifyFromStringWithBase(Convert.ToUInt32, testValues, testBases, expectedValues);
+        [Fact]
+        public void FromStringWithBase()
+        {
+            String[] testValues = { null, null, null, null, "ffffffff", "4294967295", "37777777777", "11111111111111111111111111111111", "0", "0", "0", "0", "2147483647", "2147483648", "2147483649" };
+            Int32[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2, 10, 10, 10 };
+            UInt32[] expectedValues = { 0, 0, 0, 0, UInt32.MaxValue, UInt32.MaxValue, UInt32.MaxValue, UInt32.MaxValue, UInt32.MinValue, UInt32.MinValue, UInt32.MinValue, UInt32.MinValue, (UInt32)Int32.MaxValue, (UInt32)Int32.MaxValue + 1, (UInt32)Int32.MaxValue + 2 };
+            VerifyFromStringWithBase(Convert.ToUInt32, testValues, testBases, expectedValues);
 
-        String[] overflowValues = { "18446744073709551616", "18446744073709551617", "18446744073709551618", "18446744073709551619", "18446744073709551620", "-4294967297", "11111111111111111111111111111111111111111111111111111111111111111", "1FFFFffffFFFFffff", "7777777777777777777777777" };
-        Int32[] overflowBases = { 10, 10, 10, 10, 10, 10, 2, 16, 8 };
-        VerifyFromStringWithBaseThrows<OverflowException>(Convert.ToUInt32, overflowValues, overflowBases);
+            String[] overflowValues = { "18446744073709551616", "18446744073709551617", "18446744073709551618", "18446744073709551619", "18446744073709551620", "-4294967297", "11111111111111111111111111111111111111111111111111111111111111111", "1FFFFffffFFFFffff", "7777777777777777777777777" };
+            Int32[] overflowBases = { 10, 10, 10, 10, 10, 10, 2, 16, 8 };
+            VerifyFromStringWithBaseThrows<OverflowException>(Convert.ToUInt32, overflowValues, overflowBases);
 
-        String[] formatExceptionValues = { "12", "ffffffffffffffffffff" };
-        Int32[] formatExceptionBases = { 2, 8 };
-        VerifyFromStringWithBaseThrows<FormatException>(Convert.ToUInt32, formatExceptionValues, formatExceptionBases);
+            String[] formatExceptionValues = { "12", "ffffffffffffffffffff" };
+            Int32[] formatExceptionBases = { 2, 8 };
+            VerifyFromStringWithBaseThrows<FormatException>(Convert.ToUInt32, formatExceptionValues, formatExceptionBases);
 
-        String[] argumentExceptionValues = { "10", "11", "abba", "-ab" };
-        Int32[] argumentExceptionBases = { -1, 3, 0, 16 };
-        VerifyFromStringWithBaseThrows<ArgumentException>(Convert.ToUInt32, argumentExceptionValues, argumentExceptionBases);
-    }
+            String[] argumentExceptionValues = { "10", "11", "abba", "-ab" };
+            Int32[] argumentExceptionBases = { -1, 3, 0, 16 };
+            VerifyFromStringWithBaseThrows<ArgumentException>(Convert.ToUInt32, argumentExceptionValues, argumentExceptionBases);
+        }
 
-    [Fact]
-    public void FromUInt16()
-    {
-        UInt16[] testValues = { 100, 0 };
-        UInt32[] expectedValues = { 100, 0 };
-        Verify(Convert.ToUInt32, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt16()
+        {
+            UInt16[] testValues = { 100, 0 };
+            UInt32[] expectedValues = { 100, 0 };
+            Verify(Convert.ToUInt32, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt32()
-    {
-        UInt32[] testValues = { UInt32.MaxValue, UInt32.MinValue };
-        UInt32[] expectedValues = { UInt32.MaxValue, UInt32.MinValue };
-        Verify(Convert.ToUInt32, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt32()
+        {
+            UInt32[] testValues = { UInt32.MaxValue, UInt32.MinValue };
+            UInt32[] expectedValues = { UInt32.MaxValue, UInt32.MinValue };
+            Verify(Convert.ToUInt32, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt64()
-    {
-        UInt64[] testValues = { 100, 0 };
-        UInt32[] expectedValues = { 100, 0 };
-        Verify(Convert.ToUInt32, testValues, expectedValues);
+        [Fact]
+        public void FromUInt64()
+        {
+            UInt64[] testValues = { 100, 0 };
+            UInt32[] expectedValues = { 100, 0 };
+            Verify(Convert.ToUInt32, testValues, expectedValues);
 
-        UInt64[] values = { UInt64.MaxValue };
-        VerifyThrows<OverflowException, UInt64>(Convert.ToUInt32, values);
+            UInt64[] values = { UInt64.MaxValue };
+            VerifyThrows<OverflowException, UInt64>(Convert.ToUInt32, values);
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Convert.ToUInt64.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.ToUInt64.cs
@@ -2,179 +2,181 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public class ConvertToUInt64Tests : ConvertTestBase<UInt64>
+namespace System.Tests
 {
-    [Fact]
-    public void FromBoolean()
+    public class ConvertToUInt64Tests : ConvertTestBase<UInt64>
     {
-        Boolean[] testValues = { true, false };
-        UInt64[] expectedValues = { 1, 0 };
-        Verify(Convert.ToUInt64, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromBoolean()
+        {
+            Boolean[] testValues = { true, false };
+            UInt64[] expectedValues = { 1, 0 };
+            Verify(Convert.ToUInt64, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromByte()
-    {
-        Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
-        UInt64[] expectedValues = { Byte.MaxValue, Byte.MinValue };
-        Verify(Convert.ToUInt64, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromByte()
+        {
+            Byte[] testValues = { Byte.MaxValue, Byte.MinValue };
+            UInt64[] expectedValues = { Byte.MaxValue, Byte.MinValue };
+            Verify(Convert.ToUInt64, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromChar()
-    {
-        Char[] testValues = { Char.MaxValue, Char.MinValue, 'b' };
-        UInt64[] expectedValues = { Char.MaxValue, Char.MinValue, 98 };
-        Verify(Convert.ToUInt64, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromChar()
+        {
+            Char[] testValues = { Char.MaxValue, Char.MinValue, 'b' };
+            UInt64[] expectedValues = { Char.MaxValue, Char.MinValue, 98 };
+            Verify(Convert.ToUInt64, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromDecimal()
-    {
-        Decimal[] testValues = { 1000m, 0m };
-        UInt64[] expectedValues = { 1000, 0 };
-        Verify(Convert.ToUInt64, testValues, expectedValues);
+        [Fact]
+        public void FromDecimal()
+        {
+            Decimal[] testValues = { 1000m, 0m };
+            UInt64[] expectedValues = { 1000, 0 };
+            Verify(Convert.ToUInt64, testValues, expectedValues);
 
-        Decimal[] overflowValues = { Decimal.MinValue, Decimal.MaxValue };
-        VerifyThrows<OverflowException, Decimal>(Convert.ToUInt64, overflowValues);
-    }
+            Decimal[] overflowValues = { Decimal.MinValue, Decimal.MaxValue };
+            VerifyThrows<OverflowException, Decimal>(Convert.ToUInt64, overflowValues);
+        }
 
-    [Fact]
-    public void FromDouble()
-    {
-        Double[] testValues = { 1000.0, 0.0 };
-        UInt64[] expectedValues = { (UInt64)1000, (UInt64)0 };
-        Verify(Convert.ToUInt64, testValues, expectedValues);
+        [Fact]
+        public void FromDouble()
+        {
+            Double[] testValues = { 1000.0, 0.0 };
+            UInt64[] expectedValues = { (UInt64)1000, (UInt64)0 };
+            Verify(Convert.ToUInt64, testValues, expectedValues);
 
-        Double[] overflowValues = { Double.MaxValue, -100.0 };
-        VerifyThrows<OverflowException, Double>(Convert.ToUInt64, overflowValues);
-    }
+            Double[] overflowValues = { Double.MaxValue, -100.0 };
+            VerifyThrows<OverflowException, Double>(Convert.ToUInt64, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt16()
-    {
-        Int16[] testValues = { 1000, 0, Int16.MaxValue };
-        UInt64[] expectedValues = { 1000, 0, (UInt64)Int16.MaxValue };
-        Verify(Convert.ToUInt64, testValues, expectedValues);
+        [Fact]
+        public void FromInt16()
+        {
+            Int16[] testValues = { 1000, 0, Int16.MaxValue };
+            UInt64[] expectedValues = { 1000, 0, (UInt64)Int16.MaxValue };
+            Verify(Convert.ToUInt64, testValues, expectedValues);
 
-        Int16[] overflowValues = { Int16.MinValue };
-        VerifyThrows<OverflowException, Int16>(Convert.ToUInt64, overflowValues);
-    }
+            Int16[] overflowValues = { Int16.MinValue };
+            VerifyThrows<OverflowException, Int16>(Convert.ToUInt64, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt32()
-    {
-        Int32[] testValues = { 1000, 0, Int32.MaxValue };
-        UInt64[] expectedValues = { 1000, 0, Int32.MaxValue };
-        Verify(Convert.ToUInt64, testValues, expectedValues);
+        [Fact]
+        public void FromInt32()
+        {
+            Int32[] testValues = { 1000, 0, Int32.MaxValue };
+            UInt64[] expectedValues = { 1000, 0, Int32.MaxValue };
+            Verify(Convert.ToUInt64, testValues, expectedValues);
 
-        Int32[] overflowValues = { Int32.MinValue };
-        VerifyThrows<OverflowException, Int32>(Convert.ToUInt64, overflowValues);
-    }
+            Int32[] overflowValues = { Int32.MinValue };
+            VerifyThrows<OverflowException, Int32>(Convert.ToUInt64, overflowValues);
+        }
 
-    [Fact]
-    public void FromInt64()
-    {
-        Int64[] testValues = { 1000, 0, Int64.MaxValue };
-        UInt64[] expectedValues = { 1000, 0, Int64.MaxValue };
-        Verify(Convert.ToUInt64, testValues, expectedValues);
+        [Fact]
+        public void FromInt64()
+        {
+            Int64[] testValues = { 1000, 0, Int64.MaxValue };
+            UInt64[] expectedValues = { 1000, 0, Int64.MaxValue };
+            Verify(Convert.ToUInt64, testValues, expectedValues);
 
-        Int64[] overflowValues = { Int64.MinValue };
-        VerifyThrows<OverflowException, Int64>(Convert.ToUInt64, overflowValues);
-    }
+            Int64[] overflowValues = { Int64.MinValue };
+            VerifyThrows<OverflowException, Int64>(Convert.ToUInt64, overflowValues);
+        }
 
-    [Fact]
-    public void FromObject()
-    {
-        Object[] testValues = { null };
-        UInt64[] expectedValues = { 0 };
-        VerifyFromObject(Convert.ToUInt64, Convert.ToUInt64, testValues, expectedValues);
+        [Fact]
+        public void FromObject()
+        {
+            Object[] testValues = { null };
+            UInt64[] expectedValues = { 0 };
+            VerifyFromObject(Convert.ToUInt64, Convert.ToUInt64, testValues, expectedValues);
 
-        Object[] invalidValues = { new Object(), DateTime.Now };
-        VerifyFromObjectThrows<InvalidCastException>(Convert.ToUInt64, Convert.ToUInt64, invalidValues);
-    }
+            Object[] invalidValues = { new Object(), DateTime.Now };
+            VerifyFromObjectThrows<InvalidCastException>(Convert.ToUInt64, Convert.ToUInt64, invalidValues);
+        }
 
-    [Fact]
-    public void FromSByte()
-    {
-        SByte[] testValues = { 100, 0 };
-        UInt64[] expectedValues = { 100, 0 };
-        Verify(Convert.ToUInt64, testValues, expectedValues);
+        [Fact]
+        public void FromSByte()
+        {
+            SByte[] testValues = { 100, 0 };
+            UInt64[] expectedValues = { 100, 0 };
+            Verify(Convert.ToUInt64, testValues, expectedValues);
 
-        SByte[] overflowValues = { SByte.MinValue };
-        VerifyThrows<OverflowException, SByte>(Convert.ToUInt64, overflowValues);
-    }
+            SByte[] overflowValues = { SByte.MinValue };
+            VerifyThrows<OverflowException, SByte>(Convert.ToUInt64, overflowValues);
+        }
 
-    [Fact]
-    public void FromSingle()
-    {
-        Single[] testValues = { 1000.0f, 0.0f };
-        UInt64[] expectedValues = { 1000, 0 };
-        Verify(Convert.ToUInt64, testValues, expectedValues);
+        [Fact]
+        public void FromSingle()
+        {
+            Single[] testValues = { 1000.0f, 0.0f };
+            UInt64[] expectedValues = { 1000, 0 };
+            Verify(Convert.ToUInt64, testValues, expectedValues);
 
-        Single[] overflowValues = { Single.MaxValue, -100.0f };
-        VerifyThrows<OverflowException, Single>(Convert.ToUInt64, overflowValues);
-    }
+            Single[] overflowValues = { Single.MaxValue, -100.0f };
+            VerifyThrows<OverflowException, Single>(Convert.ToUInt64, overflowValues);
+        }
 
-    [Fact]
-    public void FromString()
-    {
-        String[] testValues = { "1000", "0", UInt16.MaxValue.ToString(), UInt32.MaxValue.ToString(), UInt64.MaxValue.ToString(), "9223372036854775807", "9223372036854775808", "9223372036854775809", null };
-        UInt64[] expectedValues = { 1000, 0, UInt16.MaxValue, UInt32.MaxValue, UInt64.MaxValue, Int64.MaxValue, (UInt64)Int64.MaxValue + 1, (UInt64)Int64.MaxValue + 2, 0 };
-        VerifyFromString(Convert.ToUInt64, Convert.ToUInt64, testValues, expectedValues);
+        [Fact]
+        public void FromString()
+        {
+            String[] testValues = { "1000", "0", UInt16.MaxValue.ToString(), UInt32.MaxValue.ToString(), UInt64.MaxValue.ToString(), "9223372036854775807", "9223372036854775808", "9223372036854775809", null };
+            UInt64[] expectedValues = { 1000, 0, UInt16.MaxValue, UInt32.MaxValue, UInt64.MaxValue, Int64.MaxValue, (UInt64)Int64.MaxValue + 1, (UInt64)Int64.MaxValue + 2, 0 };
+            VerifyFromString(Convert.ToUInt64, Convert.ToUInt64, testValues, expectedValues);
 
-        String[] overflowValues = { "-1", Decimal.MaxValue.ToString() };
-        VerifyFromStringThrows<OverflowException>(Convert.ToUInt64, Convert.ToUInt64, overflowValues);
+            String[] overflowValues = { "-1", Decimal.MaxValue.ToString() };
+            VerifyFromStringThrows<OverflowException>(Convert.ToUInt64, Convert.ToUInt64, overflowValues);
 
-        String[] formatExceptionValues = { "abba" };
-        VerifyFromStringThrows<FormatException>(Convert.ToUInt64, Convert.ToUInt64, formatExceptionValues);
-    }
+            String[] formatExceptionValues = { "abba" };
+            VerifyFromStringThrows<FormatException>(Convert.ToUInt64, Convert.ToUInt64, formatExceptionValues);
+        }
 
-    [Fact]
-    public void FromStringWithBase()
-    {
-        String[] testValues = { null, null, null, null, "ffffffffffffffff", "18446744073709551615", "1777777777777777777777", "1111111111111111111111111111111111111111111111111111111111111111", "0", "0", "0", "0", "9223372036854775807", "9223372036854775808" /*VSWhidbey #526568*/, "9223372036854775809", "9223372036854775810", "9223372036854775811" };
-        Int32[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2, 10, 10, 10, 10, 10 };
-        UInt64[] expectedValues = { 0, 0, 0, 0, UInt64.MaxValue, UInt64.MaxValue, UInt64.MaxValue, UInt64.MaxValue, UInt64.MinValue, UInt64.MinValue, UInt64.MinValue, UInt64.MinValue, (UInt64)Int64.MaxValue, (UInt64)Int64.MaxValue + 1 /*VSWhidbey #526568*/, (UInt64)Int64.MaxValue + 2, (UInt64)Int64.MaxValue + 3, (UInt64)Int64.MaxValue + 4 };
-        VerifyFromStringWithBase(Convert.ToUInt64, testValues, testBases, expectedValues);
+        [Fact]
+        public void FromStringWithBase()
+        {
+            String[] testValues = { null, null, null, null, "ffffffffffffffff", "18446744073709551615", "1777777777777777777777", "1111111111111111111111111111111111111111111111111111111111111111", "0", "0", "0", "0", "9223372036854775807", "9223372036854775808" /*VSWhidbey #526568*/, "9223372036854775809", "9223372036854775810", "9223372036854775811" };
+            Int32[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2, 10, 10, 10, 10, 10 };
+            UInt64[] expectedValues = { 0, 0, 0, 0, UInt64.MaxValue, UInt64.MaxValue, UInt64.MaxValue, UInt64.MaxValue, UInt64.MinValue, UInt64.MinValue, UInt64.MinValue, UInt64.MinValue, (UInt64)Int64.MaxValue, (UInt64)Int64.MaxValue + 1 /*VSWhidbey #526568*/, (UInt64)Int64.MaxValue + 2, (UInt64)Int64.MaxValue + 3, (UInt64)Int64.MaxValue + 4 };
+            VerifyFromStringWithBase(Convert.ToUInt64, testValues, testBases, expectedValues);
 
-        String[] overflowValues = { "18446744073709551616", "18446744073709551617", "18446744073709551618", "18446744073709551619", "18446744073709551620", "-4294967297", "11111111111111111111111111111111111111111111111111111111111111111", "1FFFFffffFFFFffff", "7777777777777777777777777" };
-        Int32[] overflowBases = { 10, 10, 10, 10, 10, 10, 2, 16, 8 };
-        VerifyFromStringWithBaseThrows<OverflowException>(Convert.ToUInt64, overflowValues, overflowBases);
+            String[] overflowValues = { "18446744073709551616", "18446744073709551617", "18446744073709551618", "18446744073709551619", "18446744073709551620", "-4294967297", "11111111111111111111111111111111111111111111111111111111111111111", "1FFFFffffFFFFffff", "7777777777777777777777777" };
+            Int32[] overflowBases = { 10, 10, 10, 10, 10, 10, 2, 16, 8 };
+            VerifyFromStringWithBaseThrows<OverflowException>(Convert.ToUInt64, overflowValues, overflowBases);
 
-        String[] formatExceptionValues = { "12", "ffffffffffffffffffff" };
-        Int32[] formatExceptionBases = { 2, 8 };
-        VerifyFromStringWithBaseThrows<FormatException>(Convert.ToUInt64, formatExceptionValues, formatExceptionBases);
+            String[] formatExceptionValues = { "12", "ffffffffffffffffffff" };
+            Int32[] formatExceptionBases = { 2, 8 };
+            VerifyFromStringWithBaseThrows<FormatException>(Convert.ToUInt64, formatExceptionValues, formatExceptionBases);
 
-        String[] argumentExceptionValues = { "10", "11", "abba", "-ab" };
-        Int32[] argumentExceptionBases = { -1, 3, 0, 16 };
-        VerifyFromStringWithBaseThrows<ArgumentException>(Convert.ToUInt64, argumentExceptionValues, argumentExceptionBases);
-    }
+            String[] argumentExceptionValues = { "10", "11", "abba", "-ab" };
+            Int32[] argumentExceptionBases = { -1, 3, 0, 16 };
+            VerifyFromStringWithBaseThrows<ArgumentException>(Convert.ToUInt64, argumentExceptionValues, argumentExceptionBases);
+        }
 
-    [Fact]
-    public void FromUInt16()
-    {
-        UInt16[] testValues = { 100, 0 };
-        UInt64[] expectedValues = { 100, 0 };
-        Verify(Convert.ToUInt64, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt16()
+        {
+            UInt16[] testValues = { 100, 0 };
+            UInt64[] expectedValues = { 100, 0 };
+            Verify(Convert.ToUInt64, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt32()
-    {
-        UInt32[] testValues = { UInt32.MinValue, UInt32.MaxValue };
-        UInt64[] expectedValues = { UInt32.MinValue, UInt32.MaxValue };
-        Verify(Convert.ToUInt64, testValues, expectedValues);
-    }
+        [Fact]
+        public void FromUInt32()
+        {
+            UInt32[] testValues = { UInt32.MinValue, UInt32.MaxValue };
+            UInt64[] expectedValues = { UInt32.MinValue, UInt32.MaxValue };
+            Verify(Convert.ToUInt64, testValues, expectedValues);
+        }
 
-    [Fact]
-    public void FromUInt64()
-    {
-        UInt64[] testValues = { UInt64.MaxValue, UInt64.MinValue };
-        UInt64[] expectedValues = { UInt64.MaxValue, UInt64.MinValue };
-        Verify(Convert.ToUInt64, testValues, expectedValues);
+        [Fact]
+        public void FromUInt64()
+        {
+            UInt64[] testValues = { UInt64.MaxValue, UInt64.MinValue };
+            UInt64[] expectedValues = { UInt64.MaxValue, UInt64.MinValue };
+            Verify(Convert.ToUInt64, testValues, expectedValues);
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
+++ b/src/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
@@ -2,80 +2,81 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Threading;
-using System.Diagnostics;
 using Xunit;
 
-public static class StopwatchTests
+namespace System.Diagnostics.Tests
 {
-    private static readonly ManualResetEvent s_sleepEvent = new ManualResetEvent(false);
-
-    [Fact]
-    public static void GetTimestamp()
+    public static class StopwatchTests
     {
-        long ts1 = Stopwatch.GetTimestamp();
-        Sleep();
-        long ts2 = Stopwatch.GetTimestamp();
-        Assert.NotEqual(ts1, ts2);
-    }
+        private static readonly ManualResetEvent s_sleepEvent = new ManualResetEvent(false);
 
-    [Fact]
-    public static void ConstructStartAndStop()
-    {
-        Stopwatch watch = new Stopwatch();
-        Assert.False(watch.IsRunning);
-        watch.Start();
-        Assert.True(watch.IsRunning);
-        Sleep();
-        Assert.True(watch.Elapsed > TimeSpan.Zero);
+        [Fact]
+        public static void GetTimestamp()
+        {
+            long ts1 = Stopwatch.GetTimestamp();
+            Sleep();
+            long ts2 = Stopwatch.GetTimestamp();
+            Assert.NotEqual(ts1, ts2);
+        }
 
-        watch.Stop();
-        Assert.False(watch.IsRunning);
+        [Fact]
+        public static void ConstructStartAndStop()
+        {
+            Stopwatch watch = new Stopwatch();
+            Assert.False(watch.IsRunning);
+            watch.Start();
+            Assert.True(watch.IsRunning);
+            Sleep();
+            Assert.True(watch.Elapsed > TimeSpan.Zero);
 
-        var e1 = watch.Elapsed;
-        Sleep();
-        var e2 = watch.Elapsed;
-        Assert.Equal(e1, e2);
-        Assert.Equal((long)e1.TotalMilliseconds, watch.ElapsedMilliseconds);
+            watch.Stop();
+            Assert.False(watch.IsRunning);
 
-        var t1 = watch.ElapsedTicks;
-        Sleep();
-        var t2 = watch.ElapsedTicks;
-        Assert.Equal(t1, t2);
-    }
+            var e1 = watch.Elapsed;
+            Sleep();
+            var e2 = watch.Elapsed;
+            Assert.Equal(e1, e2);
+            Assert.Equal((long)e1.TotalMilliseconds, watch.ElapsedMilliseconds);
 
-    [Fact]
-    public static void StartNewAndReset()
-    {
-        Stopwatch watch = Stopwatch.StartNew();
-        Assert.True(watch.IsRunning);
-        watch.Start(); // should be no-op
-        Assert.True(watch.IsRunning);
-        Sleep();
-        Assert.True(watch.Elapsed > TimeSpan.Zero);
+            var t1 = watch.ElapsedTicks;
+            Sleep();
+            var t2 = watch.ElapsedTicks;
+            Assert.Equal(t1, t2);
+        }
 
-        watch.Reset();
-        Assert.False(watch.IsRunning);
-        Assert.Equal(TimeSpan.Zero, watch.Elapsed);
-    }
+        [Fact]
+        public static void StartNewAndReset()
+        {
+            Stopwatch watch = Stopwatch.StartNew();
+            Assert.True(watch.IsRunning);
+            watch.Start(); // should be no-op
+            Assert.True(watch.IsRunning);
+            Sleep();
+            Assert.True(watch.Elapsed > TimeSpan.Zero);
 
-    [Fact]
-    public static void StartNewAndRestart()
-    {
-        Stopwatch watch = Stopwatch.StartNew();
-        Assert.True(watch.IsRunning);
-        Sleep(10);
-        TimeSpan elapsedSinceStart = watch.Elapsed;
-        Assert.True(elapsedSinceStart > TimeSpan.Zero);
+            watch.Reset();
+            Assert.False(watch.IsRunning);
+            Assert.Equal(TimeSpan.Zero, watch.Elapsed);
+        }
 
-        watch.Restart();
-        Assert.True(watch.IsRunning);
-        Assert.True(watch.Elapsed < elapsedSinceStart);
-    }
+        [Fact]
+        public static void StartNewAndRestart()
+        {
+            Stopwatch watch = Stopwatch.StartNew();
+            Assert.True(watch.IsRunning);
+            Sleep(10);
+            TimeSpan elapsedSinceStart = watch.Elapsed;
+            Assert.True(elapsedSinceStart > TimeSpan.Zero);
 
-    private static void Sleep(int milliseconds = 1)
-    {
-        s_sleepEvent.WaitOne(milliseconds);
+            watch.Restart();
+            Assert.True(watch.IsRunning);
+            Assert.True(watch.Elapsed < elapsedSinceStart);
+        }
+
+        private static void Sleep(int milliseconds = 1)
+        {
+            s_sleepEvent.WaitOne(milliseconds);
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
@@ -6,27 +6,30 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Xunit;
 
-public class Environment_Exit : RemoteExecutorTestBase
+namespace System.Tests
 {
-    [Theory]
-    [InlineData(0)]
-    [InlineData(1)]
-    [InlineData(42)]
-    [InlineData(-1)]
-    [InlineData(-45)]
-    [InlineData(255)]
-    public static void CheckExitCode(int expectedExitCode)
+    public class Environment_Exit : RemoteExecutorTestBase
     {
-        using (Process p = RemoteInvoke(s => int.Parse(s), expectedExitCode.ToString()).Process)
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(42)]
+        [InlineData(-1)]
+        [InlineData(-45)]
+        [InlineData(255)]
+        public static void CheckExitCode(int expectedExitCode)
         {
-            Assert.True(p.WaitForExit(30 * 1000));
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            using (Process p = RemoteInvoke(s => int.Parse(s), expectedExitCode.ToString()).Process)
             {
-                Assert.Equal(expectedExitCode, p.ExitCode);
-            }
-            else
-            {
-                Assert.Equal((sbyte)expectedExitCode, (sbyte)p.ExitCode);
+                Assert.True(p.WaitForExit(30 * 1000));
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    Assert.Equal(expectedExitCode, p.ExitCode);
+                }
+                else
+                {
+                    Assert.Equal((sbyte)expectedExitCode, (sbyte)p.ExitCode);
+                }
             }
         }
     }

--- a/src/System.Runtime.Extensions/tests/System/Environment.ExpandEnvironmentVariables.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.ExpandEnvironmentVariables.cs
@@ -2,142 +2,141 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
-using System.Text;
-using System.Runtime.InteropServices;
 using Xunit;
 
-public class ExpandEnvironmentVariables
+namespace System.Tests
 {
-    [Fact]
-    public void NullArgumentThrowsArgumentNull()
+    public class ExpandEnvironmentVariables
     {
-        Assert.Throws<ArgumentNullException>(() => Environment.ExpandEnvironmentVariables(null));
-    }
-
-    [Fact]
-    public void EmptyArgumentReturnsEmpty()
-    {
-        Assert.Equal(String.Empty, Environment.ExpandEnvironmentVariables(String.Empty));
-    }
-
-    [Fact]
-    public void ExpansionOfVariableSucceeds()
-    {
-        // The test is going to test that we can correctly expand variables.
-        // We are going to do:
-        // envvar1=animal;
-        // and we are going to check that the expanded %envvar1% is animal.
-
-        Random r = new Random();
-        string envVar1 = "TestVariable_ExpansionOfVariableSucceeds_" + r.Next().ToString();
-        string expectedValue = "animal";
-
-        try
+        [Fact]
+        public void NullArgumentThrowsArgumentNull()
         {
-            Environment.SetEnvironmentVariable(envVar1, expectedValue);
-
-            string result = Environment.ExpandEnvironmentVariables("%" + envVar1 + "%");
-
-            Assert.Equal(expectedValue, result);
+            Assert.Throws<ArgumentNullException>(() => Environment.ExpandEnvironmentVariables(null));
         }
-        finally
+
+        [Fact]
+        public void EmptyArgumentReturnsEmpty()
         {
-            // Clear the variables we just set
-            Environment.SetEnvironmentVariable(envVar1, null);
+            Assert.Equal(String.Empty, Environment.ExpandEnvironmentVariables(String.Empty));
         }
-    }
 
-    [Fact]
-    public void VariableThatDoesNotExistGoesThroughUnexpanded()
-    {
-        string unexpanded = "%TestVariable_ThatDoesNotExist%";
-        Assert.Equal(unexpanded, Environment.ExpandEnvironmentVariables(unexpanded));
-    }
-
-    [Fact]
-    public void StringWithNoEnvironmentVariablesGoesThroughUnchnaged()
-    {
-        Assert.Equal("Hello World", Environment.ExpandEnvironmentVariables("Hello World"));
-    }
-
-    [Fact]
-    public void PotentiallyAmbiguousInputIsHandledCorrectly()
-    {
-        int count = 6;
-        string prefix = "ExpandTestVar_@";
-        string[] keys = new string[count];
-        string[] values = new string[count];
-
-        for (int i = 0; i < count; i++)
+        [Fact]
+        public void ExpansionOfVariableSucceeds()
         {
-            keys[i] = prefix + (i + 1);
-            Assert.Equal(null, Environment.GetEnvironmentVariable(keys[i]));
+            // The test is going to test that we can correctly expand variables.
+            // We are going to do:
+            // envvar1=animal;
+            // and we are going to check that the expanded %envvar1% is animal.
 
-            if (i < 3)
+            Random r = new Random();
+            string envVar1 = "TestVariable_ExpansionOfVariableSucceeds_" + r.Next().ToString();
+            string expectedValue = "animal";
+
+            try
             {
-                Environment.SetEnvironmentVariable(keys[i], "value" + (i + 1));
+                Environment.SetEnvironmentVariable(envVar1, expectedValue);
+
+                string result = Environment.ExpandEnvironmentVariables("%" + envVar1 + "%");
+
+                Assert.Equal(expectedValue, result);
+            }
+            finally
+            {
+                // Clear the variables we just set
+                Environment.SetEnvironmentVariable(envVar1, null);
             }
         }
 
-        string set1 = keys[0], set2 = keys[1], set3 = keys[2];
-        string unset1 = keys[3], unset2 = keys[4], unset3 = keys[5];
-        string value1, value2, value3;
+        [Fact]
+        public void VariableThatDoesNotExistGoesThroughUnexpanded()
+        {
+            string unexpanded = "%TestVariable_ThatDoesNotExist%";
+            Assert.Equal(unexpanded, Environment.ExpandEnvironmentVariables(unexpanded));
+        }
 
-        value1 = "value1";
-        value2 = "value2";
-        value3 = "value3";
+        [Fact]
+        public void StringWithNoEnvironmentVariablesGoesThroughUnchnaged()
+        {
+            Assert.Equal("Hello World", Environment.ExpandEnvironmentVariables("Hello World"));
+        }
 
-        Test("%",
-              "%");
+        [Fact]
+        public void PotentiallyAmbiguousInputIsHandledCorrectly()
+        {
+            int count = 6;
+            string prefix = "ExpandTestVar_@";
+            string[] keys = new string[count];
+            string[] values = new string[count];
 
-        Test("%%",
-              "%%");
+            for (int i = 0; i < count; i++)
+            {
+                keys[i] = prefix + (i + 1);
+                Assert.Equal(null, Environment.GetEnvironmentVariable(keys[i]));
 
-        Test("%%%",
-              "%%%");
+                if (i < 3)
+                {
+                    Environment.SetEnvironmentVariable(keys[i], "value" + (i + 1));
+                }
+            }
 
-        Test(("%" + set1 + "%") + set2 + ("%" + set3 + "%"),
-               value1 + set2 + value3);
+            string set1 = keys[0], set2 = keys[1], set3 = keys[2];
+            string unset1 = keys[3], unset2 = keys[4], unset3 = keys[5];
+            string value1, value2, value3;
 
-        Test("%" + ("%" + set1 + "%"),
-              "%" + value1);
+            value1 = "value1";
+            value2 = "value2";
+            value3 = "value3";
 
-        Test("%%" + ("%" + set1 + "%") + "%%",
-              "%%" + value1 + "%%");
+            Test("%",
+                  "%");
 
-        Test("%%%" + ("%" + set1 + "%") + "%",
-              "%%%" + value1 + "%");
+            Test("%%",
+                  "%%");
 
-        Test(("%" + set1 + "%") + ("%" + set2 + "%"),
-              value1 + value2);
+            Test("%%%",
+                  "%%%");
 
-        Test(("%" + unset1 + "%") + ("%" + set1 + "%"),
-              ("%" + unset1 + "%") + value1);
+            Test(("%" + set1 + "%") + set2 + ("%" + set3 + "%"),
+                   value1 + set2 + value3);
 
-        Test(("%" + set2 + "%") + "hello" + ("%" + unset2 + "%"),
-              value2 + "hello" + ("%" + unset2 + "%"));
+            Test("%" + ("%" + set1 + "%"),
+                  "%" + value1);
 
-        Test(("%" + unset2 + "%") + ("%" + unset3 + "%"),
-              ("%" + unset2 + "%") + ("%" + unset3 + "%"));
+            Test("%%" + ("%" + set1 + "%") + "%%",
+                  "%%" + value1 + "%%");
 
-        Test("% " + set1 + "%",
-              "% " + set1 + "%");
+            Test("%%%" + ("%" + set1 + "%") + "%",
+                  "%%%" + value1 + "%");
 
-        Test("%  " + set1 + "  %",
-              "%  " + set1 + "  %");
+            Test(("%" + set1 + "%") + ("%" + set2 + "%"),
+                  value1 + value2);
 
-        Test("%\t" + set1 + "%",
-              "%\t" + set1 + "%");
+            Test(("%" + unset1 + "%") + ("%" + set1 + "%"),
+                  ("%" + unset1 + "%") + value1);
 
-        Test("%%% " + set1 + "%",
-              "%%% " + set1 + "%");
-    }
+            Test(("%" + set2 + "%") + "hello" + ("%" + unset2 + "%"),
+                  value2 + "hello" + ("%" + unset2 + "%"));
 
-    private void Test(string toExpand, string expectedExpansion)
-    {
-        Assert.Equal(expectedExpansion, Environment.ExpandEnvironmentVariables(toExpand));
-        Assert.Equal("qq" + expectedExpansion + "rr", "qq" + Environment.ExpandEnvironmentVariables(toExpand) + "rr");
+            Test(("%" + unset2 + "%") + ("%" + unset3 + "%"),
+                  ("%" + unset2 + "%") + ("%" + unset3 + "%"));
+
+            Test("% " + set1 + "%",
+                  "% " + set1 + "%");
+
+            Test("%  " + set1 + "  %",
+                  "%  " + set1 + "  %");
+
+            Test("%\t" + set1 + "%",
+                  "%\t" + set1 + "%");
+
+            Test("%%% " + set1 + "%",
+                  "%%% " + set1 + "%");
+        }
+
+        private void Test(string toExpand, string expectedExpansion)
+        {
+            Assert.Equal(expectedExpansion, Environment.ExpandEnvironmentVariables(toExpand));
+            Assert.Equal("qq" + expectedExpansion + "rr", "qq" + Environment.ExpandEnvironmentVariables(toExpand) + "rr");
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Environment.GetCommandLineArgs.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetCommandLineArgs.cs
@@ -2,17 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.Reflection;
-using System.Collections;
-using System.Text;
-using System.Runtime.InteropServices;
 using Xunit;
 
-namespace System.Runtime.Extension.Tests
+namespace System.Tests
 {
-
     public class GetCommandLineArgs : RemoteExecutorTestBase
     {
         [Fact]

--- a/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
@@ -2,138 +2,140 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Runtime.InteropServices;
 using Xunit;
 
-public class GetEnvironmentVariable
+namespace System.Tests
 {
-    [Fact]
-    public void NullVariableThrowsArgumentNull()
+    public class GetEnvironmentVariable
     {
-        Assert.Throws<ArgumentNullException>(() => Environment.GetEnvironmentVariable(null));
-        Assert.Throws<ArgumentNullException>(() => Environment.SetEnvironmentVariable(null, "test"));
-        Assert.Throws<ArgumentException>(() => Environment.SetEnvironmentVariable("", "test"));
-    }
-
-    [Fact]
-    public void EmptyVariableReturnsNull()
-    {
-        Assert.Null(Environment.GetEnvironmentVariable(String.Empty));
-    }
-
-    [Fact]
-    [ActiveIssue("https://github.com/dotnet/coreclr/issues/635", PlatformID.AnyUnix)]
-    public void RandomLongVariableNameCanRoundTrip()
-    {
-        // NOTE: The limit of 32766 characters enforced by dekstop
-        // SetEnvironmentVariable is antiquated. I was
-        // able to create ~1GB names and values on my Windows 8.1 box. On
-        // desktop, GetEnvironmentVariable throws OOM during its attempt to
-        // demand huge EnvironmentPermission well before that. Also, the old
-        // test for long name case wasn't very good: it just checked that an
-        // arbitrary long name > 32766 characters returned null (not found), but
-        // that had nothing to do with the limit, the variable was simply not
-        // found!
-
-        string variable = "LongVariable_" + new string('@', 33000);
-        const string value = "TestValue";
-
-        try
+        [Fact]
+        public void NullVariableThrowsArgumentNull()
         {
-            SetEnvironmentVariableWithPInvoke(variable, value);
-
-            Assert.Equal(value, Environment.GetEnvironmentVariable(variable));
+            Assert.Throws<ArgumentNullException>(() => Environment.GetEnvironmentVariable(null));
+            Assert.Throws<ArgumentNullException>(() => Environment.SetEnvironmentVariable(null, "test"));
+            Assert.Throws<ArgumentException>(() => Environment.SetEnvironmentVariable("", "test"));
         }
-        finally
+
+        [Fact]
+        public void EmptyVariableReturnsNull()
         {
-            SetEnvironmentVariableWithPInvoke(variable, null);
+            Assert.Null(Environment.GetEnvironmentVariable(String.Empty));
         }
-    }
 
-    [Fact]
-    public void RandomVariableThatDoesNotExistReturnsNull()
-    {
-        string variable = "TestVariable_SurelyThisDoesNotExist";
-        Assert.Null(Environment.GetEnvironmentVariable(variable));
-    }
-
-    [Fact]
-    public void VariableNamesAreCaseInsensitiveAsAppropriate()
-    {
-        string value = "TestValue";
-
-        try
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/coreclr/issues/635", PlatformID.AnyUnix)]
+        public void RandomLongVariableNameCanRoundTrip()
         {
-            Environment.SetEnvironmentVariable("ThisIsATestEnvironmentVariable", value);
+            // NOTE: The limit of 32766 characters enforced by dekstop
+            // SetEnvironmentVariable is antiquated. I was
+            // able to create ~1GB names and values on my Windows 8.1 box. On
+            // desktop, GetEnvironmentVariable throws OOM during its attempt to
+            // demand huge EnvironmentPermission well before that. Also, the old
+            // test for long name case wasn't very good: it just checked that an
+            // arbitrary long name > 32766 characters returned null (not found), but
+            // that had nothing to do with the limit, the variable was simply not
+            // found!
 
-            Assert.Equal(value, Environment.GetEnvironmentVariable("ThisIsATestEnvironmentVariable"));
+            string variable = "LongVariable_" + new string('@', 33000);
+            const string value = "TestValue";
 
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            try
             {
-                value = null;
+                SetEnvironmentVariableWithPInvoke(variable, value);
+
+                Assert.Equal(value, Environment.GetEnvironmentVariable(variable));
             }
-
-            Assert.Equal(value, Environment.GetEnvironmentVariable("thisisatestenvironmentvariable"));
-            Assert.Equal(value, Environment.GetEnvironmentVariable("THISISATESTENVIRONMENTVARIABLE"));
-            Assert.Equal(value, Environment.GetEnvironmentVariable("ThISISATeSTENVIRoNMEnTVaRIABLE"));
+            finally
+            {
+                SetEnvironmentVariableWithPInvoke(variable, null);
+            }
         }
-        finally
+
+        [Fact]
+        public void RandomVariableThatDoesNotExistReturnsNull()
         {
-            Environment.SetEnvironmentVariable("ThisIsATestEnvironmentVariable", null);
+            string variable = "TestVariable_SurelyThisDoesNotExist";
+            Assert.Null(Environment.GetEnvironmentVariable(variable));
         }
-    }
 
-    [Fact]
-    public void CanGetAllVariablesIndividually()
-    {
-        Random r = new Random();
-        string envVar1 = "TestVariable_CanGetVariablesIndividually_" + r.Next().ToString();
-        string envVar2 = "TestVariable_CanGetVariablesIndividually_" + r.Next().ToString();
-
-        try
+        [Fact]
+        public void VariableNamesAreCaseInsensitiveAsAppropriate()
         {
-            Environment.SetEnvironmentVariable(envVar1, envVar1);
-            Environment.SetEnvironmentVariable(envVar2, envVar2);
+            string value = "TestValue";
 
-            IDictionary envBlock = Environment.GetEnvironmentVariables();
+            try
+            {
+                Environment.SetEnvironmentVariable("ThisIsATestEnvironmentVariable", value);
 
-            // Make sure the environment variables we set are part of the dictionary returned.
-            Assert.True(envBlock.Contains(envVar1));
-            Assert.True(envBlock.Contains(envVar1));
+                Assert.Equal(value, Environment.GetEnvironmentVariable("ThisIsATestEnvironmentVariable"));
 
-            // Make sure the values match the expected ones.
-            Assert.Equal(envVar1, envBlock[envVar1]);
-            Assert.Equal(envVar2, envBlock[envVar2]);
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    value = null;
+                }
 
-            // Make sure we can read the individual variables as well
-            Assert.Equal(envVar1, Environment.GetEnvironmentVariable(envVar1));
-            Assert.Equal(envVar2, Environment.GetEnvironmentVariable(envVar2));
+                Assert.Equal(value, Environment.GetEnvironmentVariable("thisisatestenvironmentvariable"));
+                Assert.Equal(value, Environment.GetEnvironmentVariable("THISISATESTENVIRONMENTVARIABLE"));
+                Assert.Equal(value, Environment.GetEnvironmentVariable("ThISISATeSTENVIRoNMEnTVaRIABLE"));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("ThisIsATestEnvironmentVariable", null);
+            }
         }
-        finally
+
+        [Fact]
+        public void CanGetAllVariablesIndividually()
         {
-            // Clear the variables we just set
-            Environment.SetEnvironmentVariable(envVar1, null);
-            Environment.SetEnvironmentVariable(envVar2, null);
+            Random r = new Random();
+            string envVar1 = "TestVariable_CanGetVariablesIndividually_" + r.Next().ToString();
+            string envVar2 = "TestVariable_CanGetVariablesIndividually_" + r.Next().ToString();
+
+            try
+            {
+                Environment.SetEnvironmentVariable(envVar1, envVar1);
+                Environment.SetEnvironmentVariable(envVar2, envVar2);
+
+                IDictionary envBlock = Environment.GetEnvironmentVariables();
+
+                // Make sure the environment variables we set are part of the dictionary returned.
+                Assert.True(envBlock.Contains(envVar1));
+                Assert.True(envBlock.Contains(envVar1));
+
+                // Make sure the values match the expected ones.
+                Assert.Equal(envVar1, envBlock[envVar1]);
+                Assert.Equal(envVar2, envBlock[envVar2]);
+
+                // Make sure we can read the individual variables as well
+                Assert.Equal(envVar1, Environment.GetEnvironmentVariable(envVar1));
+                Assert.Equal(envVar2, Environment.GetEnvironmentVariable(envVar2));
+            }
+            finally
+            {
+                // Clear the variables we just set
+                Environment.SetEnvironmentVariable(envVar1, null);
+                Environment.SetEnvironmentVariable(envVar2, null);
+            }
         }
+
+        private static void SetEnvironmentVariableWithPInvoke(string name, string value)
+        {
+            bool success =
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+                    SetEnvironmentVariable(name, value) :
+                    (value != null ? setenv(name, value, 1) : unsetenv(name)) == 0;
+            Assert.True(success);
+        }
+
+        [DllImport("api-ms-win-core-processenvironment-l1-1-0.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool SetEnvironmentVariable(string lpName, string lpValue);
+
+        [DllImport("libc")]
+        private static extern int setenv(string name, string value, int overwrite);
+
+        [DllImport("libc")]
+        private static extern int unsetenv(string name);
     }
-
-    private static void SetEnvironmentVariableWithPInvoke(string name, string value)
-    {
-        bool success =
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-                SetEnvironmentVariable(name, value) :
-                (value != null ? setenv(name, value, 1) : unsetenv(name)) == 0;
-        Assert.True(success);
-    }
-
-    [DllImport("api-ms-win-core-processenvironment-l1-1-0.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern bool SetEnvironmentVariable(string lpName, string lpValue);
-
-    [DllImport("libc")]
-    private static extern int setenv(string name, string value, int overwrite);
-
-    [DllImport("libc")]
-    private static extern int unsetenv(string name);
 }

--- a/src/System.Runtime.Extensions/tests/System/Environment.MachineName.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.MachineName.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.InteropServices;
 using Xunit;
 
-namespace System.Runtime.Extensions.Tests
+namespace System.Tests
 {
     public class Environment_MachineName
     {

--- a/src/System.Runtime.Extensions/tests/System/Environment.SetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.SetEnvironmentVariable.cs
@@ -2,179 +2,181 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public class SetEnvironmentVariable
+namespace System.Tests
 {
-    private const int MAX_VAR_LENGTH_ALLOWED = 32767;
-    private const string NullString = "\u0000";
-
-    [Fact]
-    public void NullVariableThrowsArgumentNull()
+    public class SetEnvironmentVariable
     {
-        Assert.Throws<ArgumentNullException>(() => Environment.SetEnvironmentVariable(null, "test"));
-    }
+        private const int MAX_VAR_LENGTH_ALLOWED = 32767;
+        private const string NullString = "\u0000";
 
-    [Fact]
-    public void IncorrectVariableThrowsArgument()
-    {
-        Assert.Throws<ArgumentException>(() => Environment.SetEnvironmentVariable(String.Empty, "test"));
-        Assert.Throws<ArgumentException>(() => Environment.SetEnvironmentVariable(NullString, "test"));
-        Assert.Throws<ArgumentException>(() => Environment.SetEnvironmentVariable("Variable=Something", "test"));
-
-        string varWithLenLongerThanAllowed = new string('c', MAX_VAR_LENGTH_ALLOWED + 1);
-        Assert.Throws<ArgumentException>(() => Environment.SetEnvironmentVariable(varWithLenLongerThanAllowed, "test"));
-    }
-
-    [Fact]
-    public void Default()
-    {
-        const string varName = "Test_SetEnvironmentVariable_Default";
-        const string value = "true";
-
-        try
+        [Fact]
+        public void NullVariableThrowsArgumentNull()
         {
+            Assert.Throws<ArgumentNullException>(() => Environment.SetEnvironmentVariable(null, "test"));
+        }
+
+        [Fact]
+        public void IncorrectVariableThrowsArgument()
+        {
+            Assert.Throws<ArgumentException>(() => Environment.SetEnvironmentVariable(String.Empty, "test"));
+            Assert.Throws<ArgumentException>(() => Environment.SetEnvironmentVariable(NullString, "test"));
+            Assert.Throws<ArgumentException>(() => Environment.SetEnvironmentVariable("Variable=Something", "test"));
+
+            string varWithLenLongerThanAllowed = new string('c', MAX_VAR_LENGTH_ALLOWED + 1);
+            Assert.Throws<ArgumentException>(() => Environment.SetEnvironmentVariable(varWithLenLongerThanAllowed, "test"));
+        }
+
+        [Fact]
+        public void Default()
+        {
+            const string varName = "Test_SetEnvironmentVariable_Default";
+            const string value = "true";
+
+            try
+            {
+                Environment.SetEnvironmentVariable(varName, value);
+                Assert.Equal(value, Environment.GetEnvironmentVariable(varName));
+            }
+            finally
+            {
+                // Clear the test variable
+                Environment.SetEnvironmentVariable(varName, null);
+            }
+        }
+
+        [Fact]
+        public void ModifyEnvironmentVariable()
+        {
+            const string varName = "Test_ModifyEnvironmentVariable";
+            const string value = "false";
+
+            try
+            {
+                // First set the value to something and then change it and ensure that it gets modified.
+                Environment.SetEnvironmentVariable(varName, "true");
+                Environment.SetEnvironmentVariable(varName, value);
+
+                // Check whether the variable exists.
+                Assert.Equal(value, Environment.GetEnvironmentVariable(varName));
+            }
+            finally
+            {
+                // Clear the test variable
+                Environment.SetEnvironmentVariable(varName, null);
+            }
+        }
+
+        [Fact]
+        public void DeleteEnvironmentVariable()
+        {
+            const string varName = "Test_DeleteEnvironmentVariable";
+            const string value = "false";
+
+            // First set the value to something and then ensure that it can be deleted.
             Environment.SetEnvironmentVariable(varName, value);
-            Assert.Equal(value, Environment.GetEnvironmentVariable(varName));
-        }
-        finally
-        {
-            // Clear the test variable
-            Environment.SetEnvironmentVariable(varName, null);
-        }
-    }
+            Environment.SetEnvironmentVariable(varName, String.Empty);
+            Assert.Equal(null, Environment.GetEnvironmentVariable(varName));
 
-    [Fact]
-    public void ModifyEnvironmentVariable()
-    {
-        const string varName = "Test_ModifyEnvironmentVariable";
-        const string value = "false";
-
-        try
-        {
-            // First set the value to something and then change it and ensure that it gets modified.
-            Environment.SetEnvironmentVariable(varName, "true");
-            Environment.SetEnvironmentVariable(varName, value);
-
-            // Check whether the variable exists.
-            Assert.Equal(value, Environment.GetEnvironmentVariable(varName));
-        }
-        finally
-        {
-            // Clear the test variable
-            Environment.SetEnvironmentVariable(varName, null);
-        }
-    }
-
-    [Fact]
-    public void DeleteEnvironmentVariable()
-    {
-        const string varName = "Test_DeleteEnvironmentVariable";
-        const string value = "false";
-
-        // First set the value to something and then ensure that it can be deleted.
-        Environment.SetEnvironmentVariable(varName, value);
-        Environment.SetEnvironmentVariable(varName, String.Empty);
-        Assert.Equal(null, Environment.GetEnvironmentVariable(varName));
-
-        Environment.SetEnvironmentVariable(varName, value);
-        Environment.SetEnvironmentVariable(varName, null);
-        Assert.Equal(null, Environment.GetEnvironmentVariable(varName));
-
-        Environment.SetEnvironmentVariable(varName, value);
-        Environment.SetEnvironmentVariable(varName, NullString);
-        Assert.Equal(null, Environment.GetEnvironmentVariable(varName));
-    }
-
-    [Fact]
-    public void DeleteEnvironmentVariableNonInitialNullInName()
-    {
-        const string varNamePrefix = "Begin_DeleteEnvironmentVariableNonInitialNullInName";
-        const string varNameSuffix = "End_DeleteEnvironmentVariableNonInitialNullInName";
-        const string varName = varNamePrefix + NullString + varNameSuffix;
-        const string value = "false";
-
-        try
-        {
             Environment.SetEnvironmentVariable(varName, value);
             Environment.SetEnvironmentVariable(varName, null);
-            Assert.Equal(Environment.GetEnvironmentVariable(varName), null);
-            Assert.Equal(Environment.GetEnvironmentVariable(varNamePrefix), null);
-        }
-        finally
-        {
-            // Clear the test variable
-            Environment.SetEnvironmentVariable(varName, null);
-        }
-    }
+            Assert.Equal(null, Environment.GetEnvironmentVariable(varName));
 
-    [Fact]
-    public void DeleteEnvironmentVariableInitialNullInValue()
-    {
-        const string value = NullString + "test";
-        const string varName = "DeleteEnvironmentVariableInitialNullInValue";
-
-        try
-        {
             Environment.SetEnvironmentVariable(varName, value);
+            Environment.SetEnvironmentVariable(varName, NullString);
             Assert.Equal(null, Environment.GetEnvironmentVariable(varName));
         }
-        finally
-        {
-            Environment.SetEnvironmentVariable(varName, String.Empty);
-        }
-    }
 
-    [Fact]
-    public void NonInitialNullCharacterInVariableName()
-    {
-        const string varNamePrefix = "NonInitialNullCharacterInVariableName_Begin";
-        const string varNameSuffix = "NonInitialNullCharacterInVariableName_End";
-        const string varName = varNamePrefix + NullString + varNameSuffix;
-        const string value = "true";
-
-        try
+        [Fact]
+        public void DeleteEnvironmentVariableNonInitialNullInName()
         {
-            Environment.SetEnvironmentVariable(varName, value);
-            Assert.Equal(value, Environment.GetEnvironmentVariable(varNamePrefix));
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(varName, String.Empty);
-            Environment.SetEnvironmentVariable(varNamePrefix, String.Empty);
-        }
-    }
+            const string varNamePrefix = "Begin_DeleteEnvironmentVariableNonInitialNullInName";
+            const string varNameSuffix = "End_DeleteEnvironmentVariableNonInitialNullInName";
+            const string varName = varNamePrefix + NullString + varNameSuffix;
+            const string value = "false";
 
-    [Fact]
-    public void NonInitialNullCharacterInValue()
-    {
-        const string varName = "Test_TestNonInitialZeroCharacterInValue";
-        const string valuePrefix = "Begin";
-        const string valueSuffix = "End";
-        const string value = valuePrefix + NullString + valueSuffix;
-
-        try
-        {
-            Environment.SetEnvironmentVariable(varName, value);
-            Assert.Equal(valuePrefix, Environment.GetEnvironmentVariable(varName));
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(varName, String.Empty);
-        }
-    }
-
-    [Fact]
-    public void DeleteNonExistentEnvironmentVariable()
-    {
-        const string varName = "Test_TestDeletingNonExistingEnvironmentVariable";
-
-        if (Environment.GetEnvironmentVariable(varName) != null)
-        {
-            Environment.SetEnvironmentVariable(varName, null);
+            try
+            {
+                Environment.SetEnvironmentVariable(varName, value);
+                Environment.SetEnvironmentVariable(varName, null);
+                Assert.Equal(Environment.GetEnvironmentVariable(varName), null);
+                Assert.Equal(Environment.GetEnvironmentVariable(varNamePrefix), null);
+            }
+            finally
+            {
+                // Clear the test variable
+                Environment.SetEnvironmentVariable(varName, null);
+            }
         }
 
-        Environment.SetEnvironmentVariable("TestDeletingNonExistingEnvironmentVariable", String.Empty);
+        [Fact]
+        public void DeleteEnvironmentVariableInitialNullInValue()
+        {
+            const string value = NullString + "test";
+            const string varName = "DeleteEnvironmentVariableInitialNullInValue";
+
+            try
+            {
+                Environment.SetEnvironmentVariable(varName, value);
+                Assert.Equal(null, Environment.GetEnvironmentVariable(varName));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(varName, String.Empty);
+            }
+        }
+
+        [Fact]
+        public void NonInitialNullCharacterInVariableName()
+        {
+            const string varNamePrefix = "NonInitialNullCharacterInVariableName_Begin";
+            const string varNameSuffix = "NonInitialNullCharacterInVariableName_End";
+            const string varName = varNamePrefix + NullString + varNameSuffix;
+            const string value = "true";
+
+            try
+            {
+                Environment.SetEnvironmentVariable(varName, value);
+                Assert.Equal(value, Environment.GetEnvironmentVariable(varNamePrefix));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(varName, String.Empty);
+                Environment.SetEnvironmentVariable(varNamePrefix, String.Empty);
+            }
+        }
+
+        [Fact]
+        public void NonInitialNullCharacterInValue()
+        {
+            const string varName = "Test_TestNonInitialZeroCharacterInValue";
+            const string valuePrefix = "Begin";
+            const string valueSuffix = "End";
+            const string value = valuePrefix + NullString + valueSuffix;
+
+            try
+            {
+                Environment.SetEnvironmentVariable(varName, value);
+                Assert.Equal(valuePrefix, Environment.GetEnvironmentVariable(varName));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(varName, String.Empty);
+            }
+        }
+
+        [Fact]
+        public void DeleteNonExistentEnvironmentVariable()
+        {
+            const string varName = "Test_TestDeletingNonExistingEnvironmentVariable";
+
+            if (Environment.GetEnvironmentVariable(varName) != null)
+            {
+                Environment.SetEnvironmentVariable(varName, null);
+            }
+
+            Environment.SetEnvironmentVariable("TestDeletingNonExistingEnvironmentVariable", String.Empty);
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/IO/Path.Combine.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/Path.Combine.cs
@@ -2,253 +2,253 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.IO;
 using Xunit;
 
-public static class PathCombineTests
+namespace System.IO.Tests
 {
-    private static readonly char s_separator = Path.DirectorySeparatorChar;
-
-    public static IEnumerable<object[]> Combine_Basic_TestData()
+    public static class PathCombineTests
     {
-        yield return new object[] { new string[0] };
-        yield return new object[] { new string[] { "abc" } };
-        yield return new object[] { new string[] { "abc", "def" } };
-        yield return new object[] { new string[] { "abc", "def", "ghi", "jkl", "mno" } };
-        yield return new object[] { new string[] { "abc" + s_separator + "def", "def", "ghi", "jkl", "mno" } };
+        private static readonly char s_separator = Path.DirectorySeparatorChar;
 
-        // All paths are empty
-        yield return new object[] { new string[] { "" } };
-        yield return new object[] { new string[] { "", "" } };
-        yield return new object[] { new string[] { "", "", "" } };
-        yield return new object[] { new string[] { "", "", "", "" } };
-        yield return new object[] { new string[] { "", "", "", "", "" } };
-
-        // Elements are all separated
-        yield return new object[] { new string[] { "abc" + s_separator, "def" + s_separator } };
-        yield return new object[] { new string[] { "abc" + s_separator, "def" + s_separator, "ghi" + s_separator } };
-        yield return new object[] { new string[] { "abc" + s_separator, "def" + s_separator, "ghi" + s_separator, "jkl" + s_separator } };
-        yield return new object[] { new string[] { "abc" + s_separator, "def" + s_separator, "ghi" + s_separator, "jkl" + s_separator, "mno" + s_separator } };
-    }
-
-    public static IEnumerable<string> Combine_CommonCases_Input_TestData()
-    {
-        // Any path is rooted (starts with \, \\, A:)
-        yield return s_separator + "abc";
-        yield return s_separator + s_separator + "abc";
-
-        // Any path is empty (skipped)
-        yield return "";
-
-        // Any path is single element
-        yield return "abc";
-        yield return "abc" + s_separator;
-
-        // Any path is multiple element
-        yield return Path.Combine("abc", Path.Combine("def", "ghi"));
-    }
-
-    public static IEnumerable<object[]> Combine_CommonCases_TestData()
-    {
-        foreach (string testPath in Combine_CommonCases_Input_TestData())
+        public static IEnumerable<object[]> Combine_Basic_TestData()
         {
-            yield return new object[] { new string[] { testPath } };
+            yield return new object[] { new string[0] };
+            yield return new object[] { new string[] { "abc" } };
+            yield return new object[] { new string[] { "abc", "def" } };
+            yield return new object[] { new string[] { "abc", "def", "ghi", "jkl", "mno" } };
+            yield return new object[] { new string[] { "abc" + s_separator + "def", "def", "ghi", "jkl", "mno" } };
 
-            yield return new object[] { new string[] { "abc", testPath } };
-            yield return new object[] { new string[] { testPath, "abc" } };
+            // All paths are empty
+            yield return new object[] { new string[] { "" } };
+            yield return new object[] { new string[] { "", "" } };
+            yield return new object[] { new string[] { "", "", "" } };
+            yield return new object[] { new string[] { "", "", "", "" } };
+            yield return new object[] { new string[] { "", "", "", "", "" } };
 
-            yield return new object[] { new string[] { "abc", "def", testPath } };
-            yield return new object[] { new string[] { "abc", testPath, "def" } };
-            yield return new object[] { new string[] { testPath, "abc", "def" } };
-
-            yield return new object[] { new string[] { "abc", "def", "ghi", testPath } };
-            yield return new object[] { new string[] { "abc", "def", testPath, "ghi" } };
-            yield return new object[] { new string[] { "abc", testPath, "def", "ghi" } };
-            yield return new object[] { new string[] { testPath, "abc", "def", "ghi" } };
-
-            yield return new object[] { new string[] { "abc", "def", "ghi", "jkl", testPath } };
-            yield return new object[] { new string[] { "abc", "def", "ghi", testPath, "jkl" } };
-            yield return new object[] { new string[] { "abc", "def", testPath, "ghi", "jkl" } };
-            yield return new object[] { new string[] { "abc", testPath, "def", "ghi", "jkl" } };
-            yield return new object[] { new string[] { testPath, "abc", "def", "ghi", "jkl" } };
-        }
-    }
-
-    [Theory]
-    [MemberData(nameof(Combine_Basic_TestData))]
-    [MemberData(nameof(Combine_CommonCases_TestData))]
-    public static void Combine(string[] paths)
-    {
-        string expected = string.Empty;
-        if (paths.Length > 0) expected = paths[0];
-        for (int i = 1; i < paths.Length; i++)
-        {
-            expected = Path.Combine(expected, paths[i]);
+            // Elements are all separated
+            yield return new object[] { new string[] { "abc" + s_separator, "def" + s_separator } };
+            yield return new object[] { new string[] { "abc" + s_separator, "def" + s_separator, "ghi" + s_separator } };
+            yield return new object[] { new string[] { "abc" + s_separator, "def" + s_separator, "ghi" + s_separator, "jkl" + s_separator } };
+            yield return new object[] { new string[] { "abc" + s_separator, "def" + s_separator, "ghi" + s_separator, "jkl" + s_separator, "mno" + s_separator } };
         }
 
-        // Combine(string[])
-        Assert.Equal(expected, Path.Combine(paths));
-
-        // Verify special cases
-        switch (paths.Length)
+        public static IEnumerable<string> Combine_CommonCases_Input_TestData()
         {
-            case 2:
-                // Combine(string, string)
-                Assert.Equal(expected, Path.Combine(paths[0], paths[1]));
-                break;
+            // Any path is rooted (starts with \, \\, A:)
+            yield return s_separator + "abc";
+            yield return s_separator + s_separator + "abc";
 
-            case 3:
-                // Combine(string, string, string)
-                Assert.Equal(expected, Path.Combine(paths[0], paths[1], paths[2]));
-                break;
+            // Any path is empty (skipped)
+            yield return "";
 
-            default:
-                // Nothing to do: everything else is pushed into an array
-                break;
+            // Any path is single element
+            yield return "abc";
+            yield return "abc" + s_separator;
+
+            // Any path is multiple element
+            yield return Path.Combine("abc", Path.Combine("def", "ghi"));
         }
-    }
 
-    [Fact]
-    public static void PathIsNull()
-    {
-        VerifyException<ArgumentNullException>(null);
-    }
-
-    [Fact]
-    public static void PathIsNullWihtoutRootedAfterArgumentNull()
-    {
-        //any path is null without rooted after (ANE)
-        CommonCasesException<ArgumentNullException>(null);
-    }
-
-    [Fact]
-    public static void ContainsInvalidCharWithoutRootedAfterArgumentNull()
-    {
-        //any path contains invalid character without rooted after (AE)
-        CommonCasesException<ArgumentException>("ab\0cd");
-    }
-
-    [Fact]
-    [PlatformSpecific(PlatformID.Windows)]
-    public static void ContainsInvalidCharWithoutRootedAfterArgumentNull_Windows()
-    {
-        //any path contains invalid character without rooted after (AE)
-        CommonCasesException<ArgumentException>("ab\"cd");
-        CommonCasesException<ArgumentException>("ab\"cd");
-        CommonCasesException<ArgumentException>("ab<cd");
-        CommonCasesException<ArgumentException>("ab>cd");
-        CommonCasesException<ArgumentException>("ab|cd");
-        CommonCasesException<ArgumentException>("ab\bcd");
-        CommonCasesException<ArgumentException>("ab\0cd");
-        CommonCasesException<ArgumentException>("ab\tcd");
-    }
-
-    [Fact]
-    public static void ContainsInvalidCharWithRootedAfterArgumentNull()
-    {
-        //any path contains invalid character with rooted after (AE)
-        CommonCasesException<ArgumentException>("ab\0cd", s_separator + "abc");
-    }
-
-    [Fact]
-    [PlatformSpecific(PlatformID.Windows)]
-    public static void ContainsInvalidCharWithRootedAfterArgumentNull_Windows()
-    {
-        //any path contains invalid character with rooted after (AE)
-        CommonCasesException<ArgumentException>("ab\"cd", s_separator + "abc");
-        CommonCasesException<ArgumentException>("ab<cd", s_separator + "abc");
-        CommonCasesException<ArgumentException>("ab>cd", s_separator + "abc");
-        CommonCasesException<ArgumentException>("ab|cd", s_separator + "abc");
-        CommonCasesException<ArgumentException>("ab\bcd", s_separator + "abc");
-        CommonCasesException<ArgumentException>("ab\tcd", s_separator + "abc");
-    }
-
-    private static void VerifyException<T>(string[] paths) where T : Exception
-    {
-        Assert.Throws<T>(() => Path.Combine(paths));
-
-        //verify passed as elements case
-        if (paths != null)
+        public static IEnumerable<object[]> Combine_CommonCases_TestData()
         {
-            Assert.InRange(paths.Length, 1, 5);
-
-            Assert.Throws<T>(() =>
+            foreach (string testPath in Combine_CommonCases_Input_TestData())
             {
-                switch (paths.Length)
-                {
-                    case 0:
-                        Path.Combine();
-                        break;
-                    case 1:
-                        Path.Combine(paths[0]);
-                        break;
-                    case 2:
-                        Path.Combine(paths[0], paths[1]);
-                        break;
-                    case 3:
-                        Path.Combine(paths[0], paths[1], paths[2]);
-                        break;
-                    case 4:
-                        Path.Combine(paths[0], paths[1], paths[2], paths[3]);
-                        break;
-                    case 5:
-                        Path.Combine(paths[0], paths[1], paths[2], paths[3], paths[4]);
-                        break;
-                }
-            });
+                yield return new object[] { new string[] { testPath } };
+
+                yield return new object[] { new string[] { "abc", testPath } };
+                yield return new object[] { new string[] { testPath, "abc" } };
+
+                yield return new object[] { new string[] { "abc", "def", testPath } };
+                yield return new object[] { new string[] { "abc", testPath, "def" } };
+                yield return new object[] { new string[] { testPath, "abc", "def" } };
+
+                yield return new object[] { new string[] { "abc", "def", "ghi", testPath } };
+                yield return new object[] { new string[] { "abc", "def", testPath, "ghi" } };
+                yield return new object[] { new string[] { "abc", testPath, "def", "ghi" } };
+                yield return new object[] { new string[] { testPath, "abc", "def", "ghi" } };
+
+                yield return new object[] { new string[] { "abc", "def", "ghi", "jkl", testPath } };
+                yield return new object[] { new string[] { "abc", "def", "ghi", testPath, "jkl" } };
+                yield return new object[] { new string[] { "abc", "def", testPath, "ghi", "jkl" } };
+                yield return new object[] { new string[] { "abc", testPath, "def", "ghi", "jkl" } };
+                yield return new object[] { new string[] { testPath, "abc", "def", "ghi", "jkl" } };
+            }
         }
-    }
 
-    private static void CommonCasesException<T>(string testing) where T : Exception
-    {
-        VerifyException<T>(new string[] { testing });
+        [Theory]
+        [MemberData(nameof(Combine_Basic_TestData))]
+        [MemberData(nameof(Combine_CommonCases_TestData))]
+        public static void Combine(string[] paths)
+        {
+            string expected = string.Empty;
+            if (paths.Length > 0) expected = paths[0];
+            for (int i = 1; i < paths.Length; i++)
+            {
+                expected = Path.Combine(expected, paths[i]);
+            }
 
-        VerifyException<T>(new string[] { "abc", testing });
-        VerifyException<T>(new string[] { testing, "abc" });
+            // Combine(string[])
+            Assert.Equal(expected, Path.Combine(paths));
 
-        VerifyException<T>(new string[] { "abc", "def", testing });
-        VerifyException<T>(new string[] { "abc", testing, "def" });
-        VerifyException<T>(new string[] { testing, "abc", "def" });
+            // Verify special cases
+            switch (paths.Length)
+            {
+                case 2:
+                    // Combine(string, string)
+                    Assert.Equal(expected, Path.Combine(paths[0], paths[1]));
+                    break;
 
-        VerifyException<T>(new string[] { "abc", "def", "ghi", testing });
-        VerifyException<T>(new string[] { "abc", "def", testing, "ghi" });
-        VerifyException<T>(new string[] { "abc", testing, "def", "ghi" });
-        VerifyException<T>(new string[] { testing, "abc", "def", "ghi" });
+                case 3:
+                    // Combine(string, string, string)
+                    Assert.Equal(expected, Path.Combine(paths[0], paths[1], paths[2]));
+                    break;
 
-        VerifyException<T>(new string[] { "abc", "def", "ghi", "jkl", testing });
-        VerifyException<T>(new string[] { "abc", "def", "ghi", testing, "jkl" });
-        VerifyException<T>(new string[] { "abc", "def", testing, "ghi", "jkl" });
-        VerifyException<T>(new string[] { "abc", testing, "def", "ghi", "jkl" });
-        VerifyException<T>(new string[] { testing, "abc", "def", "ghi", "jkl" });
-    }
+                default:
+                    // Nothing to do: everything else is pushed into an array
+                    break;
+            }
+        }
 
-    private static void CommonCasesException<T>(string testing, string testing2) where T : Exception
-    {
-        VerifyException<T>(new string[] { testing, testing2 });
+        [Fact]
+        public static void PathIsNull()
+        {
+            VerifyException<ArgumentNullException>(null);
+        }
 
-        VerifyException<T>(new string[] { "abc", testing, testing2 });
-        VerifyException<T>(new string[] { testing, "abc", testing2 });
-        VerifyException<T>(new string[] { testing, testing2, "def" });
+        [Fact]
+        public static void PathIsNullWihtoutRootedAfterArgumentNull()
+        {
+            //any path is null without rooted after (ANE)
+            CommonCasesException<ArgumentNullException>(null);
+        }
 
-        VerifyException<T>(new string[] { "abc", "def", testing, testing2 });
-        VerifyException<T>(new string[] { "abc", testing, "def", testing2 });
-        VerifyException<T>(new string[] { "abc", testing, testing2, "ghi" });
-        VerifyException<T>(new string[] { testing, "abc", "def", testing2 });
-        VerifyException<T>(new string[] { testing, "abc", testing2, "ghi" });
-        VerifyException<T>(new string[] { testing, testing2, "def", "ghi" });
+        [Fact]
+        public static void ContainsInvalidCharWithoutRootedAfterArgumentNull()
+        {
+            //any path contains invalid character without rooted after (AE)
+            CommonCasesException<ArgumentException>("ab\0cd");
+        }
 
-        VerifyException<T>(new string[] { "abc", "def", "ghi", testing, testing2 });
-        VerifyException<T>(new string[] { "abc", "def", testing, "ghi", testing2 });
-        VerifyException<T>(new string[] { "abc", "def", testing, testing2, "jkl" });
-        VerifyException<T>(new string[] { "abc", testing, "def", "ghi", testing2 });
-        VerifyException<T>(new string[] { "abc", testing, "def", testing2, "jkl" });
-        VerifyException<T>(new string[] { "abc", testing, testing2, "ghi", "jkl" });
-        VerifyException<T>(new string[] { testing, "abc", "def", "ghi", testing2 });
-        VerifyException<T>(new string[] { testing, "abc", "def", testing2, "jkl" });
-        VerifyException<T>(new string[] { testing, "abc", testing2, "ghi", "jkl" });
-        VerifyException<T>(new string[] { testing, testing2, "def", "ghi", "jkl" });
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public static void ContainsInvalidCharWithoutRootedAfterArgumentNull_Windows()
+        {
+            //any path contains invalid character without rooted after (AE)
+            CommonCasesException<ArgumentException>("ab\"cd");
+            CommonCasesException<ArgumentException>("ab\"cd");
+            CommonCasesException<ArgumentException>("ab<cd");
+            CommonCasesException<ArgumentException>("ab>cd");
+            CommonCasesException<ArgumentException>("ab|cd");
+            CommonCasesException<ArgumentException>("ab\bcd");
+            CommonCasesException<ArgumentException>("ab\0cd");
+            CommonCasesException<ArgumentException>("ab\tcd");
+        }
+
+        [Fact]
+        public static void ContainsInvalidCharWithRootedAfterArgumentNull()
+        {
+            //any path contains invalid character with rooted after (AE)
+            CommonCasesException<ArgumentException>("ab\0cd", s_separator + "abc");
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public static void ContainsInvalidCharWithRootedAfterArgumentNull_Windows()
+        {
+            //any path contains invalid character with rooted after (AE)
+            CommonCasesException<ArgumentException>("ab\"cd", s_separator + "abc");
+            CommonCasesException<ArgumentException>("ab<cd", s_separator + "abc");
+            CommonCasesException<ArgumentException>("ab>cd", s_separator + "abc");
+            CommonCasesException<ArgumentException>("ab|cd", s_separator + "abc");
+            CommonCasesException<ArgumentException>("ab\bcd", s_separator + "abc");
+            CommonCasesException<ArgumentException>("ab\tcd", s_separator + "abc");
+        }
+
+        private static void VerifyException<T>(string[] paths) where T : Exception
+        {
+            Assert.Throws<T>(() => Path.Combine(paths));
+
+            //verify passed as elements case
+            if (paths != null)
+            {
+                Assert.InRange(paths.Length, 1, 5);
+
+                Assert.Throws<T>(() =>
+                {
+                    switch (paths.Length)
+                    {
+                        case 0:
+                            Path.Combine();
+                            break;
+                        case 1:
+                            Path.Combine(paths[0]);
+                            break;
+                        case 2:
+                            Path.Combine(paths[0], paths[1]);
+                            break;
+                        case 3:
+                            Path.Combine(paths[0], paths[1], paths[2]);
+                            break;
+                        case 4:
+                            Path.Combine(paths[0], paths[1], paths[2], paths[3]);
+                            break;
+                        case 5:
+                            Path.Combine(paths[0], paths[1], paths[2], paths[3], paths[4]);
+                            break;
+                    }
+                });
+            }
+        }
+
+        private static void CommonCasesException<T>(string testing) where T : Exception
+        {
+            VerifyException<T>(new string[] { testing });
+
+            VerifyException<T>(new string[] { "abc", testing });
+            VerifyException<T>(new string[] { testing, "abc" });
+
+            VerifyException<T>(new string[] { "abc", "def", testing });
+            VerifyException<T>(new string[] { "abc", testing, "def" });
+            VerifyException<T>(new string[] { testing, "abc", "def" });
+
+            VerifyException<T>(new string[] { "abc", "def", "ghi", testing });
+            VerifyException<T>(new string[] { "abc", "def", testing, "ghi" });
+            VerifyException<T>(new string[] { "abc", testing, "def", "ghi" });
+            VerifyException<T>(new string[] { testing, "abc", "def", "ghi" });
+
+            VerifyException<T>(new string[] { "abc", "def", "ghi", "jkl", testing });
+            VerifyException<T>(new string[] { "abc", "def", "ghi", testing, "jkl" });
+            VerifyException<T>(new string[] { "abc", "def", testing, "ghi", "jkl" });
+            VerifyException<T>(new string[] { "abc", testing, "def", "ghi", "jkl" });
+            VerifyException<T>(new string[] { testing, "abc", "def", "ghi", "jkl" });
+        }
+
+        private static void CommonCasesException<T>(string testing, string testing2) where T : Exception
+        {
+            VerifyException<T>(new string[] { testing, testing2 });
+
+            VerifyException<T>(new string[] { "abc", testing, testing2 });
+            VerifyException<T>(new string[] { testing, "abc", testing2 });
+            VerifyException<T>(new string[] { testing, testing2, "def" });
+
+            VerifyException<T>(new string[] { "abc", "def", testing, testing2 });
+            VerifyException<T>(new string[] { "abc", testing, "def", testing2 });
+            VerifyException<T>(new string[] { "abc", testing, testing2, "ghi" });
+            VerifyException<T>(new string[] { testing, "abc", "def", testing2 });
+            VerifyException<T>(new string[] { testing, "abc", testing2, "ghi" });
+            VerifyException<T>(new string[] { testing, testing2, "def", "ghi" });
+
+            VerifyException<T>(new string[] { "abc", "def", "ghi", testing, testing2 });
+            VerifyException<T>(new string[] { "abc", "def", testing, "ghi", testing2 });
+            VerifyException<T>(new string[] { "abc", "def", testing, testing2, "jkl" });
+            VerifyException<T>(new string[] { "abc", testing, "def", "ghi", testing2 });
+            VerifyException<T>(new string[] { "abc", testing, "def", testing2, "jkl" });
+            VerifyException<T>(new string[] { "abc", testing, testing2, "ghi", "jkl" });
+            VerifyException<T>(new string[] { testing, "abc", "def", "ghi", testing2 });
+            VerifyException<T>(new string[] { testing, "abc", "def", testing2, "jkl" });
+            VerifyException<T>(new string[] { testing, "abc", testing2, "ghi", "jkl" });
+            VerifyException<T>(new string[] { testing, testing2, "def", "ghi", "jkl" });
+        }
     }
 }
-

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -2,663 +2,663 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
-
 using Xunit;
 
-public static class PathTests
+namespace System.IO.Tests
 {
-    [Theory]
-    [InlineData(null, null, null)]
-    [InlineData(null, "exe", null)]
-    [InlineData("", "", "")]
-    [InlineData("file.exe", null, "file")]
-    [InlineData("file.exe", "", "file.")]
-    [InlineData("file", "exe", "file.exe")]
-    [InlineData("file", ".exe", "file.exe")]
-    [InlineData("file.txt", "exe", "file.exe")]
-    [InlineData("file.txt", ".exe", "file.exe")]
-    [InlineData("file.txt.bin", "exe", "file.txt.exe")]
-    [InlineData("dir/file.t", "exe", "dir/file.exe")]
-    [InlineData("dir/file.exe", "t", "dir/file.t")]
-    [InlineData("dir/file", "exe", "dir/file.exe")]
-    public static void ChangeExtension(string path, string newExtension, string expected)
+    public static class PathTests
     {
-        if (expected != null)
-            expected = expected.Replace('/', Path.DirectorySeparatorChar);
-        if (path != null)
-            path = path.Replace('/', Path.DirectorySeparatorChar);
-        Assert.Equal(expected, Path.ChangeExtension(path, newExtension));
-    }
-
-    [Theory]
-    [InlineData(null, null)]
-    [InlineData("", null)]
-    [InlineData(".", "")]
-    [InlineData("..", "")]
-    [InlineData("baz", "")]
-    public static void GetDirectoryName(string path, string expected)
-    {
-        Assert.Equal(expected, Path.GetDirectoryName(path));
-    }
-
-    [Theory]
-    [InlineData(@"dir/baz", "dir")]
-    [InlineData(@"dir\baz", "dir")]
-    [InlineData(@"dir\baz\bar", @"dir\baz")]
-    [InlineData(@"dir\\baz", "dir")]
-    [InlineData(@" dir\baz", " dir")]
-    [InlineData(@" C:\dir\baz", @"C:\dir")]
-    [InlineData(@"..\..\files.txt", @"..\..")]
-    [InlineData(@"C:\", null)]
-    [InlineData(@"C:", null)]
-    [PlatformSpecific(PlatformID.Windows)]
-    public static void GetDirectoryName_Windows(string path, string expected)
-    {
-        Assert.Equal(expected, Path.GetDirectoryName(path));
-    }
-
-    [Theory]
-    [InlineData(@"dir/baz", @"dir")]
-    [InlineData(@"dir//baz", @"dir")]
-    [InlineData(@"dir\baz", @"")]
-    [InlineData(@"dir/baz/bar", @"dir/baz")]
-    [InlineData(@"../../files.txt", @"../..")]
-    [InlineData(@"/", null)]
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    public static void GetDirectoryName_Unix(string path, string expected)
-    {
-        Assert.Equal(expected, Path.GetDirectoryName(path));
-    }
-
-    [Fact]
-    public static void GetDirectoryName_CurrentDirectory()
-    {
-        string curDir = Directory.GetCurrentDirectory();
-        Assert.Equal(curDir, Path.GetDirectoryName(Path.Combine(curDir, "baz")));
-        Assert.Equal(null, Path.GetDirectoryName(Path.GetPathRoot(curDir)));
-    }
-
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    [Fact]
-    public static void GetDirectoryName_ControlCharacters_Unix()
-    {
-        Assert.Equal(new string('\t', 1), Path.GetDirectoryName(Path.Combine(new string('\t', 1), "file")));
-        Assert.Equal(new string('\b', 2), Path.GetDirectoryName(Path.Combine(new string('\b', 2), "fi le")));
-        Assert.Equal(new string('\v', 3), Path.GetDirectoryName(Path.Combine(new string('\v', 3), "fi\nle")));
-        Assert.Equal(new string('\n', 4), Path.GetDirectoryName(Path.Combine(new string('\n', 4), "fi\rle")));
-    }
-
-    [Theory]
-    [InlineData("file.exe", ".exe")]
-    [InlineData("file", "")]
-    [InlineData(null, null)]
-    [InlineData("file.", "")]
-    [InlineData("file.s", ".s")]
-    [InlineData("test/file", "")]
-    [InlineData("test/file.extension", ".extension")]
-    public static void GetExtension(string path, string expected)
-    {
-        if (path != null)
+        [Theory]
+        [InlineData(null, null, null)]
+        [InlineData(null, "exe", null)]
+        [InlineData("", "", "")]
+        [InlineData("file.exe", null, "file")]
+        [InlineData("file.exe", "", "file.")]
+        [InlineData("file", "exe", "file.exe")]
+        [InlineData("file", ".exe", "file.exe")]
+        [InlineData("file.txt", "exe", "file.exe")]
+        [InlineData("file.txt", ".exe", "file.exe")]
+        [InlineData("file.txt.bin", "exe", "file.txt.exe")]
+        [InlineData("dir/file.t", "exe", "dir/file.exe")]
+        [InlineData("dir/file.exe", "t", "dir/file.t")]
+        [InlineData("dir/file", "exe", "dir/file.exe")]
+        public static void ChangeExtension(string path, string newExtension, string expected)
         {
-            path = path.Replace('/', Path.DirectorySeparatorChar);
+            if (expected != null)
+                expected = expected.Replace('/', Path.DirectorySeparatorChar);
+            if (path != null)
+                path = path.Replace('/', Path.DirectorySeparatorChar);
+            Assert.Equal(expected, Path.ChangeExtension(path, newExtension));
         }
-        Assert.Equal(expected, Path.GetExtension(path));
-        Assert.Equal(!string.IsNullOrEmpty(expected), Path.HasExtension(path));
-    }
 
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    [Theory]
-    [InlineData("file.e xe", ".e xe")]
-    [InlineData("file. ", ". ")]
-    [InlineData(" file. ", ". ")]
-    [InlineData(" file.extension", ".extension")]
-    [InlineData("file.exten\tsion", ".exten\tsion")]
-    public static void GetExtension_Unix(string path, string expected)
-    {
-        Assert.Equal(expected, Path.GetExtension(path));
-        Assert.Equal(!string.IsNullOrEmpty(expected), Path.HasExtension(path));
-    }
-
-    public static IEnumerable<object[]> GetFileName_TestData()
-    {
-        yield return new object[] { null, null };
-        yield return new object[] { ".", "." };
-        yield return new object[] { "..", ".." };
-        yield return new object[] { "file", "file" };
-        yield return new object[] { "file.", "file." };
-        yield return new object[] { "file.exe", "file.exe" };
-        yield return new object[] { Path.Combine("baz", "file.exe"), "file.exe" };
-        yield return new object[] { Path.Combine("bar", "baz", "file.exe"), "file.exe" };
-        yield return new object[] { Path.Combine("bar", "baz", "file.exe") + Path.DirectorySeparatorChar, "" };
-    }
-
-    [Theory]
-    [MemberData(nameof(GetFileName_TestData))]
-    public static void GetFileName(string path, string expected)
-    {
-        Assert.Equal(expected, Path.GetFileName(path));
-    }
-
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    [Fact]
-    public static void GetFileName_Unix()
-    {
-        Assert.Equal(" . ", Path.GetFileName(" . "));
-        Assert.Equal(" .. ", Path.GetFileName(" .. "));
-        Assert.Equal("fi le", Path.GetFileName("fi le"));
-        Assert.Equal("fi  le", Path.GetFileName("fi  le"));
-        Assert.Equal("fi  le", Path.GetFileName(Path.Combine("b \r\n ar", "fi  le")));
-    }
-
-    public static IEnumerable<object[]> GetFileNameWithoutExtension_TestData()
-    {
-        yield return new object[] { null, null };
-        yield return new object[] { "", "" };
-        yield return new object[] { "file", "file" };
-        yield return new object[] { "file.exe", "file" };
-        yield return new object[] { Path.Combine("bar", "baz", "file.exe"), "file" };
-        yield return new object[] { Path.Combine("bar", "baz") + Path.DirectorySeparatorChar, "" };
-    }
-
-    [Theory]
-    [MemberData(nameof(GetFileNameWithoutExtension_TestData))]
-    public static void GetFileNameWithoutExtension(string path, string expected)
-    {
-        Assert.Equal(expected, Path.GetFileNameWithoutExtension(path));
-    }
-
-    [Fact]
-    public static void GetPathRoot()
-    {
-        Assert.Null(Path.GetPathRoot(null));
-        Assert.Equal(string.Empty, Path.GetPathRoot(string.Empty));
-
-        string cwd = Directory.GetCurrentDirectory();
-        Assert.Equal(cwd.Substring(0, cwd.IndexOf(Path.DirectorySeparatorChar) + 1), Path.GetPathRoot(cwd));
-        Assert.True(Path.IsPathRooted(cwd));
-
-        Assert.Equal(string.Empty, Path.GetPathRoot(@"file.exe"));
-        Assert.False(Path.IsPathRooted("file.exe"));
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Theory]
-    [InlineData(@"\\test\unc\path\to\something", @"\\test\unc")]
-    [InlineData(@"\\a\b\c\d\e", @"\\a\b")]
-    [InlineData(@"\\a\b\", @"\\a\b")]
-    [InlineData(@"\\a\b", @"\\a\b")]
-    [InlineData(@"\\test\unc", @"\\test\unc")]
-    [InlineData(@"\\?\UNC\test\unc\path\to\something", @"\\?\UNC\test\unc")]
-    [InlineData(@"\\?\UNC\test\unc", @"\\?\UNC\test\unc")]
-    [InlineData(@"\\?\UNC\a\b", @"\\?\UNC\a\b")]
-    [InlineData(@"\\?\UNC\a\b\", @"\\?\UNC\a\b")]
-    [InlineData(@"\\?\C:\foo\bar.txt", @"\\?\C:\")]
-    public static void GetPathRoot_Windows_UncAndExtended(string value, string expected)
-    {
-        Assert.True(Path.IsPathRooted(value));
-        Assert.Equal(expected, Path.GetPathRoot(value));
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Theory]
-    [InlineData(@"C:", @"C:")]
-    [InlineData(@"C:\", @"C:\")]
-    [InlineData(@"C:\\", @"C:\")]
-    [InlineData(@"C://", @"C:\")]
-    [InlineData(@"C:\foo", @"C:\")]
-    [InlineData(@"C:\\foo", @"C:\")]
-    [InlineData(@"C://foo", @"C:\")]
-    public static void GetPathRoot_Windows(string value, string expected)
-    {
-        Assert.True(Path.IsPathRooted(value));
-        Assert.Equal(expected, Path.GetPathRoot(value));
-    }
-
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    [Fact]
-    public static void GetPathRoot_Unix()
-    {
-        // slashes are normal filename characters
-        string uncPath = @"\\test\unc\path\to\something";
-        Assert.False(Path.IsPathRooted(uncPath));
-        Assert.Equal(string.Empty, Path.GetPathRoot(uncPath));
-    }
-
-    [Fact]
-    public static void GetRandomFileName()
-    {
-        char[] invalidChars = Path.GetInvalidFileNameChars();
-        var fileNames = new HashSet<string>();
-        for (int i = 0; i < 100; i++)
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", null)]
+        [InlineData(".", "")]
+        [InlineData("..", "")]
+        [InlineData("baz", "")]
+        public static void GetDirectoryName(string path, string expected)
         {
-            string s = Path.GetRandomFileName();
-            Assert.Equal(s.Length, 8 + 1 + 3);
-            Assert.Equal(s[8], '.');
-            Assert.Equal(-1, s.IndexOfAny(invalidChars));
-            Assert.True(fileNames.Add(s));
+            Assert.Equal(expected, Path.GetDirectoryName(path));
         }
-    }
 
-    [Fact]
-    public static void GetInvalidPathChars()
-    {
-        Assert.NotNull(Path.GetInvalidPathChars());
-        Assert.NotSame(Path.GetInvalidPathChars(), Path.GetInvalidPathChars());
-        Assert.Equal((IEnumerable<char>)Path.GetInvalidPathChars(), Path.GetInvalidPathChars());
-        Assert.True(Path.GetInvalidPathChars().Length > 0);
-        Assert.All(Path.GetInvalidPathChars(), c =>
+        [Theory]
+        [InlineData(@"dir/baz", "dir")]
+        [InlineData(@"dir\baz", "dir")]
+        [InlineData(@"dir\baz\bar", @"dir\baz")]
+        [InlineData(@"dir\\baz", "dir")]
+        [InlineData(@" dir\baz", " dir")]
+        [InlineData(@" C:\dir\baz", @"C:\dir")]
+        [InlineData(@"..\..\files.txt", @"..\..")]
+        [InlineData(@"C:\", null)]
+        [InlineData(@"C:", null)]
+        [PlatformSpecific(PlatformID.Windows)]
+        public static void GetDirectoryName_Windows(string path, string expected)
         {
-            string bad = c.ToString();
-            Assert.Throws<ArgumentException>(() => Path.ChangeExtension(bad, "ok"));
-            Assert.Throws<ArgumentException>(() => Path.Combine(bad, "ok"));
-            Assert.Throws<ArgumentException>(() => Path.Combine("ok", "ok", bad));
-            Assert.Throws<ArgumentException>(() => Path.Combine("ok", "ok", bad, "ok"));
-            Assert.Throws<ArgumentException>(() => Path.Combine(bad, bad, bad, bad, bad));
-            Assert.Throws<ArgumentException>(() => Path.GetDirectoryName(bad));
-            Assert.Throws<ArgumentException>(() => Path.GetExtension(bad));
-            Assert.Throws<ArgumentException>(() => Path.GetFileName(bad));
-            Assert.Throws<ArgumentException>(() => Path.GetFileNameWithoutExtension(bad));
-            Assert.Throws<ArgumentException>(() => Path.GetFullPath(bad));
-            Assert.Throws<ArgumentException>(() => Path.GetPathRoot(bad));
-            Assert.Throws<ArgumentException>(() => Path.IsPathRooted(bad));
-        });
-    }
+            Assert.Equal(expected, Path.GetDirectoryName(path));
+        }
 
-    [Fact]
-    public static void GetInvalidFileNameChars()
-    {
-        Assert.NotNull(Path.GetInvalidFileNameChars());
-        Assert.NotSame(Path.GetInvalidFileNameChars(), Path.GetInvalidFileNameChars());
-        Assert.Equal((IEnumerable<char>)Path.GetInvalidFileNameChars(), Path.GetInvalidFileNameChars());
-        Assert.True(Path.GetInvalidFileNameChars().Length > 0);
-    }
-
-    [Fact]
-    [OuterLoop]
-    public static void GetInvalidFileNameChars_OtherCharsValid()
-    {
-        string curDir = Directory.GetCurrentDirectory();
-        var invalidChars = new HashSet<char>(Path.GetInvalidFileNameChars());
-        for (int i = 0; i < char.MaxValue; i++)
+        [Theory]
+        [InlineData(@"dir/baz", @"dir")]
+        [InlineData(@"dir//baz", @"dir")]
+        [InlineData(@"dir\baz", @"")]
+        [InlineData(@"dir/baz/bar", @"dir/baz")]
+        [InlineData(@"../../files.txt", @"../..")]
+        [InlineData(@"/", null)]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public static void GetDirectoryName_Unix(string path, string expected)
         {
-            char c = (char)i;
-            if (!invalidChars.Contains(c))
+            Assert.Equal(expected, Path.GetDirectoryName(path));
+        }
+
+        [Fact]
+        public static void GetDirectoryName_CurrentDirectory()
+        {
+            string curDir = Directory.GetCurrentDirectory();
+            Assert.Equal(curDir, Path.GetDirectoryName(Path.Combine(curDir, "baz")));
+            Assert.Equal(null, Path.GetDirectoryName(Path.GetPathRoot(curDir)));
+        }
+
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        [Fact]
+        public static void GetDirectoryName_ControlCharacters_Unix()
+        {
+            Assert.Equal(new string('\t', 1), Path.GetDirectoryName(Path.Combine(new string('\t', 1), "file")));
+            Assert.Equal(new string('\b', 2), Path.GetDirectoryName(Path.Combine(new string('\b', 2), "fi le")));
+            Assert.Equal(new string('\v', 3), Path.GetDirectoryName(Path.Combine(new string('\v', 3), "fi\nle")));
+            Assert.Equal(new string('\n', 4), Path.GetDirectoryName(Path.Combine(new string('\n', 4), "fi\rle")));
+        }
+
+        [Theory]
+        [InlineData("file.exe", ".exe")]
+        [InlineData("file", "")]
+        [InlineData(null, null)]
+        [InlineData("file.", "")]
+        [InlineData("file.s", ".s")]
+        [InlineData("test/file", "")]
+        [InlineData("test/file.extension", ".extension")]
+        public static void GetExtension(string path, string expected)
+        {
+            if (path != null)
             {
-                string name = "file" + c + ".txt";
-                Assert.Equal(Path.Combine(curDir, name), Path.GetFullPath(name));
+                path = path.Replace('/', Path.DirectorySeparatorChar);
+            }
+            Assert.Equal(expected, Path.GetExtension(path));
+            Assert.Equal(!string.IsNullOrEmpty(expected), Path.HasExtension(path));
+        }
+
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        [Theory]
+        [InlineData("file.e xe", ".e xe")]
+        [InlineData("file. ", ". ")]
+        [InlineData(" file. ", ". ")]
+        [InlineData(" file.extension", ".extension")]
+        [InlineData("file.exten\tsion", ".exten\tsion")]
+        public static void GetExtension_Unix(string path, string expected)
+        {
+            Assert.Equal(expected, Path.GetExtension(path));
+            Assert.Equal(!string.IsNullOrEmpty(expected), Path.HasExtension(path));
+        }
+
+        public static IEnumerable<object[]> GetFileName_TestData()
+        {
+            yield return new object[] { null, null };
+            yield return new object[] { ".", "." };
+            yield return new object[] { "..", ".." };
+            yield return new object[] { "file", "file" };
+            yield return new object[] { "file.", "file." };
+            yield return new object[] { "file.exe", "file.exe" };
+            yield return new object[] { Path.Combine("baz", "file.exe"), "file.exe" };
+            yield return new object[] { Path.Combine("bar", "baz", "file.exe"), "file.exe" };
+            yield return new object[] { Path.Combine("bar", "baz", "file.exe") + Path.DirectorySeparatorChar, "" };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetFileName_TestData))]
+        public static void GetFileName(string path, string expected)
+        {
+            Assert.Equal(expected, Path.GetFileName(path));
+        }
+
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        [Fact]
+        public static void GetFileName_Unix()
+        {
+            Assert.Equal(" . ", Path.GetFileName(" . "));
+            Assert.Equal(" .. ", Path.GetFileName(" .. "));
+            Assert.Equal("fi le", Path.GetFileName("fi le"));
+            Assert.Equal("fi  le", Path.GetFileName("fi  le"));
+            Assert.Equal("fi  le", Path.GetFileName(Path.Combine("b \r\n ar", "fi  le")));
+        }
+
+        public static IEnumerable<object[]> GetFileNameWithoutExtension_TestData()
+        {
+            yield return new object[] { null, null };
+            yield return new object[] { "", "" };
+            yield return new object[] { "file", "file" };
+            yield return new object[] { "file.exe", "file" };
+            yield return new object[] { Path.Combine("bar", "baz", "file.exe"), "file" };
+            yield return new object[] { Path.Combine("bar", "baz") + Path.DirectorySeparatorChar, "" };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetFileNameWithoutExtension_TestData))]
+        public static void GetFileNameWithoutExtension(string path, string expected)
+        {
+            Assert.Equal(expected, Path.GetFileNameWithoutExtension(path));
+        }
+
+        [Fact]
+        public static void GetPathRoot()
+        {
+            Assert.Null(Path.GetPathRoot(null));
+            Assert.Equal(string.Empty, Path.GetPathRoot(string.Empty));
+
+            string cwd = Directory.GetCurrentDirectory();
+            Assert.Equal(cwd.Substring(0, cwd.IndexOf(Path.DirectorySeparatorChar) + 1), Path.GetPathRoot(cwd));
+            Assert.True(Path.IsPathRooted(cwd));
+
+            Assert.Equal(string.Empty, Path.GetPathRoot(@"file.exe"));
+            Assert.False(Path.IsPathRooted("file.exe"));
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Theory]
+        [InlineData(@"\\test\unc\path\to\something", @"\\test\unc")]
+        [InlineData(@"\\a\b\c\d\e", @"\\a\b")]
+        [InlineData(@"\\a\b\", @"\\a\b")]
+        [InlineData(@"\\a\b", @"\\a\b")]
+        [InlineData(@"\\test\unc", @"\\test\unc")]
+        [InlineData(@"\\?\UNC\test\unc\path\to\something", @"\\?\UNC\test\unc")]
+        [InlineData(@"\\?\UNC\test\unc", @"\\?\UNC\test\unc")]
+        [InlineData(@"\\?\UNC\a\b", @"\\?\UNC\a\b")]
+        [InlineData(@"\\?\UNC\a\b\", @"\\?\UNC\a\b")]
+        [InlineData(@"\\?\C:\foo\bar.txt", @"\\?\C:\")]
+        public static void GetPathRoot_Windows_UncAndExtended(string value, string expected)
+        {
+            Assert.True(Path.IsPathRooted(value));
+            Assert.Equal(expected, Path.GetPathRoot(value));
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Theory]
+        [InlineData(@"C:", @"C:")]
+        [InlineData(@"C:\", @"C:\")]
+        [InlineData(@"C:\\", @"C:\")]
+        [InlineData(@"C://", @"C:\")]
+        [InlineData(@"C:\foo", @"C:\")]
+        [InlineData(@"C:\\foo", @"C:\")]
+        [InlineData(@"C://foo", @"C:\")]
+        public static void GetPathRoot_Windows(string value, string expected)
+        {
+            Assert.True(Path.IsPathRooted(value));
+            Assert.Equal(expected, Path.GetPathRoot(value));
+        }
+
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        [Fact]
+        public static void GetPathRoot_Unix()
+        {
+            // slashes are normal filename characters
+            string uncPath = @"\\test\unc\path\to\something";
+            Assert.False(Path.IsPathRooted(uncPath));
+            Assert.Equal(string.Empty, Path.GetPathRoot(uncPath));
+        }
+
+        [Fact]
+        public static void GetRandomFileName()
+        {
+            char[] invalidChars = Path.GetInvalidFileNameChars();
+            var fileNames = new HashSet<string>();
+            for (int i = 0; i < 100; i++)
+            {
+                string s = Path.GetRandomFileName();
+                Assert.Equal(s.Length, 8 + 1 + 3);
+                Assert.Equal(s[8], '.');
+                Assert.Equal(-1, s.IndexOfAny(invalidChars));
+                Assert.True(fileNames.Add(s));
             }
         }
-    }
 
-    [Fact]
-    public static void GetTempPath_Default()
-    {
-        string tmpPath = Path.GetTempPath();
-        Assert.False(string.IsNullOrEmpty(tmpPath));
-        Assert.Equal(tmpPath, Path.GetTempPath());
-        Assert.Equal(Path.DirectorySeparatorChar, tmpPath[tmpPath.Length - 1]);
-        Assert.True(Directory.Exists(tmpPath));
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Theory]
-    [InlineData(@"C:\Users\someuser\AppData\Local\Temp\", @"C:\Users\someuser\AppData\Local\Temp")]
-    [InlineData(@"C:\Users\someuser\AppData\Local\Temp\", @"C:\Users\someuser\AppData\Local\Temp\")]
-    [InlineData(@"C:\", @"C:\")]
-    [InlineData(@"C:\tmp\", @"C:\tmp")]
-    [InlineData(@"C:\tmp\", @"C:\tmp\")]
-    public static void GetTempPath_SetEnvVar_Windows(string expected, string newTempPath)
-    {
-        GetTempPath_SetEnvVar("TMP", expected, newTempPath);
-    }
-
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    [Theory]
-    [InlineData("/tmp/", "/tmp")]
-    [InlineData("/tmp/", "/tmp/")]
-    [InlineData("/", "/")]
-    [InlineData("/var/tmp/", "/var/tmp")]
-    [InlineData("/var/tmp/", "/var/tmp/")]
-    [InlineData("~/", "~")]
-    [InlineData("~/", "~/")]
-    [InlineData(".tmp/", ".tmp")]
-    [InlineData("./tmp/", "./tmp")]
-    [InlineData("/home/someuser/sometempdir/", "/home/someuser/sometempdir/")]
-    [InlineData("/home/someuser/some tempdir/", "/home/someuser/some tempdir/")]
-    [InlineData("/tmp/", null)]
-    public static void GetTempPath_SetEnvVar_Unix(string expected, string newTempPath)
-    {
-        GetTempPath_SetEnvVar("TMPDIR", expected, newTempPath);
-    }
-
-    private static void GetTempPath_SetEnvVar(string envVar, string expected, string newTempPath)
-    {
-        string original = Path.GetTempPath();
-        Assert.NotNull(original);
-        try
+        [Fact]
+        public static void GetInvalidPathChars()
         {
-            Environment.SetEnvironmentVariable(envVar, newTempPath);
-            Assert.Equal(
-                Path.GetFullPath(expected),
-                Path.GetFullPath(Path.GetTempPath()));
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(envVar, original);
-            Assert.Equal(original, Path.GetTempPath());
-        }
-    }
-
-    [Fact]
-    public static void GetTempFileName()
-    {
-        string tmpFile = Path.GetTempFileName();
-        try
-        {
-            Assert.True(File.Exists(tmpFile));
-            Assert.Equal(".tmp", Path.GetExtension(tmpFile), ignoreCase: true, ignoreLineEndingDifferences: false, ignoreWhiteSpaceDifferences: false);
-            Assert.Equal(-1, tmpFile.IndexOfAny(Path.GetInvalidPathChars()));
-            using (FileStream fs = File.OpenRead(tmpFile))
+            Assert.NotNull(Path.GetInvalidPathChars());
+            Assert.NotSame(Path.GetInvalidPathChars(), Path.GetInvalidPathChars());
+            Assert.Equal((IEnumerable<char>)Path.GetInvalidPathChars(), Path.GetInvalidPathChars());
+            Assert.True(Path.GetInvalidPathChars().Length > 0);
+            Assert.All(Path.GetInvalidPathChars(), c =>
             {
-                Assert.Equal(0, fs.Length);
-            }
-            Assert.Equal(Path.Combine(Path.GetTempPath(), Path.GetFileName(tmpFile)), tmpFile);
-        }
-        finally
-        {
-            File.Delete(tmpFile);
-        }
-    }
-
-    [Fact]
-
-    public static void GetFullPath_InvalidArgs()
-    {
-        Assert.Throws<ArgumentNullException>(() => Path.GetFullPath(null));
-        Assert.Throws<ArgumentException>(() => Path.GetFullPath(string.Empty));
-    }
-
-    public static IEnumerable<object[]> GetFullPath_BasicExpansions_TestData()
-    {
-        string curDir = Directory.GetCurrentDirectory();
-        yield return new object[] { curDir, curDir }; // Current directory => current directory
-        yield return new object[] { ".", curDir }; // "." => current directory
-        yield return new object[] { "..", Path.GetDirectoryName(curDir) }; // "." => up a directory
-        yield return new object[] { Path.Combine(curDir, ".", ".", ".", ".", "."), curDir }; // "dir/./././." => "dir"
-        yield return new object[] { curDir + new string(Path.DirectorySeparatorChar, 3) + ".", curDir }; // "dir///." => "dir"
-        yield return new object[] { Path.Combine(curDir, "..", Path.GetFileName(curDir), ".", "..", Path.GetFileName(curDir)), curDir }; // "dir/../dir/./../dir" => "dir"
-        yield return new object[] { Path.Combine(Path.GetPathRoot(curDir), "somedir", ".."), Path.GetPathRoot(curDir) }; // "C:\somedir\.." => "C:\"
-        yield return new object[] { Path.Combine(Path.GetPathRoot(curDir), "."), Path.GetPathRoot(curDir) }; // "C:\." => "C:\"
-        yield return new object[] { Path.Combine(Path.GetPathRoot(curDir), "..", "..", "..", ".."), Path.GetPathRoot(curDir) }; // "C:\..\..\..\.." => "C:\"
-        yield return new object[] { Path.GetPathRoot(curDir) + new string(Path.DirectorySeparatorChar, 3), Path.GetPathRoot(curDir) }; // "C:\\\" => "C:\"
-
-        // Path longer than MaxPath that normalizes down to less than MaxPath
-        const int Iters = 10000;
-        var longPath = new StringBuilder(curDir, curDir.Length + (Iters * 2));
-        for (int i = 0; i < 10000; i++)
-        {
-            longPath.Append(Path.DirectorySeparatorChar).Append('.');
-        }
-        yield return new object[] { longPath.ToString(), curDir };
-    }
-
-    [Theory]
-    [MemberData(nameof(GetFullPath_BasicExpansions_TestData))]
-    public static void GetFullPath_BasicExpansions(string path, string expected)
-    {
-        Assert.Equal(expected, Path.GetFullPath(path));
-    }
-
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    [Fact]
-    public static void GetFullPath_Unix_Whitespace()
-    {
-        string curDir = Directory.GetCurrentDirectory();
-        Assert.Equal("/ / ", Path.GetFullPath("/ // "));
-        Assert.Equal(Path.Combine(curDir, "    "), Path.GetFullPath("    "));
-        Assert.Equal(Path.Combine(curDir, "\r\n"), Path.GetFullPath("\r\n"));
-    }
-
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    [Theory]
-    [InlineData("http://www.microsoft.com")]
-    [InlineData("file://somefile")]
-    public static void GetFullPath_Unix_URIsAsFileNames(string uriAsFileName)
-    {
-        // URIs are valid filenames, though the multiple slashes will be consolidated in GetFullPath
-        Assert.Equal(
-            Path.Combine(Directory.GetCurrentDirectory(), uriAsFileName.Replace("//", "/")),
-            Path.GetFullPath(uriAsFileName));
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Fact]
-    public static void GetFullPath_Windows_NormalizedLongPathTooLong()
-    {
-        // Try out a long path that normalizes down to more than MaxPath
-        string curDir = Directory.GetCurrentDirectory();
-        const int Iters = 260;
-        var longPath = new StringBuilder(curDir, curDir.Length + (Iters * 4));
-        for (int i = 0; i < Iters; i++)
-        {
-            longPath.Append(Path.DirectorySeparatorChar).Append('a').Append(Path.DirectorySeparatorChar).Append('.');
+                string bad = c.ToString();
+                Assert.Throws<ArgumentException>(() => Path.ChangeExtension(bad, "ok"));
+                Assert.Throws<ArgumentException>(() => Path.Combine(bad, "ok"));
+                Assert.Throws<ArgumentException>(() => Path.Combine("ok", "ok", bad));
+                Assert.Throws<ArgumentException>(() => Path.Combine("ok", "ok", bad, "ok"));
+                Assert.Throws<ArgumentException>(() => Path.Combine(bad, bad, bad, bad, bad));
+                Assert.Throws<ArgumentException>(() => Path.GetDirectoryName(bad));
+                Assert.Throws<ArgumentException>(() => Path.GetExtension(bad));
+                Assert.Throws<ArgumentException>(() => Path.GetFileName(bad));
+                Assert.Throws<ArgumentException>(() => Path.GetFileNameWithoutExtension(bad));
+                Assert.Throws<ArgumentException>(() => Path.GetFullPath(bad));
+                Assert.Throws<ArgumentException>(() => Path.GetPathRoot(bad));
+                Assert.Throws<ArgumentException>(() => Path.IsPathRooted(bad));
+            });
         }
 
-        // Now no longer throws unless over ~32K
-        Assert.NotNull(Path.GetFullPath(longPath.ToString()));
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Fact]
-    public static void GetFullPath_Windows_AlternateDataStreamsNotSupported()
-    {
-        // Throws via our invalid colon filtering
-        Assert.Throws<NotSupportedException>(() => Path.GetFullPath(@"bad:path"));
-        Assert.Throws<NotSupportedException>(() => Path.GetFullPath(@"C:\some\bad:path"));
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Fact]
-    public static void GetFullPath_Windows_URIFormatNotSupported()
-    {
-        // Throws via our invalid colon filtering
-        Assert.Throws<NotSupportedException>(() => Path.GetFullPath("http://www.microsoft.com"));
-        Assert.Throws<NotSupportedException>(() => Path.GetFullPath("file://www.microsoft.com"));
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Theory]
-    [InlineData(@"\\?\GLOBALROOT\")]
-    [InlineData(@"\\?\")]
-    [InlineData(@"\\?\.")]
-    [InlineData(@"\\?\..")]
-    [InlineData(@"\\?\\")]
-    [InlineData(@"\\?\C:\\")]
-    [InlineData(@"\\?\C:\|")]
-    [InlineData(@"\\?\C:\.")]
-    [InlineData(@"\\?\C:\..")]
-    [InlineData(@"\\?\C:\Foo\.")]
-    [InlineData(@"\\?\C:\Foo\..")]
-    public static void GetFullPath_Windows_ArgumentExceptionPaths(string path)
-    {
-        Assert.Throws<ArgumentException>(() => Path.GetFullPath(path));
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Theory]
-    [InlineData(@"bad::$DATA")]
-    [InlineData(@"C  :")]
-    [InlineData(@"C  :\somedir")]
-    public static void GetFullPath_Windows_NotSupportedExceptionPaths(string path)
-    {
-        // Many of these used to throw ArgumentException despite being documented as NotSupportedException
-        Assert.Throws<NotSupportedException>(() => Path.GetFullPath(path));
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Theory]
-    [InlineData(@"C:...")]
-    [InlineData(@"C:...\somedir")]
-    [InlineData(@"\.. .\")]
-    [InlineData(@"\. .\")]
-    [InlineData(@"\ .\")]
-    public static void GetFullPath_Windows_LegacyArgumentExceptionPaths(string path)
-    {
-        // These paths are legitimate Windows paths that can be created without extended syntax.
-        // We now allow them through.
-        Path.GetFullPath(path);
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Fact]
-    public static void GetFullPath_Windows_MaxPathNotTooLong()
-    {
-        // Shouldn't throw anymore
-        Path.GetFullPath(@"C:\" + new string('a', 255) + @"\");
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Fact]
-    public static void GetFullPath_Windows_PathTooLong()
-    {
-        Assert.Throws<PathTooLongException>(() => Path.GetFullPath(@"C:\" + new string('a', short.MaxValue) + @"\"));
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Theory]
-    [InlineData(@"C:\", @"C:\")]
-    [InlineData(@"C:\.", @"C:\")]
-    [InlineData(@"C:\..", @"C:\")]
-    [InlineData(@"C:\..\..", @"C:\")]
-    [InlineData(@"C:\A\..", @"C:\")]
-    [InlineData(@"C:\..\..\A\..", @"C:\")]
-    public static void GetFullPath_Windows_RelativeRoot(string path, string expected)
-    {
-        Assert.Equal(Path.GetFullPath(path), expected);
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Fact]
-    public static void GetFullPath_Windows_StrangeButLegalPaths()
-    {
-        // These are legal and creatable without using extended syntax if you use a trailing slash
-        // (such as "md ...\"). We used to filter these out, but now allow them to prevent apps from
-        // being blocked when they hit these paths.
-        string curDir = Directory.GetCurrentDirectory();
-        Assert.NotEqual(
-            Path.GetFullPath(curDir + Path.DirectorySeparatorChar),
-            Path.GetFullPath(curDir + Path.DirectorySeparatorChar + ". " + Path.DirectorySeparatorChar));
-        Assert.NotEqual(
-            Path.GetFullPath(Path.GetDirectoryName(curDir) + Path.DirectorySeparatorChar),
-            Path.GetFullPath(curDir + Path.DirectorySeparatorChar + "..." + Path.DirectorySeparatorChar));
-        Assert.NotEqual(
-            Path.GetFullPath(Path.GetDirectoryName(curDir) + Path.DirectorySeparatorChar),
-            Path.GetFullPath(curDir + Path.DirectorySeparatorChar + ".. " + Path.DirectorySeparatorChar));
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Theory]
-    [InlineData(@"\\?\C:\ ")]
-    [InlineData(@"\\?\C:\ \ ")]
-    [InlineData(@"\\?\C:\ .")]
-    [InlineData(@"\\?\C:\ ..")]
-    [InlineData(@"\\?\C:\...")]
-    public static void GetFullPath_Windows_ValidExtendedPaths(string path)
-    {
-        Assert.Equal(path, Path.GetFullPath(path));
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Theory]
-    [InlineData(@"\\server\share", @"\\server\share")]
-    [InlineData(@"\\server\share", @" \\server\share")]
-    [InlineData(@"\\server\share\dir", @"\\server\share\dir")]
-    [InlineData(@"\\server\share", @"\\server\share\.")]
-    [InlineData(@"\\server\share", @"\\server\share\..")]
-    [InlineData(@"\\server\share\", @"\\server\share\    ")]
-    [InlineData(@"\\server\  share\", @"\\server\  share\")]
-    [InlineData(@"\\?\UNC\server\share", @"\\?\UNC\server\share")]
-    [InlineData(@"\\?\UNC\server\share\dir", @"\\?\UNC\server\share\dir")]
-    [InlineData(@"\\?\UNC\server\share\. ", @"\\?\UNC\server\share\. ")]
-    [InlineData(@"\\?\UNC\server\share\.. ", @"\\?\UNC\server\share\.. ")]
-    [InlineData(@"\\?\UNC\server\share\    ", @"\\?\UNC\server\share\    ")]
-    [InlineData(@"\\?\UNC\server\  share\", @"\\?\UNC\server\  share\")]
-    public static void GetFullPath_Windows_UNC_Valid(string expected, string input)
-    {
-        Assert.Equal(expected, Path.GetFullPath(input));
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Theory]
-    [InlineData(@"\\")]
-    [InlineData(@"\\server")]
-    [InlineData(@"\\server\")]
-    [InlineData(@"\\server\\")]
-    [InlineData(@"\\server\..")]
-    [InlineData(@"\\?\UNC\")]
-    [InlineData(@"\\?\UNC\server")]
-    [InlineData(@"\\?\UNC\server\")]
-    [InlineData(@"\\?\UNC\server\\")]
-    [InlineData(@"\\?\UNC\server\..")]
-    [InlineData(@"\\?\UNC\server\share\.")]
-    [InlineData(@"\\?\UNC\server\share\..")]
-    [InlineData(@"\\?\UNC\a\b\\")]
-    public static void GetFullPath_Windows_UNC_Invalid(string invalidPath)
-    {
-        Assert.Throws<ArgumentException>(() => Path.GetFullPath(invalidPath));
-    }
-
-    [PlatformSpecific(PlatformID.Windows)]
-    [Fact]
-    public static void GetFullPath_Windows_83Paths()
-    {
-        // Create a temporary file name with a name longer than 8.3 such that it'll need to be shortened.
-        string tempFilePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
-        File.Create(tempFilePath).Dispose();
-        try
+        [Fact]
+        public static void GetInvalidFileNameChars()
         {
-            // Get its short name
-            var sb = new StringBuilder(260);
-            if (GetShortPathName(tempFilePath, sb, sb.Capacity) > 0) // only proceed if we could successfully create the short name
+            Assert.NotNull(Path.GetInvalidFileNameChars());
+            Assert.NotSame(Path.GetInvalidFileNameChars(), Path.GetInvalidFileNameChars());
+            Assert.Equal((IEnumerable<char>)Path.GetInvalidFileNameChars(), Path.GetInvalidFileNameChars());
+            Assert.True(Path.GetInvalidFileNameChars().Length > 0);
+        }
+
+        [Fact]
+        [OuterLoop]
+        public static void GetInvalidFileNameChars_OtherCharsValid()
+        {
+            string curDir = Directory.GetCurrentDirectory();
+            var invalidChars = new HashSet<char>(Path.GetInvalidFileNameChars());
+            for (int i = 0; i < char.MaxValue; i++)
             {
-                // Make sure the shortened name expands back to the original one
-                Assert.Equal(tempFilePath, Path.GetFullPath(sb.ToString()));
-
-                // Validate case where short name doesn't expand to a real file
-                string invalidShortName = @"S:\DOESNT~1\USERNA~1.RED\LOCALS~1\Temp\bg3ylpzp";
-                Assert.Equal(invalidShortName, Path.GetFullPath(invalidShortName));
-
-                // Same thing, but with a long path that normalizes down to a short enough one
-                const int Iters = 1000;
-                var shortLongName = new StringBuilder(invalidShortName, invalidShortName.Length + (Iters * 2));
-                for (int i = 0; i < Iters; i++)
+                char c = (char)i;
+                if (!invalidChars.Contains(c))
                 {
-                    shortLongName.Append(Path.DirectorySeparatorChar).Append('.');
+                    string name = "file" + c + ".txt";
+                    Assert.Equal(Path.Combine(curDir, name), Path.GetFullPath(name));
                 }
-                Assert.Equal(invalidShortName, Path.GetFullPath(shortLongName.ToString()));
             }
         }
-        finally
+
+        [Fact]
+        public static void GetTempPath_Default()
         {
-            File.Delete(tempFilePath);
+            string tmpPath = Path.GetTempPath();
+            Assert.False(string.IsNullOrEmpty(tmpPath));
+            Assert.Equal(tmpPath, Path.GetTempPath());
+            Assert.Equal(Path.DirectorySeparatorChar, tmpPath[tmpPath.Length - 1]);
+            Assert.True(Directory.Exists(tmpPath));
         }
-    }
 
-    [PlatformSpecific(PlatformID.Windows)]
-    [Theory]
-    [InlineData('*')]
-    [InlineData('?')]
-    public static void GetFullPath_Windows_Wildcards(char wildcard)
-    {
-        Assert.Throws<ArgumentException>("path", () => Path.GetFullPath("test" + wildcard + "ing"));
-    }
+        [PlatformSpecific(PlatformID.Windows)]
+        [Theory]
+        [InlineData(@"C:\Users\someuser\AppData\Local\Temp\", @"C:\Users\someuser\AppData\Local\Temp")]
+        [InlineData(@"C:\Users\someuser\AppData\Local\Temp\", @"C:\Users\someuser\AppData\Local\Temp\")]
+        [InlineData(@"C:\", @"C:\")]
+        [InlineData(@"C:\tmp\", @"C:\tmp")]
+        [InlineData(@"C:\tmp\", @"C:\tmp\")]
+        public static void GetTempPath_SetEnvVar_Windows(string expected, string newTempPath)
+        {
+            GetTempPath_SetEnvVar("TMP", expected, newTempPath);
+        }
 
-    // Windows-only P/Invoke to create 8.3 short names from long names
-    [DllImport("kernel32.dll", CharSet = CharSet.Ansi)]
-    private static extern uint GetShortPathName(string lpszLongPath, StringBuilder lpszShortPath, int cchBuffer);
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        [Theory]
+        [InlineData("/tmp/", "/tmp")]
+        [InlineData("/tmp/", "/tmp/")]
+        [InlineData("/", "/")]
+        [InlineData("/var/tmp/", "/var/tmp")]
+        [InlineData("/var/tmp/", "/var/tmp/")]
+        [InlineData("~/", "~")]
+        [InlineData("~/", "~/")]
+        [InlineData(".tmp/", ".tmp")]
+        [InlineData("./tmp/", "./tmp")]
+        [InlineData("/home/someuser/sometempdir/", "/home/someuser/sometempdir/")]
+        [InlineData("/home/someuser/some tempdir/", "/home/someuser/some tempdir/")]
+        [InlineData("/tmp/", null)]
+        public static void GetTempPath_SetEnvVar_Unix(string expected, string newTempPath)
+        {
+            GetTempPath_SetEnvVar("TMPDIR", expected, newTempPath);
+        }
+
+        private static void GetTempPath_SetEnvVar(string envVar, string expected, string newTempPath)
+        {
+            string original = Path.GetTempPath();
+            Assert.NotNull(original);
+            try
+            {
+                Environment.SetEnvironmentVariable(envVar, newTempPath);
+                Assert.Equal(
+                    Path.GetFullPath(expected),
+                    Path.GetFullPath(Path.GetTempPath()));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, original);
+                Assert.Equal(original, Path.GetTempPath());
+            }
+        }
+
+        [Fact]
+        public static void GetTempFileName()
+        {
+            string tmpFile = Path.GetTempFileName();
+            try
+            {
+                Assert.True(File.Exists(tmpFile));
+                Assert.Equal(".tmp", Path.GetExtension(tmpFile), ignoreCase: true, ignoreLineEndingDifferences: false, ignoreWhiteSpaceDifferences: false);
+                Assert.Equal(-1, tmpFile.IndexOfAny(Path.GetInvalidPathChars()));
+                using (FileStream fs = File.OpenRead(tmpFile))
+                {
+                    Assert.Equal(0, fs.Length);
+                }
+                Assert.Equal(Path.Combine(Path.GetTempPath(), Path.GetFileName(tmpFile)), tmpFile);
+            }
+            finally
+            {
+                File.Delete(tmpFile);
+            }
+        }
+
+        [Fact]
+
+        public static void GetFullPath_InvalidArgs()
+        {
+            Assert.Throws<ArgumentNullException>(() => Path.GetFullPath(null));
+            Assert.Throws<ArgumentException>(() => Path.GetFullPath(string.Empty));
+        }
+
+        public static IEnumerable<object[]> GetFullPath_BasicExpansions_TestData()
+        {
+            string curDir = Directory.GetCurrentDirectory();
+            yield return new object[] { curDir, curDir }; // Current directory => current directory
+            yield return new object[] { ".", curDir }; // "." => current directory
+            yield return new object[] { "..", Path.GetDirectoryName(curDir) }; // "." => up a directory
+            yield return new object[] { Path.Combine(curDir, ".", ".", ".", ".", "."), curDir }; // "dir/./././." => "dir"
+            yield return new object[] { curDir + new string(Path.DirectorySeparatorChar, 3) + ".", curDir }; // "dir///." => "dir"
+            yield return new object[] { Path.Combine(curDir, "..", Path.GetFileName(curDir), ".", "..", Path.GetFileName(curDir)), curDir }; // "dir/../dir/./../dir" => "dir"
+            yield return new object[] { Path.Combine(Path.GetPathRoot(curDir), "somedir", ".."), Path.GetPathRoot(curDir) }; // "C:\somedir\.." => "C:\"
+            yield return new object[] { Path.Combine(Path.GetPathRoot(curDir), "."), Path.GetPathRoot(curDir) }; // "C:\." => "C:\"
+            yield return new object[] { Path.Combine(Path.GetPathRoot(curDir), "..", "..", "..", ".."), Path.GetPathRoot(curDir) }; // "C:\..\..\..\.." => "C:\"
+            yield return new object[] { Path.GetPathRoot(curDir) + new string(Path.DirectorySeparatorChar, 3), Path.GetPathRoot(curDir) }; // "C:\\\" => "C:\"
+
+            // Path longer than MaxPath that normalizes down to less than MaxPath
+            const int Iters = 10000;
+            var longPath = new StringBuilder(curDir, curDir.Length + (Iters * 2));
+            for (int i = 0; i < 10000; i++)
+            {
+                longPath.Append(Path.DirectorySeparatorChar).Append('.');
+            }
+            yield return new object[] { longPath.ToString(), curDir };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetFullPath_BasicExpansions_TestData))]
+        public static void GetFullPath_BasicExpansions(string path, string expected)
+        {
+            Assert.Equal(expected, Path.GetFullPath(path));
+        }
+
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        [Fact]
+        public static void GetFullPath_Unix_Whitespace()
+        {
+            string curDir = Directory.GetCurrentDirectory();
+            Assert.Equal("/ / ", Path.GetFullPath("/ // "));
+            Assert.Equal(Path.Combine(curDir, "    "), Path.GetFullPath("    "));
+            Assert.Equal(Path.Combine(curDir, "\r\n"), Path.GetFullPath("\r\n"));
+        }
+
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        [Theory]
+        [InlineData("http://www.microsoft.com")]
+        [InlineData("file://somefile")]
+        public static void GetFullPath_Unix_URIsAsFileNames(string uriAsFileName)
+        {
+            // URIs are valid filenames, though the multiple slashes will be consolidated in GetFullPath
+            Assert.Equal(
+                Path.Combine(Directory.GetCurrentDirectory(), uriAsFileName.Replace("//", "/")),
+                Path.GetFullPath(uriAsFileName));
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Fact]
+        public static void GetFullPath_Windows_NormalizedLongPathTooLong()
+        {
+            // Try out a long path that normalizes down to more than MaxPath
+            string curDir = Directory.GetCurrentDirectory();
+            const int Iters = 260;
+            var longPath = new StringBuilder(curDir, curDir.Length + (Iters * 4));
+            for (int i = 0; i < Iters; i++)
+            {
+                longPath.Append(Path.DirectorySeparatorChar).Append('a').Append(Path.DirectorySeparatorChar).Append('.');
+            }
+
+            // Now no longer throws unless over ~32K
+            Assert.NotNull(Path.GetFullPath(longPath.ToString()));
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Fact]
+        public static void GetFullPath_Windows_AlternateDataStreamsNotSupported()
+        {
+            // Throws via our invalid colon filtering
+            Assert.Throws<NotSupportedException>(() => Path.GetFullPath(@"bad:path"));
+            Assert.Throws<NotSupportedException>(() => Path.GetFullPath(@"C:\some\bad:path"));
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Fact]
+        public static void GetFullPath_Windows_URIFormatNotSupported()
+        {
+            // Throws via our invalid colon filtering
+            Assert.Throws<NotSupportedException>(() => Path.GetFullPath("http://www.microsoft.com"));
+            Assert.Throws<NotSupportedException>(() => Path.GetFullPath("file://www.microsoft.com"));
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Theory]
+        [InlineData(@"\\?\GLOBALROOT\")]
+        [InlineData(@"\\?\")]
+        [InlineData(@"\\?\.")]
+        [InlineData(@"\\?\..")]
+        [InlineData(@"\\?\\")]
+        [InlineData(@"\\?\C:\\")]
+        [InlineData(@"\\?\C:\|")]
+        [InlineData(@"\\?\C:\.")]
+        [InlineData(@"\\?\C:\..")]
+        [InlineData(@"\\?\C:\Foo\.")]
+        [InlineData(@"\\?\C:\Foo\..")]
+        public static void GetFullPath_Windows_ArgumentExceptionPaths(string path)
+        {
+            Assert.Throws<ArgumentException>(() => Path.GetFullPath(path));
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Theory]
+        [InlineData(@"bad::$DATA")]
+        [InlineData(@"C  :")]
+        [InlineData(@"C  :\somedir")]
+        public static void GetFullPath_Windows_NotSupportedExceptionPaths(string path)
+        {
+            // Many of these used to throw ArgumentException despite being documented as NotSupportedException
+            Assert.Throws<NotSupportedException>(() => Path.GetFullPath(path));
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Theory]
+        [InlineData(@"C:...")]
+        [InlineData(@"C:...\somedir")]
+        [InlineData(@"\.. .\")]
+        [InlineData(@"\. .\")]
+        [InlineData(@"\ .\")]
+        public static void GetFullPath_Windows_LegacyArgumentExceptionPaths(string path)
+        {
+            // These paths are legitimate Windows paths that can be created without extended syntax.
+            // We now allow them through.
+            Path.GetFullPath(path);
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Fact]
+        public static void GetFullPath_Windows_MaxPathNotTooLong()
+        {
+            // Shouldn't throw anymore
+            Path.GetFullPath(@"C:\" + new string('a', 255) + @"\");
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Fact]
+        public static void GetFullPath_Windows_PathTooLong()
+        {
+            Assert.Throws<PathTooLongException>(() => Path.GetFullPath(@"C:\" + new string('a', short.MaxValue) + @"\"));
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Theory]
+        [InlineData(@"C:\", @"C:\")]
+        [InlineData(@"C:\.", @"C:\")]
+        [InlineData(@"C:\..", @"C:\")]
+        [InlineData(@"C:\..\..", @"C:\")]
+        [InlineData(@"C:\A\..", @"C:\")]
+        [InlineData(@"C:\..\..\A\..", @"C:\")]
+        public static void GetFullPath_Windows_RelativeRoot(string path, string expected)
+        {
+            Assert.Equal(Path.GetFullPath(path), expected);
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Fact]
+        public static void GetFullPath_Windows_StrangeButLegalPaths()
+        {
+            // These are legal and creatable without using extended syntax if you use a trailing slash
+            // (such as "md ...\"). We used to filter these out, but now allow them to prevent apps from
+            // being blocked when they hit these paths.
+            string curDir = Directory.GetCurrentDirectory();
+            Assert.NotEqual(
+                Path.GetFullPath(curDir + Path.DirectorySeparatorChar),
+                Path.GetFullPath(curDir + Path.DirectorySeparatorChar + ". " + Path.DirectorySeparatorChar));
+            Assert.NotEqual(
+                Path.GetFullPath(Path.GetDirectoryName(curDir) + Path.DirectorySeparatorChar),
+                Path.GetFullPath(curDir + Path.DirectorySeparatorChar + "..." + Path.DirectorySeparatorChar));
+            Assert.NotEqual(
+                Path.GetFullPath(Path.GetDirectoryName(curDir) + Path.DirectorySeparatorChar),
+                Path.GetFullPath(curDir + Path.DirectorySeparatorChar + ".. " + Path.DirectorySeparatorChar));
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Theory]
+        [InlineData(@"\\?\C:\ ")]
+        [InlineData(@"\\?\C:\ \ ")]
+        [InlineData(@"\\?\C:\ .")]
+        [InlineData(@"\\?\C:\ ..")]
+        [InlineData(@"\\?\C:\...")]
+        public static void GetFullPath_Windows_ValidExtendedPaths(string path)
+        {
+            Assert.Equal(path, Path.GetFullPath(path));
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Theory]
+        [InlineData(@"\\server\share", @"\\server\share")]
+        [InlineData(@"\\server\share", @" \\server\share")]
+        [InlineData(@"\\server\share\dir", @"\\server\share\dir")]
+        [InlineData(@"\\server\share", @"\\server\share\.")]
+        [InlineData(@"\\server\share", @"\\server\share\..")]
+        [InlineData(@"\\server\share\", @"\\server\share\    ")]
+        [InlineData(@"\\server\  share\", @"\\server\  share\")]
+        [InlineData(@"\\?\UNC\server\share", @"\\?\UNC\server\share")]
+        [InlineData(@"\\?\UNC\server\share\dir", @"\\?\UNC\server\share\dir")]
+        [InlineData(@"\\?\UNC\server\share\. ", @"\\?\UNC\server\share\. ")]
+        [InlineData(@"\\?\UNC\server\share\.. ", @"\\?\UNC\server\share\.. ")]
+        [InlineData(@"\\?\UNC\server\share\    ", @"\\?\UNC\server\share\    ")]
+        [InlineData(@"\\?\UNC\server\  share\", @"\\?\UNC\server\  share\")]
+        public static void GetFullPath_Windows_UNC_Valid(string expected, string input)
+        {
+            Assert.Equal(expected, Path.GetFullPath(input));
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Theory]
+        [InlineData(@"\\")]
+        [InlineData(@"\\server")]
+        [InlineData(@"\\server\")]
+        [InlineData(@"\\server\\")]
+        [InlineData(@"\\server\..")]
+        [InlineData(@"\\?\UNC\")]
+        [InlineData(@"\\?\UNC\server")]
+        [InlineData(@"\\?\UNC\server\")]
+        [InlineData(@"\\?\UNC\server\\")]
+        [InlineData(@"\\?\UNC\server\..")]
+        [InlineData(@"\\?\UNC\server\share\.")]
+        [InlineData(@"\\?\UNC\server\share\..")]
+        [InlineData(@"\\?\UNC\a\b\\")]
+        public static void GetFullPath_Windows_UNC_Invalid(string invalidPath)
+        {
+            Assert.Throws<ArgumentException>(() => Path.GetFullPath(invalidPath));
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Fact]
+        public static void GetFullPath_Windows_83Paths()
+        {
+            // Create a temporary file name with a name longer than 8.3 such that it'll need to be shortened.
+            string tempFilePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+            File.Create(tempFilePath).Dispose();
+            try
+            {
+                // Get its short name
+                var sb = new StringBuilder(260);
+                if (GetShortPathName(tempFilePath, sb, sb.Capacity) > 0) // only proceed if we could successfully create the short name
+                {
+                    // Make sure the shortened name expands back to the original one
+                    Assert.Equal(tempFilePath, Path.GetFullPath(sb.ToString()));
+
+                    // Validate case where short name doesn't expand to a real file
+                    string invalidShortName = @"S:\DOESNT~1\USERNA~1.RED\LOCALS~1\Temp\bg3ylpzp";
+                    Assert.Equal(invalidShortName, Path.GetFullPath(invalidShortName));
+
+                    // Same thing, but with a long path that normalizes down to a short enough one
+                    const int Iters = 1000;
+                    var shortLongName = new StringBuilder(invalidShortName, invalidShortName.Length + (Iters * 2));
+                    for (int i = 0; i < Iters; i++)
+                    {
+                        shortLongName.Append(Path.DirectorySeparatorChar).Append('.');
+                    }
+                    Assert.Equal(invalidShortName, Path.GetFullPath(shortLongName.ToString()));
+                }
+            }
+            finally
+            {
+                File.Delete(tempFilePath);
+            }
+        }
+
+        [PlatformSpecific(PlatformID.Windows)]
+        [Theory]
+        [InlineData('*')]
+        [InlineData('?')]
+        public static void GetFullPath_Windows_Wildcards(char wildcard)
+        {
+            Assert.Throws<ArgumentException>("path", () => Path.GetFullPath("test" + wildcard + "ing"));
+        }
+
+        // Windows-only P/Invoke to create 8.3 short names from long names
+        [DllImport("kernel32.dll", CharSet = CharSet.Ansi)]
+        private static extern uint GetShortPathName(string lpszLongPath, StringBuilder lpszShortPath, int cchBuffer);
+    }
 }

--- a/src/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/System.Runtime.Extensions/tests/System/Math.cs
@@ -2,612 +2,614 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public static class MathTests
+namespace System.Tests
 {
-    [Fact]
-    public static void Cos()
+    public static class MathTests
     {
-        Assert.Equal(0.54030230586814, Math.Cos(1.0), 10);
-        Assert.Equal(1.0, Math.Cos(0.0));
-        Assert.Equal(0.54030230586814, Math.Cos(-1.0), 10);
-        Assert.Equal(double.NaN, Math.Cos(double.NaN));
-        Assert.Equal(double.NaN, Math.Cos(double.PositiveInfinity));
-        Assert.Equal(double.NaN, Math.Cos(double.NegativeInfinity));
-    }
+        [Fact]
+        public static void Cos()
+        {
+            Assert.Equal(0.54030230586814, Math.Cos(1.0), 10);
+            Assert.Equal(1.0, Math.Cos(0.0));
+            Assert.Equal(0.54030230586814, Math.Cos(-1.0), 10);
+            Assert.Equal(double.NaN, Math.Cos(double.NaN));
+            Assert.Equal(double.NaN, Math.Cos(double.PositiveInfinity));
+            Assert.Equal(double.NaN, Math.Cos(double.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void Sin()
-    {
-        Assert.Equal(0.841470984807897, Math.Sin(1.0), 10);
-        Assert.Equal(0.0, Math.Sin(0.0));
-        Assert.Equal(-0.841470984807897, Math.Sin(-1.0), 10);
-        Assert.Equal(double.NaN, Math.Sin(double.NaN));
-        Assert.Equal(double.NaN, Math.Sin(double.PositiveInfinity));
-        Assert.Equal(double.NaN, Math.Sin(double.NegativeInfinity));
-    }
+        [Fact]
+        public static void Sin()
+        {
+            Assert.Equal(0.841470984807897, Math.Sin(1.0), 10);
+            Assert.Equal(0.0, Math.Sin(0.0));
+            Assert.Equal(-0.841470984807897, Math.Sin(-1.0), 10);
+            Assert.Equal(double.NaN, Math.Sin(double.NaN));
+            Assert.Equal(double.NaN, Math.Sin(double.PositiveInfinity));
+            Assert.Equal(double.NaN, Math.Sin(double.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void Tan()
-    {
-        Assert.Equal(1.5574077246549, Math.Tan(1.0), 10);
-        Assert.Equal(0.0, Math.Tan(0.0));
-        Assert.Equal(-1.5574077246549, Math.Tan(-1.0), 10);
-        Assert.Equal(double.NaN, Math.Tan(double.NaN));
-        Assert.Equal(double.NaN, Math.Tan(double.PositiveInfinity));
-        Assert.Equal(double.NaN, Math.Tan(double.NegativeInfinity));
-    }
+        [Fact]
+        public static void Tan()
+        {
+            Assert.Equal(1.5574077246549, Math.Tan(1.0), 10);
+            Assert.Equal(0.0, Math.Tan(0.0));
+            Assert.Equal(-1.5574077246549, Math.Tan(-1.0), 10);
+            Assert.Equal(double.NaN, Math.Tan(double.NaN));
+            Assert.Equal(double.NaN, Math.Tan(double.PositiveInfinity));
+            Assert.Equal(double.NaN, Math.Tan(double.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void Cosh()
-    {
-        Assert.Equal(1.54308063481524, Math.Cosh(1.0), 10);
-        Assert.Equal(1.0, Math.Cosh(0.0));
-        Assert.Equal(1.54308063481524, Math.Cosh(-1.0), 10);
-        Assert.Equal(double.NaN, Math.Cosh(double.NaN));
-        Assert.Equal(double.PositiveInfinity, Math.Cosh(double.PositiveInfinity));
-        Assert.Equal(double.PositiveInfinity, Math.Cosh(double.NegativeInfinity));
-    }
+        [Fact]
+        public static void Cosh()
+        {
+            Assert.Equal(1.54308063481524, Math.Cosh(1.0), 10);
+            Assert.Equal(1.0, Math.Cosh(0.0));
+            Assert.Equal(1.54308063481524, Math.Cosh(-1.0), 10);
+            Assert.Equal(double.NaN, Math.Cosh(double.NaN));
+            Assert.Equal(double.PositiveInfinity, Math.Cosh(double.PositiveInfinity));
+            Assert.Equal(double.PositiveInfinity, Math.Cosh(double.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void Sinh()
-    {
-        Assert.Equal(1.1752011936438, Math.Sinh(1.0), 10);
-        Assert.Equal(0.0, Math.Sinh(0.0));
-        Assert.Equal(-1.1752011936438, Math.Sinh(-1.0), 10);
-        Assert.Equal(double.NaN, Math.Sinh(double.NaN));
-        Assert.Equal(double.PositiveInfinity, Math.Sinh(double.PositiveInfinity));
-        Assert.Equal(double.NegativeInfinity, Math.Sinh(double.NegativeInfinity));
-    }
+        [Fact]
+        public static void Sinh()
+        {
+            Assert.Equal(1.1752011936438, Math.Sinh(1.0), 10);
+            Assert.Equal(0.0, Math.Sinh(0.0));
+            Assert.Equal(-1.1752011936438, Math.Sinh(-1.0), 10);
+            Assert.Equal(double.NaN, Math.Sinh(double.NaN));
+            Assert.Equal(double.PositiveInfinity, Math.Sinh(double.PositiveInfinity));
+            Assert.Equal(double.NegativeInfinity, Math.Sinh(double.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void Tanh()
-    {
-        Assert.Equal(0.761594155955765, Math.Tanh(1.0), 10);
-        Assert.Equal(0.0, Math.Tanh(0.0));
-        Assert.Equal(-0.761594155955765, Math.Tanh(-1.0), 10);
-        Assert.Equal(double.NaN, Math.Tanh(double.NaN));
-        Assert.Equal(1.0, Math.Tanh(double.PositiveInfinity));
-        Assert.Equal(-1.0, Math.Tanh(double.NegativeInfinity));
-    }
+        [Fact]
+        public static void Tanh()
+        {
+            Assert.Equal(0.761594155955765, Math.Tanh(1.0), 10);
+            Assert.Equal(0.0, Math.Tanh(0.0));
+            Assert.Equal(-0.761594155955765, Math.Tanh(-1.0), 10);
+            Assert.Equal(double.NaN, Math.Tanh(double.NaN));
+            Assert.Equal(1.0, Math.Tanh(double.PositiveInfinity));
+            Assert.Equal(-1.0, Math.Tanh(double.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void Acos()
-    {
-        Assert.Equal(0.0, Math.Acos(1.0));
-        Assert.Equal(1.5707963267949, Math.Acos(0.0), 10);
-        Assert.Equal(3.14159265358979, Math.Acos(-1.0), 10);
-        Assert.Equal(double.NaN, Math.Acos(double.NaN));
-        Assert.Equal(double.NaN, Math.Acos(double.PositiveInfinity));
-        Assert.Equal(double.NaN, Math.Acos(double.NegativeInfinity));
-    }
+        [Fact]
+        public static void Acos()
+        {
+            Assert.Equal(0.0, Math.Acos(1.0));
+            Assert.Equal(1.5707963267949, Math.Acos(0.0), 10);
+            Assert.Equal(3.14159265358979, Math.Acos(-1.0), 10);
+            Assert.Equal(double.NaN, Math.Acos(double.NaN));
+            Assert.Equal(double.NaN, Math.Acos(double.PositiveInfinity));
+            Assert.Equal(double.NaN, Math.Acos(double.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void Asin()
-    {
-        Assert.Equal(1.5707963267949, Math.Asin(1.0), 10);
-        Assert.Equal(0.0, Math.Asin(0.0));
-        Assert.Equal(-1.5707963267949, Math.Asin(-1.0), 10);
-        Assert.Equal(double.NaN, Math.Asin(double.NaN));
-        Assert.Equal(double.NaN, Math.Asin(double.PositiveInfinity));
-        Assert.Equal(double.NaN, Math.Asin(double.NegativeInfinity));
-    }
+        [Fact]
+        public static void Asin()
+        {
+            Assert.Equal(1.5707963267949, Math.Asin(1.0), 10);
+            Assert.Equal(0.0, Math.Asin(0.0));
+            Assert.Equal(-1.5707963267949, Math.Asin(-1.0), 10);
+            Assert.Equal(double.NaN, Math.Asin(double.NaN));
+            Assert.Equal(double.NaN, Math.Asin(double.PositiveInfinity));
+            Assert.Equal(double.NaN, Math.Asin(double.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void Atan()
-    {
-        Assert.Equal(0.785398163397448, Math.Atan(1.0), 10);
-        Assert.Equal(0.0, Math.Atan(0.0));
-        Assert.Equal(-0.785398163397448, Math.Atan(-1.0), 10);
-        Assert.Equal(double.NaN, Math.Atan(double.NaN));
-        Assert.Equal(1.5707963267949, Math.Atan(double.PositiveInfinity), 4);
-        Assert.Equal(-1.5707963267949, Math.Atan(double.NegativeInfinity), 4);
-    }
+        [Fact]
+        public static void Atan()
+        {
+            Assert.Equal(0.785398163397448, Math.Atan(1.0), 10);
+            Assert.Equal(0.0, Math.Atan(0.0));
+            Assert.Equal(-0.785398163397448, Math.Atan(-1.0), 10);
+            Assert.Equal(double.NaN, Math.Atan(double.NaN));
+            Assert.Equal(1.5707963267949, Math.Atan(double.PositiveInfinity), 4);
+            Assert.Equal(-1.5707963267949, Math.Atan(double.NegativeInfinity), 4);
+        }
 
-    [Fact]
-    public static void Atan2()
-    {
-        Assert.Equal(0.0, Math.Atan2(0.0, 0.0));
-        Assert.Equal(1.5707963267949, Math.Atan2(1.0, 0.0), 10);
-        Assert.Equal(0.588002603547568, Math.Atan2(2.0, 3.0), 10);
-        Assert.Equal(0.0, Math.Atan2(0.0, 3.0));
-        Assert.Equal(-0.588002603547568, Math.Atan2(-2.0, 3.0), 10);
-        Assert.Equal(double.NaN, Math.Atan2(double.NaN, 1.0));
-        Assert.Equal(double.NaN, Math.Atan2(1.0, double.NaN));
-        Assert.Equal(1.5707963267949, Math.Atan2(double.PositiveInfinity, 1.0), 10);
-        Assert.Equal(-1.5707963267949, Math.Atan2(double.NegativeInfinity, 1.0), 10);
-        Assert.Equal(0.0, Math.Atan2(1.0, double.PositiveInfinity));
-        Assert.Equal(3.14159265358979, Math.Atan2(1.0, double.NegativeInfinity), 10);
-    }
+        [Fact]
+        public static void Atan2()
+        {
+            Assert.Equal(0.0, Math.Atan2(0.0, 0.0));
+            Assert.Equal(1.5707963267949, Math.Atan2(1.0, 0.0), 10);
+            Assert.Equal(0.588002603547568, Math.Atan2(2.0, 3.0), 10);
+            Assert.Equal(0.0, Math.Atan2(0.0, 3.0));
+            Assert.Equal(-0.588002603547568, Math.Atan2(-2.0, 3.0), 10);
+            Assert.Equal(double.NaN, Math.Atan2(double.NaN, 1.0));
+            Assert.Equal(double.NaN, Math.Atan2(1.0, double.NaN));
+            Assert.Equal(1.5707963267949, Math.Atan2(double.PositiveInfinity, 1.0), 10);
+            Assert.Equal(-1.5707963267949, Math.Atan2(double.NegativeInfinity, 1.0), 10);
+            Assert.Equal(0.0, Math.Atan2(1.0, double.PositiveInfinity));
+            Assert.Equal(3.14159265358979, Math.Atan2(1.0, double.NegativeInfinity), 10);
+        }
 
-    [Fact]
-    public static void Ceiling_Decimal()
-    {
-        Assert.Equal(2.0m, Math.Ceiling(1.1m));
-        Assert.Equal(2.0m, Math.Ceiling(1.9m));
-        Assert.Equal(-1.0m, Math.Ceiling(-1.1m));
-    }
+        [Fact]
+        public static void Ceiling_Decimal()
+        {
+            Assert.Equal(2.0m, Math.Ceiling(1.1m));
+            Assert.Equal(2.0m, Math.Ceiling(1.9m));
+            Assert.Equal(-1.0m, Math.Ceiling(-1.1m));
+        }
 
-    [Fact]
-    public static void Ceiling_Double()
-    {
-        Assert.Equal(2.0, Math.Ceiling(1.1));
-        Assert.Equal(2.0, Math.Ceiling(1.9));
-        Assert.Equal(-1.0, Math.Ceiling(-1.1));
-        Assert.Equal(double.NaN, Math.Ceiling(double.NaN));
-        Assert.Equal(double.PositiveInfinity, Math.Ceiling(double.PositiveInfinity));
-        Assert.Equal(double.NegativeInfinity, Math.Ceiling(double.NegativeInfinity));
-    }
+        [Fact]
+        public static void Ceiling_Double()
+        {
+            Assert.Equal(2.0, Math.Ceiling(1.1));
+            Assert.Equal(2.0, Math.Ceiling(1.9));
+            Assert.Equal(-1.0, Math.Ceiling(-1.1));
+            Assert.Equal(double.NaN, Math.Ceiling(double.NaN));
+            Assert.Equal(double.PositiveInfinity, Math.Ceiling(double.PositiveInfinity));
+            Assert.Equal(double.NegativeInfinity, Math.Ceiling(double.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void Floor_Decimal()
-    {
-        Assert.Equal(1.0m, Math.Floor(1.1m));
-        Assert.Equal(1.0m, Math.Floor(1.9m));
-        Assert.Equal(-2.0m, Math.Floor(-1.1m));
-    }
+        [Fact]
+        public static void Floor_Decimal()
+        {
+            Assert.Equal(1.0m, Math.Floor(1.1m));
+            Assert.Equal(1.0m, Math.Floor(1.9m));
+            Assert.Equal(-2.0m, Math.Floor(-1.1m));
+        }
 
-    [Fact]
-    public static void Floor_Double()
-    {
-        Assert.Equal(1.0, Math.Floor(1.1));
-        Assert.Equal(1.0, Math.Floor(1.9));
-        Assert.Equal(-2.0, Math.Floor(-1.1));
-        Assert.Equal(double.NaN, Math.Floor(double.NaN));
-        Assert.Equal(double.PositiveInfinity, Math.Floor(double.PositiveInfinity));
-        Assert.Equal(double.NegativeInfinity, Math.Floor(double.NegativeInfinity));
-    }
+        [Fact]
+        public static void Floor_Double()
+        {
+            Assert.Equal(1.0, Math.Floor(1.1));
+            Assert.Equal(1.0, Math.Floor(1.9));
+            Assert.Equal(-2.0, Math.Floor(-1.1));
+            Assert.Equal(double.NaN, Math.Floor(double.NaN));
+            Assert.Equal(double.PositiveInfinity, Math.Floor(double.PositiveInfinity));
+            Assert.Equal(double.NegativeInfinity, Math.Floor(double.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void Round_Decimal()
-    {
-        Assert.Equal(0.0m, Math.Round(0.0m));
-        Assert.Equal(1.0m, Math.Round(1.4m));
-        Assert.Equal(2.0m, Math.Round(1.5m));
-        Assert.Equal(2e16m, Math.Round(2e16m));
-        Assert.Equal(0.0m, Math.Round(-0.0m));
-        Assert.Equal(-1.0m, Math.Round(-1.4m));
-        Assert.Equal(-2.0m, Math.Round(-1.5m));
-        Assert.Equal(-2e16m, Math.Round(-2e16m));
-    }
+        [Fact]
+        public static void Round_Decimal()
+        {
+            Assert.Equal(0.0m, Math.Round(0.0m));
+            Assert.Equal(1.0m, Math.Round(1.4m));
+            Assert.Equal(2.0m, Math.Round(1.5m));
+            Assert.Equal(2e16m, Math.Round(2e16m));
+            Assert.Equal(0.0m, Math.Round(-0.0m));
+            Assert.Equal(-1.0m, Math.Round(-1.4m));
+            Assert.Equal(-2.0m, Math.Round(-1.5m));
+            Assert.Equal(-2e16m, Math.Round(-2e16m));
+        }
 
-    [Fact]
-    public static void Round_Decimal_Digits()
-    {
-        Assert.Equal(3.422m, Math.Round(3.42156m, 3, MidpointRounding.AwayFromZero));
-        Assert.Equal(-3.422m, Math.Round(-3.42156m, 3, MidpointRounding.AwayFromZero));
-        Assert.Equal(Decimal.Zero, Math.Round(Decimal.Zero, 3, MidpointRounding.AwayFromZero));
-    }
+        [Fact]
+        public static void Round_Decimal_Digits()
+        {
+            Assert.Equal(3.422m, Math.Round(3.42156m, 3, MidpointRounding.AwayFromZero));
+            Assert.Equal(-3.422m, Math.Round(-3.42156m, 3, MidpointRounding.AwayFromZero));
+            Assert.Equal(Decimal.Zero, Math.Round(Decimal.Zero, 3, MidpointRounding.AwayFromZero));
+        }
 
-    [Fact]
-    public static void Round_Double()
-    {
-        Assert.Equal(0.0, Math.Round(0.0));
-        Assert.Equal(1.0, Math.Round(1.4));
-        Assert.Equal(2.0, Math.Round(1.5));
-        Assert.Equal(2e16, Math.Round(2e16));
-        Assert.Equal(0.0, Math.Round(-0.0));
-        Assert.Equal(-1.0, Math.Round(-1.4));
-        Assert.Equal(-2.0, Math.Round(-1.5));
-        Assert.Equal(-2e16, Math.Round(-2e16));
-    }
+        [Fact]
+        public static void Round_Double()
+        {
+            Assert.Equal(0.0, Math.Round(0.0));
+            Assert.Equal(1.0, Math.Round(1.4));
+            Assert.Equal(2.0, Math.Round(1.5));
+            Assert.Equal(2e16, Math.Round(2e16));
+            Assert.Equal(0.0, Math.Round(-0.0));
+            Assert.Equal(-1.0, Math.Round(-1.4));
+            Assert.Equal(-2.0, Math.Round(-1.5));
+            Assert.Equal(-2e16, Math.Round(-2e16));
+        }
 
-    [Fact]
-    public static void Round_Double_Digits()
-    {
-        Assert.Equal(3.422, Math.Round(3.42156, 3, MidpointRounding.AwayFromZero), 10);
-        Assert.Equal(-3.422, Math.Round(-3.42156, 3, MidpointRounding.AwayFromZero), 10);
-        Assert.Equal(0.0, Math.Round(0.0, 3, MidpointRounding.AwayFromZero));
-        Assert.Equal(double.NaN, Math.Round(double.NaN, 3, MidpointRounding.AwayFromZero));
-        Assert.Equal(double.PositiveInfinity, Math.Round(double.PositiveInfinity, 3, MidpointRounding.AwayFromZero));
-        Assert.Equal(double.NegativeInfinity, Math.Round(double.NegativeInfinity, 3, MidpointRounding.AwayFromZero));
-    }
+        [Fact]
+        public static void Round_Double_Digits()
+        {
+            Assert.Equal(3.422, Math.Round(3.42156, 3, MidpointRounding.AwayFromZero), 10);
+            Assert.Equal(-3.422, Math.Round(-3.42156, 3, MidpointRounding.AwayFromZero), 10);
+            Assert.Equal(0.0, Math.Round(0.0, 3, MidpointRounding.AwayFromZero));
+            Assert.Equal(double.NaN, Math.Round(double.NaN, 3, MidpointRounding.AwayFromZero));
+            Assert.Equal(double.PositiveInfinity, Math.Round(double.PositiveInfinity, 3, MidpointRounding.AwayFromZero));
+            Assert.Equal(double.NegativeInfinity, Math.Round(double.NegativeInfinity, 3, MidpointRounding.AwayFromZero));
+        }
 
-    [Fact]
-    public static void Sqrt()
-    {
-        Assert.Equal(1.73205080756888, Math.Sqrt(3.0), 10);
-        Assert.Equal(0.0, Math.Sqrt(0.0));
-        Assert.Equal(double.NaN, Math.Sqrt(-3.0));
-        Assert.Equal(double.NaN, Math.Sqrt(double.NaN));
-        Assert.Equal(double.PositiveInfinity, Math.Sqrt(double.PositiveInfinity));
-        Assert.Equal(double.NaN, Math.Sqrt(double.NegativeInfinity));
-    }
+        [Fact]
+        public static void Sqrt()
+        {
+            Assert.Equal(1.73205080756888, Math.Sqrt(3.0), 10);
+            Assert.Equal(0.0, Math.Sqrt(0.0));
+            Assert.Equal(double.NaN, Math.Sqrt(-3.0));
+            Assert.Equal(double.NaN, Math.Sqrt(double.NaN));
+            Assert.Equal(double.PositiveInfinity, Math.Sqrt(double.PositiveInfinity));
+            Assert.Equal(double.NaN, Math.Sqrt(double.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void Log()
-    {
-        Assert.Equal(1.09861228866811, Math.Log(3.0), 10);
-        Assert.Equal(double.NegativeInfinity, Math.Log(0.0));
-        Assert.Equal(double.NaN, Math.Log(-3.0));
-        Assert.Equal(double.NaN, Math.Log(double.NaN));
-        Assert.Equal(double.PositiveInfinity, Math.Log(double.PositiveInfinity));
-        Assert.Equal(double.NaN, Math.Log(double.NegativeInfinity));
-    }
+        [Fact]
+        public static void Log()
+        {
+            Assert.Equal(1.09861228866811, Math.Log(3.0), 10);
+            Assert.Equal(double.NegativeInfinity, Math.Log(0.0));
+            Assert.Equal(double.NaN, Math.Log(-3.0));
+            Assert.Equal(double.NaN, Math.Log(double.NaN));
+            Assert.Equal(double.PositiveInfinity, Math.Log(double.PositiveInfinity));
+            Assert.Equal(double.NaN, Math.Log(double.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void LogWithBase()
-    {
-        Assert.Equal(1.0, Math.Log(3.0, 3.0));
-        Assert.Equal(2.40217350273, Math.Log(14, 3.0), 10);
-        Assert.Equal(double.NegativeInfinity, Math.Log(0.0, 3.0));
-        Assert.Equal(double.NaN, Math.Log(-3.0, 3.0));
-        Assert.Equal(double.NaN, Math.Log(double.NaN, 3.0));
-        Assert.Equal(double.PositiveInfinity, Math.Log(double.PositiveInfinity, 3.0));
-        Assert.Equal(double.NaN, Math.Log(double.NegativeInfinity, 3.0));
-    }
+        [Fact]
+        public static void LogWithBase()
+        {
+            Assert.Equal(1.0, Math.Log(3.0, 3.0));
+            Assert.Equal(2.40217350273, Math.Log(14, 3.0), 10);
+            Assert.Equal(double.NegativeInfinity, Math.Log(0.0, 3.0));
+            Assert.Equal(double.NaN, Math.Log(-3.0, 3.0));
+            Assert.Equal(double.NaN, Math.Log(double.NaN, 3.0));
+            Assert.Equal(double.PositiveInfinity, Math.Log(double.PositiveInfinity, 3.0));
+            Assert.Equal(double.NaN, Math.Log(double.NegativeInfinity, 3.0));
+        }
 
-    [Fact]
-    public static void Log10()
-    {
-        Assert.Equal(0.477121254719662, Math.Log10(3.0), 10);
-        Assert.Equal(double.NegativeInfinity, Math.Log10(0.0));
-        Assert.Equal(double.NaN, Math.Log10(-3.0));
-        Assert.Equal(double.NaN, Math.Log10(double.NaN));
-        Assert.Equal(double.PositiveInfinity, Math.Log10(double.PositiveInfinity));
-        Assert.Equal(double.NaN, Math.Log10(double.NegativeInfinity));
-    }
+        [Fact]
+        public static void Log10()
+        {
+            Assert.Equal(0.477121254719662, Math.Log10(3.0), 10);
+            Assert.Equal(double.NegativeInfinity, Math.Log10(0.0));
+            Assert.Equal(double.NaN, Math.Log10(-3.0));
+            Assert.Equal(double.NaN, Math.Log10(double.NaN));
+            Assert.Equal(double.PositiveInfinity, Math.Log10(double.PositiveInfinity));
+            Assert.Equal(double.NaN, Math.Log10(double.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void Pow()
-    {
-        Assert.Equal(1.0, Math.Pow(0.0, 0.0));
-        Assert.Equal(1.0, Math.Pow(1.0, 0.0));
-        Assert.Equal(8.0, Math.Pow(2.0, 3.0));
-        Assert.Equal(0.0, Math.Pow(0.0, 3.0));
-        Assert.Equal(-8.0, Math.Pow(-2.0, 3.0));
-        Assert.Equal(double.NaN, Math.Pow(double.NaN, 1.0));
-        Assert.Equal(double.NaN, Math.Pow(1.0, double.NaN));
-        Assert.Equal(double.PositiveInfinity, Math.Pow(double.PositiveInfinity, 1.0));
-        Assert.Equal(double.NegativeInfinity, Math.Pow(double.NegativeInfinity, 1.0));
-        Assert.Equal(1.0, Math.Pow(1.0, double.PositiveInfinity));
-        Assert.Equal(1.0, Math.Pow(1.0, double.NegativeInfinity));
-        Assert.Equal(double.NaN, Math.Pow(-1.0, double.PositiveInfinity));
-        Assert.Equal(double.NaN, Math.Pow(-1.0, double.NegativeInfinity));
-        Assert.Equal(double.PositiveInfinity, Math.Pow(1.1, double.PositiveInfinity));
-        Assert.Equal(0.0, Math.Pow(1.1, double.NegativeInfinity));
-    }
+        [Fact]
+        public static void Pow()
+        {
+            Assert.Equal(1.0, Math.Pow(0.0, 0.0));
+            Assert.Equal(1.0, Math.Pow(1.0, 0.0));
+            Assert.Equal(8.0, Math.Pow(2.0, 3.0));
+            Assert.Equal(0.0, Math.Pow(0.0, 3.0));
+            Assert.Equal(-8.0, Math.Pow(-2.0, 3.0));
+            Assert.Equal(double.NaN, Math.Pow(double.NaN, 1.0));
+            Assert.Equal(double.NaN, Math.Pow(1.0, double.NaN));
+            Assert.Equal(double.PositiveInfinity, Math.Pow(double.PositiveInfinity, 1.0));
+            Assert.Equal(double.NegativeInfinity, Math.Pow(double.NegativeInfinity, 1.0));
+            Assert.Equal(1.0, Math.Pow(1.0, double.PositiveInfinity));
+            Assert.Equal(1.0, Math.Pow(1.0, double.NegativeInfinity));
+            Assert.Equal(double.NaN, Math.Pow(-1.0, double.PositiveInfinity));
+            Assert.Equal(double.NaN, Math.Pow(-1.0, double.NegativeInfinity));
+            Assert.Equal(double.PositiveInfinity, Math.Pow(1.1, double.PositiveInfinity));
+            Assert.Equal(0.0, Math.Pow(1.1, double.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void Abs_Decimal()
-    {
-        Assert.Equal(3.0m, Math.Abs(3.0m));
-        Assert.Equal(0.0m, Math.Abs(0.0m));
-        Assert.Equal(0.0m, Math.Abs(-0.0m));
-        Assert.Equal(3.0m, Math.Abs(-3.0m));
-        Assert.Equal(Decimal.MaxValue, Math.Abs(Decimal.MinValue));
-    }
+        [Fact]
+        public static void Abs_Decimal()
+        {
+            Assert.Equal(3.0m, Math.Abs(3.0m));
+            Assert.Equal(0.0m, Math.Abs(0.0m));
+            Assert.Equal(0.0m, Math.Abs(-0.0m));
+            Assert.Equal(3.0m, Math.Abs(-3.0m));
+            Assert.Equal(Decimal.MaxValue, Math.Abs(Decimal.MinValue));
+        }
 
-    [Fact]
-    public static void Abs_Double()
-    {
-        Assert.Equal(3.0, Math.Abs(3.0));
-        Assert.Equal(0.0, Math.Abs(0.0));
-        Assert.Equal(3.0, Math.Abs(-3.0));
-        Assert.Equal(double.NaN, Math.Abs(double.NaN));
-        Assert.Equal(double.PositiveInfinity, Math.Abs(double.PositiveInfinity));
-        Assert.Equal(double.PositiveInfinity, Math.Abs(double.NegativeInfinity));
-    }
+        [Fact]
+        public static void Abs_Double()
+        {
+            Assert.Equal(3.0, Math.Abs(3.0));
+            Assert.Equal(0.0, Math.Abs(0.0));
+            Assert.Equal(3.0, Math.Abs(-3.0));
+            Assert.Equal(double.NaN, Math.Abs(double.NaN));
+            Assert.Equal(double.PositiveInfinity, Math.Abs(double.PositiveInfinity));
+            Assert.Equal(double.PositiveInfinity, Math.Abs(double.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void Abs_Short()
-    {
-        Assert.Equal((short)3, Math.Abs((short)3));
-        Assert.Equal((short)0, Math.Abs((short)0));
-        Assert.Equal((short)3, Math.Abs((short)(-3)));
-        Assert.Throws<OverflowException>(() => Math.Abs(short.MinValue));
-    }
+        [Fact]
+        public static void Abs_Short()
+        {
+            Assert.Equal((short)3, Math.Abs((short)3));
+            Assert.Equal((short)0, Math.Abs((short)0));
+            Assert.Equal((short)3, Math.Abs((short)(-3)));
+            Assert.Throws<OverflowException>(() => Math.Abs(short.MinValue));
+        }
 
-    [Fact]
-    public static void Abs_Int()
-    {
-        Assert.Equal(3, Math.Abs(3));
-        Assert.Equal(0, Math.Abs(0));
-        Assert.Equal(3, Math.Abs(-3));
-        Assert.Throws<OverflowException>(() => Math.Abs(int.MinValue));
-    }
+        [Fact]
+        public static void Abs_Int()
+        {
+            Assert.Equal(3, Math.Abs(3));
+            Assert.Equal(0, Math.Abs(0));
+            Assert.Equal(3, Math.Abs(-3));
+            Assert.Throws<OverflowException>(() => Math.Abs(int.MinValue));
+        }
 
-    [Fact]
-    public static void Abs_Long()
-    {
-        Assert.Equal(3L, Math.Abs(3L));
-        Assert.Equal(0L, Math.Abs(0L));
-        Assert.Equal(3L, Math.Abs(-3L));
-        Assert.Throws<OverflowException>(() => Math.Abs(long.MinValue));
-    }
+        [Fact]
+        public static void Abs_Long()
+        {
+            Assert.Equal(3L, Math.Abs(3L));
+            Assert.Equal(0L, Math.Abs(0L));
+            Assert.Equal(3L, Math.Abs(-3L));
+            Assert.Throws<OverflowException>(() => Math.Abs(long.MinValue));
+        }
 
-    [Fact]
-    public static void Abs_SByte()
-    {
-        Assert.Equal((sbyte)3, Math.Abs((sbyte)3));
-        Assert.Equal((sbyte)0, Math.Abs((sbyte)0));
-        Assert.Equal((sbyte)3, Math.Abs((sbyte)(-3)));
-        Assert.Throws<OverflowException>(() => Math.Abs(sbyte.MinValue));
-    }
+        [Fact]
+        public static void Abs_SByte()
+        {
+            Assert.Equal((sbyte)3, Math.Abs((sbyte)3));
+            Assert.Equal((sbyte)0, Math.Abs((sbyte)0));
+            Assert.Equal((sbyte)3, Math.Abs((sbyte)(-3)));
+            Assert.Throws<OverflowException>(() => Math.Abs(sbyte.MinValue));
+        }
 
-    [Fact]
-    public static void Abs_Float()
-    {
-        Assert.Equal(3.0, Math.Abs(3.0f));
-        Assert.Equal(0.0, Math.Abs(0.0f));
-        Assert.Equal(3.0, Math.Abs(-3.0f));
-        Assert.Equal(float.NaN, Math.Abs(float.NaN));
-        Assert.Equal(float.PositiveInfinity, Math.Abs(float.PositiveInfinity));
-        Assert.Equal(float.PositiveInfinity, Math.Abs(float.NegativeInfinity));
-    }
+        [Fact]
+        public static void Abs_Float()
+        {
+            Assert.Equal(3.0, Math.Abs(3.0f));
+            Assert.Equal(0.0, Math.Abs(0.0f));
+            Assert.Equal(3.0, Math.Abs(-3.0f));
+            Assert.Equal(float.NaN, Math.Abs(float.NaN));
+            Assert.Equal(float.PositiveInfinity, Math.Abs(float.PositiveInfinity));
+            Assert.Equal(float.PositiveInfinity, Math.Abs(float.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void Exp()
-    {
-        Assert.Equal(20.0855369231877, Math.Exp(3.0), 10);
-        Assert.Equal(1.0, Math.Exp(0.0));
-        Assert.Equal(0.0497870683678639, Math.Exp(-3.0), 10);
-        Assert.Equal(double.NaN, Math.Exp(double.NaN));
-        Assert.Equal(double.PositiveInfinity, Math.Exp(double.PositiveInfinity));
-        Assert.Equal(0.0, Math.Exp(double.NegativeInfinity));
-    }
+        [Fact]
+        public static void Exp()
+        {
+            Assert.Equal(20.0855369231877, Math.Exp(3.0), 10);
+            Assert.Equal(1.0, Math.Exp(0.0));
+            Assert.Equal(0.0497870683678639, Math.Exp(-3.0), 10);
+            Assert.Equal(double.NaN, Math.Exp(double.NaN));
+            Assert.Equal(double.PositiveInfinity, Math.Exp(double.PositiveInfinity));
+            Assert.Equal(0.0, Math.Exp(double.NegativeInfinity));
+        }
 
-    [Fact]
-    public static void IEEERemainder()
-    {
-        Assert.Equal(-1.0, Math.IEEERemainder(3, 2));
-        Assert.Equal(0.0, Math.IEEERemainder(4, 2));
-        Assert.Equal(1.0, Math.IEEERemainder(10, 3));
-        Assert.Equal(-1.0, Math.IEEERemainder(11, 3));
-        Assert.Equal(-2.0, Math.IEEERemainder(28, 5));
-        Assert.Equal(1.8, Math.IEEERemainder(17.8, 4), 10);
-        Assert.Equal(1.4, Math.IEEERemainder(17.8, 4.1), 10);
-        Assert.Equal(0.0999999999999979, Math.IEEERemainder(-16.3, 4.1), 10);
-        Assert.Equal(1.4, Math.IEEERemainder(17.8, -4.1), 10);
-        Assert.Equal(-1.4, Math.IEEERemainder(-17.8, -4.1), 10);
-    }
+        [Fact]
+        public static void IEEERemainder()
+        {
+            Assert.Equal(-1.0, Math.IEEERemainder(3, 2));
+            Assert.Equal(0.0, Math.IEEERemainder(4, 2));
+            Assert.Equal(1.0, Math.IEEERemainder(10, 3));
+            Assert.Equal(-1.0, Math.IEEERemainder(11, 3));
+            Assert.Equal(-2.0, Math.IEEERemainder(28, 5));
+            Assert.Equal(1.8, Math.IEEERemainder(17.8, 4), 10);
+            Assert.Equal(1.4, Math.IEEERemainder(17.8, 4.1), 10);
+            Assert.Equal(0.0999999999999979, Math.IEEERemainder(-16.3, 4.1), 10);
+            Assert.Equal(1.4, Math.IEEERemainder(17.8, -4.1), 10);
+            Assert.Equal(-1.4, Math.IEEERemainder(-17.8, -4.1), 10);
+        }
 
-    [Fact]
-    public static void Min_Byte()
-    {
-        Assert.Equal((byte)2, Math.Min((byte)3, (byte)2));
-        Assert.Equal(byte.MinValue, Math.Min(byte.MinValue, byte.MaxValue));
-    }
+        [Fact]
+        public static void Min_Byte()
+        {
+            Assert.Equal((byte)2, Math.Min((byte)3, (byte)2));
+            Assert.Equal(byte.MinValue, Math.Min(byte.MinValue, byte.MaxValue));
+        }
 
-    [Fact]
-    public static void Min_Decimal()
-    {
-        Assert.Equal(-2.0m, Math.Min(3.0m, -2.0m));
-        Assert.Equal(decimal.MinValue, Math.Min(decimal.MinValue, decimal.MaxValue));
-    }
+        [Fact]
+        public static void Min_Decimal()
+        {
+            Assert.Equal(-2.0m, Math.Min(3.0m, -2.0m));
+            Assert.Equal(decimal.MinValue, Math.Min(decimal.MinValue, decimal.MaxValue));
+        }
 
-    [Fact]
-    public static void Min_Double()
-    {
-        Assert.Equal(-2.0, Math.Min(3.0, -2.0));
-        Assert.Equal(double.MinValue, Math.Min(double.MinValue, double.MaxValue));
-        Assert.Equal(double.NegativeInfinity, Math.Min(double.NegativeInfinity, double.PositiveInfinity));
-        Assert.Equal(double.NaN, Math.Min(double.NegativeInfinity, double.NaN));
-        Assert.Equal(double.NaN, Math.Min(double.NaN, double.NaN));
-    }
+        [Fact]
+        public static void Min_Double()
+        {
+            Assert.Equal(-2.0, Math.Min(3.0, -2.0));
+            Assert.Equal(double.MinValue, Math.Min(double.MinValue, double.MaxValue));
+            Assert.Equal(double.NegativeInfinity, Math.Min(double.NegativeInfinity, double.PositiveInfinity));
+            Assert.Equal(double.NaN, Math.Min(double.NegativeInfinity, double.NaN));
+            Assert.Equal(double.NaN, Math.Min(double.NaN, double.NaN));
+        }
 
-    [Fact]
-    public static void Min_Short()
-    {
-        Assert.Equal((short)(-2), Math.Min((short)3, (short)(-2)));
-        Assert.Equal(short.MinValue, Math.Min(short.MinValue, short.MaxValue));
-    }
+        [Fact]
+        public static void Min_Short()
+        {
+            Assert.Equal((short)(-2), Math.Min((short)3, (short)(-2)));
+            Assert.Equal(short.MinValue, Math.Min(short.MinValue, short.MaxValue));
+        }
 
-    [Fact]
-    public static void Min_Int()
-    {
-        Assert.Equal(-2, Math.Min(3, -2));
-        Assert.Equal(int.MinValue, Math.Min(int.MinValue, int.MaxValue));
-    }
+        [Fact]
+        public static void Min_Int()
+        {
+            Assert.Equal(-2, Math.Min(3, -2));
+            Assert.Equal(int.MinValue, Math.Min(int.MinValue, int.MaxValue));
+        }
 
-    [Fact]
-    public static void Min_Long()
-    {
-        Assert.Equal(-2L, Math.Min(3L, -2L));
-        Assert.Equal(long.MinValue, Math.Min(long.MinValue, long.MaxValue));
-    }
+        [Fact]
+        public static void Min_Long()
+        {
+            Assert.Equal(-2L, Math.Min(3L, -2L));
+            Assert.Equal(long.MinValue, Math.Min(long.MinValue, long.MaxValue));
+        }
 
-    [Fact]
-    public static void Min_SByte()
-    {
-        Assert.Equal((sbyte)(-2), Math.Min((sbyte)3, (sbyte)(-2)));
-        Assert.Equal(sbyte.MinValue, Math.Min(sbyte.MinValue, sbyte.MaxValue));
-    }
+        [Fact]
+        public static void Min_SByte()
+        {
+            Assert.Equal((sbyte)(-2), Math.Min((sbyte)3, (sbyte)(-2)));
+            Assert.Equal(sbyte.MinValue, Math.Min(sbyte.MinValue, sbyte.MaxValue));
+        }
 
-    [Fact]
-    public static void Min_Float()
-    {
-        Assert.Equal(-2.0f, Math.Min(3.0f, -2.0f));
-        Assert.Equal(float.MinValue, Math.Min(float.MinValue, float.MaxValue));
-        Assert.Equal(float.NegativeInfinity, Math.Min(float.NegativeInfinity, float.PositiveInfinity));
-        Assert.Equal(float.NaN, Math.Min(float.NegativeInfinity, float.NaN));
-        Assert.Equal(float.NaN, Math.Min(float.NaN, float.NaN));
-    }
+        [Fact]
+        public static void Min_Float()
+        {
+            Assert.Equal(-2.0f, Math.Min(3.0f, -2.0f));
+            Assert.Equal(float.MinValue, Math.Min(float.MinValue, float.MaxValue));
+            Assert.Equal(float.NegativeInfinity, Math.Min(float.NegativeInfinity, float.PositiveInfinity));
+            Assert.Equal(float.NaN, Math.Min(float.NegativeInfinity, float.NaN));
+            Assert.Equal(float.NaN, Math.Min(float.NaN, float.NaN));
+        }
 
-    [Fact]
-    public static void Min_UShort()
-    {
-        Assert.Equal((ushort)2, Math.Min((ushort)3, (ushort)2));
-        Assert.Equal(ushort.MinValue, Math.Min(ushort.MinValue, ushort.MaxValue));
-    }
+        [Fact]
+        public static void Min_UShort()
+        {
+            Assert.Equal((ushort)2, Math.Min((ushort)3, (ushort)2));
+            Assert.Equal(ushort.MinValue, Math.Min(ushort.MinValue, ushort.MaxValue));
+        }
 
-    [Fact]
-    public static void Min_UInt()
-    {
-        Assert.Equal((uint)2, Math.Min((uint)3, (uint)2));
-        Assert.Equal(uint.MinValue, Math.Min(uint.MinValue, uint.MaxValue));
-    }
+        [Fact]
+        public static void Min_UInt()
+        {
+            Assert.Equal((uint)2, Math.Min((uint)3, (uint)2));
+            Assert.Equal(uint.MinValue, Math.Min(uint.MinValue, uint.MaxValue));
+        }
 
-    [Fact]
-    public static void Min_ULong()
-    {
-        Assert.Equal((ulong)2, Math.Min((ulong)3, (ulong)2));
-        Assert.Equal(ulong.MinValue, Math.Min(ulong.MinValue, ulong.MaxValue));
-    }
+        [Fact]
+        public static void Min_ULong()
+        {
+            Assert.Equal((ulong)2, Math.Min((ulong)3, (ulong)2));
+            Assert.Equal(ulong.MinValue, Math.Min(ulong.MinValue, ulong.MaxValue));
+        }
 
-    [Fact]
-    public static void Max_Byte()
-    {
-        Assert.Equal((byte)3, Math.Max((byte)2, (byte)3));
-        Assert.Equal(byte.MaxValue, Math.Max(byte.MinValue, byte.MaxValue));
-    }
+        [Fact]
+        public static void Max_Byte()
+        {
+            Assert.Equal((byte)3, Math.Max((byte)2, (byte)3));
+            Assert.Equal(byte.MaxValue, Math.Max(byte.MinValue, byte.MaxValue));
+        }
 
-    [Fact]
-    public static void Max_Decimal()
-    {
-        Assert.Equal(3.0m, Math.Max(-2.0m, 3.0m));
-        Assert.Equal(decimal.MaxValue, Math.Max(decimal.MinValue, decimal.MaxValue));
-    }
+        [Fact]
+        public static void Max_Decimal()
+        {
+            Assert.Equal(3.0m, Math.Max(-2.0m, 3.0m));
+            Assert.Equal(decimal.MaxValue, Math.Max(decimal.MinValue, decimal.MaxValue));
+        }
 
-    [Fact]
-    public static void Max_Double()
-    {
-        Assert.Equal(3.0, Math.Max(3.0, -2.0));
-        Assert.Equal(double.MaxValue, Math.Max(double.MinValue, double.MaxValue));
-        Assert.Equal(double.PositiveInfinity, Math.Max(double.NegativeInfinity, double.PositiveInfinity));
-        Assert.Equal(double.NaN, Math.Max(double.PositiveInfinity, double.NaN));
-        Assert.Equal(double.NaN, Math.Max(double.NaN, double.NaN));
-    }
+        [Fact]
+        public static void Max_Double()
+        {
+            Assert.Equal(3.0, Math.Max(3.0, -2.0));
+            Assert.Equal(double.MaxValue, Math.Max(double.MinValue, double.MaxValue));
+            Assert.Equal(double.PositiveInfinity, Math.Max(double.NegativeInfinity, double.PositiveInfinity));
+            Assert.Equal(double.NaN, Math.Max(double.PositiveInfinity, double.NaN));
+            Assert.Equal(double.NaN, Math.Max(double.NaN, double.NaN));
+        }
 
-    [Fact]
-    public static void Max_Short()
-    {
-        Assert.Equal((short)3, Math.Max((short)(-2), (short)3));
-        Assert.Equal(short.MaxValue, Math.Max(short.MinValue, short.MaxValue));
-    }
+        [Fact]
+        public static void Max_Short()
+        {
+            Assert.Equal((short)3, Math.Max((short)(-2), (short)3));
+            Assert.Equal(short.MaxValue, Math.Max(short.MinValue, short.MaxValue));
+        }
 
-    [Fact]
-    public static void Max_Int()
-    {
-        Assert.Equal(3, Math.Max(-2, 3));
-        Assert.Equal(int.MaxValue, Math.Max(int.MinValue, int.MaxValue));
-    }
+        [Fact]
+        public static void Max_Int()
+        {
+            Assert.Equal(3, Math.Max(-2, 3));
+            Assert.Equal(int.MaxValue, Math.Max(int.MinValue, int.MaxValue));
+        }
 
-    [Fact]
-    public static void Max_Long()
-    {
-        Assert.Equal(3L, Math.Max(-2L, 3L));
-        Assert.Equal(long.MaxValue, Math.Max(long.MinValue, long.MaxValue));
-    }
+        [Fact]
+        public static void Max_Long()
+        {
+            Assert.Equal(3L, Math.Max(-2L, 3L));
+            Assert.Equal(long.MaxValue, Math.Max(long.MinValue, long.MaxValue));
+        }
 
-    [Fact]
-    public static void Max_SByte()
-    {
-        Assert.Equal((sbyte)3, Math.Max((sbyte)(-2), (sbyte)3));
-        Assert.Equal(sbyte.MaxValue, Math.Max(sbyte.MinValue, sbyte.MaxValue));
-    }
+        [Fact]
+        public static void Max_SByte()
+        {
+            Assert.Equal((sbyte)3, Math.Max((sbyte)(-2), (sbyte)3));
+            Assert.Equal(sbyte.MaxValue, Math.Max(sbyte.MinValue, sbyte.MaxValue));
+        }
 
-    [Fact]
-    public static void Max_Float()
-    {
-        Assert.Equal(3.0f, Math.Max(3.0f, -2.0f));
-        Assert.Equal(float.MaxValue, Math.Max(float.MinValue, float.MaxValue));
-        Assert.Equal(float.PositiveInfinity, Math.Max(float.NegativeInfinity, float.PositiveInfinity));
-        Assert.Equal(float.NaN, Math.Max(float.PositiveInfinity, float.NaN));
-        Assert.Equal(float.NaN, Math.Max(float.NaN, float.NaN));
-    }
+        [Fact]
+        public static void Max_Float()
+        {
+            Assert.Equal(3.0f, Math.Max(3.0f, -2.0f));
+            Assert.Equal(float.MaxValue, Math.Max(float.MinValue, float.MaxValue));
+            Assert.Equal(float.PositiveInfinity, Math.Max(float.NegativeInfinity, float.PositiveInfinity));
+            Assert.Equal(float.NaN, Math.Max(float.PositiveInfinity, float.NaN));
+            Assert.Equal(float.NaN, Math.Max(float.NaN, float.NaN));
+        }
 
-    [Fact]
-    public static void Max_UShort()
-    {
-        Assert.Equal((ushort)3, Math.Max((ushort)2, (ushort)3));
-        Assert.Equal(ushort.MaxValue, Math.Max(ushort.MinValue, ushort.MaxValue));
-    }
+        [Fact]
+        public static void Max_UShort()
+        {
+            Assert.Equal((ushort)3, Math.Max((ushort)2, (ushort)3));
+            Assert.Equal(ushort.MaxValue, Math.Max(ushort.MinValue, ushort.MaxValue));
+        }
 
-    [Fact]
-    public static void Max_UInt()
-    {
-        Assert.Equal((uint)3, Math.Max((uint)2, (uint)3));
-        Assert.Equal(uint.MaxValue, Math.Max(uint.MinValue, uint.MaxValue));
-    }
+        [Fact]
+        public static void Max_UInt()
+        {
+            Assert.Equal((uint)3, Math.Max((uint)2, (uint)3));
+            Assert.Equal(uint.MaxValue, Math.Max(uint.MinValue, uint.MaxValue));
+        }
 
-    [Fact]
-    public static void Max_ULong()
-    {
-        Assert.Equal((ulong)3, Math.Max((ulong)2, (ulong)3));
-        Assert.Equal(ulong.MaxValue, Math.Max(ulong.MinValue, ulong.MaxValue));
-    }
+        [Fact]
+        public static void Max_ULong()
+        {
+            Assert.Equal((ulong)3, Math.Max((ulong)2, (ulong)3));
+            Assert.Equal(ulong.MaxValue, Math.Max(ulong.MinValue, ulong.MaxValue));
+        }
 
-    [Fact]
-    public static void Sign_Decimal()
-    {
-        Assert.Equal(0, Math.Sign(0.0m));
-        Assert.Equal(0, Math.Sign(-0.0m));
-        Assert.Equal(-1, Math.Sign(-3.14m));
-        Assert.Equal(1, Math.Sign(3.14m));
-    }
+        [Fact]
+        public static void Sign_Decimal()
+        {
+            Assert.Equal(0, Math.Sign(0.0m));
+            Assert.Equal(0, Math.Sign(-0.0m));
+            Assert.Equal(-1, Math.Sign(-3.14m));
+            Assert.Equal(1, Math.Sign(3.14m));
+        }
 
-    [Fact]
-    public static void Sign_Double()
-    {
-        Assert.Equal(0, Math.Sign(0.0));
-        Assert.Equal(0, Math.Sign(-0.0));
-        Assert.Equal(-1, Math.Sign(-3.14));
-        Assert.Equal(1, Math.Sign(3.14));
-        Assert.Equal(-1, Math.Sign(double.NegativeInfinity));
-        Assert.Equal(1, Math.Sign(double.PositiveInfinity));
-        Assert.Throws<ArithmeticException>(() => Math.Sign(double.NaN));
-    }
+        [Fact]
+        public static void Sign_Double()
+        {
+            Assert.Equal(0, Math.Sign(0.0));
+            Assert.Equal(0, Math.Sign(-0.0));
+            Assert.Equal(-1, Math.Sign(-3.14));
+            Assert.Equal(1, Math.Sign(3.14));
+            Assert.Equal(-1, Math.Sign(double.NegativeInfinity));
+            Assert.Equal(1, Math.Sign(double.PositiveInfinity));
+            Assert.Throws<ArithmeticException>(() => Math.Sign(double.NaN));
+        }
 
-    [Fact]
-    public static void Sign_Short()
-    {
-        Assert.Equal(0, Math.Sign((short)0));
-        Assert.Equal(-1, Math.Sign((short)(-3)));
-        Assert.Equal(1, Math.Sign((short)3));
-    }
+        [Fact]
+        public static void Sign_Short()
+        {
+            Assert.Equal(0, Math.Sign((short)0));
+            Assert.Equal(-1, Math.Sign((short)(-3)));
+            Assert.Equal(1, Math.Sign((short)3));
+        }
 
-    [Fact]
-    public static void Sign_Int()
-    {
-        Assert.Equal(0, Math.Sign(0));
-        Assert.Equal(-1, Math.Sign(-3));
-        Assert.Equal(1, Math.Sign(3));
-    }
+        [Fact]
+        public static void Sign_Int()
+        {
+            Assert.Equal(0, Math.Sign(0));
+            Assert.Equal(-1, Math.Sign(-3));
+            Assert.Equal(1, Math.Sign(3));
+        }
 
-    [Fact]
-    public static void Sign_Long()
-    {
-        Assert.Equal(0, Math.Sign(0));
-        Assert.Equal(-1, Math.Sign(-3));
-        Assert.Equal(1, Math.Sign(3));
-    }
+        [Fact]
+        public static void Sign_Long()
+        {
+            Assert.Equal(0, Math.Sign(0));
+            Assert.Equal(-1, Math.Sign(-3));
+            Assert.Equal(1, Math.Sign(3));
+        }
 
-    [Fact]
-    public static void Sign_SByte()
-    {
-        Assert.Equal(0, Math.Sign((sbyte)0));
-        Assert.Equal(-1, Math.Sign((sbyte)(-3)));
-        Assert.Equal(1, Math.Sign((sbyte)3));
-    }
+        [Fact]
+        public static void Sign_SByte()
+        {
+            Assert.Equal(0, Math.Sign((sbyte)0));
+            Assert.Equal(-1, Math.Sign((sbyte)(-3)));
+            Assert.Equal(1, Math.Sign((sbyte)3));
+        }
 
-    [Fact]
-    public static void Sign_Float()
-    {
-        Assert.Equal(0, Math.Sign(0.0f));
-        Assert.Equal(0, Math.Sign(-0.0f));
-        Assert.Equal(-1, Math.Sign(-3.14f));
-        Assert.Equal(1, Math.Sign(3.14f));
-        Assert.Equal(-1, Math.Sign(float.NegativeInfinity));
-        Assert.Equal(1, Math.Sign(float.PositiveInfinity));
-        Assert.Throws<ArithmeticException>(() => Math.Sign(float.NaN));
-    }
+        [Fact]
+        public static void Sign_Float()
+        {
+            Assert.Equal(0, Math.Sign(0.0f));
+            Assert.Equal(0, Math.Sign(-0.0f));
+            Assert.Equal(-1, Math.Sign(-3.14f));
+            Assert.Equal(1, Math.Sign(3.14f));
+            Assert.Equal(-1, Math.Sign(float.NegativeInfinity));
+            Assert.Equal(1, Math.Sign(float.PositiveInfinity));
+            Assert.Throws<ArithmeticException>(() => Math.Sign(float.NaN));
+        }
 
-    [Fact]
-    public static void Truncate_Decimal()
-    {
-        Assert.Equal(0.0m, Math.Truncate(0.12345m));
-        Assert.Equal(3.0m, Math.Truncate(3.14159m));
-        Assert.Equal(-3.0m, Math.Truncate(-3.14159m));
-    }
+        [Fact]
+        public static void Truncate_Decimal()
+        {
+            Assert.Equal(0.0m, Math.Truncate(0.12345m));
+            Assert.Equal(3.0m, Math.Truncate(3.14159m));
+            Assert.Equal(-3.0m, Math.Truncate(-3.14159m));
+        }
 
-    [Fact]
-    public static void Truncate_Double()
-    {
-        Assert.Equal(0.0, Math.Truncate(0.12345));
-        Assert.Equal(3.0, Math.Truncate(3.14159));
-        Assert.Equal(-3.0, Math.Truncate(-3.14159));
+        [Fact]
+        public static void Truncate_Double()
+        {
+            Assert.Equal(0.0, Math.Truncate(0.12345));
+            Assert.Equal(3.0, Math.Truncate(3.14159));
+            Assert.Equal(-3.0, Math.Truncate(-3.14159));
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
@@ -3,9 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-
 using Xunit;
-    
+
 namespace System.Net.Tests
 {
     public class WebUtilityTests

--- a/src/System.Runtime.Extensions/tests/System/Random.cs
+++ b/src/System.Runtime.Extensions/tests/System/Random.cs
@@ -2,73 +2,75 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
-public static class RandomTests
+namespace System.Tests
 {
-    [Fact]
-    public static void Unseeded()
+    public static class RandomTests
     {
-        Random r = new Random();
-        for (int i = 0; i < 1000; i++)
+        [Fact]
+        public static void Unseeded()
         {
-            int x = r.Next(20);
-            Assert.True(x >= 0 && x < 20);
+            Random r = new Random();
+            for (int i = 0; i < 1000; i++)
+            {
+                int x = r.Next(20);
+                Assert.True(x >= 0 && x < 20);
+            }
+            for (int i = 0; i < 1000; i++)
+            {
+                int x = r.Next(20, 30);
+                Assert.True(x >= 20 && x < 30);
+            }
+            for (int i = 0; i < 1000; i++)
+            {
+                double x = r.NextDouble();
+                Assert.True(x >= 0.0 && x < 1.0);
+            }
         }
-        for (int i = 0; i < 1000; i++)
+
+        [Fact]
+        public static void Seeded()
         {
-            int x = r.Next(20, 30);
-            Assert.True(x >= 20 && x < 30);
+            int seed = Environment.TickCount;
+
+            Random r1 = new Random(seed);
+            Random r2 = new Random(seed);
+
+            byte[] b1 = new byte[1000];
+            r1.NextBytes(b1);
+            byte[] b2 = new byte[1000];
+            r2.NextBytes(b2);
+            for (int i = 0; i < b1.Length; i++)
+            {
+                Assert.Equal(b1[i], b2[i]);
+            }
+            for (int i = 0; i < b1.Length; i++)
+            {
+                int x1 = r1.Next();
+                int x2 = r2.Next();
+                Assert.Equal(x1, x2);
+            }
         }
-        for (int i = 0; i < 1000; i++)
+
+        [Fact]
+        public static void Sample()
         {
-            double x = r.NextDouble();
-            Assert.True(x >= 0.0 && x < 1.0);
+            SubRandom r = new SubRandom();
+
+            for (int i = 0; i < 1000; i++)
+            {
+                double d = r.ExposeSample();
+                Assert.True(d >= 0.0 && d < 1.0);
+            }
         }
-    }
 
-    [Fact]
-    public static void Seeded()
-    {
-        int seed = Environment.TickCount;
-
-        Random r1 = new Random(seed);
-        Random r2 = new Random(seed);
-
-        byte[] b1 = new byte[1000];
-        r1.NextBytes(b1);
-        byte[] b2 = new byte[1000];
-        r2.NextBytes(b2);
-        for (int i = 0; i < b1.Length; i++)
+        private class SubRandom : Random
         {
-            Assert.Equal(b1[i], b2[i]);
-        }
-        for (int i = 0; i < b1.Length; i++)
-        {
-            int x1 = r1.Next();
-            int x2 = r2.Next();
-            Assert.Equal(x1, x2);
-        }
-    }
-
-    [Fact]
-    public static void Sample()
-    {
-        SubRandom r = new SubRandom();
-
-        for (int i = 0; i < 1000; i++)
-        {
-            double d = r.ExposeSample();
-            Assert.True(d >= 0.0 && d < 1.0);
-        }
-    }
-
-    private class SubRandom : Random
-    {
-        public double ExposeSample()
-        {
-            return Sample();
+            public double ExposeSample()
+            {
+                return Sample();
+            }
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Runtime/Versioning/FrameworkName.cs
+++ b/src/System.Runtime.Extensions/tests/System/Runtime/Versioning/FrameworkName.cs
@@ -2,159 +2,160 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Runtime.Versioning;
 using Xunit;
 
-public static class FrameworkNameTests
+namespace System.Runtime.Versioning.Tests
 {
-    private const string TestIdentifier = "TestFramework";
-    private const string TestProfile = "TestProfile";
-
-    private static readonly Version s_testVersion = new Version(1, 2, 3, 4);
-    private static readonly string s_testNameString = string.Format("{0},Version=v{1},Profile={2}", TestIdentifier, s_testVersion, TestProfile);
-    private static readonly string s_testNameNoProfileString = string.Format("{0},Version=v{1}", TestIdentifier, s_testVersion);
-    private static readonly FrameworkName s_testName = new FrameworkName(s_testNameString);
-    private static readonly FrameworkName s_testNameNoProfile = new FrameworkName(s_testNameNoProfileString);
-
-    [Fact]
-    public static void ConstructFromString()
+    public static class FrameworkNameTests
     {
-        VerifyConstructor(s_testName, s_testNameString, TestIdentifier, s_testVersion, TestProfile);
-    }
+        private const string TestIdentifier = "TestFramework";
+        private const string TestProfile = "TestProfile";
 
-    [Fact]
-    public static void ConstructFromStringWithWhitespace()
-    {
-        var nameString = string.Format("   \r{0}\r\n, Version = {1}\t,  Profile =  {2} \r\n", TestIdentifier, s_testVersion, TestProfile);
-        VerifyConstructor(new FrameworkName(nameString), s_testNameString, TestIdentifier, s_testVersion, TestProfile);
-    }
+        private static readonly Version s_testVersion = new Version(1, 2, 3, 4);
+        private static readonly string s_testNameString = string.Format("{0},Version=v{1},Profile={2}", TestIdentifier, s_testVersion, TestProfile);
+        private static readonly string s_testNameNoProfileString = string.Format("{0},Version=v{1}", TestIdentifier, s_testVersion);
+        private static readonly FrameworkName s_testName = new FrameworkName(s_testNameString);
+        private static readonly FrameworkName s_testNameNoProfile = new FrameworkName(s_testNameNoProfileString);
 
-    [Fact]
-    public static void ConstructFromStringOmitProfile()
-    {
-        VerifyConstructor(s_testNameNoProfile, s_testNameNoProfileString, TestIdentifier, s_testVersion, string.Empty);
-    }
-
-    [Fact]
-    public static void ConstructFromInvalidString()
-    {
-        Assert.Throws<ArgumentNullException>(() => new FrameworkName(null));
-        Assert.Throws<ArgumentException>(() => new FrameworkName(string.Empty));
-        Assert.Throws<ArgumentException>(() => new FrameworkName(" ,A"));
-        Assert.Throws<ArgumentException>(() => new FrameworkName("A"));
-        Assert.Throws<ArgumentException>(() => new FrameworkName("A,B"));
-        Assert.Throws<ArgumentException>(() => new FrameworkName("A,B,C"));
-        Assert.Throws<ArgumentException>(() => new FrameworkName("A,Version=1.0.0.0,C"));
-        Assert.Throws<ArgumentException>(() => new FrameworkName("A,1.0.0.0,Profile=C"));
-        Assert.Throws<ArgumentException>(() => new FrameworkName("A,Version=1.z.0.0,Profile=C"));
-        Assert.Throws<ArgumentException>(() => new FrameworkName("A,Something=1.z.0.0,Profile=C"));
-        Assert.Throws<ArgumentException>(() => new FrameworkName("A,Profile=C"));
-    }
-
-    [Fact]
-    public static void ConstructFromIdentifierVersion()
-    {
-        VerifyConstructor(new FrameworkName(TestIdentifier, s_testVersion),
-            s_testNameNoProfileString, TestIdentifier, s_testVersion, string.Empty);
-    }
-
-    [Fact]
-    public static void ConstructFromInvalidIdentifierVersion()
-    {
-        Assert.Throws<ArgumentNullException>(() => new FrameworkName(null, s_testVersion));
-        Assert.Throws<ArgumentException>(() => new FrameworkName(string.Empty, s_testVersion));
-        Assert.Throws<ArgumentException>(() => new FrameworkName("   \r\n\t", s_testVersion));
-
-        Assert.Throws<ArgumentNullException>(() => new FrameworkName(TestIdentifier, null));
-    }
-
-    [Fact]
-    public static void ConstructFromIdentifierVersionProfile()
-    {
-        VerifyConstructor(new FrameworkName(TestIdentifier, s_testVersion, TestProfile),
-            s_testNameString, TestIdentifier, s_testVersion, TestProfile);
-
-        VerifyConstructor(new FrameworkName(TestIdentifier, s_testVersion, null),
-            s_testNameNoProfileString, TestIdentifier, s_testVersion, string.Empty);
-    }
-
-    [Fact]
-    public static void ConstructFromInvalidIdentifierVersionProfile()
-    {
-        Assert.Throws<ArgumentNullException>(() => new FrameworkName(null, s_testVersion, TestProfile));
-        Assert.Throws<ArgumentException>(() => new FrameworkName(string.Empty, s_testVersion, TestProfile));
-        Assert.Throws<ArgumentException>(() => new FrameworkName("   \r\n\t", s_testVersion, TestProfile));
-
-        Assert.Throws<ArgumentNullException>(() => new FrameworkName(TestIdentifier, null, TestProfile));
-    }
-
-    [Fact]
-    public static void ConstructFromVersionWithoutBuildRevision()
-    {
-        var majorMinor = new Version(1, 2);
-        Assert.Equal(-1, new FrameworkName(s_testName.Identifier, majorMinor).Version.Build);
-        Assert.Equal(-1, new FrameworkName(s_testName.Identifier, majorMinor).Version.Revision);
-
-        var majorMinorBuild = new Version(1, 2, 3);
-        Assert.Equal(3, new FrameworkName(s_testName.Identifier, majorMinorBuild).Version.Build);
-        Assert.Equal(-1, new FrameworkName(s_testName.Identifier, majorMinorBuild).Version.Revision);
-
-        var majorMinorBuildRevision = new Version(1, 2, 3, 4);
-        Assert.Equal(3, new FrameworkName(s_testName.Identifier, majorMinorBuildRevision).Version.Build);
-        Assert.Equal(4, new FrameworkName(s_testName.Identifier, majorMinorBuildRevision).Version.Revision);
-    }
-
-    [Fact]
-    public static void Equality()
-    {
-        VerifyEquality(null, null);
-        VerifyEquality(s_testName, s_testName);
-        VerifyEquality(s_testName, new FrameworkName(s_testNameString));
-        VerifyEquality(s_testName, new FrameworkName(TestIdentifier, s_testVersion, TestProfile));
-    }
-
-    [Fact]
-    public static void Inequality()
-    {
-        VerifyInequality(null, s_testName);
-        VerifyInequality(s_testName, null);
-        VerifyInequality(s_testName, new FrameworkName("NotTheTestIdentifier", s_testVersion, TestProfile));
-        VerifyInequality(s_testName, new FrameworkName(TestIdentifier, s_testVersion));
-        VerifyInequality(s_testName, new FrameworkName(TestIdentifier, new Version(9, 8, 7, 6), TestProfile));
-    }
-
-    private static void VerifyConstructor(FrameworkName name, string expectedName, string expectedIdentifier, Version expectedVersion, string expectedProfile)
-    {
-        Assert.Equal(expectedName, name.FullName);
-        Assert.Equal(expectedName, name.ToString());
-        Assert.Equal(expectedIdentifier, name.Identifier);
-        Assert.Equal(expectedProfile, name.Profile);
-        Assert.Equal(expectedVersion, name.Version);
-    }
-
-    private static void VerifyInequality(FrameworkName x, FrameworkName y)
-    {
-        Assert.True(x != y);
-        Assert.False(x == y);
-        if (x != null)
+        [Fact]
+        public static void ConstructFromString()
         {
-            Assert.False(x.Equals(y));
-            Assert.False(x.Equals((object)y));
-            Assert.False(((IEquatable<FrameworkName>)x).Equals(y));
+            VerifyConstructor(s_testName, s_testNameString, TestIdentifier, s_testVersion, TestProfile);
         }
-    }
 
-    private static void VerifyEquality(FrameworkName x, FrameworkName y)
-    {
-        Assert.True(x == y);
-        Assert.False(x != y);
-        if (x != null)
+        [Fact]
+        public static void ConstructFromStringWithWhitespace()
         {
-            Assert.True(x.Equals(y));
-            Assert.True(x.Equals((object)y));
-            Assert.True(((IEquatable<FrameworkName>)x).Equals(y));
-            Assert.Equal(x.GetHashCode(), y.GetHashCode());
+            var nameString = string.Format("   \r{0}\r\n, Version = {1}\t,  Profile =  {2} \r\n", TestIdentifier, s_testVersion, TestProfile);
+            VerifyConstructor(new FrameworkName(nameString), s_testNameString, TestIdentifier, s_testVersion, TestProfile);
+        }
+
+        [Fact]
+        public static void ConstructFromStringOmitProfile()
+        {
+            VerifyConstructor(s_testNameNoProfile, s_testNameNoProfileString, TestIdentifier, s_testVersion, string.Empty);
+        }
+
+        [Fact]
+        public static void ConstructFromInvalidString()
+        {
+            Assert.Throws<ArgumentNullException>(() => new FrameworkName(null));
+            Assert.Throws<ArgumentException>(() => new FrameworkName(string.Empty));
+            Assert.Throws<ArgumentException>(() => new FrameworkName(" ,A"));
+            Assert.Throws<ArgumentException>(() => new FrameworkName("A"));
+            Assert.Throws<ArgumentException>(() => new FrameworkName("A,B"));
+            Assert.Throws<ArgumentException>(() => new FrameworkName("A,B,C"));
+            Assert.Throws<ArgumentException>(() => new FrameworkName("A,Version=1.0.0.0,C"));
+            Assert.Throws<ArgumentException>(() => new FrameworkName("A,1.0.0.0,Profile=C"));
+            Assert.Throws<ArgumentException>(() => new FrameworkName("A,Version=1.z.0.0,Profile=C"));
+            Assert.Throws<ArgumentException>(() => new FrameworkName("A,Something=1.z.0.0,Profile=C"));
+            Assert.Throws<ArgumentException>(() => new FrameworkName("A,Profile=C"));
+        }
+
+        [Fact]
+        public static void ConstructFromIdentifierVersion()
+        {
+            VerifyConstructor(new FrameworkName(TestIdentifier, s_testVersion),
+                s_testNameNoProfileString, TestIdentifier, s_testVersion, string.Empty);
+        }
+
+        [Fact]
+        public static void ConstructFromInvalidIdentifierVersion()
+        {
+            Assert.Throws<ArgumentNullException>(() => new FrameworkName(null, s_testVersion));
+            Assert.Throws<ArgumentException>(() => new FrameworkName(string.Empty, s_testVersion));
+            Assert.Throws<ArgumentException>(() => new FrameworkName("   \r\n\t", s_testVersion));
+
+            Assert.Throws<ArgumentNullException>(() => new FrameworkName(TestIdentifier, null));
+        }
+
+        [Fact]
+        public static void ConstructFromIdentifierVersionProfile()
+        {
+            VerifyConstructor(new FrameworkName(TestIdentifier, s_testVersion, TestProfile),
+                s_testNameString, TestIdentifier, s_testVersion, TestProfile);
+
+            VerifyConstructor(new FrameworkName(TestIdentifier, s_testVersion, null),
+                s_testNameNoProfileString, TestIdentifier, s_testVersion, string.Empty);
+        }
+
+        [Fact]
+        public static void ConstructFromInvalidIdentifierVersionProfile()
+        {
+            Assert.Throws<ArgumentNullException>(() => new FrameworkName(null, s_testVersion, TestProfile));
+            Assert.Throws<ArgumentException>(() => new FrameworkName(string.Empty, s_testVersion, TestProfile));
+            Assert.Throws<ArgumentException>(() => new FrameworkName("   \r\n\t", s_testVersion, TestProfile));
+
+            Assert.Throws<ArgumentNullException>(() => new FrameworkName(TestIdentifier, null, TestProfile));
+        }
+
+        [Fact]
+        public static void ConstructFromVersionWithoutBuildRevision()
+        {
+            var majorMinor = new Version(1, 2);
+            Assert.Equal(-1, new FrameworkName(s_testName.Identifier, majorMinor).Version.Build);
+            Assert.Equal(-1, new FrameworkName(s_testName.Identifier, majorMinor).Version.Revision);
+
+            var majorMinorBuild = new Version(1, 2, 3);
+            Assert.Equal(3, new FrameworkName(s_testName.Identifier, majorMinorBuild).Version.Build);
+            Assert.Equal(-1, new FrameworkName(s_testName.Identifier, majorMinorBuild).Version.Revision);
+
+            var majorMinorBuildRevision = new Version(1, 2, 3, 4);
+            Assert.Equal(3, new FrameworkName(s_testName.Identifier, majorMinorBuildRevision).Version.Build);
+            Assert.Equal(4, new FrameworkName(s_testName.Identifier, majorMinorBuildRevision).Version.Revision);
+        }
+
+        [Fact]
+        public static void Equality()
+        {
+            VerifyEquality(null, null);
+            VerifyEquality(s_testName, s_testName);
+            VerifyEquality(s_testName, new FrameworkName(s_testNameString));
+            VerifyEquality(s_testName, new FrameworkName(TestIdentifier, s_testVersion, TestProfile));
+        }
+
+        [Fact]
+        public static void Inequality()
+        {
+            VerifyInequality(null, s_testName);
+            VerifyInequality(s_testName, null);
+            VerifyInequality(s_testName, new FrameworkName("NotTheTestIdentifier", s_testVersion, TestProfile));
+            VerifyInequality(s_testName, new FrameworkName(TestIdentifier, s_testVersion));
+            VerifyInequality(s_testName, new FrameworkName(TestIdentifier, new Version(9, 8, 7, 6), TestProfile));
+        }
+
+        private static void VerifyConstructor(FrameworkName name, string expectedName, string expectedIdentifier, Version expectedVersion, string expectedProfile)
+        {
+            Assert.Equal(expectedName, name.FullName);
+            Assert.Equal(expectedName, name.ToString());
+            Assert.Equal(expectedIdentifier, name.Identifier);
+            Assert.Equal(expectedProfile, name.Profile);
+            Assert.Equal(expectedVersion, name.Version);
+        }
+
+        private static void VerifyInequality(FrameworkName x, FrameworkName y)
+        {
+            Assert.True(x != y);
+            Assert.False(x == y);
+            if (x != null)
+            {
+                Assert.False(x.Equals(y));
+                Assert.False(x.Equals((object)y));
+                Assert.False(((IEquatable<FrameworkName>)x).Equals(y));
+            }
+        }
+
+        private static void VerifyEquality(FrameworkName x, FrameworkName y)
+        {
+            Assert.True(x == y);
+            Assert.False(x != y);
+            if (x != null)
+            {
+                Assert.True(x.Equals(y));
+                Assert.True(x.Equals((object)y));
+                Assert.True(((IEquatable<FrameworkName>)x).Equals(y));
+                Assert.Equal(x.GetHashCode(), y.GetHashCode());
+            }
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/StringComparer.cs
+++ b/src/System.Runtime.Extensions/tests/System/StringComparer.cs
@@ -2,62 +2,64 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using Xunit;
 
-public static class StringComparerTests
+namespace System.Tests
 {
-    [Fact]
-    public static void TestCurrent()
+    public static class StringComparerTests
     {
-        VerifyComparer(StringComparer.CurrentCulture, false);
-        VerifyComparer(StringComparer.CurrentCultureIgnoreCase, true);
-    }
+        [Fact]
+        public static void TestCurrent()
+        {
+            VerifyComparer(StringComparer.CurrentCulture, false);
+            VerifyComparer(StringComparer.CurrentCultureIgnoreCase, true);
+        }
 
-    [Fact]
-    public static void TestOrdinal()
-    {
-        VerifyComparer(StringComparer.Ordinal, false);
-        VerifyComparer(StringComparer.OrdinalIgnoreCase, true);
-    }
+        [Fact]
+        public static void TestOrdinal()
+        {
+            VerifyComparer(StringComparer.Ordinal, false);
+            VerifyComparer(StringComparer.OrdinalIgnoreCase, true);
+        }
 
-    private static void VerifyComparer(StringComparer sc, bool ignoreCase)
-    {
-        String s1 = "Hello";
-        String s1a = "Hello";
-        String s1b = "HELLO";
-        String s2 = "There";
+        private static void VerifyComparer(StringComparer sc, bool ignoreCase)
+        {
+            String s1 = "Hello";
+            String s1a = "Hello";
+            String s1b = "HELLO";
+            String s2 = "There";
 
-        Assert.True(sc.Equals(s1, s1a));
-        Assert.True(sc.Equals(s1, s1a));
+            Assert.True(sc.Equals(s1, s1a));
+            Assert.True(sc.Equals(s1, s1a));
 
-        Assert.Equal(0, sc.Compare(s1, s1a));
-        Assert.Equal(0, ((IComparer)sc).Compare(s1, s1a));
+            Assert.Equal(0, sc.Compare(s1, s1a));
+            Assert.Equal(0, ((IComparer)sc).Compare(s1, s1a));
 
-        Assert.True(sc.Equals(s1, s1));
-        Assert.True(((IEqualityComparer)sc).Equals(s1, s1));
-        Assert.Equal(0, sc.Compare(s1, s1));
-        Assert.Equal(0, ((IComparer)sc).Compare(s1, s1));
+            Assert.True(sc.Equals(s1, s1));
+            Assert.True(((IEqualityComparer)sc).Equals(s1, s1));
+            Assert.Equal(0, sc.Compare(s1, s1));
+            Assert.Equal(0, ((IComparer)sc).Compare(s1, s1));
 
-        Assert.False(sc.Equals(s1, s2));
-        Assert.False(((IEqualityComparer)sc).Equals(s1, s2));
-        Assert.True(sc.Compare(s1, s2) < 0);
-        Assert.True(((IComparer)sc).Compare(s1, s2) < 0);
+            Assert.False(sc.Equals(s1, s2));
+            Assert.False(((IEqualityComparer)sc).Equals(s1, s2));
+            Assert.True(sc.Compare(s1, s2) < 0);
+            Assert.True(((IComparer)sc).Compare(s1, s2) < 0);
 
-        Assert.Equal(ignoreCase, sc.Equals(s1, s1b));
-        Assert.Equal(ignoreCase, ((IEqualityComparer)sc).Equals(s1, s1b));
+            Assert.Equal(ignoreCase, sc.Equals(s1, s1b));
+            Assert.Equal(ignoreCase, ((IEqualityComparer)sc).Equals(s1, s1b));
 
-        int result = sc.Compare(s1, s1b);
-        if (ignoreCase)
-            Assert.Equal(0, result);
-        else
-            Assert.NotEqual(0, result);
+            int result = sc.Compare(s1, s1b);
+            if (ignoreCase)
+                Assert.Equal(0, result);
+            else
+                Assert.NotEqual(0, result);
 
-        result = ((IComparer)sc).Compare(s1, s1b);
-        if (ignoreCase)
-            Assert.Equal(0, result);
-        else
-            Assert.NotEqual(0, result);
+            result = ((IComparer)sc).Compare(s1, s1b);
+            if (ignoreCase)
+                Assert.Equal(0, result);
+            else
+                Assert.NotEqual(0, result);
+        }
     }
 }


### PR DESCRIPTION
I noticed that System.Runtime.Extensions had no test namespaces after #6198 was merged.

Contributes to #2898
Append ?w=1 to the url to see a cleaner diff