### PR TITLE
Add Debug.Assert messages to System.Net.Sockets Unix code

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.FdSet.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.FdSet.cs
@@ -26,7 +26,7 @@ internal static partial class Interop
             {
                 ThrowInvalidFileDescriptor(fd);
             }
-            Debug.Assert(fdset != null);
+            Debug.Assert(fdset != null, "fdset was null");
 
             fdset[fd / FD_SETSIZE_UINTS] |= (1u << (fd % FD_SETSIZE_UINTS));
         }
@@ -37,14 +37,14 @@ internal static partial class Interop
             {
                 ThrowInvalidFileDescriptor(fd);
             }
-            Debug.Assert(fdset != null);
+            Debug.Assert(fdset != null, "fdset was null");
 
             return (fdset[fd / FD_SETSIZE_UINTS] & (1u << (fd % FD_SETSIZE_UINTS))) != 0;
         }
 
         internal static unsafe void FD_ZERO(uint* fdset)
         {
-            Debug.Assert(fdset != null);
+            Debug.Assert(fdset != null, "fdset was null");
             Interop.Sys.MemSet(fdset, 0, (UIntPtr)FD_SETSIZE_BYTES);
         }
 

--- a/src/Common/src/Interop/Unix/System.Native/Interop.IPAddress.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.IPAddress.cs
@@ -46,8 +46,8 @@ internal static partial class Interop
 
         internal unsafe static uint IPAddressToString(byte[] address, bool isIPv6, StringBuilder addressString, uint scope = 0)
         {
-            Debug.Assert(address != null);
-            Debug.Assert((address.Length == IPv4AddressBytes) || (address.Length == IPv6AddressBytes));
+            Debug.Assert(address != null, "address was null");
+            Debug.Assert((address.Length == IPv4AddressBytes) || (address.Length == IPv6AddressBytes), $"Unexpected address length: {address.Length}");
 
             int err;
             fixed (byte* rawAddress = address)

--- a/src/Common/src/System/Net/InteropIPAddressExtensions.Unix.cs
+++ b/src/Common/src/System/Net/InteropIPAddressExtensions.Unix.cs
@@ -14,7 +14,7 @@ namespace System.Net
             var nativeIPAddress = default(Interop.Sys.IPAddress);
 
             byte[] bytes = ipAddress.GetAddressBytes();
-            Debug.Assert(bytes.Length == sizeof(uint) || bytes.Length == Interop.Sys.IPv6AddressBytes);
+            Debug.Assert(bytes.Length == sizeof(uint) || bytes.Length == Interop.Sys.IPv6AddressBytes, $"Unexpected length: {bytes.Length}");
 
             for (int i = 0; i < bytes.Length && i < Interop.Sys.IPv6AddressBytes; i++)
             {

--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -67,7 +67,7 @@ namespace System.Net.Sockets
             }
             set
             {
-                Debug.Assert(value == -1 || value > 0);
+                Debug.Assert(value == -1 || value > 0, $"Unexpected value: {value}");
                 _receiveTimeout = value;;
             }
         }
@@ -80,7 +80,7 @@ namespace System.Net.Sockets
             }
             set
             {
-                Debug.Assert(value == -1 || value > 0);
+                Debug.Assert(value == -1 || value > 0, $"Unexpected value: {value}");
                 _sendTimeout = value;
             }
         }
@@ -218,7 +218,7 @@ namespace System.Net.Sockets
                 Interop.Error error = Interop.Sys.Socket(addressFamily, socketType, protocolType, &fd);
                 if (error == Interop.Error.SUCCESS)
                 {
-                    Debug.Assert(fd != -1);
+                    Debug.Assert(fd != -1, "fd should not be -1");
 
                     errorCode = SocketError.Success;
 
@@ -237,7 +237,7 @@ namespace System.Net.Sockets
                 }
                 else
                 {
-                    Debug.Assert(fd == -1);
+                    Debug.Assert(fd == -1, $"Unexpected fd: {fd}");
 
                     errorCode = SocketPal.GetSocketErrorForErrorCode(error);
                 }

--- a/src/Common/src/System/Net/SocketAddressPal.Unix.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Unix.cs
@@ -20,7 +20,7 @@ namespace System.Net
         {
             int ipv6AddressSize, unused;
             Interop.Error err = Interop.Sys.GetIPSocketAddressSizes(&unused, &ipv6AddressSize);
-            Debug.Assert(err == Interop.Error.SUCCESS);
+            Debug.Assert(err == Interop.Error.SUCCESS, $"Unexpected err: {err}");
             return ipv6AddressSize;
         }
 
@@ -28,7 +28,7 @@ namespace System.Net
         {
             int ipv4AddressSize, unused;
             Interop.Error err = Interop.Sys.GetIPSocketAddressSizes(&ipv4AddressSize, &unused);
-            Debug.Assert(err == Interop.Error.SUCCESS);
+            Debug.Assert(err == Interop.Error.SUCCESS, $"Unexpected err: {err}");
             return ipv4AddressSize;
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Unix.cs
@@ -22,7 +22,7 @@ namespace System.Net.Sockets
             {
                 // *nix does not support the reuse of an existing socket as the accepted
                 // socket.
-                Debug.Assert(value == null);
+                Debug.Assert(value == null, $"Unexpected value: {value}");
             }
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Unix.cs
@@ -23,7 +23,7 @@ namespace System.Net.Sockets
         {
             if (_socketAddress != null)
             {
-                Debug.Assert(socketAddress == null || _socketAddress.Buffer == socketAddress);
+                Debug.Assert(socketAddress == null || _socketAddress.Buffer == socketAddress, $"Unexpected socket address: {socketAddress}");
                 _socketAddressSize = socketAddressSize;
             }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.Unix.cs
@@ -17,8 +17,8 @@ namespace System.Net.Sockets
 
         public void CompletionCallback(int numBytes, byte[] socketAddress, int socketAddressSize, SocketFlags receivedFlags, IPPacketInformation ipPacketInformation, SocketError errorCode)
         {
-            Debug.Assert(_socketAddress != null);
-            Debug.Assert(socketAddress == null || _socketAddress.Buffer == socketAddress);
+            Debug.Assert(_socketAddress != null, "_socketAddress was null");
+            Debug.Assert(socketAddress == null || _socketAddress.Buffer == socketAddress, $"Unexpected socketAddress: {socketAddress}");
 
             _socketAddressSize = socketAddressSize;
             _socketFlags = receivedFlags;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -41,7 +41,7 @@ namespace System.Net.Sockets
 
             public bool TryRegister(SafeCloseSocket socket, Interop.Sys.SocketEvents current, Interop.Sys.SocketEvents events, out Interop.Error error)
             {
-                Debug.Assert(WasAllocated);
+                Debug.Assert(WasAllocated, "Expected WasAllocated to be true");
                 return _engine.TryRegister(socket, current, events, _handle, out error);
             }
         }
@@ -139,8 +139,8 @@ namespace System.Net.Sockets
 
         private IntPtr AllocateHandle(SocketAsyncContext context)
         {
-            Debug.Assert(Monitor.IsEntered(s_lock));
-            Debug.Assert(!IsFull);
+            Debug.Assert(Monitor.IsEntered(s_lock), "Expected s_lock to be held");
+            Debug.Assert(!IsFull, "Expected !IsFull");
 
             IntPtr handle = _nextHandle;
             _handleToContextMap.Add(handle, context);
@@ -154,13 +154,13 @@ namespace System.Net.Sockets
                 s_currentEngine = null;
             }
 
-            Debug.Assert(handle != ShutdownHandle);
+            Debug.Assert(handle != ShutdownHandle, $"Expected handle != ShutdownHandle: {handle}");
             return handle;
         }
 
         private void FreeHandle(IntPtr handle)
         {
-            Debug.Assert(handle != ShutdownHandle);
+            Debug.Assert(handle != ShutdownHandle, $"Expected handle != ShutdownHandle: {handle}");
 
             bool shutdownNeeded = false;
 
@@ -169,7 +169,7 @@ namespace System.Net.Sockets
                 if (_handleToContextMap.Remove(handle))
                 {
                     _outstandingHandles = IntPtr.Subtract(_outstandingHandles, 1);
-                    Debug.Assert(_outstandingHandles.ToInt64() >= 0);
+                    Debug.Assert(_outstandingHandles.ToInt64() >= 0, $"Unexpected _outstandingHandles: {_outstandingHandles}");
 
                     //
                     // If we've allocated all possible handles for this instance, and freed them all, then 
@@ -193,8 +193,8 @@ namespace System.Net.Sockets
 
         private SocketAsyncContext GetContextFromHandle(IntPtr handle)
         {
-            Debug.Assert(handle != ShutdownHandle);
-            Debug.Assert(handle.ToInt64() < MaxHandles.ToInt64());
+            Debug.Assert(handle != ShutdownHandle, $"Expected handle != ShutdownHandle: {handle}");
+            Debug.Assert(handle.ToInt64() < MaxHandles.ToInt64(), $"Unexpected values: handle={handle}, MaxHandles={MaxHandles}");
             lock (s_lock)
             {
                 SocketAsyncContext context;
@@ -270,7 +270,7 @@ namespace System.Net.Sockets
                     }
 
                     // The native shim is responsible for ensuring this condition.
-                    Debug.Assert(numEvents > 0);
+                    Debug.Assert(numEvents > 0, $"Unexpected numEvents: {numEvents}");
 
                     for (int i = 0; i < numEvents; i++)
                     {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -55,7 +55,7 @@ namespace System.Net.Sockets
             // TODO: receive bytes on socket if requested
 
             _acceptedFileDescriptor = acceptedFileDescriptor;
-            Debug.Assert(socketAddress == null || socketAddress == _acceptBuffer);
+            Debug.Assert(socketAddress == null || socketAddress == _acceptBuffer, $"Unexpected socketAddress: {socketAddress}");
             _acceptAddressBufferCount = socketAddressSize;
 
             CompletionCallback(0, socketError);
@@ -63,7 +63,7 @@ namespace System.Net.Sockets
 
         internal unsafe SocketError DoOperationAccept(Socket socket, SafeCloseSocket handle, SafeCloseSocket acceptHandle, out int bytesTransferred)
         {
-            Debug.Assert(acceptHandle == null);
+            Debug.Assert(acceptHandle == null, $"Unexpected acceptHandle: {acceptHandle}");
 
             bytesTransferred = 0;
 
@@ -94,7 +94,7 @@ namespace System.Net.Sockets
 
         private void TransferCompletionCallback(int bytesTransferred, byte[] socketAddress, int socketAddressSize, SocketFlags receivedFlags, SocketError socketError)
         {
-            Debug.Assert(socketAddress == null || socketAddress == _socketAddress.Buffer);
+            Debug.Assert(socketAddress == null || socketAddress == _socketAddress.Buffer, $"Unexpected socketAddress: {socketAddress}");
             _socketAddressSize = socketAddressSize;
             _receivedFlags = receivedFlags;
 
@@ -156,8 +156,8 @@ namespace System.Net.Sockets
 
         private void ReceiveMessageFromCompletionCallback(int bytesTransferred, byte[] socketAddress, int socketAddressSize, SocketFlags receivedFlags, IPPacketInformation ipPacketInformation, SocketError errorCode)
         {
-            Debug.Assert(_socketAddress != null);
-            Debug.Assert(socketAddress == null || _socketAddress.Buffer == socketAddress);
+            Debug.Assert(_socketAddress != null, "Expected non-null _socketAddress");
+            Debug.Assert(socketAddress == null || _socketAddress.Buffer == socketAddress, $"Unexpected socketAddress: {socketAddress}");
 
             _socketAddressSize = socketAddressSize;
             _receivedFlags = receivedFlags;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -159,7 +159,7 @@ namespace System.Net.Sockets
 
         private static unsafe int Receive(SafeCloseSocket socket, SocketFlags flags, int available, byte[] buffer, int offset, int count, byte[] socketAddress, ref int socketAddressLen, out SocketFlags receivedFlags, out Interop.Error errno)
         {
-            Debug.Assert(socketAddress != null || socketAddressLen == 0);
+            Debug.Assert(socketAddress != null || socketAddressLen == 0, $"Unexpected values: socketAddress={socketAddress}, socketAddressLen={socketAddressLen}");
 
             long received;
 
@@ -262,7 +262,7 @@ namespace System.Net.Sockets
                 for (int i = 0; i < maxBuffers; i++, startOffset = 0)
                 {
                     ArraySegment<byte> buffer = buffers[startIndex + i];
-                    Debug.Assert(buffer.Offset + startOffset < buffer.Array.Length);
+                    Debug.Assert(buffer.Offset + startOffset < buffer.Array.Length, $"Unexpected values: Offset={buffer.Offset}, startOffset={startOffset}, Length={buffer.Array.Length}");
 
                     handles[i] = GCHandle.Alloc(buffer.Array, GCHandleType.Pinned);
                     iovecs[i].Base = &((byte*)handles[i].AddrOfPinnedObject())[buffer.Offset + startOffset];
@@ -399,7 +399,7 @@ namespace System.Net.Sockets
 
         private static unsafe int ReceiveMessageFrom(SafeCloseSocket socket, SocketFlags flags, int available, byte[] buffer, int offset, int count, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out Interop.Error errno)
         {
-            Debug.Assert(socketAddress != null);
+            Debug.Assert(socketAddress != null, "Expected non-null socketAddress");
 
             int cmsgBufferLen = Interop.Sys.GetControlMessageBufferSize(isIPv4, isIPv6);
             var cmsgBuffer = stackalloc byte[cmsgBufferLen];
@@ -466,7 +466,7 @@ namespace System.Net.Sockets
 
             if (errno == Interop.Error.SUCCESS)
             {
-                Debug.Assert(fd != -1);
+                Debug.Assert(fd != -1, "Expected fd != -1");
 
                 socketAddressLen = sockAddrLen;
                 errorCode = SocketError.Success;
@@ -488,8 +488,8 @@ namespace System.Net.Sockets
 
         public static unsafe bool TryStartConnect(SafeCloseSocket socket, byte[] socketAddress, int socketAddressLen, out SocketError errorCode)
         {
-            Debug.Assert(socketAddress != null);
-            Debug.Assert(socketAddressLen > 0);
+            Debug.Assert(socketAddress != null, "Expected non-null socketAddress");
+            Debug.Assert(socketAddressLen > 0, $"Unexpected socketAddressLen: {socketAddressLen}");
 
             Interop.Error err;
             fixed (byte* rawSocketAddress = socketAddress)
@@ -530,7 +530,7 @@ namespace System.Net.Sockets
 
             if (err != Interop.Error.SUCCESS)
             {
-                Debug.Assert(err == Interop.Error.EBADF);
+                Debug.Assert(err == Interop.Error.EBADF, $"Unexpected err: {err}");
                 errorCode = SocketError.SocketError;
                 return true;
             }
@@ -988,7 +988,7 @@ namespace System.Net.Sockets
 
         public static unsafe SocketError SetMulticastOption(SafeCloseSocket handle, SocketOptionName optionName, MulticastOption optionValue)
         {
-            Debug.Assert(optionName == SocketOptionName.AddMembership || optionName == SocketOptionName.DropMembership);
+            Debug.Assert(optionName == SocketOptionName.AddMembership || optionName == SocketOptionName.DropMembership, $"Unexpected optionName: {optionName}");
 
             Interop.Sys.MulticastOption optName = optionName == SocketOptionName.AddMembership ?
                 Interop.Sys.MulticastOption.MULTICAST_ADD :
@@ -1006,7 +1006,7 @@ namespace System.Net.Sockets
 
         public static unsafe SocketError SetIPv6MulticastOption(SafeCloseSocket handle, SocketOptionName optionName, IPv6MulticastOption optionValue)
         {
-            Debug.Assert(optionName == SocketOptionName.AddMembership || optionName == SocketOptionName.DropMembership);
+            Debug.Assert(optionName == SocketOptionName.AddMembership || optionName == SocketOptionName.DropMembership, $"Unexpected optionName={optionName}");
 
             Interop.Sys.MulticastOption optName = optionName == SocketOptionName.AddMembership ?
                 Interop.Sys.MulticastOption.MULTICAST_ADD :
@@ -1095,7 +1095,7 @@ namespace System.Net.Sockets
 
         public static unsafe SocketError GetMulticastOption(SafeCloseSocket handle, SocketOptionName optionName, out MulticastOption optionValue)
         {
-            Debug.Assert(optionName == SocketOptionName.AddMembership || optionName == SocketOptionName.DropMembership);
+            Debug.Assert(optionName == SocketOptionName.AddMembership || optionName == SocketOptionName.DropMembership, $"Unexpected optionName={optionName}");
 
             Interop.Sys.MulticastOption optName = optionName == SocketOptionName.AddMembership ?
                 Interop.Sys.MulticastOption.MULTICAST_ADD :
@@ -1120,7 +1120,7 @@ namespace System.Net.Sockets
 
         public static unsafe SocketError GetIPv6MulticastOption(SafeCloseSocket handle, SocketOptionName optionName, out IPv6MulticastOption optionValue)
         {
-            Debug.Assert(optionName == SocketOptionName.AddMembership || optionName == SocketOptionName.DropMembership);
+            Debug.Assert(optionName == SocketOptionName.AddMembership || optionName == SocketOptionName.DropMembership, $"Unexpected optionName={optionName}");
 
             Interop.Sys.MulticastOption optName = optionName == SocketOptionName.AddMembership ?
                 Interop.Sys.MulticastOption.MULTICAST_ADD :
@@ -1336,7 +1336,7 @@ namespace System.Net.Sockets
 
         public static SocketError AcceptAsync(Socket socket, SafeCloseSocket handle, SafeCloseSocket acceptHandle, int receiveSize, int socketAddressSize, AcceptOverlappedAsyncResult asyncResult)
         {
-            Debug.Assert(acceptHandle == null);
+            Debug.Assert(acceptHandle == null, $"Unexpected acceptHandle: {acceptHandle}");
 
             byte[] socketAddressBuffer = new byte[socketAddressSize];
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Unix.cs
@@ -402,7 +402,7 @@ namespace System.Net.Sockets
                 }
                 else
                 {
-                    Debug.Assert(typeof(T) == typeof(LingerOption));
+                    Debug.Assert(typeof(T) == typeof(LingerOption), $"Unexpected type: {typeof(T)}");
                     s.SetSocketOption(level, name, value);
                 }
             }


### PR DESCRIPTION
With the current lack of PDB support on Unix, Debug.Assert failures don't include file / line number information, which makes it harder to debug, especially when there are multiple asserts in a single function.  This commit adds messages to all of the Debug.Asserts in the Unix-specific code in System.Net.Sockets.  Values are included in the messages where they may be helpful in debugging.

cc: @ericeil 
#6506 