### PR TITLE
Fix a NullReferenceException on Unix in SetMulticastOption

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -994,9 +994,11 @@ namespace System.Net.Sockets
                 Interop.Sys.MulticastOption.MULTICAST_ADD :
                 Interop.Sys.MulticastOption.MULTICAST_DROP;
 
+            IPAddress localAddress = optionValue.LocalAddress ?? IPAddress.Any;
+
             var opt = new Interop.Sys.IPv4MulticastOption {
                 MulticastAddress = unchecked((uint)optionValue.Group.GetAddress()),
-                LocalAddress = unchecked((uint)optionValue.LocalAddress.GetAddress()),
+                LocalAddress = unchecked((uint)localAddress.GetAddress()),
                 InterfaceIndex = optionValue.InterfaceIndex
             };
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -78,5 +78,22 @@ namespace System.Net.Sockets.Tests
             int optionValue = (int)socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseUnicastPort);
             Assert.Equal(1, optionValue);
         }
+
+        [Fact]
+        public void MulticastOption_CreateSocketSetGetOption_GroupAndInterfaceIndex_SetSucceeds_GetThrows()
+        {
+            int interfaceIndex = 0;
+            int port = 54321;
+            IPAddress groupIp = IPAddress.Parse("239.1.2.3");
+
+            using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
+            {
+                socket.Bind(new IPEndPoint(IPAddress.Any, port));
+
+                socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(groupIp, interfaceIndex));
+
+                Assert.Throws<SocketException>(() => socket.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership));
+            }
+        }
     }
 }


### PR DESCRIPTION
The implementation was assuming that MulticastOption.LocalAddress is always set, but it'll be null if an interface index was provided.

cc: @ericeil, @pgavlin, @davidsh, @tmds
Fixes #6513 