### PR TITLE
Move System.Text.RegularExpressions tests to xunit

### DIFF
--- a/src/System.Text.RegularExpressions/tests/CaptureCollectionTests.cs
+++ b/src/System.Text.RegularExpressions/tests/CaptureCollectionTests.cs
@@ -2,73 +2,50 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Xunit;
 using System;
 using System.Text.RegularExpressions;
 using System.Collections;
+using Xunit;
 
 namespace Test
 {
-    /// <summary>
-    /// Tests the CaptureCollection class.
-    /// </summary>
     public class CaptureCollectionTests
     {
         [Fact]
-        public static void CaptureCollection_GetEnumeratorTest_Negative()
+        public static void GetEnumerator()
         {
-            Regex rgx1 = new Regex(@"(?<A1>a*)(?<A2>b*)(?<A3>c*)");
-            String strInput = "aaabbccccccccccaaaabc";
-            Match mtch1 = rgx1.Match(strInput);
-            CaptureCollection captrc1 = mtch1.Captures;
+            Regex regex = new Regex(@"(?<A1>a*)(?<A2>b*)(?<A3>c*)");
+            Match match = regex.Match("aaabbccccccccccaaaabc");
 
-            IEnumerator enmtr1 = captrc1.GetEnumerator();
-
-            Capture currentCapture;
-
-            Assert.Throws<InvalidOperationException>(() => currentCapture = (Capture)enmtr1.Current);
-
-
-            for (int i = 0; i < captrc1.Count; i++)
+            CaptureCollection captures = match.Captures;
+            IEnumerator enumerator = captures.GetEnumerator();
+            for (int i = 0; i < 2; i++)
             {
-                enmtr1.MoveNext();
+                int counter = 0;
+                while (enumerator.MoveNext())
+                {
+                    Assert.Equal(captures[counter], enumerator.Current);
+                    counter++;
+                }
+                Assert.Equal(captures.Count, counter);
+                enumerator.Reset();
             }
-
-            enmtr1.MoveNext();
-
-            Assert.Throws<InvalidOperationException>(() => currentCapture = (Capture)enmtr1.Current);
-            enmtr1.Reset();
-
-            Assert.Throws<InvalidOperationException>(() => currentCapture = (Capture)enmtr1.Current);
         }
 
         [Fact]
-        public static void CaptureCollection_GetEnumeratorTest()
+        public static void GetEnumeratorTest_Invalid()
         {
-            Regex rgx1 = new Regex(@"(?<A1>a*)(?<A2>b*)(?<A3>c*)");
-            String strInput = "aaabbccccccccccaaaabc";
-            Match mtch1 = rgx1.Match(strInput);
-            CaptureCollection captrc1 = mtch1.Captures;
+            Regex regex = new Regex(@"(?<A1>a*)(?<A2>b*)(?<A3>c*)");
+            Match match = regex.Match("aaabbccccccccccaaaabc");
+            IEnumerator enumerator = match.Captures.GetEnumerator();
 
-            IEnumerator enmtr1 = captrc1.GetEnumerator();
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
 
-            for (int i = 0; i < captrc1.Count; i++)
-            {
-                enmtr1.MoveNext();
+            while (enumerator.MoveNext()) ;
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
 
-                Assert.Equal(enmtr1.Current, captrc1[i]);
-            }
-
-            Assert.False(enmtr1.MoveNext(), "Err_5! enmtr1.MoveNext returned true");
-
-            enmtr1.Reset();
-
-            for (int i = 0; i < captrc1.Count; i++)
-            {
-                enmtr1.MoveNext();
-
-                Assert.Equal(enmtr1.Current, captrc1[i]);
-            }
+            enumerator.Reset();
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
         }
     }
 }

--- a/src/System.Text.RegularExpressions/tests/CaptureTests.cs
+++ b/src/System.Text.RegularExpressions/tests/CaptureTests.cs
@@ -2,62 +2,57 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Xunit;
 using System;
 using System.Text.RegularExpressions;
 using System.Collections;
+using Xunit;
 
 namespace Test
 {
-    /// <summary>
-    /// Tests the Capture class.
-    /// </summary>
     public class CaptureTests
     {
         [Fact]
         public static void Capture_Test()
         {
             Match match = Regex.Match("adfadsfSUCCESSadsfadsf", @".*\B(SUCCESS)\B.*");
-            Int32[] iMatch1 = { 0, 22 };
-            String strMatch1 = "adfadsfSUCCESSadsfadsf";
+            int[] iMatch1 = { 0, 22 };
+            string strMatch1 = "adfadsfSUCCESSadsfadsf";
 
-            String[] strGroup1 = { "adfadsfSUCCESSadsfadsf", "SUCCESS" };
-            Int32[] iGroup1 = { 7, 7 };
-            String[] strGrpCap1 = { "SUCCESS" };
+            string[] strGroup1 = { "adfadsfSUCCESSadsfadsf", "SUCCESS" };
+            int[] iGroup1 = { 7, 7 };
+            string[] strGrpCap1 = { "SUCCESS" };
 
-            Assert.True(match.Success, "Fail Do not found a match");
+            Assert.True(match.Success);
 
-            Assert.True(match.Value.Equals(strMatch1), "Expected to return TRUE");
-            Assert.Equal(match.Index, iMatch1[0]);
-            Assert.Equal(match.Length, iMatch1[1]);
-            Assert.Equal(match.Captures.Count, 1);
+            Assert.Equal(strMatch1, match.Value);
+            Assert.Equal(iMatch1[0], match.Index);
+            Assert.Equal(iMatch1[1], match.Length);
+            Assert.Equal(1, match.Captures.Count);
 
-            Assert.True(match.Captures[0].Value.Equals(strMatch1), "Expected to return TRUE");
-            Assert.Equal(match.Captures[0].Index, iMatch1[0]);
-            Assert.Equal(match.Captures[0].Length, iMatch1[1]);
+            Assert.Equal(strMatch1, match.Captures[0].Value);
+            Assert.Equal(iMatch1[0], match.Captures[0].Index);
+            Assert.Equal(iMatch1[1], match.Captures[0].Length);
 
-            Assert.Equal(match.Groups.Count, 2);
+            Assert.Equal(2, match.Groups.Count);
 
-            //Group 0 always is the Match
-            Assert.True(match.Groups[0].Value.Equals(strMatch1), "Expected to return TRUE");
-            Assert.Equal(match.Groups[0].Index, iMatch1[0]);
-            Assert.Equal(match.Groups[0].Length, iMatch1[1]);
-            Assert.Equal(match.Groups[0].Captures.Count, 1);
+            // Group 0 always is the Match
+            Assert.Equal(strMatch1, match.Groups[0].Value);
+            Assert.Equal(iMatch1[0], match.Groups[0].Index);
+            Assert.Equal(iMatch1[1], match.Groups[0].Length);
+            Assert.Equal(1, match.Groups[0].Captures.Count);
 
-
-            //Group 0's Capture is always the Match
-            Assert.True(match.Groups[0].Captures[0].Value.Equals(strMatch1), "Expected to return TRUE");
-            Assert.Equal(match.Groups[0].Captures[0].Index, iMatch1[0]);
-            Assert.Equal(match.Groups[0].Captures[0].Length, iMatch1[1]);
+            // Group 0's Capture is always the Match
+            Assert.Equal(strMatch1, match.Groups[0].Captures[0].Value);
+            Assert.Equal(iMatch1[0], match.Groups[0].Captures[0].Index);
+            Assert.Equal(iMatch1[1], match.Groups[0].Captures[0].Length);
 
             for (int i = 1; i < match.Groups.Count; i++)
             {
-                Assert.True(match.Groups[i].Value.Equals(strGroup1[i]), "Expected to return TRUE");
-                Assert.Equal(match.Groups[i].Index, iGroup1[0]);
-                Assert.Equal(match.Groups[i].Length, iGroup1[0]);
-                Assert.Equal(match.Groups[i].Captures.Count, 1);
+                Assert.Equal(strGroup1[i], match.Groups[i].Value);
+                Assert.Equal(iGroup1[0], match.Groups[i].Index);
+                Assert.Equal(iGroup1[0], match.Groups[i].Length);
+                Assert.Equal(1, match.Groups[i].Captures.Count);
             }
-
         }
     }
 }

--- a/src/System.Text.RegularExpressions/tests/CharacterClassSubtractionSimple.cs
+++ b/src/System.Text.RegularExpressions/tests/CharacterClassSubtractionSimple.cs
@@ -8,40 +8,13 @@ using Xunit;
 
 public class CharacterClassSubtraction
 {
-    // This tests CharacterClassSubtraction by specifying pattern, input and expected groups
     [Fact]
     public static void CharacterClassSubtractionTestCase()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-
-        try
+        for (int i = 0; i < s_regexTests.Length; i++)
         {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-
-            for (int i = 0; i < s_regexTests.Length; i++)
-            {
-                iCountTestcases++;
-                if (!s_regexTests[i].Run())
-                {
-                    Console.WriteLine("Err_79872asnko! Test {0} FAILED Pattern={1}, Input={2}\n", i, s_regexTests[i].Pattern, s_regexTests[i].Input);
-                    iCountErrors++;
-                }
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
+            Assert.True(s_regexTests[i].Run());
         }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
     }
 
     private static RegexTestCase[] s_regexTests = new RegexTestCase[] {

--- a/src/System.Text.RegularExpressions/tests/EscapeUnescapeTests.cs
+++ b/src/System.Text.RegularExpressions/tests/EscapeUnescapeTests.cs
@@ -8,53 +8,12 @@ using Xunit;
 
 public class EscapeUnescapeTests
 {
-    /*
-    Tested Methods:
-
-        public static String Escape(String str);     round tripping "#$^*+(){}<>\\|. "
-
-        public static String Unescape(string str);
-
-    */
-
     [Fact]
     public static void EscapeUnescape()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        String s1;
-        String s2;
-        String s3;
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] public static String Escape(String str);     round tripping "#$^*+(){}<>\\|. "
-            //    public static String Unescape(string str);
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            s1 = "#$^*+(){}<>\\|. ";
-            s2 = Regex.Escape(s1);
-            s3 = Regex.Unescape(s2);
-            if (!s1.Equals(s3))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_234fsadg! doesnot match");
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
-        }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+        string source = "#$^*+(){}<>\\|. ";
+        string escaped = Regex.Escape(source);
+        string unescaped = Regex.Unescape(escaped);
+        Assert.Equal(source, unescaped);
     }
 }

--- a/src/System.Text.RegularExpressions/tests/GroupNamesAndNumbers.cs
+++ b/src/System.Text.RegularExpressions/tests/GroupNamesAndNumbers.cs
@@ -9,691 +9,159 @@ using Xunit;
 public class GroupNamesAndNumber
 {
     /*
-    Tested Methods:
-
         public string[] GetGroupNames();
-
         public int[] GetGroupNumbers();
-
         public string GroupNameFromNumber(int i);
-
         public int GroupNumberFromName(string name);
-
     */
-
     [Fact]
     public static void GroupNamesAndNumberTestCase()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Regex r;
-        String s;
-        String[] expectedNames;
-        String[] expectedGroups;
-        int[] expectedNumbers;
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            //[]Vanilla
-            s = "Ryan Byington";
-            r = new Regex("(?<first_name>\\S+)\\s(?<last_name>\\S+)");
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            expectedNames = new String[]
-            {
-            "0", "first_name", "last_name"
-            }
-
-            ;
-            expectedNumbers = new int[]
-            {
-            0, 1, 2
-            }
-
-            ;
-            expectedGroups = new String[]
-            {
-            "Ryan Byington", "Ryan", "Byington"
-            }
-
-            ;
-            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_79793asdwk! Unexpected GroupNames");
-            }
-
-            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_12087ahas! Unexpected GroupNumbers");
-            }
-
-            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_08712saopz! Unexpected Groups");
-            }
-
-            //[]RegEx from SDK
-            s = "abc208923xyzanqnakl";
-            r = new Regex(@"((?<One>abc)\d+)?(?<Two>xyz)(.*)");
-            strLoc = "Loc_0822aws";
-            iCountTestcases++;
-            expectedNames = new String[]
-            {
-            "0", "1", "2", "One", "Two"
-            }
-
-            ;
-            expectedNumbers = new int[]
-            {
-            0, 1, 2, 3, 4
-            }
-
-            ;
-            expectedGroups = new String[]
-            {
-            "abc208923xyzanqnakl", "abc208923", "anqnakl", "abc", "xyz"
-            }
-
-            ;
-            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_79793asdwk! Unexpected GroupNames");
-            }
-
-            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_12087ahas! Unexpected GroupNumbers");
-            }
-
-            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_0822klas! Unexpected Groups");
-            }
-
-            //[]RegEx with numeric names
-            s = "0272saasdabc8978xyz][]12_+-";
-            r = new Regex(@"((?<256>abc)\d+)?(?<16>xyz)(.*)");
-            strLoc = "Loc_0982asd";
-            iCountTestcases++;
-            expectedNames = new String[]
-            {
-            "0", "1", "2", "16", "256"
-            }
-
-            ;
-            expectedNumbers = new int[]
-            {
-            0, 1, 2, 16, 256
-            }
-
-            ;
-            expectedGroups = new String[]
-            {
-            "abc8978xyz][]12_+-", "abc8978", "][]12_+-", "xyz", "abc"
-            }
-
-            ;
-            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_79793asdwk! Unexpected GroupNames");
-            }
-
-            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_12087ahas! Unexpected GroupNumbers");
-            }
-
-            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_7072ankla! Unexpected Groups");
-            }
-
-            //[]RegEx with numeric names and string names
-            s = "0272saasdabc8978xyz][]12_+-";
-            r = new Regex(@"((?<4>abc)(?<digits>\d+))?(?<2>xyz)(?<everything_else>.*)");
-            strLoc = "Loc_98968asdf";
-            iCountTestcases++;
-            expectedNames = new String[]
-            {
-            "0", "1", "2", "digits", "4", "everything_else"
-            }
-
-            ;
-            expectedNumbers = new int[]
-            {
-            0, 1, 2, 3, 4, 5
-            }
-
-            ;
-            expectedGroups = new String[]
-            {
-            "abc8978xyz][]12_+-", "abc8978", "xyz", "8978", "abc", "][]12_+-"
-            }
-
-            ;
-            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_9496sad! Unexpected GroupNames");
-            }
-
-            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_6984awsd! Unexpected GroupNumbers");
-            }
-
-            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_7072ankla! Unexpected Groups");
-            }
-
-            //[]RegEx with 0 numeric names
-            try
-            {
-                r = new Regex(@"foo(?<0>bar)");
-                iCountErrors++;
-                Console.WriteLine("Err_16891 Expected Regex to throw ArgumentException and nothing was thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception e)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_9877sawa Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
-            }
-
-            //[]RegEx without closing >
-            try
-            {
-                r = new Regex(@"foo(?<1bar)");
-                iCountErrors++;
-                Console.WriteLine("Err_2389uop Expected Regex to throw ArgumentException and nothing was thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception e)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_3298asoia Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
-            }
-
-            //[] Duplicate string names
-            s = "Ryan Byington";
-            r = new Regex("(?<first_name>\\S+)\\s(?<first_name>\\S+)");
-            strLoc = "Loc_sdfa9849";
-            iCountTestcases++;
-            expectedNames = new String[]
-            {
-            "0", "first_name"
-            }
-
-            ;
-            expectedNumbers = new int[]
-            {
-            0, 1
-            }
-
-            ;
-            expectedGroups = new String[]
-            {
-            "Ryan Byington", "Byington"
-            }
-
-            ;
-            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_32189asdd! Unexpected GroupNames");
-            }
-
-            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_7978assd! Unexpected GroupNumbers");
-            }
-
-            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_98732soiya! Unexpected Groups");
-            }
-
-            //[] Duplicate numeric names
-            s = "Ryan Byington";
-            r = new Regex("(?<15>\\S+)\\s(?<15>\\S+)");
-            strLoc = "Loc_89198asda";
-            iCountTestcases++;
-            expectedNames = new String[]
-            {
-            "0", "15"
-            }
-
-            ;
-            expectedNumbers = new int[]
-            {
-            0, 15
-            }
-
-            ;
-            expectedGroups = new String[]
-            {
-            "Ryan Byington", "Byington"
-            }
-
-            ;
-            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_97654awwa! Unexpected GroupNames");
-            }
-
-            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_6498asde! Unexpected GroupNumbers");
-            }
-
-            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_316jkkl! Unexpected Groups");
-            }
-
-            /******************************************************************
-            Repeat the same steps from above but using (?'foo') instead
-            ******************************************************************/
-            //[]Vanilla
-            s = "Ryan Byington";
-            r = new Regex("(?'first_name'\\S+)\\s(?'last_name'\\S+)");
-            strLoc = "Loc_0982aklpas";
-            iCountTestcases++;
-            expectedNames = new String[]
-            {
-            "0", "first_name", "last_name"
-            }
-
-            ;
-            expectedNumbers = new int[]
-            {
-            0, 1, 2
-            }
-
-            ;
-            expectedGroups = new String[]
-            {
-            "Ryan Byington", "Ryan", "Byington"
-            }
-
-            ;
-            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_464658safsd! Unexpected GroupNames");
-            }
-
-            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_15689asda! Unexpected GroupNumbers");
-            }
-
-            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_31568kjkj! Unexpected Groups");
-            }
-
-            //[]RegEx from SDK
-            s = "abc208923xyzanqnakl";
-            r = new Regex(@"((?'One'abc)\d+)?(?'Two'xyz)(.*)");
-            strLoc = "Loc_98977uouy";
-            iCountTestcases++;
-            expectedNames = new String[]
-            {
-            "0", "1", "2", "One", "Two"
-            }
-
-            ;
-            expectedNumbers = new int[]
-            {
-            0, 1, 2, 3, 4
-            }
-
-            ;
-            expectedGroups = new String[]
-            {
-            "abc208923xyzanqnakl", "abc208923", "anqnakl", "abc", "xyz"
-            }
-
-            ;
-            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_65498yuiy! Unexpected GroupNames");
-            }
-
-            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_5698yuiyh! Unexpected GroupNumbers");
-            }
-
-            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_2168hkjh! Unexpected Groups");
-            }
-
-            //[]RegEx with numeric names
-            s = "0272saasdabc8978xyz][]12_+-";
-            r = new Regex(@"((?'256'abc)\d+)?(?'16'xyz)(.*)");
-            strLoc = "Loc_9879hjly";
-            iCountTestcases++;
-            expectedNames = new String[]
-            {
-            "0", "1", "2", "16", "256"
-            }
-
-            ;
-            expectedNumbers = new int[]
-            {
-            0, 1, 2, 16, 256
-            }
-
-            ;
-            expectedGroups = new String[]
-            {
-            "abc8978xyz][]12_+-", "abc8978", "][]12_+-", "xyz", "abc"
-            }
-
-            ;
-            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_21689hjkh! Unexpected GroupNames");
-            }
-
-            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_2689juj! Unexpected GroupNumbers");
-            }
-
-            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_2358adea! Unexpected Groups");
-            }
-
-            //[]RegEx with numeric names and string names
-            s = "0272saasdabc8978xyz][]12_+-";
-            r = new Regex(@"((?'4'abc)(?'digits'\d+))?(?'2'xyz)(?'everything_else'.*)");
-            strLoc = "Loc_23189uioyp";
-            iCountTestcases++;
-            expectedNames = new String[]
-            {
-            "0", "1", "2", "digits", "4", "everything_else"
-            }
-
-            ;
-            expectedNumbers = new int[]
-            {
-            0, 1, 2, 3, 4, 5
-            }
-
-            ;
-            expectedGroups = new String[]
-            {
-            "abc8978xyz][]12_+-", "abc8978", "xyz", "8978", "abc", "][]12_+-"
-            }
-
-            ;
-            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_3219hjkj! Unexpected GroupNames");
-            }
-
-            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_23189aseq! Unexpected GroupNumbers");
-            }
-
-            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_2318adew! Unexpected Groups");
-            }
-
-            //[]RegEx with 0 numeric names
-            try
-            {
-                r = new Regex(@"foo(?'0'bar)");
-                iCountErrors++;
-                Console.WriteLine("Err_16891 Expected Regex to throw ArgumentException and nothing was thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception e)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_9877sawa Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
-            }
-
-            //[]RegEx without closing >
-            try
-            {
-                r = new Regex(@"foo(?'1bar)");
-                iCountErrors++;
-                Console.WriteLine("Err_979asja Expected Regex to throw ArgumentException and nothing was thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception e)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_16889asdfw Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
-            }
-
-            //[] Duplicate string names
-            s = "Ryan Byington";
-            r = new Regex("(?'first_name'\\S+)\\s(?'first_name'\\S+)");
-            strLoc = "Loc_2318opa";
-            iCountTestcases++;
-            expectedNames = new String[]
-            {
-            "0", "first_name"
-            }
-
-            ;
-            expectedNumbers = new int[]
-            {
-            0, 1
-            }
-
-            ;
-            expectedGroups = new String[]
-            {
-            "Ryan Byington", "Byington"
-            }
-
-            ;
-            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_28978adfe! Unexpected GroupNames");
-            }
-
-            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_3258adsw! Unexpected GroupNumbers");
-            }
-
-            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_2198asd! Unexpected Groups");
-            }
-
-            //[] Duplicate numeric names
-            s = "Ryan Byington";
-            r = new Regex("(?'15'\\S+)\\s(?'15'\\S+)");
-            strLoc = "Loc_3289hjaa";
-            iCountTestcases++;
-            expectedNames = new String[]
-            {
-            "0", "15"
-            }
-
-            ;
-            expectedNumbers = new int[]
-            {
-            0, 15
-            }
-
-            ;
-            expectedGroups = new String[]
-            {
-            "Ryan Byington", "Byington"
-            }
-
-            ;
-            if (!VerifyGroupNames(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_13289asd! Unexpected GroupNames");
-            }
-
-            if (!VerifyGroupNumbers(r, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_23198asdf! Unexpected GroupNumbers");
-            }
-
-            if (!VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_15689teraku! Unexpected Groups");
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
-        }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+        string s = "Ryan Byington";
+        Regex r = new Regex("(?<first_name>\\S+)\\s(?<last_name>\\S+)");
+        string[] expectedNames = new string[] { "0", "first_name", "last_name" };
+        int[] expectedNumbers = new int[] { 0, 1, 2 };
+        string[] expectedGroups = new string[] { "Ryan Byington", "Ryan", "Byington" };
+        
+        VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers);
+
+        // Regex from SDK
+        s = "abc208923xyzanqnakl";
+        r = new Regex(@"((?<One>abc)\d+)?(?<Two>xyz)(.*)");
+        expectedNames = new string[] { "0", "1", "2", "One", "Two" };
+        expectedNumbers = new int[] { 0, 1, 2, 3, 4 };
+        expectedGroups = new string[] { "abc208923xyzanqnakl", "abc208923", "anqnakl", "abc", "xyz" };
+        
+        VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers);
+
+        // Regex with numeric names
+        s = "0272saasdabc8978xyz][]12_+-";
+        r = new Regex(@"((?<256>abc)\d+)?(?<16>xyz)(.*)");
+        expectedNames = new string[] { "0", "1", "2", "16", "256" };
+        expectedNumbers = new int[] { 0, 1, 2, 16, 256 };
+        expectedGroups = new string[] { "abc8978xyz][]12_+-", "abc8978", "][]12_+-", "xyz", "abc" };
+        
+        VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers);
+
+        // Regex with numeric names and string names
+        s = "0272saasdabc8978xyz][]12_+-";
+        r = new Regex(@"((?<4>abc)(?<digits>\d+))?(?<2>xyz)(?<everything_else>.*)");
+        expectedNames = new string[] { "0", "1", "2", "digits", "4", "everything_else" };
+        expectedNumbers = new int[] { 0, 1, 2, 3, 4, 5 };
+        expectedGroups = new string[] { "abc8978xyz][]12_+-", "abc8978", "xyz", "8978", "abc", "][]12_+-" };
+        
+        VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers);
+
+        // Regex with 0 numeric names
+        Assert.Throws<ArgumentException>(() => new Regex(@"foo(?<0>bar)"));
+
+        // Regex without closing >
+        Assert.Throws<ArgumentException>(() => new Regex(@"foo(?<1bar)"));
+
+        // Duplicate string names
+        s = "Ryan Byington";
+        r = new Regex("(?<first_name>\\S+)\\s(?<first_name>\\S+)");
+        expectedNames = new string[] { "0", "first_name" };
+        expectedNumbers = new int[] { 0, 1 };
+        expectedGroups = new string[] { "Ryan Byington", "Byington" };
+        
+        VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers);
+
+        // Duplicate numeric names
+        s = "Ryan Byington";
+        r = new Regex("(?<15>\\S+)\\s(?<15>\\S+)");
+        expectedNames = new string[] { "0", "15" };
+        expectedNumbers = new int[] { 0, 15 };
+        expectedGroups = new string[] { "Ryan Byington", "Byington" };
+        
+        VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers);
+
+        /******************************************************************
+        Repeat the same steps from above but using (?'foo') instead
+        ******************************************************************/
+        // Vanilla
+        s = "Ryan Byington";
+        r = new Regex("(?'first_name'\\S+)\\s(?'last_name'\\S+)");
+        expectedNames = new string[] { "0", "first_name", "last_name" };
+        expectedNumbers = new int[] { 0, 1, 2 };
+        expectedGroups = new string[] { "Ryan Byington", "Ryan", "Byington" };
+        
+        VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers);
+
+        // Regex from SDK
+        s = "abc208923xyzanqnakl";
+        r = new Regex(@"((?'One'abc)\d+)?(?'Two'xyz)(.*)");
+        expectedNames = new string[] { "0", "1", "2", "One", "Two" };
+        expectedNumbers = new int[] { 0, 1, 2, 3, 4 };
+        expectedGroups = new string[] { "abc208923xyzanqnakl", "abc208923", "anqnakl", "abc", "xyz" };
+        
+        VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers);
+
+        // Regex with numeric names
+        s = "0272saasdabc8978xyz][]12_+-";
+        r = new Regex(@"((?'256'abc)\d+)?(?'16'xyz)(.*)");
+        expectedNames = new string[] { "0", "1", "2", "16", "256" };
+        expectedNumbers = new int[] { 0, 1, 2, 16, 256 };
+        expectedGroups = new string[] { "abc8978xyz][]12_+-", "abc8978", "][]12_+-", "xyz", "abc" };
+        
+        VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers);
+
+        // Regex with numeric names and string names
+        s = "0272saasdabc8978xyz][]12_+-";
+        r = new Regex(@"((?'4'abc)(?'digits'\d+))?(?'2'xyz)(?'everything_else'.*)");
+        expectedNames = new string[] { "0", "1", "2", "digits", "4", "everything_else" };
+        expectedNumbers = new int[] { 0, 1, 2, 3, 4, 5 };
+        expectedGroups = new string[] { "abc8978xyz][]12_+-", "abc8978", "xyz", "8978", "abc", "][]12_+-" };
+        
+        VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers);
+
+        // Regex with 0 numeric names
+        Assert.Throws<ArgumentException>(() => new Regex(@"foo(?'0'bar)"));
+
+        // Regex without closing >
+        Assert.Throws<ArgumentException>(() => new Regex(@"foo(?'1bar)"));
+
+        // Duplicate string names
+        s = "Ryan Byington";
+        r = new Regex("(?'first_name'\\S+)\\s(?'first_name'\\S+)");
+        expectedNames = new string[] { "0", "first_name" };
+        expectedNumbers = new int[] { 0, 1 };
+        expectedGroups = new string[] { "Ryan Byington", "Byington" };
+        
+        VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers);
+
+        // Duplicate numeric names
+        s = "Ryan Byington";
+        r = new Regex("(?'15'\\S+)\\s(?'15'\\S+)");
+        expectedNames = new string[] { "0", "15" } ;
+        expectedNumbers = new int[] { 0, 15 };
+        expectedGroups = new string[] { "Ryan Byington", "Byington" };
+
+        VerifyGroups(r, s, expectedGroups, expectedNames, expectedNumbers);
     }
 
-    public static bool VerifyGroupNames(Regex r, String[] expectedNames, int[] expectedNumbers)
+    public static void VerifyGroups(Regex regex, string input, string[] expectedGroups, string[] expectedNames, int[] expectedNumbers)
     {
-        string[] names = r.GetGroupNames();
-        if (names.Length != expectedNames.Length)
-        {
-            Console.WriteLine("Err_08722aswa! Expect {0} names actual={1}", expectedNames.Length, names.Length);
-            return false;
-        }
+        Match match = regex.Match(input);
+        Assert.True(match.Success);
 
-        for (int i = 0; i < expectedNames.Length; i++)
-        {
-            if (!names[i].Equals(expectedNames[i]))
-            {
-                Console.WriteLine("Err_09878asfas! Expected GroupNames[{0}]={1} actual={2}", i, expectedNames[i], names[i]);
-                return false;
-            }
+        int[] numbers = regex.GetGroupNumbers();
+        Assert.Equal(expectedNumbers.Length, numbers.Length);
 
-            if (expectedNames[i] != r.GroupNameFromNumber(expectedNumbers[i]))
-            {
-                Console.WriteLine("Err_6589sdafn!GroupNameFromNumber({0})={1} actual={2}", expectedNumbers[i], expectedNames[i], r.GroupNameFromNumber(expectedNumbers[i]));
-                return false;
-            }
-        }
+        string[] names = regex.GetGroupNames();
+        Assert.Equal(expectedNames.Length, names.Length);
 
-        return true;
-    }
-
-    public static bool VerifyGroupNumbers(Regex r, String[] expectedNames, int[] expectedNumbers)
-    {
-        int[] numbers = r.GetGroupNumbers();
-        if (numbers.Length != expectedNumbers.Length)
-        {
-            Console.WriteLine("Err_7978awoyp! Expect {0} numbers actual={1}", expectedNumbers.Length, numbers.Length);
-            return false;
-        }
-
+        Assert.Equal(expectedGroups.Length, match.Groups.Count);
         for (int i = 0; i < expectedNumbers.Length; i++)
         {
-            if (numbers[i] != expectedNumbers[i])
-            {
-                Console.WriteLine("Err_4342asnmc! Expected GroupNumbers[{0}]={1} actual={2}", i, expectedNumbers[i], numbers[i]);
-                return false;
-            }
+            Assert.Equal(expectedGroups[i], match.Groups[expectedNames[i]].Value);
+            Assert.Equal(expectedGroups[i], match.Groups[expectedNumbers[i]].Value);
 
-            if (expectedNumbers[i] != r.GroupNumberFromName(expectedNames[i]))
-            {
-                Console.WriteLine("Err_98795ajkas!GroupNumberFromName({0})={1} actual={2}", expectedNames[i], expectedNumbers[i], r.GroupNumberFromName(expectedNames[i]));
-                return false;
-            }
+            Assert.Equal(expectedNumbers[i], numbers[i]);
+            Assert.Equal(expectedNumbers[i], regex.GroupNumberFromName(expectedNames[i]));
+
+            Assert.Equal(expectedNames[i], names[i]);
+            Assert.Equal(expectedNames[i], regex.GroupNameFromNumber(expectedNumbers[i]));
         }
-
-        return true;
-    }
-
-    public static bool VerifyGroups(Regex r, String s, String[] expectedGroups, String[] expectedNames, int[] expectedNumbers)
-    {
-        Match m = r.Match(s);
-        Group g;
-        if (!m.Success)
-        {
-            Console.WriteLine("Err_08220kha Match not a success");
-            return false;
-        }
-
-        if (m.Groups.Count != expectedGroups.Length)
-        {
-            Console.WriteLine("Err_9722asqa! Expect {0} groups actual={1}", expectedGroups.Length, m.Groups.Count);
-            return false;
-        }
-
-        for (int i = 0; i < expectedNumbers.Length; i++)
-        {
-            if (null == (g = m.Groups[expectedNames[i]]) || expectedGroups[i] != g.Value)
-            {
-                Console.WriteLine("Err_3327nkoo! Expected Groups[{0}]={1} actual={2}", expectedNames[i], expectedGroups[i], g == null ? "<null>" : g.Value);
-                return false;
-            }
-
-            if (null == (g = m.Groups[expectedNumbers[i]]) || expectedGroups[i] != g.Value)
-            {
-                Console.WriteLine("Err_9465sdjh! Expected Groups[{0}]={1} actual={2}", expectedNumbers[i], expectedGroups[i], g == null ? "<null>" : g.Value);
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/src/System.Text.RegularExpressions/tests/IsMatchMatchSplitTests.cs
+++ b/src/System.Text.RegularExpressions/tests/IsMatchMatchSplitTests.cs
@@ -8,93 +8,31 @@ using Xunit;
 
 public class IsMatchMatchSplitTests
 {
-    /*
-    Tested Methods:
-
-
-        public static Boolean IsMatch() variants
-
-        public static Match Match(string input, String pattern, String options);     "abc","[aBc]","i"
-
-        public static String[] Split(string input, String pattern, String options);     "[abc]", "i"
-            "1A2B3C4"
-    */
-
-    [Fact]
-    public static void IsMatchMatchSplit()
+    [Theory]
+    [InlineData("abc", "abc", RegexOptions.None, true)]
+    [InlineData("abc", "aBc", RegexOptions.None, false)]
+    [InlineData("abc", "abc", RegexOptions.IgnoreCase, true)]
+    public static void IsMatch(string input, string pattern, RegexOptions options, bool expected)
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        String s;
-        String[] sa;
-        String[] saExp1 =
+        if (options == RegexOptions.None)
         {
-        "a", "b", "c"
+            Assert.Equal(expected, Regex.IsMatch(input, pattern, options));
         }
+        Assert.Equal(expected, Regex.IsMatch(input, pattern, options));
+    }
 
-        ;
-        String[] saExp2 =
-        {
-        "1", "2", "3", "4"
-        }
-
-        ;
-        int i = 0;
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] public static Boolean IsMatch() variants
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            if (!Regex.IsMatch("abc", "abc"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_234fsadg! doesnot match");
-            }
-
-            if (!Regex.IsMatch("abc", "aBc", RegexOptions.IgnoreCase))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_7432rwe! doesnot match");
-            }
-
-            if (!Regex.IsMatch("abc", "aBc", RegexOptions.IgnoreCase))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_7432rwe! doesnot match");
-            }
-
-            strLoc = "Loc_0003";
-            iCountTestcases++;
-            // [] Scenario 3 
-            //-----------------------------------------------------------------
-            strLoc = "Loc_746tegd";
-            iCountTestcases++;
-            s = "1A2B3C4";
-            sa = Regex.Split(s, "[abc]", RegexOptions.IgnoreCase);
-            for (i = 0; i < sa.Length; i++)
-            {
-                if (!saExp2[i].Equals(sa[i]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_452wfdf! doesnot match");
-                }
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
-        }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+    /*
+        public static Match Match(string input, String pattern, String options); "abc","[aBc]", 3"i"
+        public static String[] Split(string input, String pattern, String options); "[abc]", "i", "1A2B3C4"
+    */
+    [Fact]
+    public static void Split()
+    {
+        string[] saExp1 = { "a", "b", "c" };
+        string[] saExp2 = { "1", "2", "3", "4" };
+                
+        string s = "1A2B3C4";
+        string[] sa = Regex.Split(s, "[abc]", RegexOptions.IgnoreCase);
+        Assert.Equal(sa, saExp2);
     }
 }

--- a/src/System.Text.RegularExpressions/tests/R2LGetGroupNamesMatchTests.cs
+++ b/src/System.Text.RegularExpressions/tests/R2LGetGroupNamesMatchTests.cs
@@ -9,92 +9,20 @@ using Xunit;
 public class R2LGetGroupNamesMatchTests
 {
     /*
-    Tested Methods:
-
-        public static Boolean RightToLeft;
-
-        public static String[] GetGroupNames();     "(?<first_name>\\S+)\\s(?<last_name>\\S+)"
-
-        public static Match Match(string input);
-            "David Bau"
-
-        public static Boolean IsMatch(string input);     //D+
-            "12321"
-
+        public static String[] GetGroupNames(); "(?<first_name>\\S+)\\s(?<last_name>\\S+)"
+        public static Match Match(string input); "David Bau"
+        public static Boolean IsMatch(string input); //D+, "12321"
     */
-
     [Fact]
     public static void R2LGetGroupNamesMatch()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Regex r;
-        Match m;
-        String s;
-        String[] names;
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            s = "David Bau";
-            r = new Regex("(?<first_name>\\S+)\\s(?<last_name>\\S+)");
-            // [] public static String[] GetGroupNames();     "(?<first_name>\\S+)\\s(?<last_name>\\S+)"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            names = r.GetGroupNames();
-            if (!names[0].Equals("0"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_234fsadg! unexpected result");
-            }
+        Regex regex = new Regex("(?<first_name>\\S+)\\s(?<last_name>\\S+)");
+        Assert.Equal(new string[] { "0", "first_name", "last_name" }, regex.GetGroupNames());
 
-            if (!names[1].Equals("first_name"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_234fsadg! unexpected result");
-            }
-
-            if (!names[2].Equals("last_name"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_234fsadg! unexpected result");
-            }
-
-            // [] public static Match Match(string input);
-            //"David Bau"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_563sdfg";
-            iCountTestcases++;
-            m = r.Match(s);
-            if (!m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_87543! doesnot match");
-            }
-
-            // [] public static Match Match(string input);
-            //"David Bau"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            s = "12321";
-            r = new Regex(@"\D+");
-            if (r.IsMatch(s))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_fsdf! doesnot match");
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
-        }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
+        Match match = regex.Match("David Bau");
+        Assert.True(match.Success);
+        
+        regex = new Regex(@"\D+");
+        Assert.False(regex.IsMatch("12321"));
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RegexComponentsSplitTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexComponentsSplitTests.cs
@@ -12,8 +12,8 @@ public class RegexComponentsSplitTests
     public static void RegexComponentsSplit()
     {
         //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
+        string strLoc = "Loc_000oo";
+        string strValue = string.Empty;
         int iCountErrors = 0;
         int iCountTestcases = 0;
         try
@@ -47,37 +47,37 @@ public class RegexComponentsSplitTests
         /*********************************************************
             ValidCases
             *********************************************************/
-    new RegexComponentsSplitTestCase(@"(\s)?(-)", "once -upon-a time", new String[]
+    new RegexComponentsSplitTestCase(@"(\s)?(-)", "once -upon-a time", new string[]
     {
     "once", " ", "-", "upon", "-", "a time"
     }
 
-    ), new RegexComponentsSplitTestCase(@"(\s)?(-)", "once upon a time", new String[]
+    ), new RegexComponentsSplitTestCase(@"(\s)?(-)", "once upon a time", new string[]
     {
     "once upon a time"
     }
 
-    ), new RegexComponentsSplitTestCase(@"(\s)?(-)", "once - -upon- a- time", new String[]
+    ), new RegexComponentsSplitTestCase(@"(\s)?(-)", "once - -upon- a- time", new string[]
     {
     "once", " ", "-", "", " ", "-", "upon", "-", " a", "-", " time"
     }
 
-    ), new RegexComponentsSplitTestCase(@"a(.)c(.)e", "123abcde456aBCDe789", new String[]
+    ), new RegexComponentsSplitTestCase(@"a(.)c(.)e", "123abcde456aBCDe789", new string[]
     {
     "123", "b", "d", "456aBCDe789"
     }
 
-    ), new RegexComponentsSplitTestCase(@"a(.)c(.)e", RegexOptions.IgnoreCase, "123abcde456aBCDe789", new String[]
+    ), new RegexComponentsSplitTestCase(@"a(.)c(.)e", RegexOptions.IgnoreCase, "123abcde456aBCDe789", new string[]
     {
     "123", "b", "d", "456", "B", "D", "789"
     }
 
-    ), new RegexComponentsSplitTestCase(@"a(?<dot1>.)c(.)e", "123abcde456aBCDe789", new String[]
+    ), new RegexComponentsSplitTestCase(@"a(?<dot1>.)c(.)e", "123abcde456aBCDe789", new string[]
     {
     "123", "d", "b", "456aBCDe789"
     }
 
-    ), new RegexComponentsSplitTestCase(@"a(?<dot1>.)c(.)e", RegexOptions.IgnoreCase, "123abcde456aBCDe789", new String[]
+    ), new RegexComponentsSplitTestCase(@"a(?<dot1>.)c(.)e", RegexOptions.IgnoreCase, "123abcde456aBCDe789", new string[]
     {
     "123", "d", "b", "456", "D", "B", "789"
     }
@@ -85,22 +85,22 @@ public class RegexComponentsSplitTests
     ), /*********************************************************
         RightToLeft
         *********************************************************/
-new RegexComponentsSplitTestCase(@"a(.)c(.)e", RegexOptions.RightToLeft, "123abcde456aBCDe789", new String[]
+new RegexComponentsSplitTestCase(@"a(.)c(.)e", RegexOptions.RightToLeft, "123abcde456aBCDe789", new string[]
     {
     "123", "d", "b", "456aBCDe789"
     }
 
-    ), new RegexComponentsSplitTestCase(@"a(.)c(.)e", RegexOptions.IgnoreCase | RegexOptions.RightToLeft, "123abcde456aBCDe789", new String[]
+    ), new RegexComponentsSplitTestCase(@"a(.)c(.)e", RegexOptions.IgnoreCase | RegexOptions.RightToLeft, "123abcde456aBCDe789", new string[]
     {
     "123", "d", "b", "456", "D", "B", "789"
     }
 
-    ), new RegexComponentsSplitTestCase(@"a(?<dot1>.)c(.)e", RegexOptions.RightToLeft, "123abcde456aBCDe789", new String[]
+    ), new RegexComponentsSplitTestCase(@"a(?<dot1>.)c(.)e", RegexOptions.RightToLeft, "123abcde456aBCDe789", new string[]
     {
     "123", "b", "d", "456aBCDe789"
     }
 
-    ), new RegexComponentsSplitTestCase(@"a(?<dot1>.)c(.)e", RegexOptions.RightToLeft | RegexOptions.IgnoreCase, "123abcde456aBCDe789", new String[]
+    ), new RegexComponentsSplitTestCase(@"a(?<dot1>.)c(.)e", RegexOptions.RightToLeft | RegexOptions.IgnoreCase, "123abcde456aBCDe789", new string[]
     {
     "123", "b", "d", "456", "B", "D", "789"
     }
@@ -110,16 +110,16 @@ new RegexComponentsSplitTestCase(@"a(.)c(.)e", RegexOptions.RightToLeft, "123abc
     ;
     public class RegexComponentsSplitTestCase
     {
-        private String _pattern;
-        private String _input;
+        private string _pattern;
+        private string _input;
         private RegexOptions _options;
-        private String[] _expectedResult;
-        public RegexComponentsSplitTestCase(String pattern, String input, String[] expectedResult)
+        private string[] _expectedResult;
+        public RegexComponentsSplitTestCase(string pattern, string input, string[] expectedResult)
             : this(pattern, RegexOptions.None, input, expectedResult)
         {
         }
 
-        public RegexComponentsSplitTestCase(String pattern, RegexOptions options, String input, String[] expectedResult)
+        public RegexComponentsSplitTestCase(string pattern, RegexOptions options, string input, string[] expectedResult)
         {
             _pattern = pattern;
             _options = options;
@@ -151,7 +151,7 @@ new RegexComponentsSplitTestCase(@"a(.)c(.)e", RegexOptions.RightToLeft, "123abc
             }
         }
 
-        public String[] ExpectedResult
+        public string[] ExpectedResult
         {
             get
             {
@@ -170,7 +170,7 @@ new RegexComponentsSplitTestCase(@"a(.)c(.)e", RegexOptions.RightToLeft, "123abc
         public bool Run()
         {
             Regex r;
-            String[] result = null;
+            string[] result = null;
             r = new Regex(_pattern, _options);
             try
             {

--- a/src/System.Text.RegularExpressions/tests/RegexConstructorTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexConstructorTests.cs
@@ -9,166 +9,30 @@ using Xunit;
 public class RegexConstructorTests
 {
     [Fact]
-    public static void RegexConstructor()
+    public static void Ctor()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Regex r;
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            //[]RegEx with null expression
-            strLoc = "Loc_sdfa9849";
-            iCountTestcases++;
-            try
-            {
-                r = new Regex(null, RegexOptions.None);
-                iCountErrors++;
-                Console.WriteLine("Err_16891 Expected Regex to throw ArgumentNullException and nothing was thrown");
-            }
-            catch (ArgumentNullException)
-            {
-            }
-            catch (Exception e)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_9877sawa Expected Regex to throw ArgumentNullException and the following exception was thrown:\n {0}", e);
-            }
+        // Should not throw
+        new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant);
+    }
 
-            //[]RegEx with negative RegexOptions
-            strLoc = "Loc_3198sdf";
-            iCountTestcases++;
-            try
-            {
-                r = new Regex("foo", (RegexOptions)(-1));
-                iCountErrors++;
-                Console.WriteLine("Err_2389asfd Expected Regex to throw ArgumentException and nothing was thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception e)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_898asdf Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
-            }
+    [Fact]
+    public static void Ctor_Invalid()
+    {
+        // Pattern is null
+        Assert.Throws<ArgumentNullException>(() => new Regex(null));
+        Assert.Throws<ArgumentNullException>(() => new Regex(null, RegexOptions.None));
+        Assert.Throws<ArgumentNullException>(() => new Regex(null, RegexOptions.None, new TimeSpan()));
+        
+        // Options is invalid
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("foo", (RegexOptions)(-1)));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("foo", (RegexOptions)(-1), new TimeSpan()));
 
-            //[]RegEx with to high RegexOptions
-            strLoc = "Loc_23198awd";
-            iCountTestcases++;
-            try
-            {
-                r = new Regex("foo", (RegexOptions)0x400);
-                iCountErrors++;
-                Console.WriteLine("Err_1238sadw Expected Regex to throw ArgumentException and nothing was thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception e)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_6579asdf Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
-            }
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("foo", (RegexOptions)0x400));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("foo", (RegexOptions)0x400, new TimeSpan()));
 
-            //[]RegEx with ECMA RegexOptions with all other valid options
-            strLoc = "Loc_3198sdf";
-            iCountTestcases++;
-            try
-            {
-                r = new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant);
-            }
-            catch (Exception e)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_97878dsaw Expected Regex not to throw and the following exception was thrown:\n {0}", e);
-            }
-
-            //[]RegEx with ECMA RegexOptions with all other valid options plus RightToLeft
-            strLoc = "Loc_9875asd";
-            iCountTestcases++;
-            try
-            {
-                r = new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.RightToLeft);
-                iCountErrors++;
-                Console.WriteLine("Err_9789swd Expected Regex to throw ArgumentException and nothing was thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception e)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_9489sdjk Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
-            }
-
-            //[]RegEx with ECMA RegexOptions with all other valid options plus ExplicitCapture
-            strLoc = "Loc_54864jhlt";
-            iCountTestcases++;
-            try
-            {
-                r = new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture);
-                iCountErrors++;
-                Console.WriteLine("Err_6556jhkj Expected Regex to throw ArgumentException and nothing was thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception e)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_2189jhss Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
-            }
-
-            //[]RegEx with ECMA RegexOptions with all other valid options plus Singleline
-            strLoc = "Loc_9891asfes";
-            iCountTestcases++;
-            try
-            {
-                r = new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Singleline);
-                iCountErrors++;
-                Console.WriteLine("Err_3156add Expected Regex to throw ArgumentException and nothing was thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception e)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_456hjhj Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
-            }
-
-            //[]RegEx with ECMA RegexOptions with all other valid options plus IgnorePatternWhitespace
-            strLoc = "Loc_23889asddf";
-            iCountTestcases++;
-            try
-            {
-                r = new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.IgnorePatternWhitespace);
-                iCountErrors++;
-                Console.WriteLine("Err_3568sdae Expected Regex to throw ArgumentException and nothing was thrown");
-            }
-            catch (ArgumentException)
-            {
-            }
-            catch (Exception e)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_4657dsacd Expected Regex to throw ArgumentException and the following exception was thrown:\n {0}", e);
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
-        }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.RightToLeft));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Singleline));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.IgnorePatternWhitespace));
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RegexLangElementsCoverageTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexLangElementsCoverageTests.cs
@@ -13,47 +13,10 @@ public class RegexLangElementsCoverageTests
     [Fact]
     public static void RegexLangElementsCoverage()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-
-        try
+        for (int i = 0; i < s_regexTests.Length; i++)
         {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-
-            //AppDomain.CurrentDomain.AssemblyLoad += AssemblyLoadEventHandler;
-
-            for (int i = 0; i < s_regexTests.Length; i++)
-            {
-                try
-                {
-                    iCountTestcases++;
-                    if (!s_regexTests[i].Run())
-                    {
-                        Console.WriteLine("Err_79872asnko! Test {0} FAILED Pattern={1}, Input={2}\n", i, s_regexTests[i].Pattern, s_regexTests[i].Input);
-                        iCountErrors++;
-                    }
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine("Err_79872asnko! Test {0} FAILED Pattern={1}, Input={2} threw the following exception:", i, s_regexTests[i].Pattern, s_regexTests[i].Input);
-                    Console.WriteLine(e);
-                    iCountErrors++;
-                }
-            }
-
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
+            Assert.True(s_regexTests[i].Run());
         }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
     }
 
     //private const int GERMAN_PHONEBOOK = 0x10407;
@@ -169,14 +132,14 @@ public class RegexLangElementsCoverageTests
         /*********************************************************
             \x, \u, \a, \b, \e, \f, \n, \r, \t, \v, \c, inside character range 
             *********************************************************/
-       new RegexTestCase(@"(cat)([\x41]*)(dog)", "catAAAdog", new String[] {"catAAAdog", "cat", "AAA", "dog"}),
-       new RegexTestCase(@"(cat)([\u0041]*)(dog)", "catAAAdog", new String[] {"catAAAdog", "cat", "AAA", "dog"}),
-       new RegexTestCase(@"(cat)([\a]*)(dog)", "cat\a\a\adog", new String[] {"cat\a\a\adog", "cat", "\a\a\a", "dog"}),
-       new RegexTestCase(@"(cat)([\b]*)(dog)", "cat\b\b\bdog", new String[] {"cat\b\b\bdog", "cat", "\b\b\b", "dog"}),
-       new RegexTestCase(@"(cat)([\e]*)(dog)", "cat\u001B\u001B\u001Bdog", new String[] {"cat\u001B\u001B\u001Bdog", "cat", "\u001B\u001B\u001B", "dog"}),
-       new RegexTestCase(@"(cat)([\f]*)(dog)", "cat\f\f\fdog", new String[] {"cat\f\f\fdog", "cat", "\f\f\f", "dog"}),
-       new RegexTestCase(@"(cat)([\r]*)(dog)", "cat\r\r\rdog", new String[] {"cat\r\r\rdog", "cat", "\r\r\r", "dog"}),
-       new RegexTestCase(@"(cat)([\v]*)(dog)", "cat\v\v\vdog", new String[] {"cat\v\v\vdog", "cat", "\v\v\v", "dog"}),
+       new RegexTestCase(@"(cat)([\x41]*)(dog)", "catAAAdog", new string[] {"catAAAdog", "cat", "AAA", "dog"}),
+       new RegexTestCase(@"(cat)([\u0041]*)(dog)", "catAAAdog", new string[] {"catAAAdog", "cat", "AAA", "dog"}),
+       new RegexTestCase(@"(cat)([\a]*)(dog)", "cat\a\a\adog", new string[] {"cat\a\a\adog", "cat", "\a\a\a", "dog"}),
+       new RegexTestCase(@"(cat)([\b]*)(dog)", "cat\b\b\bdog", new string[] {"cat\b\b\bdog", "cat", "\b\b\b", "dog"}),
+       new RegexTestCase(@"(cat)([\e]*)(dog)", "cat\u001B\u001B\u001Bdog", new string[] {"cat\u001B\u001B\u001Bdog", "cat", "\u001B\u001B\u001B", "dog"}),
+       new RegexTestCase(@"(cat)([\f]*)(dog)", "cat\f\f\fdog", new string[] {"cat\f\f\fdog", "cat", "\f\f\f", "dog"}),
+       new RegexTestCase(@"(cat)([\r]*)(dog)", "cat\r\r\rdog", new string[] {"cat\r\r\rdog", "cat", "\r\r\r", "dog"}),
+       new RegexTestCase(@"(cat)([\v]*)(dog)", "cat\v\v\vdog", new string[] {"cat\v\v\vdog", "cat", "\v\v\v", "dog"}),
        new RegexTestCase(@"(cat)([\o]*)(dog)", typeof(ArgumentException)),
 
 
@@ -257,12 +220,12 @@ public class RegexLangElementsCoverageTests
        new RegexTestCase(@"(cat) #cat
                             \s+ #followed by 1 or more whitespace
                             (dog)  #followed by dog
-                            ", RegexOptions.IgnorePatternWhitespace, "cat    dog", new String[] {"cat    dog", "cat", "dog" }),
+                            ", RegexOptions.IgnorePatternWhitespace, "cat    dog", new string[] {"cat    dog", "cat", "dog" }),
        new RegexTestCase(@"(cat) #cat
                             \s+ #followed by 1 or more whitespace
-                            (dog)  #followed by dog", RegexOptions.IgnorePatternWhitespace, "cat    dog", new String[] {"cat    dog", "cat", "dog" }),
+                            (dog)  #followed by dog", RegexOptions.IgnorePatternWhitespace, "cat    dog", new string[] {"cat    dog", "cat", "dog" }),
        new RegexTestCase(@"(cat) (?#cat)    \s+ (?#followed by 1 or more whitespace) (dog)  (?#followed by dog)",
-           RegexOptions.IgnorePatternWhitespace, "cat    dog", new String[] {"cat    dog", "cat", "dog" }),
+           RegexOptions.IgnorePatternWhitespace, "cat    dog", new string[] {"cat    dog", "cat", "dog" }),
        new RegexTestCase(@"(cat) (?#cat)    \s+ (?#followed by 1 or more whitespace",
            RegexOptions.IgnorePatternWhitespace, typeof(ArgumentException)),
 
@@ -637,10 +600,10 @@ Use special unicode characters
         Lazy operator Backtracking
         *********************************************************/
        new RegexTestCase(@"http://([a-zA-z0-9\-]*\.?)*?(:[0-9]*)??/",  RegexOptions.IgnoreCase, "http://www.msn.com", null),
-       new RegexTestCase(@"http://([a-zA-z0-9\-]*\.?)*?(:[0-9]*)??/",  RegexOptions.IgnoreCase, "http://www.msn.com/", new string[] {"http://www.msn.com/", "com", String.Empty}),
+       new RegexTestCase(@"http://([a-zA-z0-9\-]*\.?)*?(:[0-9]*)??/",  RegexOptions.IgnoreCase, "http://www.msn.com/", new string[] {"http://www.msn.com/", "com", string.Empty}),
        new RegexTestCase(@"http://([a-zA-Z0-9\-]*\.?)*?/", RegexOptions.IgnoreCase, @"http://www.google.com/", new string[] {"http://www.google.com/", "com"}),
 
-       new RegexTestCase(@"([a-z]*?)([\w])",  RegexOptions.IgnoreCase, "cat", new string[] {"c", String.Empty, "c"}),
+       new RegexTestCase(@"([a-z]*?)([\w])",  RegexOptions.IgnoreCase, "cat", new string[] {"c", string.Empty, "c"}),
        new RegexTestCase(@"^([a-z]*?)([\w])$",  RegexOptions.IgnoreCase, "cat", new string[] {"cat", "ca", "t"}),
 
         // TODO: Come up with more scenarios here
@@ -716,20 +679,20 @@ Use special unicode characters
        new RegexTestCase(@"(?<!", typeof(ArgumentException)),
        new RegexTestCase(@"(?>", typeof(ArgumentException)),
 
-       new RegexTestCase(@"()", "cat", new string[] {String.Empty, String.Empty}),
+       new RegexTestCase(@"()", "cat", new string[] { string.Empty, string.Empty}),
        new RegexTestCase(@"(?)", typeof(ArgumentException)),
        new RegexTestCase(@"(?<)", typeof(ArgumentException)),
-       new RegexTestCase(@"(?<cat>)", "cat", new string[] {String.Empty, String.Empty}),
+       new RegexTestCase(@"(?<cat>)", "cat", new string[] { string.Empty, string.Empty}),
        new RegexTestCase(@"(?')", typeof(ArgumentException)),
-       new RegexTestCase(@"(?'cat')", "cat", new string[] {String.Empty, String.Empty}),
-       new RegexTestCase(@"(?:)", "cat", new string[] {String.Empty}),
-       new RegexTestCase(@"(?imn)", "cat", new string[] {String.Empty}),
+       new RegexTestCase(@"(?'cat')", "cat", new string[] { string.Empty, string.Empty}),
+       new RegexTestCase(@"(?:)", "cat", new string[] { string.Empty}),
+       new RegexTestCase(@"(?imn)", "cat", new string[] { string.Empty}),
        new RegexTestCase(@"(?imn)cat", "(?imn)cat", new string[] {"cat"}),
-       new RegexTestCase(@"(?=)", "cat", new string[] {String.Empty}),
+       new RegexTestCase(@"(?=)", "cat", new string[] { string.Empty}),
        new RegexTestCase(@"(?!)", "(?!)cat"),
-       new RegexTestCase(@"(?<=)", "cat", new string[] {String.Empty}),
+       new RegexTestCase(@"(?<=)", "cat", new string[] { string.Empty}),
        new RegexTestCase(@"(?<!)", "(?<!)cat"),
-       new RegexTestCase(@"(?>)", "cat", new string[] {String.Empty}),
+       new RegexTestCase(@"(?>)", "cat", new string[] { string.Empty}),
 
         /*********************************************************
         Grouping Constructs Invalid Regular Expressions

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests0.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests0.cs
@@ -9,183 +9,75 @@ using Xunit;
 public partial class RegexMatchTests
 {
     /*
-    Tested Methods:
-
-        public static Match Match(string input, string pattern);     Testing \B special character escape
-            "adfadsfSUCCESSadsfadsf", ".*\\B(SUCCESS)\\B.*"
-
-        public static Match Match(string input, string pattern);     Testing octal sequence matches
-            "011", "\\060(\\061)?\\061"
-
-        public static Match Match(string input, string pattern);     Testing hexadecimal sequence matches
-            "012", "(\\x30\\x31\\x32)"
-
-        public static Match Match(string input, string pattern);     Testing control character escapes???
-            "2", "(\u0032)"
-
+    public static Match Match(string input, string pattern);
+        - Testing \B special character escape: "adfadsfSUCCESSadsfadsf", ".*\\B(SUCCESS)\\B.*"
+        - Testing octal sequence matches: "011", "\\060(\\061)?\\061"
+        - Testing hexadecimal sequence matches: "012", "(\\x30\\x31\\x32)"
+        - Testing control character escapes???: "2", "(\u0032)"
     */
-
     [Fact]
     public static void RegexMatchTestCase0()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Match match;
-        String s;
-        String strMatch1 = "adfadsfSUCCESSadsfadsf";
-        Int32[] iMatch1 =
-        {
-        0, 22
-        }
+        string strMatch1 = "adfadsfSUCCESSadsfadsf";
+        int[] iMatch1 = { 0, 22 };
+        string[] strGroup1 = { "adfadsfSUCCESSadsfadsf", "SUCCESS" };
+        int[] iGroup1 = { 7, 7 };
+        string[] strGrpCap1 = { "SUCCESS" };
+        int[,] iGrpCap1 = { { 7, 7 } };
+        
+        // Testing \B special character escape
+        // "adfadsfSUCCESSadsfadsf", ".*\\B(SUCCESS)\\B.*"
+        Match match = Regex.Match("adfadsfSUCCESSadsfadsf", @".*\B(SUCCESS)\B.*");
+        Assert.True(match.Success);
+        Assert.Equal(strMatch1, match.Value);
+        Assert.Equal(iMatch1[0], match.Index);
+        Assert.Equal(iMatch1[1], match.Length);
 
-        ;
-        String[] strGroup1 =
-        {
-        "adfadsfSUCCESSadsfadsf", "SUCCESS"
-        }
+        Assert.Equal(1, match.Captures.Count);
+        Assert.Equal(strMatch1, match.Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Captures[0].Length);
 
-        ;
-        Int32[] iGroup1 =
-        {
-        7, 7
-        }
+        Assert.Equal(2, match.Groups.Count);
+        Assert.Equal(strMatch1, match.Groups[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Length);
 
-        ;
-        String[] strGrpCap1 =
-        {
-        "SUCCESS"
-        }
+        Assert.Equal(1, match.Groups[0].Captures.Count);
+        Assert.Equal(strMatch1, match.Groups[0].Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Captures[0].Length);
 
-        ;
-        Int32[,] iGrpCap1 =
+        for (int i = 1; i < match.Groups.Count; i++)
         {
-        {
-        7, 7
-        }
-        }
+            Assert.Equal(strGroup1[i], match.Groups[i].Value);
+            Assert.Equal(iGroup1[0], match.Groups[i].Index);
+            Assert.Equal(iGroup1[1], match.Groups[i].Length);
+            Assert.Equal(1, match.Groups[i].Captures.Count);
 
-        ;
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] public static Match Match(string input, string pattern);     Testing \B special character escape
-            //"adfadsfSUCCESSadsfadsf", ".*\\B(SUCCESS)\\B.*"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            match = Regex.Match("adfadsfSUCCESSadsfadsf", @".*\B(SUCCESS)\B.*");
-            if (!match.Success)
+            for (int j = 0; j < match.Groups[i].Captures.Count; j++)
             {
-                iCountErrors++;
-                Console.WriteLine("Err_7356wgd! Fail Do not found a match");
+                Assert.Equal(strGrpCap1[j], match.Groups[i].Captures[j].Value);
+                Assert.Equal(iGrpCap1[j, 0], match.Groups[i].Captures[j].Index);
+                Assert.Equal(iGrpCap1[j, 1], match.Groups[i].Captures[j].Length);
             }
-            else
-            {
-                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_98275dsg: unexpected return result");
-                }
-
-                //Match.Captures always is Match
-                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                if (match.Groups.Count != 2)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_75324sg! unexpected return result");
-                }
-
-                //Group 0 always is the Match
-                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                //Group 0's Capture is always the Match
-                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2975edg!! unexpected return result");
-                }
-
-                for (int i = 1; i < match.Groups.Count; i++)
-                {
-                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[0]) || (match.Groups[i].Length != iGroup1[1]) || (match.Groups[i].Captures.Count != 1))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[0], iGroup1[1]);
-                    }
-
-                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
-                    {
-                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[j, 0]) || (match.Groups[i].Captures[j].Length != iGrpCap1[j, 1]))
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "!! unexpected return result, Value = {0}, Index = {1}, Length = {2}", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length);
-                        }
-                    }
-                }
-            }
-
-            // [] public static Match Match(string input, string pattern);     Testing octal sequence matches
-            //"011", "\\060(\\061)?\\061"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            //Octal \061 is ASCII 49
-            match = Regex.Match("011", @"\060(\061)?\061");
-            if (!match.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_576trffg! Do not found octal sequence match");
-            }
-
-            // [] public static Match Match(string input, string pattern);     Testing hexadecimal sequence matches
-            //"012", "(\\x30\\x31\\x32)"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_746tegd";
-            iCountTestcases++;
-            //Hex \x31 is ASCII 49
-            match = Regex.Match("012", @"(\x30\x31\x32)");
-            if (!match.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_674tgdg! Do not found hexadecimal sequence match");
-            }
-
-            // [] public static Match Match(string input, string pattern);     Testing control character escapes???
-            //"2", "(\u0032)"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_743gf";
-            iCountTestcases++;
-            s = "4"; // or "\u0034"
-            match = Regex.Match(s, "(\u0034)");
-            if (!match.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_4532gvfs! Do not found unicode character match");
-            }
-
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
-        }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error: Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
         }
 
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+        // Testing octal sequence matches
+        // "011", "\\060(\\061)?\\061"
+        // Octal \061 is ASCII 49
+        match = Regex.Match("011", @"\060(\061)?\061");
+        Assert.True(match.Success);
+
+        // Testing hexadecimal sequence matches
+        // "012", "(\\x30\\x31\\x32)"
+        // Hex \x31 is ASCII 49
+        match = Regex.Match("012", @"(\x30\x31\x32)");
+        Assert.True(match.Success);
+
+        // Testing control character escapes???
+        // "2", "(\u0032)"
+        match = Regex.Match("4", "(\u0034)");
+        Assert.True(match.Success);
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests1.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests1.cs
@@ -9,185 +9,68 @@ using Xunit;
 public partial class RegexMatchTests
 {
     /*
-    Tested Methods:
-
-        public static Match Match(string input);     Using *, +, ?, {} : Actual - "a+\\.?b*\\.?c{2}"
-            "ab.cc"
-
-        public static Match Match(string input);     Using |, (), ^, $, .: Actual - "^aaa(bb.+)(d|c)$"
-            "aaabb.cc"
+    public Match Match(string input);
+        - Using *, +, ?, {} : Actual - "a+\\.?b*\\.?c{2}", "ab.cc"
+        - Using |, (), ^, $, .: Actual - "^aaa(bb.+)(d|c)$", "aaabb.cc"
     */
-
     [Fact]
     public static void RegexMatchTestCase1()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        String strMatch1 = "aaabb.cc";
-        Int32[] iMatch1 =
-        {
-        0, 8
-        }
+        string strMatch1 = "aaabb.cc";
+        int[] iMatch1 = { 0, 8 };
+        string[] strGroup1 = { "aaabb.cc", "bb.c", "c" };
+        int[,] iGroup1 = { { 0, 8 }, { 3, 4 }, { 7, 1 } };
 
-        ;
-        String[] strGroup1 =
-        {
-        "aaabb.cc", "bb.c", "c"
-        }
+        // This could be a rectangular array
+        string[,] strGrpCap1 = { { "aaabb.cc" }, { "bb.c" }, { "c" } };
+        int[,,] iGrpCap1 = { { { 0, 8 } }, { { 3, 4 } }, { { 7, 1 } } };
 
-        ;
-        Int32[,] iGroup1 =
-        {
-        {
-        0, 8
-        }
+        // Using *, +, ?, {} : Actual - "a+\\.?b*\\.?c{2}"
+        // "ab.cc"
+        Regex regex = new Regex(@"a+\.?b*\.+c{2}");
+        Match match = regex.Match("ab.cc");
+        Assert.True(match.Success);
 
-        , {
-        3, 4
-        }
+        // Using |, (), ^, $, .: Actual - "^aaa(bb.+)(d|c)$"
+        // "aaabb.cc"
+        regex = new Regex("^aaa(bb.+)(d|c)$");
+        match = regex.Match("aaabb.cc");
+        Assert.True(match.Success);
 
-        , {
-        7, 1
-        }
-        }
+        Assert.Equal(strMatch1, match.Value);
+        Assert.Equal(iMatch1[0], match.Index);
+        Assert.Equal(iMatch1[1], match.Length);
 
-        ;
-        //This could be a rectangular array
-        String[,] strGrpCap1 =
-        {
-        {
-        "aaabb.cc"
-        }
+        Assert.Equal(1, match.Captures.Count);
+        Assert.Equal(strMatch1, match.Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Captures[0].Length);
 
-        , {
-        "bb.c"
-        }
+        // Group 0 always is the Match
+        Assert.Equal(3, match.Groups.Count);
+        Assert.Equal(strMatch1, match.Groups[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Length);
 
-        , {
-        "c"
-        }
-        }
+        // Group 0's Capture is always the Match
+        Assert.Equal(1, match.Groups[0].Captures.Count);
+        Assert.Equal(strMatch1, match.Groups[0].Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Captures[0].Length);
+        
+        for (int i = 1; i < match.Groups.Count; i++)
+        {
+            Assert.Equal(strGroup1[i], match.Groups[i].Value);
+            Assert.Equal(iGroup1[i, 0], match.Groups[i].Index);
+            Assert.Equal(iGroup1[i, 1], match.Groups[i].Length);
 
-        ;
-        Int32[,,] iGrpCap1 =
-        {
-        {
-        {
-        0, 8
-        }
-        }
-
-        , {
-        {
-        3, 4
-        }
-        }
-
-        , {
-        {
-        7, 1
-        }
-        }
-        }
-
-        ;
-        Regex r;
-        Match match;
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] public static Match Match(string input);     Using *, +, ?, {} : Actual - "a+\\.?b*\\.?c{2}"
-            //"ab.cc"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            r = new Regex(@"a+\.?b*\.+c{2}");
-            match = r.Match("ab.cc");
-            if (!match.Success)
+            Assert.Equal(1, match.Groups[i].Captures.Count);
+            for (int j = 0; j < match.Groups[i].Captures.Count; j++)
             {
-                iCountErrors++;
-                Console.WriteLine("Err_4532gvfs! 1 do not match");
+                Assert.Equal(strGrpCap1[i, j], match.Groups[i].Captures[j].Value);
+                Assert.Equal(iGrpCap1[i, j, 0], match.Groups[i].Captures[j].Index);
+                Assert.Equal(iGrpCap1[i, j, 1], match.Groups[i].Captures[j].Length);
             }
-
-            // [] public static Match Match(string input);     Using |, (), ^, $, .: Actual - "^aaa(bb.+)(d|c)$"
-            //"aaabb.cc"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            r = new Regex("^aaa(bb.+)(d|c)$");
-            match = r.Match("aaabb.cc");
-            if (!match.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_7563rfsgf! 2 do not match");
-            }
-            else
-            {
-                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_98275dsg: unexpected return result");
-                }
-
-                //Match.Captures always is Match
-                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                if (match.Groups.Count != 3)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_75324sg! unexpected return result");
-                }
-
-                //Group 0 always is the Match
-                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                //Group 0's Capture is always the Match
-                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2975edg!! unexpected return result");
-                }
-
-                for (int i = 1; i < match.Groups.Count; i++)
-                {
-                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != 1))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1]);
-                    }
-
-                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
-                    {
-                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i, j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i, j, 0]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i, j, 1]))
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i, j], iGrpCap1[i, j, 0], iGrpCap1[i, j, 1]);
-                        }
-                    }
-                }
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
         }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests10.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests10.cs
@@ -9,127 +9,57 @@ using Xunit;
 public partial class RegexMatchTests
 {
     /*
-    Tested Methods:
-
-        public static Match Match(string input); First testing pattern "abcabc" : Actual    "(abc){2}"
+    public Match Match(string input);
+        - First testing pattern "abcabc" : Actual "(abc){2}"
             " !abcabcasl  dkfjasiduf 12343214-//asdfjzpiouxoifzuoxpicvql23r\\` #$3245,2345278 :asdfas &  100% @daeeffga (ryyy27343) poiweurwabcabcasdfalksdhfaiuyoiruqwer{234}/[(132387 + x)]'aaa''?"
 
-        public static Match Match(string input); Searching for numeric characters : Actual    "[0-9]"
-            "12345asdfasdfasdfljkhsda67890"
-
-        public static Match Match(string input); Different pattern specification. This time range of symbols is allowed. : Actual    "[a-z0-9]+"
-            "[token1]? GARBAGEtoken2GARBAGE ;token3!"
-
-        public static Match Match(string input); Trying empty string. : Actual    "[a-z0-9]+"
-            ""
-
+        - Searching for numeric characters : Actual "[0-9]", "12345asdfasdfasdfljkhsda67890"
+        - Different pattern specification. This time range of symbols is allowed. : Actual "[a-z0-9]+", "[token1]? GARBAGEtoken2GARBAGE ;token3!"
+        - Trying empty string: Actual "[a-z0-9]+", ""
     */
-
     [Fact]
     public static void MatchTestCase10()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Regex r;
-        Match m;
-        String s;
-        Int32 i;
-        Int32[] iaExp1 =
+        Match match;
+        int[] iaExp1 = { 0, 1, 2, 3, 4, 24, 25, 26, 27, 28 };
+        string[] saExp2 = { "token1", "token2", "token3" };
+        int[] iaExp2 = { 1, 17, 32 };
+        
+        // First testing pattern "abcabc": Actual "(abc){2}"
+        // " !abcabcasl  dkfjasiduf 12343214-//asdfjzpiouxoifzuoxpicvql23r\\` #$3245,2345278 :asdfas & 100% @daeeffga (ryyy27343) poiweurwabcabcasdfalksdhfaiuyoiruqwer{234}/[(132387 + x)]'aaa''?"
+        Regex regex = new Regex("(abc){2}");
+        string s = " !abcabcasl  dkfjasiduf 12343214-//asdfjzpiouxoifzuoxpicvql23r\\` #$3245,2345278 :asdfas & 100% @daeeffga (ryyy27343) poiweurwabcabcasdfalksdhfaiuyoiruqwer{234}/[(132387 + x)]'aaa''?";
+        for (match = regex.Match(s); match.Success; match = match.NextMatch())
         {
-        0, 1, 2, 3, 4, 24, 25, 26, 27, 28
+            Assert.Equal("abcabc", match.Groups[0].Value);
+            Assert.True(match.Groups[0].Index == 2 || match.Groups[0].Index == 125);
         }
 
-        ;
-        String[] saExp2 =
+        // Searching for numeric characters: Actual "[0-9]"
+        // "12345asdfasdfasdfljkhsda67890"
+        regex = new Regex("[0-9]");
+        s = "12345asdfasdfasdfljkhsda67890";
+        int i = 0;
+        for (match = regex.Match(s); match.Success; match = match.NextMatch(), i++)
         {
-        "token1", "token2", "token3"
+            Assert.True(char.IsDigit(match.Groups[0].Value[0]));
+            Assert.Equal(iaExp1[i], match.Groups[0].Index);
         }
 
-        ;
-        Int32[] iaExp2 =
+        // Different pattern specification. This time range of symbols is allowed: Actual "[a-z0-9]+"
+        // "[token1]? GARBAGEtoken2GARBAGE ;token3!"
+        regex = new Regex("[a-z0-9]+");
+        s = "[token1]? GARBAGEtoken2GARBAGE ;token3!";
+        i = 0;
+        for (match = regex.Match(s); match.Success; match = match.NextMatch(), i++)
         {
-        1, 17, 32
+            Assert.Equal(saExp2[i], match.Groups[0].Value);
+            Assert.Equal(iaExp2[i], match.Groups[0].Index);
         }
 
-        ;
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] public static Match Match(string input); First testing pattern "abcabc" : Actual    "(abc){2}"
-            //" !abcabcasl  dkfjasiduf 12343214-//asdfjzpiouxoifzuoxpicvql23r\\` #$3245,2345278 :asdfas & 100% @daeeffga (ryyy27343) poiweurwabcabcasdfalksdhfaiuyoiruqwer{234}/[(132387 + x)]'aaa''?"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            r = new Regex("(abc){2}");
-            s = " !abcabcasl  dkfjasiduf 12343214-//asdfjzpiouxoifzuoxpicvql23r\\` #$3245,2345278 :asdfas & 100% @daeeffga (ryyy27343) poiweurwabcabcasdfalksdhfaiuyoiruqwer{234}/[(132387 + x)]'aaa''?";
-            for (m = r.Match(s); m.Success; m = m.NextMatch())
-            {
-                if (!m.Groups[0].ToString().Equals("abcabc") && ((m.Groups[0].Index != 2) || (m.Groups[0].Index != 125)))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_234fsadg! doesnot match");
-                }
-            }
-
-            // [] public static Match Match(string input); Searching for numeric characters : Actual    "[0-9]"
-            //"12345asdfasdfasdfljkhsda67890"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            r = new Regex("[0-9]");
-            s = "12345asdfasdfasdfljkhsda67890";
-            i = 0;
-            for (m = r.Match(s); m.Success; m = m.NextMatch(), i++)
-            {
-                if (!Char.IsDigit(m.Groups[0].Value[0]) || m.Groups[0].Index != iaExp1[i])
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_234fsadg! doesnot match " + m.Groups[0].Index);
-                }
-            }
-
-            // [] public static Match Match(string input); Different pattern specification. This time range of symbols is allowed. : Actual    "[a-z0-9]+"
-            //"[token1]? GARBAGEtoken2GARBAGE ;token3!"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_746tegd";
-            iCountTestcases++;
-            r = new Regex("[a-z0-9]+");
-            s = "[token1]? GARBAGEtoken2GARBAGE ;token3!";
-            i = 0;
-            for (m = r.Match(s); m.Success; m = m.NextMatch(), i++)
-            {
-                if (!m.Groups[0].ToString().Equals(saExp2[i]) || m.Groups[0].Index != iaExp2[i])
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_452wfdf! doesnot match " + m.Groups[0].ToString() + " " + m.Groups[0].Index);
-                }
-            }
-
-            // [] Scenario 4 
-            //-----------------------------------------------------------------
-            strLoc = "Loc_563rfg";
-            iCountTestcases++;
-            r = new Regex("[a-z0-9]+");
-            m = r.Match("");
-            if (m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_865rfsg! doesnot match");
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
-        }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+        // Trying empty string: Actual "[a-z0-9]+", ""
+        regex = new Regex("[a-z0-9]+");
+        match = regex.Match("");
+        Assert.False(match.Success);
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests11.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests11.cs
@@ -9,219 +9,84 @@ using Xunit;
 public partial class RegexMatchTests
 {
     /*
-    Tested Methods:
-
-        public static Match Match(string input);     Numbering pattern slots: "(?< 1>\\d{3})(?< 2>\\d{3})(?< 3>\\d{4})"
-            "8885551111"
-
-        public static Match Match(string input);     Not naming pattern slots at all: "^(cat|chat)"
-            "cats are bad"
-
-        public static Match Match(string input);      "([0-9]+(\\.[0-9]+){3})"
-            "209.25.0.111"
-
+    public Match Match(string input);
+        - Numbering pattern slots: "(?< 1>\\d{3})(?< 2>\\d{3})(?< 3>\\d{4})", "8885551111"
+        - Not naming pattern slots at all: "^(cat|chat)", "cats are bad"
+        - "([0-9]+(\\.[0-9]+){3})", "209.25.0.111"
     */
-
     [Fact]
     public static void RegexMatchTestCase11()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Regex r;
-        Match m;
-        Match match;
-        String s;
-        String strMatch1 = "209.25.0.111";
-        Int32[] iMatch1 =
-        {
-        0, 12
-        }
+        string strMatch1 = "209.25.0.111";
+        int[] iMatch1 = { 0, 12 };
+        string[] strGroup1 = { "209.25.0.111", "209.25.0.111", ".111" };
+        int[,] iGroup1 = { { 0, 12 }, { 0, 12 }, { 8, 4 } };
+        string[][] strGrpCap1 = new string[3][];
+        strGrpCap1[0] = new string[] { "209.25.0.111" };
+        strGrpCap1[1] = new string[] { "209.25.0.111" };
+        strGrpCap1[2] = new string[] { ".25", ".0", ".111" };
+        int[][] iGrpCap1 = new int[3][];
+        iGrpCap1[0] = new int[] { 0, 12 };
+        iGrpCap1[1] = new int[] { 0, 12 };
+        iGrpCap1[2] = new int[] { 3, 6, 8, 3, 2, 4 };
+        int[] iGrpCapCnt1 = { 1, 1, 3 };
 
-        ;
-        String[] strGroup1 =
-        {
-        "209.25.0.111", "209.25.0.111", ".111"
-        }
+        // Numbering pattern slots: "(?<1>\\d{3})(?<2>\\d{3})(?<3>\\d{4})"
+        // "8885551111"
+        Regex regex = new Regex(@"(?<1>\d{3})(?<2>\d{3})(?<3>\d{4})");
+        Match match = regex.Match("8885551111");
+        Assert.True(match.Success);
+        
+        match = regex.Match("Invalid string");
+        Assert.False(match.Success);
 
-        ;
-        Int32[,] iGroup1 =
-        {
-        {
-        0, 12
-        }
+        // Not naming pattern slots at all: "^(cat|chat)"
+        // "cats are bad"
+        regex = new Regex("^(cat|chat)");
+        match = regex.Match("cats are bad");
+        Assert.True(match.Success);
 
-        , {
-        0, 12
-        }
+        // "([0-9]+(\\.[0-9]+){3})"
+        // "209.25.0.111"
+        regex = new Regex(@"([0-9]+(\.[0-9]+){3})");
+        match = regex.Match("209.25.0.111");
+        Assert.True(match.Success);
 
-        , {
-        8, 4
-        }
-        }
+        Assert.Equal(strMatch1, match.Value);
+        Assert.Equal(iMatch1[0], match.Index);
+        Assert.Equal(iMatch1[1], match.Length);
 
-        ;
-        String[][] strGrpCap1 = new String[3][];
-        strGrpCap1[0] = new String[]
+        Assert.Equal(1, match.Captures.Count);
+
+        Assert.Equal(strMatch1, match.Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Captures[0].Length);
+
+        Assert.Equal(3, match.Groups.Count);
+
+        // Group 0 always is the Match
+        Assert.Equal(strMatch1, match.Groups[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Length);
+
+        Assert.Equal(1, match.Groups[0].Captures.Count);
+        Assert.Equal(strMatch1, match.Groups[0].Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Captures[0].Length);
+        
+        for (int i = 1; i < match.Groups.Count; i++)
         {
-        "209.25.0.111"
-        }
+            Assert.Equal(strGroup1[i], match.Groups[i].Value);
+            Assert.Equal(iGroup1[i, 0], match.Groups[i].Index);
+            Assert.Equal(iGroup1[i, 1], match.Groups[i].Length);
 
-        ;
-        strGrpCap1[1] = new String[]
-        {
-        "209.25.0.111"
-        }
-
-        ;
-        strGrpCap1[2] = new String[]
-        {
-        ".25", ".0", ".111"
-        }
-
-        ;
-        Int32[][] iGrpCap1 = new Int32[3][];
-        iGrpCap1[0] = new Int32[]
-        {
-        0, 12
-        }
-
-        ; //This is ignored
-        iGrpCap1[1] = new Int32[]
-        {
-        0, 12
-        }
-
-        ; //The first half contains the Index and the latter half the Lengths
-        iGrpCap1[2] = new Int32[]
-        {
-        3, 6, 8, 3, 2, 4
-        }
-
-        ; //The first half contains the Index and the latter half the Lengths
-        Int32[] iGrpCapCnt1 =
-        {
-        1, 1, 3
-        }
-
-        ; //0 is ignored
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] public static Match Match(string input);     Numbering pattern slots: "(?<1>\\d{3})(?<2>\\d{3})(?<3>\\d{4})"
-            //"8885551111"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            s = "8885551111";
-            r = new Regex(@"(?<1>\d{3})(?<2>\d{3})(?<3>\d{4})");
-            m = r.Match(s);
-            if (!m.Success)
+            Assert.Equal(iGrpCapCnt1[i], match.Groups[i].Captures.Count);
+            for (int j = 0; j < match.Groups[i].Captures.Count; j++)
             {
-                iCountErrors++;
-                Console.WriteLine("Err_234fsadg! doesnot match");
+                Assert.Equal(strGrpCap1[i][j], match.Groups[i].Captures[j].Value);
+                Assert.Equal(iGrpCap1[i][j], match.Groups[i].Captures[j].Index);
+                Assert.Equal(iGrpCap1[i][match.Groups[i].Captures.Count + j], match.Groups[i].Captures[j].Length);
             }
-
-            s = "Invalid string";
-            m = r.Match(s);
-            if (m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_764efdg! doesnot match");
-            }
-
-            // [] public static Match Match(string input);     Not naming pattern slots at all: "^(cat|chat)"
-            //"cats are bad"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            r = new Regex("^(cat|chat)");
-            m = r.Match("cats are bad");
-            if (!m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_87543! doesnot match");
-            }
-
-            // [] public static Match Match(string input);      "([0-9]+(\\.[0-9]+){3})"
-            //"209.25.0.111"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            s = "209.25.0.111";
-            r = new Regex(@"([0-9]+(\.[0-9]+){3})");
-            match = r.Match(s);
-            if (!match.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_87543! doesnot match");
-            }
-            else
-            {
-                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_98275dsg: unexpected return result");
-                }
-
-                //Match.Captures always is Match
-                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                if (match.Groups.Count != 3)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_75324sg! unexpected return result");
-                }
-
-                //Group 0 always is the Match
-                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                //Group 0's Capture is always the Match
-                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2975edg!! unexpected return result");
-                }
-
-                for (int i = 1; i < match.Groups.Count; i++)
-                {
-                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != iGrpCapCnt1[i]))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>, CaptureCount = <{6}:{7}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1], match.Groups[i].Captures.Count, iGrpCapCnt1[i]);
-                    }
-
-                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
-                    {
-                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i][match.Groups[i].Captures.Count + j]))
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i][j], iGrpCap1[i][j], iGrpCap1[i][match.Groups[i].Captures.Count + j]);
-                        }
-                    }
-                }
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
         }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests2.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests2.cs
@@ -9,82 +9,30 @@ using Xunit;
 public partial class RegexMatchTests
 {
     /*
-    Tested Methods:
-
-        public static Match Match(string input);     Using [a-z], \s, \w : Actual - "([a-zA-Z]+)\\s(\\w+)"
-            "David Bau"
-
-        public static Match Match(string input);     \\S, \\d, \\D, \\W: Actual - "(\\S+):\\W(\\d+)\\s(\\D+)"
-            "Price: 5 dollars"
-
-        public static Match Match(string input);     \\S, \\d, \\D, \\W: Actual - "[^0-9]+(\\d+)"
-            "Price: 30 dollars"
-
+    public Match Match(string input);
+        - Using [a-z], \s, \w : Actual - "([a-zA-Z]+)\\s(\\w+)", "David Bau"
+        - \\S, \\d, \\D, \\W: Actual - "(\\S+):\\W(\\d+)\\s(\\D+)", "Price: 5 dollars"
+        - \\S, \\d, \\D, \\W: Actual - "[^0-9]+(\\d+)", "Price: 30 dollars"
     */
-
     [Fact]
     public static void RegexMatchTestCase2()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Regex r;
-        Match m;
-        Match match;
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] public static Match Match(string input);     Using [a-z], \s, \w : Actual - "([a-zA-Z]+)\\s(\\w+)"
-            //"David Bau"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            r = new Regex(@"([a-zA-Z]+)\s(\w+)");
-            match = r.Match("David Bau");
-            if (!match.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_7563rfsgf! doesnot match");
-            }
+        // Using [a-z], \s, \w : Actual - "([a-zA-Z]+)\\s(\\w+)"
+        // "David Bau"
+        Regex regex = new Regex(@"([a-zA-Z]+)\s(\w+)");
+        Match match = regex.Match("David Bau");
+        Assert.True(match.Success);
 
-            // [] public static Match Match(string input);     \\S, \\d, \\D, \\W: Actual - "(\\S+):\\W(\\d+)\\s(\\D+)"
-            //"Price: 5 dollars"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            r = new Regex(@"(\S+):\W(\d+)\s(\D+)");
-            m = r.Match("Price: 5 dollars");
-            if (!m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_75erfdg! doesnot match");
-            }
+        // \\S, \\d, \\D, \\W: Actual - "(\\S+):\\W(\\d+)\\s(\\D+)"
+        // "Price: 5 dollars"
+        regex = new Regex(@"(\S+):\W(\d+)\s(\D+)");
+        match = regex.Match("Price: 5 dollars");
+        Assert.True(match.Success);
 
-            // [] public static Match Match(string input);     \\S, \\d, \\D, \\W: Actual - "[^0-9]+(\\d+)"
-            //"Price: 30 dollars"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_746tegd";
-            iCountTestcases++;
-            r = new Regex(@"[^0-9]+(\d+)");
-            m = r.Match("Price: 30 dollars");
-            if (!m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_5743rfsfg! doesnot match");
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
-        }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+        // \\S, \\d, \\D, \\W: Actual - "[^0-9]+(\\d+)"
+        // "Price: 30 dollars"
+        regex = new Regex(@"[^0-9]+(\d+)");
+        match = regex.Match("Price: 30 dollars");
+        Assert.True(match.Success);
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests3.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests3.cs
@@ -9,338 +9,133 @@ using Xunit;
 public partial class RegexMatchTests
 {
     /*
-    Tested Methods:
-
-        public static Match Match(string input);     Using greedy quantifiers : Actual - "(a+)(b*)(c?)"
-            "aaabbbccc"
-
-        public static Match Match(string input);     Using lazy quantifiers: Actual - "(d+?)(e*?)(f??)"
-            "dddeeefff"
-
+    public Match Match(string input);
+        - Using greedy quantifiers : Actual - "(a+)(b*)(c?)", "aaabbbccc"
+        - Using lazy quantifiers: Actual - "(d+?)(e*?)(f??)", "dddeeefff"
     */
-
     [Fact]
     public static void RegexMatchTestCase3()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Regex r;
-        Match match;
-        String strMatch1 = "aaabbbc";
-        Int32[] iMatch1 =
+        string strMatch1 = "aaabbbc";
+        int[] iMatch1 = { 0, 7 };
+        string[] strGroup1 = { "aaabbbc", "aaa", "bbb", "c" };
+        int[,] iGroup1 = { { 0, 7 }, { 0, 3 }, { 3, 3 }, { 6, 1 } };
+
+        string[][] strGrpCap1 = new string[4][];
+        strGrpCap1[0] = new string[] { "aaabbbc" };
+        strGrpCap1[1] = new string[] { "aaa" };
+        strGrpCap1[2] = new string[] { "bbb" };
+        strGrpCap1[3] = new string[] { "c" };
+
+        int[][] iGrpCap1 = new int[4][];
+        iGrpCap1[0] = new int[] { 5, 9, 3, 3 };
+        iGrpCap1[1] = new int[] { 0, 3 };
+        iGrpCap1[2] = new int[] { 3, 3 };
+        iGrpCap1[3] = new int[] { 6, 1 };
+
+        string strMatch2 = "d";
+        int[] iMatch2 = { 0, 1 };
+        string[] strGroup2 = { "d", "d", string.Empty, string.Empty };
+        int[,] iGroup2 = { { 0, 1 }, { 0, 1 }, { 1, 0 }, { 1, 0 } };
+
+        string[][] strGrpCap2 = new string[4][];
+        strGrpCap2[0] = new string[] { "d" };
+        strGrpCap2[1] = new string[] { "d" };
+        strGrpCap2[2] = new string[] { string.Empty };
+        strGrpCap2[3] = new string[] { string.Empty };
+
+        int[][] iGrpCap2 = new int[4][];
+        iGrpCap2[0] = new int[] { 0, 1 };
+        iGrpCap2[1] = new int[] { 0, 1 };
+        iGrpCap2[2] = new int[] { 1, 0 };
+        iGrpCap2[3] = new int[] { 1, 0 };
+
+        // - Using greedy quantifiers : Actual - "(a+)(b*)(c?)"
+        // "aaabbbccc"
+        Regex regex = new Regex("(a+)(b*)(c?)");
+        Match match = regex.Match("aaabbbccc");
+        Assert.True(match.Success);
+
+        Assert.Equal(strMatch1, match.Value);
+        Assert.Equal(iMatch1[0], match.Index);
+        Assert.Equal(iMatch1[1], match.Length);
+
+        Assert.Equal(1, match.Captures.Count);
+        Assert.Equal(strMatch1, match.Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Captures[0].Length);
+
+        Assert.Equal(4, match.Groups.Count);
+
+        // Group 0 always is the Match
+        Assert.Equal(strMatch1, match.Groups[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Length);
+
+        //Group 0's Capture is always the Match
+        Assert.Equal(1, match.Groups[0].Captures.Count);
+        Assert.Equal(strMatch1, match.Groups[0].Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Captures[0].Length);
+
+        for (int i = 1; i < match.Groups.Count; i++)
         {
-        0, 7
-        }
+            Assert.Equal(strGroup1[i], match.Groups[i].Value);
+            Assert.Equal(iGroup1[i, 0], match.Groups[i].Index);
+            Assert.Equal(iGroup1[i, 1], match.Groups[i].Length);
 
-        ;
-        String[] strGroup1 =
-        {
-        "aaabbbc", "aaa", "bbb", "c"
-        }
+            Assert.Equal(1, match.Groups[i].Captures.Count);
 
-        ;
-        Int32[,] iGroup1 =
-        {
-        {
-        0, 7
-        }
-
-        , {
-        0, 3
-        }
-
-        , {
-        3, 3
-        }
-
-        , {
-        6, 1
-        }
-        }
-
-        ;
-        String[][] strGrpCap1 = new String[4][];
-        strGrpCap1[0] = new String[]
-        {
-        "aaabbbc"
-        }
-
-        ;
-        strGrpCap1[1] = new String[]
-        {
-        "aaa"
-        }
-
-        ;
-        strGrpCap1[2] = new String[]
-        {
-        "bbb"
-        }
-
-        ;
-        strGrpCap1[3] = new String[]
-        {
-        "c"
-        }
-
-        ;
-        Int32[][] iGrpCap1 = new Int32[4][];
-        iGrpCap1[0] = new Int32[]
-        {
-        5, 9, 3, 3
-        }
-
-        ; //This is ignored
-        iGrpCap1[1] = new Int32[]
-        {
-        0, 3
-        }
-
-        ; //The first half contains the Index and the latter half the Lengths
-        iGrpCap1[2] = new Int32[]
-        {
-        3, 3
-        }
-
-        ; //The first half contains the Index and the latter half the Lengths
-        iGrpCap1[3] = new Int32[]
-        {
-        6, 1
-        }
-
-        ; //The first half contains the Index and the latter half the Lengths
-        String strMatch2 = "d";
-        Int32[] iMatch2 =
-        {
-        0, 1
-        }
-
-        ;
-        String[] strGroup2 =
-        {
-        "d", "d", String.Empty, String.Empty
-        }
-
-        ;
-        Int32[,] iGroup2 =
-        {
-        {
-        0, 1
-        }
-
-        , {
-        0, 1
-        }
-
-        , {
-        1, 0
-        }
-
-        , {
-        1, 0
-        }
-        }
-
-        ;
-        String[][] strGrpCap2 = new String[4][];
-        strGrpCap2[0] = new String[]
-        {
-        "d"
-        }
-
-        ;
-        strGrpCap2[1] = new String[]
-        {
-        "d"
-        }
-
-        ;
-        strGrpCap2[2] = new String[]
-        {
-        String.Empty
-        }
-
-        ;
-        strGrpCap2[3] = new String[]
-        {
-        String.Empty
-        }
-
-        ;
-        Int32[][] iGrpCap2 = new Int32[4][];
-        iGrpCap2[0] = new Int32[]
-        {
-        0, 1
-        }
-
-        ; //This is ignored
-        iGrpCap2[1] = new Int32[]
-        {
-        0, 1
-        }
-
-        ; //The first half contains the Index and the latter half the Lengths
-        iGrpCap2[2] = new Int32[]
-        {
-        1, 0
-        }
-
-        ; //The first half contains the Index and the latter half the Lengths
-        iGrpCap2[3] = new Int32[]
-        {
-        1, 0
-        }
-
-        ; //The first half contains the Index and the latter half the Lengths
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] public static Match Match(string input);     Using greedy quantifiers : Actual - "(a+)(b*)(c?)"
-            //"aaabbbccc"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            r = new Regex("(a+)(b*)(c?)");
-            match = r.Match("aaabbbccc");
-            if (!match.Success)
+            for (int j = 0; j < match.Groups[i].Captures.Count; j++)
             {
-                iCountErrors++;
-                Console.WriteLine("Err_5743rfsfg! doesnot match");
+                Assert.Equal(strGrpCap1[i][j], match.Groups[i].Captures[j].Value);
+                Assert.Equal(iGrpCap1[i][j], match.Groups[i].Captures[j].Index);
+                Assert.Equal(iGrpCap1[i][match.Groups[i].Captures.Count + j], match.Groups[i].Captures[j].Length);
             }
-            else
-            {
-                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_98275dsg: unexpected return result");
-                }
-
-                //Match.Captures always is Match
-                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                if (match.Groups.Count != 4)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_75324sg! unexpected return result");
-                }
-
-                //Group 0 always is the Match
-                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                //Group 0's Capture is always the Match
-                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2975edg!! unexpected return result");
-                }
-
-                for (int i = 1; i < match.Groups.Count; i++)
-                {
-                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != 1))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1]);
-                    }
-
-                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
-                    {
-                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i][match.Groups[i].Captures.Count + j]))
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i][j], iGrpCap1[i][j], iGrpCap1[i][match.Groups[i].Captures.Count + j]);
-                        }
-                    }
-                }
-            }
-
-            // [] public static Match Match(string input);     Using lazy quantifiers: Actual - "(d+?)(e*?)(f??)"
-            //"dddeeefff"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            //Interesting match from this pattern and input. If needed to go to the end of the string change the ? to + in the last lazy quantifier
-            r = new Regex("(d+?)(e*?)(f??)");
-            match = r.Match("dddeeefff");
-            if (!match.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_78653refgs! doesnot match");
-            }
-            else
-            {
-                if (!match.Value.Equals(strMatch2) || (match.Index != iMatch2[0]) || (match.Length != iMatch2[1]) || (match.Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_98275dsg: unexpected return result");
-                }
-
-                //Match.Captures always is Match
-                if (!match.Captures[0].Value.Equals(strMatch2) || (match.Captures[0].Index != iMatch2[0]) || (match.Captures[0].Length != iMatch2[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                if (match.Groups.Count != 4)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_873gfsg! unexpected return result");
-                }
-
-                //Group 0 always is the Match
-                if (!match.Groups[0].Value.Equals(strMatch2) || (match.Groups[0].Index != iMatch2[0]) || (match.Groups[0].Length != iMatch2[1]) || (match.Groups[0].Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                //Group 0's Capture is always the Match
-                if (!match.Groups[0].Captures[0].Value.Equals(strMatch2) || (match.Groups[0].Captures[0].Index != iMatch2[0]) || (match.Groups[0].Captures[0].Length != iMatch2[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2975edg!! unexpected return result");
-                }
-
-                for (int i = 1; i < match.Groups.Count; i++)
-                {
-                    if (!match.Groups[i].Value.Equals(strGroup2[i]) || (match.Groups[i].Index != iGroup2[i, 0]) || (match.Groups[i].Length != iGroup2[i, 1]) || (match.Groups[i].Captures.Count != 1))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_845sgds_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup2[i], iGroup2[i, 0], iGroup2[i, 1]);
-                    }
-
-                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
-                    {
-                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap2[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap2[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap2[i][match.Groups[i].Captures.Count + j]))
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_2075egg_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap2[i][j], iGrpCap2[i][j], iGrpCap2[i][match.Groups[i].Captures.Count + j]);
-                        }
-                    }
-                }
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
         }
-        catch (Exception exc_general)
+
+        // Using lazy quantifiers: Actual - "(d+?)(e*?)(f??)"
+        // "dddeeefff"
+        // Interesting match from this pattern and input. If needed to go to the end of the string change the ? to + in the last lazy quantifier
+        regex = new Regex("(d+?)(e*?)(f??)");
+        match = regex.Match("dddeeefff");
+        Assert.True(match.Success);
+
+        Assert.Equal(strMatch2, match.Value);
+        Assert.Equal(iMatch2[0], match.Index);
+        Assert.Equal(iMatch2[1], match.Length);
+
+        Assert.Equal(1, match.Captures.Count);
+        Assert.Equal(strMatch2, match.Captures[0].Value);
+        Assert.Equal(iMatch2[0], match.Captures[0].Index);
+        Assert.Equal(iMatch2[1], match.Captures[0].Length);
+
+        Assert.Equal(4, match.Groups.Count);
+
+        // Group 0 always is the Match
+        Assert.Equal(strMatch2, match.Groups[0].Value);
+        Assert.Equal(iMatch2[0], match.Groups[0].Index);
+        Assert.Equal(iMatch2[1], match.Groups[0].Length);
+
+        //Group 0's Capture is always the Match
+        Assert.Equal(1, match.Groups[0].Captures.Count);
+        Assert.Equal(strMatch2, match.Groups[0].Captures[0].Value);
+        Assert.Equal(iMatch2[0], match.Groups[0].Captures[0].Index);
+        Assert.Equal(iMatch2[1], match.Groups[0].Captures[0].Length);
+
+        for (int i = 1; i < match.Groups.Count; i++)
         {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
+            Assert.Equal(strGroup2[i], match.Groups[i].Value);
+            Assert.Equal(iGroup2[i, 0], match.Groups[i].Index);
+            Assert.Equal(iGroup2[i, 1], match.Groups[i].Length);
 
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+            Assert.Equal(1, match.Groups[i].Captures.Count);
+            for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+            {
+                Assert.Equal(strGrpCap2[i][j], match.Groups[i].Captures[j].Value);
+                Assert.Equal(iGrpCap2[i][j], match.Groups[i].Captures[j].Index);
+                Assert.Equal(iGrpCap2[i][match.Groups[i].Captures.Count + j], match.Groups[i].Captures[j].Length);
+            }
+        }
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests4.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests4.cs
@@ -9,337 +9,129 @@ using Xunit;
 public partial class RegexMatchTests
 {
     /*
-    Tested Methods:
-
-        public static Match Match(string input);     Noncapturing group : Actual - "(a+)(?:b*)(ccc)"
-            "aaabbbccc"
-
-        public static Match Match(string input);     Zero-width positive lookahead assertion: Actual - "abc(?=XXX)\\w+"
-            "abcXXXdef"
-
-        public static Match Match(string input);     Zero-width negative lookahead assertion: Actual - "abc(?!XXX)\\w+"
-            "abcXXXdef" - Negative
-
-        public static Match Match(string input);     Zero-width positive lookbehind assertion: Actual - "(\\w){6}(?<  =  XXX ) def "
-            " abcXXXdef "
-        public  static  Match  Match ( string  input ) ; Zero-width  negative  lookbehind  assertion :  Actual - " ( \ \ w ) { 6 } ( ? < ! XXX ) def "
-            " XXXabcdef "
-        public  static  Match  Match ( string  input ) ; Nonbacktracking  subexpression :  Actual - " [ ^ 0 - 9 ] + ( ?>[0-9]+)3"
-            "abc123"
-
+    public Match Match(string input);
+        - Noncapturing group: Actual - "(a+)(?:b*)(ccc)", "aaabbbccc"
+        - Zero-width positive lookahead assertion: Actual - "abc(?=XXX)\\w+", "abcXXXdef"
+        - Zero-width negative lookahead assertion: Actual - "abc(?!XXX)\\w+", "abcXXXdef" - Negative
+        - Zero-width positive lookbehind assertion: Actual - "(\\w){6}(?<  =  XXX ) def ", " abcXXXdef "
+        - Zero-width  negative  lookbehind  assertion: Actual - " ( \ \ w ) { 6 } ( ? < ! XXX ) def ", " XXXabcdef "
+        - Nonbacktracking subexpression: Actual - " [ ^ 0 - 9 ] + ( ?>[0-9]+)3", "abc123"
     */
-
     [Fact]
     public static void RegexMatchTestCase4()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Regex r;
-        Match match;
-        String strMatch1 = "aaabbbccc";
-        Int32[] iMatch1 =
-        {
-        0, 9
-        }
+        string strMatch1 = "aaabbbccc";
+        int[] iMatch1 = { 0, 9 };
+        string[] strGroup1 = { "aaabbbccc", "aaa", "ccc" };
+        int[,] iGroup1 = { { 0, 9 }, { 0, 3 }, { 6, 3 } };
+        string[][] strGrpCap1 = new string[3][];
+        strGrpCap1[0] = new string[] { "aaabbbccc" };
+        strGrpCap1[1] = new string[] { "aaa" };
+        strGrpCap1[2] = new string[] { "ccc" };
+        int[][] iGrpCap1 = new int[3][];
+        iGrpCap1[0] = new int[] { 5, 9 };
+        iGrpCap1[1] = new int[] { 0, 3 };
+        iGrpCap1[2] = new int[] { 6, 3 };
 
-        ;
-        String[] strGroup1 =
-        {
-        "aaabbbccc", "aaa", "ccc"
-        }
+        string strMatch2 = "abcXXXdef";
+        int[] iMatch2 = { 0, 9 };
 
-        ;
-        Int32[,] iGroup1 =
-        {
-        {
-        0, 9
-        }
+        // Noncapturing group : Actual - "(a+)(?:b*)(ccc)"
+        // "aaabbbccc"
+        Regex regex = new Regex("(a+)(?:b*)(ccc)");
+        Match match = regex.Match("aaabbbccc");
+        Assert.True(match.Success);
 
-        , {
-        0, 3
-        }
+        Assert.Equal(strMatch1, match.Value);
+        Assert.Equal(iMatch1[0], match.Index);
+        Assert.Equal(iMatch1[1], match.Length);
 
-        , {
-        6, 3
-        }
-        }
+        Assert.Equal(1, match.Captures.Count);
+        Assert.Equal(strMatch1, match.Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Captures[0].Length);
 
-        ;
-        String[][] strGrpCap1 = new String[3][];
-        strGrpCap1[0] = new String[]
-        {
-        "aaabbbccc"
-        }
+        Assert.Equal(3, match.Groups.Count);
 
-        ;
-        strGrpCap1[1] = new String[]
-        {
-        "aaa"
-        }
+        // Group 0 always is the Match
+        Assert.Equal(strMatch1, match.Groups[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Length);
 
-        ;
-        strGrpCap1[2] = new String[]
-        {
-        "ccc"
-        }
+        Assert.Equal(1, match.Groups[0].Captures.Count);
 
-        ;
-        Int32[][] iGrpCap1 = new Int32[3][];
-        iGrpCap1[0] = new Int32[]
-        {
-        5, 9
-        }
+        // Group 0's Capture is always the Match
+        Assert.Equal(strMatch1, match.Groups[0].Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Captures[0].Length);
 
-        ; //This is ignored
-        iGrpCap1[1] = new Int32[]
+        for (int i = 1; i < match.Groups.Count; i++)
         {
-        0, 3
-        }
+            Assert.Equal(strGroup1[i], match.Groups[i].Value);
+            Assert.Equal(iGroup1[i, 0], match.Groups[i].Index);
+            Assert.Equal(iGroup1[i, 1], match.Groups[i].Length);
 
-        ; //The first half contains the Index and the latter half the Lengths
-        iGrpCap1[2] = new Int32[]
-        {
-        6, 3
-        }
-
-        ; //The first half contains the Index and the latter half the Lengths
-        String strMatch2 = "abcXXXdef";
-        Int32[] iMatch2 =
-        {
-        0, 9
-        }
-
-        ;
-        String[] strGroup2 =
-        {
-        "abcXXXdef"
-        }
-
-        ;
-        Int32[,] iGroup2 =
-        {
-        {
-        0, 9
-        }
-        }
-
-        ;
-        String[][] strGrpCap2 = new String[1][];
-        strGrpCap2[0] = new String[]
-        {
-        "abcXXXdef"
-        }
-
-        ;
-        Int32[][] iGrpCap2 = new Int32[1][];
-        iGrpCap2[0] = new Int32[]
-        {
-        0, 9
-        }
-
-        ; //This is ignored
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] public static Match Match(string input);     Noncapturing group : Actual - "(a+)(?:b*)(ccc)"
-            //"aaabbbccc"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            r = new Regex("(a+)(?:b*)(ccc)");
-            match = r.Match("aaabbbccc");
-            if (!match.Success)
+            Assert.Equal(1, match.Groups[i].Captures.Count);
+            for (int j = 0; j < match.Groups[i].Captures.Count; j++)
             {
-                iCountErrors++;
-                Console.WriteLine("Err_78653refgs! doesnot match");
+                Assert.Equal(strGrpCap1[i][j], match.Groups[i].Captures[j].Value);
+                Assert.Equal(iGrpCap1[i][j], match.Groups[i].Captures[j].Index);
+                Assert.Equal(iGrpCap1[i][match.Groups[i].Captures.Count + j], match.Groups[i].Captures[j].Length);
             }
-            else
-            {
-                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_98275dsg: unexpected return result");
-                }
-
-                //Match.Captures always is Match
-                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                if (match.Groups.Count != 3)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_75324sg! unexpected return result");
-                }
-
-                //Group 0 always is the Match
-                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                //Group 0's Capture is always the Match
-                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2975edg!! unexpected return result");
-                }
-
-                for (int i = 1; i < match.Groups.Count; i++)
-                {
-                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != 1))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1]);
-                    }
-
-                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
-                    {
-                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i][match.Groups[i].Captures.Count + j]))
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i][j], iGrpCap1[i][j], iGrpCap1[i][match.Groups[i].Captures.Count + j]);
-                        }
-                    }
-                }
-            }
-
-            // [] public static Match Match(string input);     Zero-width positive lookahead assertion: Actual - "abc(?=XXX)\\w+"
-            //"abcXXXdef"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            r = new Regex(@"abc(?=XXX)\w+");
-            match = r.Match("abcXXXdef");
-            if (!match.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_7453efg! doesnot match");
-            }
-            else
-            {
-                if (!match.Value.Equals(strMatch2) || (match.Index != iMatch2[0]) || (match.Length != iMatch2[1]) || (match.Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_827345sdf! unexpected return result");
-                }
-
-                //Match.Captures always is Match
-                if (!match.Captures[0].Value.Equals(strMatch2) || (match.Captures[0].Index != iMatch2[0]) || (match.Captures[0].Length != iMatch2[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_1074sf! unexpected return result");
-                }
-
-                if (match.Groups.Count != 1)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2175sgg! unexpected return result");
-                }
-
-                //Group 0 always is the Match
-                if (!match.Groups[0].Value.Equals(strMatch2) || (match.Groups[0].Index != iMatch2[0]) || (match.Groups[0].Length != iMatch2[1]) || (match.Groups[0].Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_68217fdgs! unexpected return result");
-                }
-
-                //Group 0's Capture is always the Match
-                if (!match.Groups[0].Captures[0].Value.Equals(strMatch2) || (match.Groups[0].Captures[0].Index != iMatch2[0]) || (match.Groups[0].Captures[0].Length != iMatch2[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_139wn!! unexpected return result");
-                }
-
-                for (int i = 1; i < match.Groups.Count; i++)
-                {
-                    if (!match.Groups[i].Value.Equals(strGroup2[i]) || (match.Groups[i].Index != iGroup2[i, 0]) || (match.Groups[i].Length != iGroup2[i, 1]) || (match.Groups[i].Captures.Count != 1))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_107vxg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup2[i], iGroup2[i, 0], iGroup2[i, 1]);
-                    }
-
-                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
-                    {
-                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap2[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap2[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap2[i][match.Groups[i].Captures.Count + j]))
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_745dsgg_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap2[i][j], iGrpCap2[i][j], iGrpCap2[i][match.Groups[i].Captures.Count + j]);
-                        }
-                    }
-                }
-            }
-
-            // [] public static Match Match(string input);     Zero-width negative lookahead assertion: Actual - "abc(?!XXX)\\w+"
-            //"abcXXXdef" - Negative
-            //-----------------------------------------------------------------
-            strLoc = "Loc_746tegd";
-            iCountTestcases++;
-            r = new Regex(@"abc(?!XXX)\w+");
-            match = r.Match("abcXXXdef");
-            if (match.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_756tdfg! doesnot match");
-            }
-
-            // [] public static Match Match(string input);     Zero-width positive lookbehind assertion: Actual - "(\\w){6}(?<=XXX)def"
-            //"abcXXXdef"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_563rfg";
-            iCountTestcases++;
-            r = new Regex(@"(\w){6}(?<=XXX)def");
-            match = r.Match("abcXXXdef");
-            if (!match.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_1072gdg! doesnot match");
-            }
-
-            // [] public static Match Match(string input);     Zero-width negative lookbehind assertion: Actual - "(\\w){6}(?<!XXX)def"
-            //"XXXabcdef"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_563rfg";
-            iCountTestcases++;
-            r = new Regex(@"(\w){6}(?<!XXX)def");
-            match = r.Match("XXXabcdef");
-            if (!match.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_532resgf! doesnot match");
-            }
-
-            // [] public static Match Match(string input);     Nonbacktracking subexpression: Actual - "[^0-9]+(?>[0-9]+)3"
-            //"abc123"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_563rfg";
-            iCountTestcases++;
-            r = new Regex("[^0-9]+(?>[0-9]+)3");
-            //The last 3 causes the match to fail, since the non backtracking subexpression does not give up the last digit it matched
-            //for it to be a success. For a correct match, remove the last character, '3' from the pattern
-            match = r.Match("abc123");
-            if (match.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_234fsadg! doesnot match");
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
-        }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
         }
 
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+        // Zero-width positive lookahead assertion: Actual - "abc(?=XXX)\\w+"
+        // "abcXXXdef"
+        regex = new Regex(@"abc(?=XXX)\w+");
+        match = regex.Match("abcXXXdef");
+        Assert.True(match.Success);
+        Assert.Equal(strMatch2, match.Value);
+        Assert.Equal(iMatch2[0], match.Index);
+        Assert.Equal(iMatch2[1], match.Length);
+
+        Assert.Equal(1, match.Captures.Count);
+        Assert.Equal(strMatch2, match.Captures[0].Value);
+        Assert.Equal(iMatch2[0], match.Captures[0].Index);
+        Assert.Equal(iMatch2[1], match.Captures[0].Length);
+
+        Assert.Equal(1, match.Groups.Count);
+
+        // Group 0 always is the Match
+        Assert.Equal(strMatch2, match.Groups[0].Value);
+        Assert.Equal(iMatch2[0], match.Groups[0].Index);
+        Assert.Equal(iMatch2[1], match.Groups[0].Length);
+
+        Assert.Equal(1, match.Groups[0].Captures.Count);
+
+        // Group 0's Capture is always the Match
+        Assert.Equal(strMatch2, match.Groups[0].Captures[0].Value);
+        Assert.Equal(iMatch2[0], match.Groups[0].Captures[0].Index);
+        Assert.Equal(iMatch2[1], match.Groups[0].Captures[0].Length);
+
+        // Zero-width negative lookahead assertion: Actual - "abc(?!XXX)\\w+"
+        // "abcXXXdef" - Negative
+        regex = new Regex(@"abc(?!XXX)\w+");
+        match = regex.Match("abcXXXdef");
+        Assert.False(match.Success);
+
+        // Zero-width positive lookbehind assertion: Actual - "(\\w){6}(?<=XXX)def"
+        // "abcXXXdef"
+        regex = new Regex(@"(\w){6}(?<=XXX)def");
+        match = regex.Match("abcXXXdef");
+        Assert.True(match.Success);
+
+        // Zero-width negative lookbehind assertion: Actual - "(\\w){6}(?<!XXX)def"
+        // "XXXabcdef"
+        regex = new Regex(@"(\w){6}(?<!XXX)def");
+        match = regex.Match("XXXabcdef");
+        Assert.True(match.Success);
+
+        // Nonbacktracking subexpression: Actual - "[^0-9]+(?>[0-9]+)3"
+        // "abc123"
+        // The last 3 causes the match to fail, since the non backtracking subexpression does not give up the last digit it matched
+        // for it to be a success. For a correct match, remove the last character, '3' from the pattern
+        regex = new Regex("[^0-9]+(?>[0-9]+)3");
+        match = regex.Match("abc123");
+        Assert.False(match.Success);
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests5.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests5.cs
@@ -9,97 +9,39 @@ using Xunit;
 public partial class RegexMatchTests
 {
     /*
-    Tested Methods:
+    public Match Match(string input);
+        - Using beginning/end of string chars \A, \Z, ^ : Actual - "\\Aaaa\\w+zzz\\Z", "aaaasdfajsdlfjzzz"
+        - Using beginning/end of string chars \A, \Z, ^ : Actual - "\\Aaaa\\w+zzz\\Z", "aaaasdfajsdlfjzzza"
 
-        public static Match Match(string input);     Using beginning/end of string chars \A, \Z, ^ : Actual - "\\Aaaa\\w+zzz\\Z"
-            "aaaasdfajsdlfjzzz"
-
-        public static Match Match(string input);     Using beginning/end of string chars \A, \Z, ^ : Actual - "\\Aaaa\\w+zzz\\Z"
-            "aaaasdfajsdlfjzzza"
-
-        public static Match Match(string input, Int32 startat);     Using beginning/end of string chars \A, \Z, ^ : Actual - "\\Gbbb"
-            "aaabbb", 3
-
-        public static Match Match(string input, Int32 startat);     Using beginning/end of string chars \A, \Z, ^ : Actual - "^b"
-            "ab", 1
-
+    public Match Match(string input, int start);
+        - Using beginning/end of string chars \A, \Z, ^ : Actual - "\\Gbbb", "aaabbb", 3
+        - Using beginning/end of string chars \A, \Z, ^ : Actual - "^b", "ab", 1
     */
-
     [Fact]
     public static void RegexMatchTestCase5()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Regex r;
-        Match m;
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] public static Match Match(string input);     Using beginning/end of string chars \A, \Z : Actual - "\\Aaaa\\w+zzz\\Z"
-            //"aaaasdfajsdlfjzzz"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            r = new Regex(@"\Aaaa\w+zzz\Z");
-            m = r.Match("aaaasdfajsdlfjzzz");
-            if (!m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_234fsadg! doesnot match");
-            }
+        // Using beginning/end of string chars \A, \Z : Actual - "\\Aaaa\\w+zzz\\Z"
+        // "aaaasdfajsdlfjzzz"
+        Regex regex = new Regex(@"\Aaaa\w+zzz\Z");
+        Match match = regex.Match("aaaasdfajsdlfjzzz");
+        Assert.True(match.Success);
 
-            // [] public static Match Match(string input);     Using beginning/end of string chars \A, \Z : Actual - "\\Aaaa\\w+zzz\\Z"
-            //"aaaasdfajsdlfjzzza"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            r = new Regex(@"\Aaaa\w+zzz\Z");
-            m = r.Match("aaaasdfajsdlfjzzza");
-            if (m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_87543! doesnot match");
-            }
+        // Using beginning/end of string chars \A, \Z : Actual - "\\Aaaa\\w+zzz\\Z"
+        // "aaaasdfajsdlfjzzza"
+        regex = new Regex(@"\Aaaa\w+zzz\Z");
+        match = regex.Match("aaaasdfajsdlfjzzza");
+        Assert.False(match.Success);
 
-            // [] public static Match Match(string input);     Using beginning/end of string chars \A, \Z : Actual - "\\Aaaa\\w+zzz\\Z"
-            //"line2\nline3\n"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            r = new Regex(@"\A(line2\n)line3\Z", RegexOptions.Multiline);
-            m = r.Match("line2\nline3\n");
-            if (!m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_872nj! doesnot match");
-            }
+        // Using beginning/end of string chars \A, \Z : Actual - "\\Aaaa\\w+zzz\\Z"
+        // "line2\nline3\n"
+        regex = new Regex(@"\A(line2\n)line3\Z", RegexOptions.Multiline);
+        match = regex.Match("line2\nline3\n");
+        Assert.True(match.Success);
 
-            // [] public static Match Match(string input, Int32 startat);     Using beginning/end of string chars ^ : Actual - "^b"
-            //"ab", 1
-            //-----------------------------------------------------------------
-            strLoc = "Loc_563rfg";
-            iCountTestcases++;
-            r = new Regex("^b");
-            m = r.Match("ab");
-            if (m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_865rfsg! doesnot match");
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
-        }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+        // Using beginning/end of string chars ^ : Actual - "^b"
+        // "ab", 1
+        regex = new Regex("^b");
+        match = regex.Match("ab");
+        Assert.False(match.Success);
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests6.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests6.cs
@@ -9,186 +9,78 @@ using Xunit;
 public partial class RegexMatchTests
 {
     /*
-    Tested Methods:
-
-        public static Match Match(string input);     Backreferences : Actual - "(\\w)\\1"
-            "aa"
-
-        public static Match Match(string input);      : Actual - "(?<char>\\w)\\<char>"
-            "aa"
-
-        public static Match Match(string input);      : Actual - "(?< 4 3>\\w)\\43"
-            "aa"
-
+    public static Match Match(string input);
+        - Backreferences : Actual - "(\\w)\\1", "aa"
+        - Actual - "(?<char>\\w)\\<char>", "aa"
+        - Actual - "(?< 4 3>\\w)\\43", "aa"
     */
-
     [Fact]
     public static void RegexMatchTestCase6()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Regex r;
-        Match m;
-        Match match;
-        String strMatch1 = "aa";
-        Int32[] iMatch1 =
-        {
-        0, 2
-        }
+        string strMatch1 = "aa";
+        int[] iMatch1 = { 0, 2 };
+        string[] strGroup1 = { "aa", "a" };
+        int[,] iGroup1 = { { 0, 2 }, { 0, 1 } };
+        string[][] strGrpCap1 = new string[2][];
+        strGrpCap1[0] = new string[] { "aa" };
+        strGrpCap1[1] = new string[] { "a" };
+        int[][] iGrpCap1 = new int[2][];
+        iGrpCap1[0] = new int[] { 0, 2 };
+        iGrpCap1[1] = new int[] { 0, 1 };
 
-        ;
-        String[] strGroup1 =
-        {
-        "aa", "a"
-        }
+        // Backreferences : Actual - "(\\w)\\1"
+        // "aa"
+        Regex regex = new Regex(@"(\w)\1");
+        Match match = regex.Match("aa"); Assert.True(match.Success);
 
-        ;
-        Int32[,] iGroup1 =
-        {
-        {
-        0, 2
-        }
+        Assert.Equal(strMatch1, match.Value);
+        Assert.Equal(iMatch1[0], match.Index);
+        Assert.Equal(iMatch1[1], match.Length);
 
-        , {
-        0, 1
-        }
-        }
+        Assert.Equal(1, match.Captures.Count);
+        Assert.Equal(strMatch1, match.Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Captures[0].Length);
 
-        ;
-        String[][] strGrpCap1 = new String[2][];
-        strGrpCap1[0] = new String[]
-        {
-        "aa"
-        }
+        Assert.Equal(2, match.Groups.Count);
 
-        ;
-        strGrpCap1[1] = new String[]
-        {
-        "a"
-        }
+        // Group 0 always is the Match
+        Assert.Equal(strMatch1, match.Groups[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Length);
 
-        ;
-        Int32[][] iGrpCap1 = new Int32[2][];
-        iGrpCap1[0] = new Int32[]
-        {
-        0, 2
-        }
+        Assert.Equal(1, match.Groups[0].Captures.Count);
 
-        ; //This is ignored
-        iGrpCap1[1] = new Int32[]
-        {
-        0, 1
-        }
+        // Group 0's Capture is always the Match
+        Assert.Equal(strMatch1, match.Groups[0].Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Captures[0].Length);
 
-        ; //The first half contains the Index and the latter half the Lengths
-        try
+        for (int i = 1; i < match.Groups.Count; i++)
         {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] public static Match Match(string input);     Backreferences : Actual - "(\\w)\\1"
-            //"aa"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            r = new Regex(@"(\w)\1");
-            match = r.Match("aa");
-            if (!match.Success)
+            Assert.Equal(strGroup1[i], match.Groups[i].Value);
+            Assert.Equal(iGroup1[i, 0], match.Groups[i].Index);
+            Assert.Equal(iGroup1[i, 1], match.Groups[i].Length);
+
+            Assert.Equal(1, match.Groups[i].Captures.Count);
+            for (int j = 0; j < match.Groups[i].Captures.Count; j++)
             {
-                iCountErrors++;
-                Console.WriteLine("Err_234fsadg! doesnot match");
+                Assert.Equal(strGrpCap1[i][j], match.Groups[i].Captures[j].Value);
+                Assert.Equal(iGrpCap1[i][j], match.Groups[i].Captures[j].Index);
+                Assert.Equal(iGrpCap1[i][match.Groups[i].Captures.Count + j], match.Groups[i].Captures[j].Length);
             }
-            else
-            {
-                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_98275dsg: unexpected return result");
-                }
-
-                //Match.Captures always is Match
-                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                if (match.Groups.Count != 2)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_75324sg! unexpected return result");
-                }
-
-                //Group 0 always is the Match
-                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                //Group 0's Capture is always the Match
-                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2975edg!! unexpected return result");
-                }
-
-                for (int i = 1; i < match.Groups.Count; i++)
-                {
-                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != 1))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1]);
-                    }
-
-                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
-                    {
-                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i][match.Groups[i].Captures.Count + j]))
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i][j], iGrpCap1[i][j], iGrpCap1[i][match.Groups[i].Captures.Count + j]);
-                        }
-                    }
-                }
-            }
-
-            // [] public static Match Match(string input);      : Actual - "(?<char>\\w)\\<char>"
-            //"aa"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            r = new Regex(@"(?<char>\w)\<char>");
-            m = r.Match("aa");
-            if (!m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_87543! doesnot match");
-            }
-
-            // [] public static Match Match(string input);      : Actual - "(?<43>\\w)\\43"
-            //"aa"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_746tegd";
-            iCountTestcases++;
-            r = new Regex(@"(?<43>\w)\43");
-            m = r.Match("aa");
-            if (!m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_452wfdf! doesnot match");
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
-        }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
         }
 
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+        // Actual - "(?<char>\\w)\\<char>"
+        // "aa"
+        regex = new Regex(@"(?<char>\w)\<char>");
+        match = regex.Match("aa");
+        Assert.True(match.Success);
+
+        // Actual - "(?<43>\\w)\\43"
+        // "aa"
+        regex = new Regex(@"(?<43>\w)\43");
+        match = regex.Match("aa");
+        Assert.True(match.Success);
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests7.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests7.cs
@@ -9,291 +9,80 @@ using Xunit;
 public partial class RegexMatchTests
 {
     /*
-    Tested Methods:
-
-        public static Match Match(string input);     Alternation constructs : Actual - "(111|aaa)"
-            "aaa"
-
-        public static Match Match(string input);      : Actual - "abc(?(1)111|222)"
-            "abc222"
-
-        public static Match Match(string input);      : Actual - "(?< 1>\\d+)abc(?(1)222|111)"
-            "111abc222"
-
+    public static Match Match(string input);
+        - Alternation constructs : Actual - "(111|aaa)", "aaa"
+        - Actual - "abc(?(1)111|222)", "abc222"
+        - Actual - "(?< 1>\\d+)abc(?(1)222|111)", "111abc222"
     */
-
     [Fact]
     public static void RegexMatchTestCase7()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Regex r;
-        Match m;
-        Match match;
-        String strMatch1 = "abc222";
-        Int32[] iMatch1 =
-        {
-        0, 6
-        }
+        string strMatch = "111abc222";
+        int[] iMatch = { 0, 9 };
+        string[] strGroup = { "111abc222", "111" };
+        int[,] iGroup = { { 0, 9 }, { 0, 3 } };
+        string[][] strGrpCap = new string[2][];
+        strGrpCap[0] = new string[] { "111abc222" };
+        strGrpCap[1] = new string[] { "111" };
+        int[][] iGrpCap = new int[2][];
+        iGrpCap[0] = new int[] { 0, 9 };
+        iGrpCap[1] = new int[] { 0, 3 };
+        int[] iGrpCapCnt = { 1, 1 };
 
-        ;
-        String[] strGroup1 =
-        {
-        "abc222", String.Empty
-        }
+        // Alternation constructs : Actual - "(111|aaa)"
+        // "aaa"
+        Regex regex = new Regex("(111|aaa)");
+        Match match = regex.Match("aaa");
+        Assert.True(match.Success);
+        Assert.Equal("aaa", match.Groups[1].Value);
 
-        ;
-        Int32[,] iGroup1 =
-        {
-        {
-        0, 6
-        }
+        // Actual - "abc(?(1)111|222)"
+        // "abc222"
+        regex = new Regex("(abbc)(?(1)111|222)");
+        match = regex.Match("abbc222");
+        Assert.False(match.Success);
 
-        , {
-        0, 0
-        }
-        }
+        // Actual - "(?<1>\\d+)abc(?(1)222|111)"
+        // "111abc222"
+        regex = new Regex(@"(?<MyDigits>\d+)abc(?(MyDigits)222|111)");
+        match = regex.Match("111abc222"); Assert.True(match.Success);
+        Assert.True(match.Success);
 
-        ;
-        String[][] strGrpCap1 = new String[2][];
-        strGrpCap1[0] = new String[]
-        {
-        "abc222"
-        }
+        Assert.Equal(strMatch, match.Value);
+        Assert.Equal(iMatch[0], match.Index);
+        Assert.Equal(iMatch[1], match.Length);
 
-        ;
-        strGrpCap1[1] = new String[]
-        {
-        String.Empty
-        }
+        Assert.Equal(1, match.Captures.Count);
+        Assert.Equal(strMatch, match.Captures[0].Value);
+        Assert.Equal(iMatch[0], match.Captures[0].Index);
+        Assert.Equal(iMatch[1], match.Captures[0].Length);
 
-        ;
-        Int32[][] iGrpCap1 = new Int32[2][];
-        iGrpCap1[0] = new Int32[]
-        {
-        0, 6
-        }
+        Assert.Equal(2, match.Groups.Count);
 
-        ; //This is ignored
-        iGrpCap1[1] = new Int32[]
-        {
-        0, 0
-        }
+        // Group 0 always is the Match
+        Assert.Equal(strMatch, match.Groups[0].Value);
+        Assert.Equal(iMatch[0], match.Groups[0].Index);
+        Assert.Equal(iMatch[1], match.Groups[0].Length);
 
-        ; //The first half contains the Index and the latter half the Lengths
-        String strMatch2 = "111abc222";
-        Int32[] iMatch2 =
-        {
-        0, 9
-        }
+        //Group 0's Capture is always the Match
+        Assert.Equal(1, match.Groups[0].Captures.Count);
+        Assert.Equal(strMatch, match.Groups[0].Captures[0].Value);
+        Assert.Equal(iMatch[0], match.Groups[0].Captures[0].Index);
+        Assert.Equal(iMatch[1], match.Groups[0].Captures[0].Length);
 
-        ;
-        String[] strGroup2 =
+        for (int i = 1; i < match.Groups.Count; i++)
         {
-        "111abc222", "111"
-        }
+            Assert.Equal(strGroup[i], match.Groups[i].Value);
+            Assert.Equal(iGroup[i, 0], match.Groups[i].Index);
+            Assert.Equal(iGroup[i, 1], match.Groups[i].Length);
 
-        ;
-        Int32[,] iGroup2 =
-        {
-        {
-        0, 9
-        }
-
-        , {
-        0, 3
-        }
-        }
-
-        ;
-        String[][] strGrpCap2 = new String[2][];
-        strGrpCap2[0] = new String[]
-        {
-        "111abc222"
-        }
-
-        ;
-        strGrpCap2[1] = new String[]
-        {
-        "111"
-        }
-
-        ;
-        Int32[][] iGrpCap2 = new Int32[2][];
-        iGrpCap2[0] = new Int32[]
-        {
-        0, 9
-        }
-
-        ; //This is ignored
-        iGrpCap2[1] = new Int32[]
-        {
-        0, 3
-        }
-
-        ; //The first half contains the Index and the latter half the Lengths
-        Int32[] iGrpCapCnt2 =
-        {
-        1, 1
-        }
-
-        ;
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] public static Match Match(string input);     Alternation constructs : Actual - "(111|aaa)"
-            //"aaa"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            r = new Regex("(111|aaa)");
-            m = r.Match("aaa");
-            if (!m.Success || !m.Groups[1].Value.Equals("aaa"))
+            Assert.Equal(1, match.Groups[i].Captures.Count);
+            for (int j = 0; j < match.Groups[i].Captures.Count; j++)
             {
-                iCountErrors++;
-                Console.WriteLine("Err_234fsadg! doesnot match");
+                Assert.Equal(strGrpCap[i][j], match.Groups[i].Captures[j].Value);
+                Assert.Equal(iGrpCap[i][j], match.Groups[i].Captures[j].Index);
+                Assert.Equal(iGrpCap[i][match.Groups[i].Captures.Count + j], match.Groups[i].Captures[j].Length);
             }
-
-            // [] public static Match Match(string input);      : Actual - "abc(?(1)111|222)"
-            //"abc222"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            r = new Regex("(abbc)(?(1)111|222)");
-            match = r.Match("abc222");
-            if (match.Success)
-            {
-                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_98275dsg: unexpected return result");
-                }
-
-                //Match.Captures always is Match
-                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                if (match.Groups.Count != 2)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_75324sg! unexpected return result");
-                }
-
-                //Group 0 always is the Match
-                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                //Group 0's Capture is always the Match
-                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2975edg!! unexpected return result");
-                }
-
-                for (int i = 1; i < match.Groups.Count; i++)
-                {
-                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != 0))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>, CaptureCount={6}", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1], match.Groups[i].Captures.Count);
-                    }
-
-                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
-                    {
-                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i][match.Groups[i].Captures.Count + j]))
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i][j], iGrpCap1[i][j], iGrpCap1[i][match.Groups[i].Captures.Count + j]);
-                        }
-                    }
-                }
-            }
-
-            // [] public static Match Match(string input);      : Actual - "(?<1>\\d+)abc(?(1)222|111)"
-            //"111abc222"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_746tegd";
-            iCountTestcases++;
-            r = new Regex(@"(?<MyDigits>\d+)abc(?(MyDigits)222|111)");
-            match = r.Match("111abc222");
-            if (!match.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_452wfdf! doesnot match");
-            }
-            else
-            {
-                if (!match.Value.Equals(strMatch2) || (match.Index != iMatch2[0]) || (match.Length != iMatch2[1]) || (match.Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_827345sdf! unexpected return result");
-                }
-
-                //Match.Captures always is Match
-                if (!match.Captures[0].Value.Equals(strMatch2) || (match.Captures[0].Index != iMatch2[0]) || (match.Captures[0].Length != iMatch2[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_1074sf! unexpected return result");
-                }
-
-                if (match.Groups.Count != 2)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2175sgg! unexpected return result");
-                }
-
-                //Group 0 always is the Match
-                if (!match.Groups[0].Value.Equals(strMatch2) || (match.Groups[0].Index != iMatch2[0]) || (match.Groups[0].Length != iMatch2[1]) || (match.Groups[0].Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_68217fdgs! unexpected return result");
-                }
-
-                //Group 0's Capture is always the Match
-                if (!match.Groups[0].Captures[0].Value.Equals(strMatch2) || (match.Groups[0].Captures[0].Index != iMatch2[0]) || (match.Groups[0].Captures[0].Length != iMatch2[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_139wn!! unexpected return result");
-                }
-
-                for (int i = 1; i < match.Groups.Count; i++)
-                {
-                    if (!match.Groups[i].Value.Equals(strGroup2[i]) || (match.Groups[i].Index != iGroup2[i, 0]) || (match.Groups[i].Length != iGroup2[i, 1]) || (match.Groups[i].Captures.Count != iGrpCapCnt2[i]))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_107vxg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>, CaptureCount = {6}", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup2[i], iGroup2[i, 0], iGroup2[i, 1], match.Groups[i].Captures.Count);
-                    }
-
-                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
-                    {
-                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap2[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap2[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap2[i][match.Groups[i].Captures.Count + j]))
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_745dsgg_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap2[i][j], iGrpCap2[i][j], iGrpCap2[i][match.Groups[i].Captures.Count + j]);
-                        }
-                    }
-                }
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
         }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests8.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests8.cs
@@ -9,318 +9,136 @@ using Xunit;
 public partial class RegexMatchTests
 {
     /*
-    Tested Methods:
-
-        public static Match Match(string input);     Using "n" Regex option. Only explicitly named groups should be captured : Actual - "([0-9]*)\\s(?<s>[a-z_A-Z]+)", "n"
-            "200 dollars"
-
-        public static Match Match(string input);     Single line mode "s". Includes new line character. : Actual - "([^/]+)","s"
-            "abc\n"
-
-        public static Match Match(string input);     "x" option. Removes unescaped white space from the pattern. : Actual - " ([^/]+) ","x"
-            "abc"
-
-        public static Match Match(string input);     "x" option. Removes unescaped white space from the pattern. : Actual - "\x20([^/]+)\x20","x"
-            "abc"
-
+    public Match Match(string input, RegexOptions options);
+        - Using "n" Regex option. Only explicitly named groups should be captured: Actual - "([0-9]*)\\s(?<s>[a-z_A-Z]+)", "n", "200 dollars"
+        - Single line mode "s". Includes new line character: Actual - "([^/]+)","s", "abc\n"
+        - "x" option. Removes unescaped white space from the pattern: Actual - " ([^/]+) ","x", "abc"
+        - "x" option. Removes unescaped white space from the pattern: Actual - "\x20([^/]+)\x20","x", "abc"
     */
-
     [Fact]
     public static void RegexMatchTestCase8()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Regex r;
-        Match m;
-        Match match;
-        String strMatch1 = "200 dollars";
-        Int32[] iMatch1 =
-        {
-        0, 11
-        }
+        string strMatch1 = "200 dollars";
+        int[] iMatch1 = { 0, 11 };
+        string[] strGroup1 = { "200 dollars", "dollars" };
+        int[,] iGroup1 = { { 0, 11 }, { 4, 7 } };
+        string[][] strGrpCap1 = new string[2][];
+        strGrpCap1[0] = new string[] { "200 dollars" };
+        strGrpCap1[1] = new string[] { "dollars" };
+        int[][] iGrpCap1 = new int[2][];
+        iGrpCap1[0] = new int[] { 0, 11 };
+        iGrpCap1[1] = new int[] { 4, 7 };
+        int[] iGrpCapCnt1 = { 1, 1 };
 
-        ;
-        String[] strGroup1 =
-        {
-        "200 dollars", "dollars"
-        }
+        string strMatch2 = "abc\nsfc";
+        int[] iMatch2 = { 0, 7 };
+        string[] strGroup2 = { "abc\nsfc", "abc\nsfc" };
+        int[,] iGroup2 = { { 0, 7 }, { 0, 7 } };
+        string[][] strGrpCap2 = new string[2][];
+        strGrpCap2[0] = new string[] { "abc\nsfc" };
+        strGrpCap2[1] = new string[] { "abc\nsfc" };
+        int[][] iGrpCap2 = new int[2][];
+        iGrpCap2[0] = new int[] { 0, 11 };
+        iGrpCap2[1] = new int[] { 0, 7 };
+        int[] iGrpCapCnt2 = { 1, 1 };
 
-        ;
-        Int32[,] iGroup1 =
-        {
-        {
-        0, 11
-        }
+        // Using "n" Regex option. Only explicitly named groups should be captured : Actual - "([0-9]*)\\s(?<s>[a-z_A-Z]+)", "n"
+        // "200 dollars"
+        Regex regex = new Regex(@"([0-9]*)\s(?<s>[a-z_A-Z]+)", RegexOptions.ExplicitCapture);
+        Match match = regex.Match("200 dollars");
+        Assert.True(match.Success);
 
-        , {
-        4, 7
-        }
-        }
+        Assert.Equal(strMatch1, match.Value);
+        Assert.Equal(iMatch1[0], match.Index);
+        Assert.Equal(iMatch1[1], match.Length);
 
-        ;
-        String[][] strGrpCap1 = new String[2][];
-        strGrpCap1[0] = new String[]
-        {
-        "200 dollars"
-        }
+        Assert.Equal(1, match.Captures.Count);
+        Assert.Equal(strMatch1, match.Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Captures[0].Length);
 
-        ;
-        strGrpCap1[1] = new String[]
-        {
-        "dollars"
-        }
+        Assert.Equal(2, match.Groups.Count);
 
-        ;
-        Int32[][] iGrpCap1 = new Int32[2][];
-        iGrpCap1[0] = new Int32[]
-        {
-        0, 11
-        }
+        // Group 0 always is the Match
+        Assert.Equal(strMatch1, match.Groups[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Length);
 
-        ; //This is ignored
-        iGrpCap1[1] = new Int32[]
-        {
-        4, 7
-        }
+        //Group 0's Capture is always the Match
+        Assert.Equal(1, match.Groups[0].Captures.Count);
+        Assert.Equal(strMatch1, match.Groups[0].Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Captures[0].Length);
 
-        ; //The first half contains the Index and the latter half the Lengths
-        Int32[] iGrpCapCnt1 =
+        for (int i = 1; i < match.Groups.Count; i++)
         {
-        1, 1
-        }
+            Assert.Equal(strGroup1[i], match.Groups[i].Value);
+            Assert.Equal(iGroup1[i, 0], match.Groups[i].Index);
+            Assert.Equal(iGroup1[i, 1], match.Groups[i].Length);
 
-        ; //0 is ignored
-        String strMatch2 = "abc\nsfc";
-        Int32[] iMatch2 =
-        {
-        0, 7
-        }
+            Assert.Equal(1, match.Groups[i].Captures.Count);
 
-        ;
-        String[] strGroup2 =
-        {
-        "abc\nsfc", "abc\nsfc"
-        }
-
-        ;
-        Int32[,] iGroup2 =
-        {
-        {
-        0, 7
-        }
-
-        , {
-        0, 7
-        }
-        }
-
-        ;
-        String[][] strGrpCap2 = new String[2][];
-        strGrpCap2[0] = new String[]
-        {
-        "abc\nsfc"
-        }
-
-        ;
-        strGrpCap2[1] = new String[]
-        {
-        "abc\nsfc"
-        }
-
-        ;
-        Int32[][] iGrpCap2 = new Int32[2][];
-        iGrpCap2[0] = new Int32[]
-        {
-        0, 11
-        }
-
-        ; //This is ignored
-        iGrpCap2[1] = new Int32[]
-        {
-        0, 7
-        }
-
-        ; //The first half contains the Index and the latter half the Lengths
-        Int32[] iGrpCapCnt2 =
-        {
-        1, 1
-        }
-
-        ; //0 is ignored
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] public static Match Match(string input);     Using "n" Regex option. Only explicitly named groups should be captured : Actual - "([0-9]*)\\s(?<s>[a-z_A-Z]+)", "n"
-            //"200 dollars"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            r = new Regex(@"([0-9]*)\s(?<s>[a-z_A-Z]+)", RegexOptions.ExplicitCapture);
-            match = r.Match("200 dollars");
-            if (!match.Success)
+            for (int j = 0; j < match.Groups[i].Captures.Count; j++)
             {
-                iCountErrors++;
-                Console.WriteLine("Err_234fsadg! doesnot match");
+                Assert.Equal(strGrpCap1[i][j], match.Groups[i].Captures[j].Value);
+                Assert.Equal(iGrpCap1[i][j], match.Groups[i].Captures[j].Index);
+                Assert.Equal(iGrpCap1[i][match.Groups[i].Captures.Count + j], match.Groups[i].Captures[j].Length);
             }
-            else
-            {
-                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_98275dsg: unexpected return result");
-                }
-
-                //Match.Captures always is Match
-                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                if (match.Groups.Count != 2)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_75324sg! unexpected return result");
-                }
-
-                //Group 0 always is the Match
-                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                //Group 0's Capture is always the Match
-                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2975edg!! unexpected return result");
-                }
-
-                for (int i = 1; i < match.Groups.Count; i++)
-                {
-                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != iGrpCapCnt1[i]))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>, CaptureCount = <{6}:{7}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1], match.Groups[i].Captures.Count, iGrpCapCnt1[i]);
-                    }
-
-                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
-                    {
-                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i][match.Groups[i].Captures.Count + j]))
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i][j], iGrpCap1[i][j], iGrpCap1[i][match.Groups[i].Captures.Count + j]);
-                        }
-                    }
-                }
-            }
-
-            // [] public static Match Match(string input);     Single line mode "s". Includes new line character. : Actual - "([^/]+)","s"
-            //"abc\n"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            r = new Regex("(.*)", RegexOptions.Singleline);
-            match = r.Match("abc\nsfc");
-            if (!match.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_87543! doesnot match");
-            }
-            else
-            {
-                if (!match.Value.Equals(strMatch2) || (match.Index != iMatch2[0]) || (match.Length != iMatch2[1]) || (match.Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_827345sdf! unexpected return result");
-                }
-
-                //Match.Captures always is Match
-                if (!match.Captures[0].Value.Equals(strMatch2) || (match.Captures[0].Index != iMatch2[0]) || (match.Captures[0].Length != iMatch2[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_1074sf! unexpected return result");
-                }
-
-                if (match.Groups.Count != 2)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2175sgg! unexpected return result");
-                }
-
-                //Group 0 always is the Match
-                if (!match.Groups[0].Value.Equals(strMatch2) || (match.Groups[0].Index != iMatch2[0]) || (match.Groups[0].Length != iMatch2[1]) || (match.Groups[0].Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_68217fdgs! unexpected return result");
-                }
-
-                //Group 0's Capture is always the Match
-                if (!match.Groups[0].Captures[0].Value.Equals(strMatch2) || (match.Groups[0].Captures[0].Index != iMatch2[0]) || (match.Groups[0].Captures[0].Length != iMatch2[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_139wn!! unexpected return result");
-                }
-
-                for (int i = 1; i < match.Groups.Count; i++)
-                {
-                    if (!match.Groups[i].Value.Equals(strGroup2[i]) || (match.Groups[i].Index != iGroup2[i, 0]) || (match.Groups[i].Length != iGroup2[i, 1]) || (match.Groups[i].Captures.Count != iGrpCapCnt2[i]))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_107vxg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>, CaptureCount = <{6}:{7}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup2[i], iGroup2[i, 0], iGroup2[i, 1], match.Groups[i].Captures.Count, iGrpCapCnt2[i]);
-                    }
-
-                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
-                    {
-                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap2[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap2[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap2[i][match.Groups[i].Captures.Count + j]))
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_745dsgg_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap2[i][j], iGrpCap2[i][j], iGrpCap2[i][match.Groups[i].Captures.Count + j]);
-                        }
-                    }
-                }
-            }
-
-            // [] public static Match Match(string input);     "x" option. Removes unescaped white space from the pattern. : Actual - " ([^/]+) ","x"
-            //"abc"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_746tegd";
-            iCountTestcases++;
-            r = new Regex("            ((.)+)      ", RegexOptions.IgnorePatternWhitespace);
-            m = r.Match("abc");
-            if (!m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_452wfdf! doesnot match");
-            }
-
-            // [] public static Match Match(string input);     "x" option. Removes unescaped white space from the pattern. : Actual - "\x20([^/]+)\x20","x"
-            //"abc"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_563rfg";
-            iCountTestcases++;
-            r = new Regex("\x20([^/]+)\x20\x20\x20\x20\x20\x20\x20", RegexOptions.IgnorePatternWhitespace);
-            m = r.Match(" abc       ");
-            if (!m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_865rfsg! doesnot match");
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
         }
-        catch (Exception exc_general)
+
+        // Single line mode "s". Includes new line character. : Actual - "([^/]+)","s"
+        // "abc\n"
+        regex = new Regex("(.*)", RegexOptions.Singleline);
+        match = regex.Match("abc\nsfc");
+        Assert.True(match.Success);
+
+        Assert.Equal(strMatch2, match.Value);
+        Assert.Equal(iMatch2[0], match.Index);
+        Assert.Equal(iMatch2[1], match.Length);
+
+        Assert.Equal(1, match.Captures.Count);
+        Assert.Equal(strMatch2, match.Captures[0].Value);
+        Assert.Equal(iMatch2[0], match.Captures[0].Index);
+        Assert.Equal(iMatch2[1], match.Captures[0].Length);
+
+        Assert.Equal(2, match.Groups.Count);
+
+        // Group 0 always is the Match
+        Assert.Equal(strMatch2, match.Groups[0].Value);
+        Assert.Equal(iMatch2[0], match.Groups[0].Index);
+        Assert.Equal(iMatch2[1], match.Groups[0].Length);
+
+        //Group 0's Capture is always the Match
+        Assert.Equal(1, match.Groups[0].Captures.Count);
+        Assert.Equal(strMatch2, match.Groups[0].Captures[0].Value);
+        Assert.Equal(iMatch2[0], match.Groups[0].Captures[0].Index);
+        Assert.Equal(iMatch2[1], match.Groups[0].Captures[0].Length);
+
+        for (int i = 1; i < match.Groups.Count; i++)
         {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+            Assert.Equal(strGroup2[i], match.Groups[i].Value);
+            Assert.Equal(iGroup2[i, 0], match.Groups[i].Index);
+            Assert.Equal(iGroup2[i, 1], match.Groups[i].Length);
+
+            Assert.Equal(1, match.Groups[i].Captures.Count);
+            for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+            {
+                Assert.Equal(strGrpCap2[i][j], match.Groups[i].Captures[j].Value);
+                Assert.Equal(iGrpCap2[i][j], match.Groups[i].Captures[j].Index);
+                Assert.Equal(iGrpCap2[i][match.Groups[i].Captures.Count + j], match.Groups[i].Captures[j].Length);
+            }
         }
 
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+        // "x" option. Removes unescaped white space from the pattern. : Actual - " ([^/]+) ","x"
+        // "abc"
+        regex = new Regex("            ((.)+)      ", RegexOptions.IgnorePatternWhitespace);
+        match = regex.Match("abc");
+        Assert.True(match.Success);
+
+        // "x" option. Removes unescaped white space from the pattern. : Actual - "\x20([^/]+)\x20","x"
+        // "abc"
+        regex = new Regex("\x20([^/]+)\x20\x20\x20\x20\x20\x20\x20", RegexOptions.IgnorePatternWhitespace);
+        match = regex.Match(" abc       ");
+        Assert.True(match.Success);
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RegexMatchTests9.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchTests9.cs
@@ -9,100 +9,42 @@ using Xunit;
 public partial class RegexMatchTests
 {
     /*
-    Tested Methods:
-
-        public static Match Match(string input);     Turning on case insensitive option in mid-pattern : Actual - "aaa(?i:match this)bbb"
-            "aaaMaTcH ThIsbbb"
-
-        public static Match Match(string input);     Turning off case insensitive option in mid-pattern : Actual - "aaa(?-i:match this)bbb", "i"
-            "AaAmatch thisBBb"
-
-        public static Match Match(string input);     Turning on/off all the options at once : Actual - "aaa(?imnsx-imnsx:match this)bbb", "i"
-            "AaAmatch thisBBb"
-
-        public static Match Match(string input);     Comments : Actual - "aaa(?#ignore this completely)bbb"
-            "aaabbb"
-
+    public Match Match(string input, RegexOptions options);
+        - Turning on case insensitive option in mid-pattern : Actual - "aaa(?i:match this)bbb", "aaaMaTcH ThIsbbb"
+        - Turning off case insensitive option in mid-pattern : Actual - "aaa(?-i:match this)bbb", "i", "AaAmatch thisBBb"
+        - Turning on/off all the options at once : Actual - "aaa(?imnsx-imnsx:match this)bbb", "i", "AaAmatch thisBBb"
+        - Actual - "aaa(?#ignore this completely)bbb", "aaabbb"
     */
-
     [Fact]
     public static void RegexMatchTestCase9()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Regex r;
-        Match m;
-        try
+        // Turning on case insensitive option in mid-pattern : Actual - "aaa(?i:match this)bbb"
+        // "aaaMaTcH ThIsbbb"
+        Regex regex;
+        Match match;
+        if ("i".ToUpper() == "I")
         {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] public static Match Match(string input);     Turning on case insensitive option in mid-pattern : Actual - "aaa(?i:match this)bbb"
-            //"aaaMaTcH ThIsbbb"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            if ("i".ToUpper() == "I")
-            {
-                r = new Regex("aaa(?i:match this)bbb");
-                m = r.Match("aaaMaTcH ThIsbbb");
-                if (!m.Success)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_234fsadg! doesnot match");
-                }
-            }
-
-            // [] public static Match Match(string input);     Turning off case insensitive option in mid-pattern : Actual - "aaa(?-i:match this)bbb", "i"
-            //"AaAmatch thisBBb"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            r = new Regex("aaa(?-i:match this)bbb", RegexOptions.IgnoreCase);
-            m = r.Match("AaAmatch thisBBb");
-            if (!m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_87543! doesnot match");
-            }
-
-            // [] public static Match Match(string input);     Turning on/off all the options at once : Actual - "aaa(?imnsx-imnsx:match this)bbb", "i"
-            //"AaAmatch thisBBb"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_746tegd";
-            iCountTestcases++;
-            r = new Regex("aaa(?-i:match this)bbb", RegexOptions.IgnoreCase);
-            m = r.Match("AaAmatcH thisBBb");
-            if (m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_452wfdf! doesnot match");
-            }
-
-            // [] public static Match Match(string input);     Comments : Actual - "aaa(?#ignore this completely)bbb"
-            //"aaabbb"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_563rfg";
-            iCountTestcases++;
-            r = new Regex("aaa(?#ignore this completely)bbb");
-            m = r.Match("aaabbb");
-            if (!m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_865rfsg! doesnot match");
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
-        }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+            regex = new Regex("aaa(?i:match this)bbb");
+            match = regex.Match("aaaMaTcH ThIsbbb");
+            Assert.True(match.Success);
         }
 
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+        // Turning off case insensitive option in mid-pattern : Actual - "aaa(?-i:match this)bbb", "i"
+        // "AaAmatch thisBBb"
+        regex = new Regex("aaa(?-i:match this)bbb", RegexOptions.IgnoreCase);
+        match = regex.Match("AaAmatch thisBBb");
+        Assert.True(match.Success);
+
+        // Turning on/off all the options at once : Actual - "aaa(?imnsx-imnsx:match this)bbb", "i"
+        // "AaAmatch thisBBb"
+        regex = new Regex("aaa(?-i:match this)bbb", RegexOptions.IgnoreCase);
+        match = regex.Match("AaAmatcH thisBBb");
+        Assert.False(match.Success);
+
+        // Actual - "aaa(?#ignore this completely)bbb"
+        // "aaabbb"
+        regex = new Regex("aaa(?#ignore this completely)bbb");
+        match = regex.Match("aaabbb");
+        Assert.True(match.Success);
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RegexMatchValueTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexMatchValueTests.cs
@@ -11,216 +11,78 @@ public class RegexMatchValueTests
     [Fact]
     public static void MatchValue()
     {
-        //////////// Global Variables used for all tests
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        String strLoc = "Loc_000oo";
-        Regex rgx1;
-        Match mtch1;
-        String strInput;
-        String strExpected;
-        GroupCollection grpc1;
-        CaptureCollection capc1;
-        String[] arrGroupExp =
+        string[] arrGroupExp = { "aaabbcccccccccc", "aaa", "bb", "cccccccccc" };
+        string[] arrGroupExp1 = { "abracadabra", "abra", "cad" };
+        string[] arrCaptureExp = { "aaabbcccccccccc", "aaa", "bb", "cccccccccc" };
+        string[] arrCaptureExp1 = { "abracad", "abra" };
+
+        // Test the Value property of Match, Group and Capture here. Value is the more semantic equivalent of
+        // the current ToString
+        // trim leading and trailing white spaces
+        // my answer to the csharp alias, Regex.Replace(strInput, @"\s*(.*?)\s*$", "${1}") works fine, Even Freidl gives it
+        // a solution, albeit not a very fast one
+        Regex regex = new Regex(@"\s*(.*?)\s*$");
+        string input = " Hello World ";
+        Match match = regex.Match(input);
+        if (match.Success)
         {
-        "aaabbcccccccccc", "aaa", "bb", "cccccccccc"
+            Assert.Equal(input, match.Value);
         }
 
-        ;
-        String[] arrGroupExp1 =
+        // for Groups and Captures
+        regex = new Regex(@"(?<A1>a*)(?<A2>b*)(?<A3>c*)");
+        input = "aaabbccccccccccaaaabc";
+        match = regex.Match(input);
+        if (match.Success)
         {
-        "abracadabra", "abra", "cad"
-        }
+            string expected = "aaabbcccccccccc";
+            Assert.Equal(expected, match.Value);
 
-        ;
-        String[] arrCaptureExp =
-        {
-        "aaabbcccccccccc", "aaa", "bb", "cccccccccc"
-        }
-
-        ;
-        String[] arrCaptureExp1 =
-        {
-        "abracad", "abra"
-        }
-
-        ;
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            //[] We are testing the Value property of Match, Group and Capture here. Value is the more semantic equivalent of
-            //the current ToString
-            //trim leading and trailing white spaces
-            //my answer to the csharp alias, Regex.Replace(strInput, @"\s*(.*?)\s*$", "${1}") works fine, Even Freidl gives it
-            //a solution, albeit not a very fast one
-            iCountTestcases++;
-            rgx1 = new Regex(@"\s*(.*?)\s*$");
-            strInput = " Hello World ";
-            mtch1 = rgx1.Match(strInput);
-            if (mtch1.Success)
+            Assert.Equal(4, match.Groups.Count);
+            for (int i = 0; i < match.Groups.Count; i++)
             {
-                strExpected = strInput;
-                if (!strExpected.Equals(mtch1.Value))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_759ed! The expected value was not returned, Expected - {0} Returned - {1}", strExpected, mtch1.Value);
-                }
+                Assert.Equal(arrGroupExp[i], match.Groups[i].Value);
+
+                Assert.Equal(1, match.Groups[i].Captures.Count);
+                Assert.Equal(arrGroupExp[i], match.Groups[i].Captures[0].Value);
             }
 
-            //[]for Groups and Captures
-            iCountTestcases++;
-            rgx1 = new Regex(@"(?<A1>a*)(?<A2>b*)(?<A3>c*)");
-            strInput = "aaabbccccccccccaaaabc";
-            mtch1 = rgx1.Match(strInput);
-            if (mtch1.Success)
-            {
-                strExpected = "aaabbcccccccccc";
-                if (!strExpected.Equals(mtch1.Value))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_745fg! The expected value was not returned, Expected - {0} Returned - {1}", strExpected, mtch1.Value);
-                }
-
-                grpc1 = mtch1.Groups;
-                if (grpc1.Count != 4)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_67fdaq! The expected value was not returned, Expected - 4 Returned - {0}", grpc1.Count);
-                }
-
-                for (int i = 0; i < grpc1.Count; i++)
-                {
-                    if (!arrGroupExp[i].Equals(grpc1[i].Value))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_00213534_{2}! The expected value was not returned, Expected - {0} Returned - {1}", arrGroupExp[i], grpc1[i].Value, i);
-                    }
-
-                    //Group has a Captures property too
-                    capc1 = grpc1[i].Captures;
-                    if (capc1.Count != 1)
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_0834esfd! The expected value was not returned, Expected - 1 Returned - {0}", capc1.Count);
-                    }
-
-                    if (!arrGroupExp[i].Equals(capc1[0].Value))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_974535! The expected value was not returned, Expected - {0} Returned - {1}", arrGroupExp[i], capc1[0].Value);
-                    }
-                }
-
-                capc1 = mtch1.Captures;
-                if (capc1.Count != 1)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_863trfg! The expected value was not returned, Expected - 1 Returned - {0}", capc1.Count);
-                }
-
-                strExpected = "aaabbcccccccccc";
-                if (!strExpected.Equals(capc1[0].Value))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_97463dfsg! The expected value was not returned, Expected - {0} Returned - {1}", strExpected, capc1[0].Value);
-                }
-            }
-
-            //Another example - given by Brad Merril in an article on RegularExpressions
-            iCountTestcases++;
-            rgx1 = new Regex(@"(abra(cad)?)+");
-            strInput = "abracadabra1abracadabra2abracadabra3";
-            mtch1 = rgx1.Match(strInput);
-            while (mtch1.Success)
-            {
-                strExpected = "abracadabra";
-                if (!strExpected.Equals(mtch1.Value))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_7342wsdg! The expected value was not returned, Expected - {0} Returned - {1}", strExpected, mtch1.Value);
-                }
-
-                grpc1 = mtch1.Groups;
-                if (grpc1.Count != 3)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_9745fgg! The expected value was not returned, Expected - 4 Returned - {0}", grpc1.Count);
-                }
-
-                for (int i = 0; i < grpc1.Count; i++)
-                {
-                    if (!arrGroupExp1[i].Equals(grpc1[i].Value))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_8756fdg! The expected value was not returned, Expected - {0} Returned - {1}", arrGroupExp1[i], grpc1[i].Value, i);
-                    }
-
-                    //Group has a Captures property too
-                    capc1 = grpc1[i].Captures;
-                    switch (i)
-                    {
-                        case 1:
-                            if (capc1.Count != 2)
-                            {
-                                iCountErrors++;
-                                Console.WriteLine("Err_9745fgs! The expected value was not returned, Expected - 1 Returned - {0}", capc1.Count);
-                            }
-
-                            for (int j = 0; j < capc1.Count; j++)
-                            {
-                                if (!arrCaptureExp1[j].Equals(capc1[j].Value))
-                                {
-                                    iCountErrors++;
-                                    Console.WriteLine("Err_97453sdf! The expected value was not returned, Expected - {0} Returned - {1}", arrGroupExp[j], capc1[j].Value);
-                                }
-                            }
-
-                            break;
-                        case 2:
-                            if (capc1.Count != 1)
-                            {
-                                iCountErrors++;
-                                Console.WriteLine("Err_8473rsg! The expected value was not returned, Expected - 1 Returned - {0}", capc1.Count);
-                            }
-
-                            strExpected = "cad";
-                            if (!strExpected.Equals(capc1[0].Value))
-                            {
-                                iCountErrors++;
-                                Console.WriteLine("Err_9743rfsfg! The expected value was not returned, Expected - {0} Returned - {1}", strExpected, capc1[0].Value);
-                            }
-
-                            break;
-                    }
-                }
-
-                capc1 = mtch1.Captures;
-                if (capc1.Count != 1)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_7453fgds! The expected value was not returned, Expected - 1 Returned - {0}", capc1.Count);
-                }
-
-                strExpected = "abracadabra";
-                if (!strExpected.Equals(capc1[0].Value))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_0753rdg! The expected value was not returned, Expected - {0} Returned - {1}", strExpected, capc1[0].Value);
-                }
-
-                mtch1 = mtch1.NextMatch();
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
+            Assert.Equal(1, match.Captures.Count);
+            Assert.Equal(expected, match.Captures[0].Value);
         }
-        catch (Exception exc_general)
+
+        // Another example - given by Brad Merril in an article on RegularExpressions
+        regex = new Regex(@"(abra(cad)?)+");
+        input = "abracadabra1abracadabra2abracadabra3";
+        match = regex.Match(input);
+        while (match.Success)
         {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==\n" + exc_general.ToString());
-        }
+            string expected = "abracadabra";
+            Assert.Equal(expected, match.Value);
 
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+            Assert.Equal(3, match.Groups.Count);
+            for (int i = 0; i < match.Groups.Count; i++)
+            {
+                Assert.Equal(arrGroupExp1[i], match.Groups[i].Value);
+                // Group has a Captures property too
+                if (i == 1)
+                {
+                    Assert.Equal(2, match.Groups[i].Captures.Count);
+                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+                    {
+                        Assert.Equal(arrCaptureExp1[j], match.Groups[i].Captures[j].Value);
+                    }
+                }
+                else if (i == 2)
+                {
+                    expected = "cad";
+                    Assert.Equal(1, match.Groups[i].Captures.Count);
+                    Assert.Equal(expected, match.Groups[i].Captures[0].Value);
+                }
+            }
+            Assert.Equal(1, match.Captures.Count);
+            Assert.Equal("abracadabra", match.Captures[0].Value);
+            match = match.NextMatch();
+        }
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RegexReplaceStringTests0.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexReplaceStringTests0.cs
@@ -12,299 +12,151 @@ public partial class RegexReplaceStringTests
     [Fact]
     public static void RegexReplaceStringTestCase0()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Regex r;
-        String s;
-        String sResult;
-        Int32 i;
-        String pattern;
-        String sExp;
-        Match match;
-        try
+        string input = "08/10/99 16:00";
+        Regex regex = new Regex(@"(?<1>\d{1,2})/(?<2>\d{1,2})/(?<3>\d{2,4})\s(?<time>\S+)");
+        Match match = regex.Match(input);
+        string result = regex.Match(input).Result("${time}");
+
+        Assert.Equal("16:00", result);
+
+        result = regex.Match(input).Result("$1");
+        Assert.Equal("08", result);
+
+        result = regex.Match(input).Result("$2");
+        Assert.Equal("10", result);
+
+        result = regex.Match(input).Result("$3");
+        Assert.Equal("99", result);
+
+        // Regex.Replace()
+        input = "08/10/99 16:00";
+        result = Regex.Replace(input, @"[^ ]+\s(?<time>)", "${time}");
+        Assert.Equal("16:00", result);
+        Assert.Equal("08/10/99 16:00", input);
+
+        input = "MiCrOsOfT";
+        result = Regex.Replace(input, "icrosoft", "icrosoft", RegexOptions.IgnoreCase);
+        Assert.Equal("Microsoft", result);
+
+        input = "my dog has fleas";
+        result = Regex.Replace(input, "dog", "CAT", RegexOptions.IgnoreCase);
+        Assert.Equal("my CAT has fleas", result);
+
+        input = "D.Bau";
+        regex = new Regex(@"D\.(.+)");
+        result = regex.Replace(input, "David $1");
+        Assert.Equal("David Bau", result);
+
+        input = "aaaaa";
+        regex = new Regex("a");
+        result = regex.Replace(input, "b", 2);
+        Assert.Equal("bbaaa", result);
+
+        result = regex.Replace(input, "b", 2, 3);
+        Assert.Equal("aaabb", result);
+        
+        // Replace with MatchEvaluators - relevant fn's for this are defined below
+        result = Regex.Replace("Big mountain", "(Big|Small)", new MatchEvaluator(Rep1));
+        Assert.Equal("Huge mountain", result);
+
+        result = Regex.Replace("Small village", "(Big|Small)", new MatchEvaluator(Rep1));
+        Assert.Equal("Tiny village", result);
+
+        if ("i".ToUpper() == "I")
         {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] Group name checks
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            s = "08/10/99 16:00";
-            r = new Regex(@"(?<1>\d{1,2})/(?<2>\d{1,2})/(?<3>\d{2,4})\s(?<time>\S+)");
-            match = r.Match(s);
-            sResult = r.Match(s).Result("${time}");
-            if (!sResult.Equals("16:00"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_234fsadg! doesnot match, " + sResult);
-            }
-
-            sResult = r.Match(s).Result("$1");
-            if (!sResult.Equals("08"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_234fsadg! doesnot match, " + sResult);
-            }
-
-            sResult = r.Match(s).Result("$2");
-            if (!sResult.Equals("10"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_234fsadg! doesnot match, " + sResult);
-            }
-
-            sResult = r.Match(s).Result("$3");
-            if (!sResult.Equals("99"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_234fsadg! doesnot match, " + sResult);
-            }
-
-            // [] Regex.Replace()
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            s = "08/10/99 16:00";
-            sResult = Regex.Replace(s, @"[^ ]+\s(?<time>)", "${time}");
-            if (!sResult.Equals("16:00") || !s.Equals("08/10/99 16:00"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_0723gsg! doesnot match, " + sResult + " " + s);
-            }
-
-            s = "MiCrOsOfT";
-            sResult = Regex.Replace(s, "icrosoft", "icrosoft", RegexOptions.IgnoreCase);
-            if (!sResult.Equals("Microsoft"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_174ds! doesnot match, " + sResult + " " + s);
-            }
-
-            s = "my dog has fleas";
-            sResult = Regex.Replace(s, "dog", "CAT", RegexOptions.IgnoreCase);
-            if (!sResult.Equals("my CAT has fleas"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_174ds! doesnot match, " + sResult + " " + s);
-            }
-
-            s = "D.Bau";
-            r = new Regex(@"D\.(.+)");
-            sResult = r.Replace(s, "David $1");
-            if (!sResult.Equals("David Bau"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_5734s! doesnot match, " + sResult + " " + s);
-            }
-
-            s = "aaaaa";
-            r = new Regex("a");
-            sResult = r.Replace(s, "b", 2);
-            if (!sResult.Equals("bbaaa"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_78453fgs! doesnot match, " + sResult + " " + s);
-            }
-
-            sResult = r.Replace(s, "b", 2, 3);
-            if (!sResult.Equals("aaabb"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_712ff! doesnot match, " + sResult + " " + s);
-            }
-
-            // [] Replace with MatchEvaluators - relevant fn's for this are defined below
-            //-----------------------------------------------------------------
-            strLoc = "Loc_746tegd";
-            sResult = Regex.Replace("Big mountain", "(Big|Small)", new MatchEvaluator(Rep1));
-            iCountTestcases++;
-            if (!sResult.Equals("Huge mountain"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_452wfdf! doesnot match, " + sResult);
-            }
-
-            sResult = Regex.Replace("Small village", "(Big|Small)", new MatchEvaluator(Rep1));
-            if (!sResult.Equals("Tiny village"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_8420sgf! doesnot match, " + sResult);
-            }
-
-            if ("i".ToUpper() == "I")
-            {
-                sResult = Regex.Replace("bIG horse", "(Big|Small)", new MatchEvaluator(Rep1), RegexOptions.IgnoreCase);
-                if (!sResult.Equals("Huge horse"))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_232fg! doesnot match, " + sResult);
-                }
-            }
-
-            sResult = Regex.Replace("sMaLl dog", "(Big|Small)", new MatchEvaluator(Rep1), RegexOptions.IgnoreCase);
-            if (!sResult.Equals("Tiny dog"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_073235rdfa! doesnot match, " + sResult);
-            }
-
-            r = new Regex(".+");
-            sResult = r.Replace("XSP_TEST_FAILURE", new MatchEvaluator(Rep2));
-            if (!sResult.Equals("SUCCESS"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_246egsd! doesnot match, " + sResult);
-            }
-
-            r = new Regex("[abcabc]");
-            sResult = r.Replace("abcabc", new MatchEvaluator(Rep3));
-            if (!sResult.Equals("ABCABC"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_75432sg! doesnot match, " + sResult);
-            }
-
-            r = new Regex("[abcabc]");
-            sResult = r.Replace("abcabc", new MatchEvaluator(Rep3), 3);
-            if (!sResult.Equals("ABCabc"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_75432sg! doesnot match, " + sResult);
-            }
-
-            r = new Regex("[abcabc]");
-            sResult = r.Replace("abcabc", new MatchEvaluator(Rep3), 3, 2);
-            if (!sResult.Equals("abCABc"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_75432sg! doesnot match, " + sResult);
-            }
-
-            // [] Replace with group numbers
-            //-----------------------------------------------------------------
-            strLoc = "Loc_563rfg";
-            iCountTestcases++;
-            r = new Regex("([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z])))))))))))))))");
-            sResult = r.Replace("abcdefghiklmnop", "$15");
-            if (!sResult.Equals("p"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_865rfsg! doesnot match, " + sResult);
-            }
-
-            sResult = r.Replace("abcdefghiklmnop", "$3");
-            if (!sResult.Equals("cdefghiklmnop"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_9752fsf! doesnot match, " + sResult);
-            }
-
-            //Stress
-            pattern = String.Empty;
-            for (i = 0; i < 1000; i++)
-                pattern += "([a-z]";
-            for (i = 0; i < 1000; i++)
-                pattern += ")";
-            s = String.Empty;
-            for (i = 0; i < 200; i++)
-                s += "abcde";
-            r = new Regex(pattern);
-            sResult = r.Replace(s, "$1000");
-            if (!sResult.Equals("e"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_98725rdfsg! doesnot match, " + sResult);
-            }
-
-            sResult = r.Replace(s, "$1");
-            sExp = String.Empty;
-            for (i = 0; i < 200; i++)
-                sExp += "abcde";
-            if (!sResult.Equals(sExp))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_1074wf! doesnot match, " + sResult);
-            }
-
-            //undefined group
-            sResult = Regex.Replace("abc", "([a_z])(.+)", "$3");
-            if (!sResult.Equals("$3"))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_1074wf! doesnot match, " + sResult);
-            }
-
-            // Regression test:
-            // Regex treating Devanagari matra characters as matching "\b"
-            // Unicode characters in the "Mark, NonSpacing" Category, U+0902=Devanagari sign anusvara, U+0947=Devanagri vowel sign E
-            try
-            {
-                iCountTestcases++;
-                Regex regexRendering = new Regex(@"\u0915\u0930.*?\b", RegexOptions.CultureInvariant | RegexOptions.Singleline);
-                String strBoldedText = regexRendering.Replace("\u092f\u0939 \u0915\u0930 \u0935\u0939 \u0915\u0930\u0947\u0902 \u0939\u0948\u0964", RepBold);
-                String expectedBoldedText = "\u092f\u0939 <b>\u0915\u0930</b> \u0935\u0939 <b>\u0915\u0930\u0947\u0902</b> \u0939\u0948\u0964";
-                if (strBoldedText != expectedBoldedText)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_788921gh! Devanagari matra characters are threated as \"\b\"");
-                    Console.WriteLine("Expected string: {0}\nActual string: {1}", GetUnicodeString(expectedBoldedText), GetUnicodeString(strBoldedText));
-                }
-            }
-            catch (Exception e)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_788921! Unexpected Exception: " + e);
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
-        }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
+            result = Regex.Replace("bIG horse", "(Big|Small)", new MatchEvaluator(Rep1), RegexOptions.IgnoreCase);
+            Assert.Equal("Huge horse", result);
         }
 
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+        result = Regex.Replace("sMaLl dog", "(Big|Small)", new MatchEvaluator(Rep1), RegexOptions.IgnoreCase);
+        Assert.Equal("Tiny dog", result);
+
+        regex = new Regex(".+");
+        result = regex.Replace("XSP_TEST_FAILURE", new MatchEvaluator(Rep2));
+        Assert.Equal("SUCCESS", result);
+
+        regex = new Regex("[abcabc]");
+        result = regex.Replace("abcabc", new MatchEvaluator(Rep3));
+        Assert.Equal("ABCABC", result);
+
+        regex = new Regex("[abcabc]");
+        result = regex.Replace("abcabc", new MatchEvaluator(Rep3), 3);
+        Assert.Equal("ABCabc", result);
+
+        regex = new Regex("[abcabc]");
+        result = regex.Replace("abcabc", new MatchEvaluator(Rep3), 3, 2);
+        Assert.Equal("abCABc", result);
+
+        // Replace with group numbers
+        regex = new Regex("([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z]([a-z])))))))))))))))");
+        result = regex.Replace("abcdefghiklmnop", "$15");
+        Assert.Equal("p", result);
+
+        result = regex.Replace("abcdefghiklmnop", "$3");
+        Assert.Equal("cdefghiklmnop", result);
+
+        // Stress
+        string pattern = string.Empty;
+        for (int i = 0; i < 1000; i++)
+            pattern += "([a-z]";
+        for (int i = 0; i < 1000; i++)
+            pattern += ")";
+        input = string.Empty;
+        for (int i = 0; i < 200; i++)
+            input += "abcde";
+        regex = new Regex(pattern);
+        result = regex.Replace(input, "$1000");
+        Assert.Equal("e", result);
+
+        result = regex.Replace(input, "$1");
+        string sExp = string.Empty;
+        for (int i = 0; i < 200; i++)
+            sExp += "abcde";
+        Assert.Equal(sExp, result);
+
+        // Undefined group
+        result = Regex.Replace("abc", "([a_z])(.+)", "$3");
+        Assert.Equal("$3", result);
+
+        // Regression test:
+        // Regex treating Devanagari matra characters as matching "\b"
+        // Unicode characters in the "Mark, NonSpacing" Category, U+0902=Devanagari sign anusvara, U+0947=Devanagri vowel sign E
+        Regex regexRendering = new Regex(@"\u0915\u0930.*?\b", RegexOptions.CultureInvariant | RegexOptions.Singleline);
+        string strBoldedText = regexRendering.Replace("\u092f\u0939 \u0915\u0930 \u0935\u0939 \u0915\u0930\u0947\u0902 \u0939\u0948\u0964", RepBold);
+        string expectedBoldedText = "\u092f\u0939 <b>\u0915\u0930</b> \u0935\u0939 <b>\u0915\u0930\u0947\u0902</b> \u0939\u0948\u0964";
+        Assert.Equal(expectedBoldedText, strBoldedText);
     }
 
-    public static String Rep1(Match input)
+    public static string Rep1(Match input)
     {
-        String s = String.Empty;
-        if (String.Compare(input.ToString(), "Big", StringComparison.CurrentCultureIgnoreCase) == 0)
-            s = "Huge";
+        if (string.Compare(input.ToString(), "Big", StringComparison.CurrentCultureIgnoreCase) == 0)
+            return "Huge";
         else
-            s = "Tiny";
-        return s;
+            return "Tiny";
     }
 
-    public static String Rep2(Match input)
+    public static string Rep2(Match input)
     {
         return "SUCCESS";
     }
 
-    public static String Rep3(Match input)
+    public static string Rep3(Match input)
     {
-        String s = String.Empty;
-        if (input.ToString().Equals("a"))
-            s = "A";
-        if (input.ToString().Equals("b"))
-            s = "B";
-        if (input.ToString().Equals("c"))
-            s = "C";
-        return s;
+        if (input.Value.Equals("a"))
+            return "A";
+        if (input.Value.Equals("b"))
+            return "B";
+        if (input.Value.Equals("c"))
+            return "C";
+        return string.Empty;
     }
 
-    public static String RepBold(Match m)
+    public static string RepBold(Match m)
     {
-        string str = m.ToString();
-        return String.Format("<b>{0}</b>", str);
+        return string.Format("<b>{0}</b>", m.Value);
     }
 
-    static String GetUnicodeString(String str)
+    private static string GetUnicodeString(string str)
     {
         StringBuilder buffer = new StringBuilder();
         for (int i = 0; i < str.Length; i++)
@@ -323,6 +175,6 @@ public partial class RegexReplaceStringTests
             }
         }
 
-        return (buffer.ToString());
+        return buffer.ToString();
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RegexReplaceStringTests1.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexReplaceStringTests1.cs
@@ -11,38 +11,13 @@ public partial class RegexReplaceStringTests
     [Fact]
     public static void RegexReplaceStringTestCase1()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        try
+        for (int i = 0; i < s_regexTests.Length; i++)
         {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            for (int i = 0; i < _regexTests.Length; i++)
-            {
-                iCountTestcases++;
-                if (!_regexTests[i].Run())
-                {
-                    Console.WriteLine("Err_79872asnko! Test {0} FAILED Pattern={1}, Input={2} ReplaceString={3}\n", i, _regexTests[i].Pattern, _regexTests[i].Input, _regexTests[i].ReplaceString);
-                    iCountErrors++;
-                }
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
+            Assert.True(s_regexTests[i].Run());
         }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
     }
 
-    private static RegexReplaceStringTest[] _regexTests = new RegexReplaceStringTest[]
+    private static RegexReplaceStringTest[] s_regexTests = new RegexReplaceStringTest[]
     {
         /*********************************************************
         ValidCases
@@ -58,18 +33,18 @@ public partial class RegexReplaceStringTests
     ;
     public class RegexReplaceStringTest
     {
-        private String _pattern;
-        private String _input;
+        private string _pattern;
+        private string _input;
         private RegexOptions _options;
-        private String _replaceString;
-        private String _expectedResult;
+        private string _replaceString;
+        private string _expectedResult;
         private Type _expectedExceptionType;
-        public RegexReplaceStringTest(String pattern, String input, String replaceString, String expectedResult)
+        public RegexReplaceStringTest(string pattern, string input, string replaceString, string expectedResult)
             : this(pattern, RegexOptions.None, input, replaceString, expectedResult)
         {
         }
 
-        public RegexReplaceStringTest(String pattern, RegexOptions options, String input, String replaceString, String expectedResult)
+        public RegexReplaceStringTest(string pattern, RegexOptions options, string input, string replaceString, string expectedResult)
         {
             _pattern = pattern;
             _options = options;
@@ -78,12 +53,12 @@ public partial class RegexReplaceStringTests
             _expectedResult = expectedResult;
         }
 
-        public RegexReplaceStringTest(String pattern, String input, String replaceString, Type expectedExceptionType)
+        public RegexReplaceStringTest(string pattern, string input, string replaceString, Type expectedExceptionType)
             : this(pattern, RegexOptions.None, input, replaceString, expectedExceptionType)
         {
         }
 
-        public RegexReplaceStringTest(String pattern, RegexOptions options, String input, String replaceString, Type expectedExceptionType)
+        public RegexReplaceStringTest(string pattern, RegexOptions options, string input, string replaceString, Type expectedExceptionType)
         {
             _pattern = pattern;
             _options = options;
@@ -116,7 +91,7 @@ public partial class RegexReplaceStringTests
             }
         }
 
-        public String ReplaceString
+        public string ReplaceString
         {
             get
             {
@@ -124,7 +99,7 @@ public partial class RegexReplaceStringTests
             }
         }
 
-        public String ExpectedResult
+        public string ExpectedResult
         {
             get
             {
@@ -159,7 +134,7 @@ public partial class RegexReplaceStringTests
         public bool Run()
         {
             Regex r;
-            String result = null;
+            string result = null;
             r = new Regex(_pattern, _options);
             try
             {

--- a/src/System.Text.RegularExpressions/tests/RegexSplitTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexSplitTests.cs
@@ -9,142 +9,35 @@ using Xunit;
 public class RegexSplitTests
 {
     /*
-    Tested Methods:
-
-        public static String[] Split(string input);     ":"
-            "kkk:lll:mmm:nnn:ooo"
-
-        public static String[] Split(string input, Int32 count);     ":"
-            "kkk:lll:mmm:nnn:ooo", 2
-
-        public static String[] Split(string input, Int32 count, Int32 startat);     ":"
-            "kkk:lll:mmm:nnn:ooo", 3, 6
-
+        public static String[] Split(string input); ":", "kkk:lll:mmm:nnn:ooo"
+        public static String[] Split(string input, Int32 count); ":", "kkk:lll:mmm:nnn:ooo", 2
+        public static String[] Split(string input, Int32 count, Int32 startat); ":", "kkk:lll:mmm:nnn:ooo", 3, 6
     */
-
     [Fact]
     public static void RegexSplit()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Regex r;
-        String s;
-        String[] sa;
-        String[] saExp = new String[]
-        {
-        "kkk", "lll", "mmm", "nnn", "ooo"
-        }
+        string[] saExp = new string[] { "kkk", "lll", "mmm", "nnn", "ooo" };
+        string[] saExp1 = new string[] { "kkk", "lll:mmm:nnn:ooo" };
+        string[] saExp2 = new string[] { "kkk:lll", "mmm", "nnn:ooo" };
+        string input = "kkk:lll:mmm:nnn:ooo";
+        Regex regex = new Regex(":");
 
-        ;
-        String[] saExp1 = new String[]
-        {
-        "kkk", "lll:mmm:nnn:ooo"
-        }
+        // Split(string)
+        string[] result = regex.Split(input);
+        Assert.Equal(saExp, result);
 
-        ;
-        String[] saExp2 = new String[]
-        {
-        "kkk:lll", "mmm", "nnn:ooo"
-        }
+        // A count of 0 means split all
+        result = regex.Split(input, 0);
+        Assert.Equal(saExp, result);
 
-        ;
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            s = "kkk:lll:mmm:nnn:ooo";
-            r = new Regex(":");
-            // [] Scenario 1 
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            sa = r.Split(s);
-            if (sa.Length != 5)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_8452esgf! doesnot match");
-            }
+        // public static String[] Split(string input, Int32 count); ":"
+        // "kkk:lll:mmm:nnn:ooo", 2
+        result = regex.Split(input, 2);
+        Assert.Equal(saExp1, result);
 
-            for (int i = 0; i < sa.Length; i++)
-            {
-                if (!sa[i].Equals(saExp[i]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_234fsadg! doesnot match {0} Expected - {1} Returned - {2}", i, saExp[i], sa[i]);
-                }
-            }
-
-            //a count of 0 means split all
-            sa = r.Split(s, 0);
-            if (sa.Length != 5)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_765wgdd! doesnot match");
-            }
-
-            for (int i = 0; i < sa.Length; i++)
-            {
-                if (!sa[i].Equals(saExp[i]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_0174wfg! doesnot match {0} Expected - {1} Returned - {2}", i, saExp[i], sa[i]);
-                }
-            }
-
-            // [] public static String[] Split(string input, Int32 count);     ":"
-            //"kkk:lll:mmm:nnn:ooo", 2
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            sa = r.Split(s, 2);
-            if (sa.Length != 2)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_2435fsd! doesnot match");
-            }
-
-            for (int i = 0; i < sa.Length; i++)
-            {
-                if (!sa[i].Equals(saExp1[i]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_s2345fs! doesnot match {0} Expected - {1} Returned - {2}", i, saExp1[i], sa[i]);
-                }
-            }
-
-            // [] public static String[] Split(string input, Int32 count, Int32 startat);     ":"
-            //"kkk:lll:mmm:nnn:ooo", 3, 6
-            //-----------------------------------------------------------------
-            strLoc = "Loc_746tegd";
-            iCountTestcases++;
-            sa = r.Split(s, 3, 6);
-            if (sa.Length != 3)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_4532gdg! does not match");
-            }
-
-            for (int i = 0; i < sa.Length; i++)
-            {
-                if (!sa[i].Equals(saExp2[i]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_845fd! doesnot match {0} Expected - {1} Returned - {2}", i, saExp2[i], sa[i]);
-                }
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
-        }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+        // public static String[] Split(string input, Int32 count, Int32 startat); ":"
+        // "kkk:lll:mmm:nnn:ooo", 3, 6
+        result = regex.Split(input, 3, 6);
+        Assert.Equal(saExp2, result);
     }
 }

--- a/src/System.Text.RegularExpressions/tests/ReturnValueChecks.cs
+++ b/src/System.Text.RegularExpressions/tests/ReturnValueChecks.cs
@@ -12,173 +12,61 @@ public class ReturnValueChecks
     [Fact]
     public static void ReturnValueChecksTests()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        String strMatch1 = "aaabb.cc";
-        Int32[] iMatch1 =
-        {
-        0, 8
-        }
+        string strMatch1 = "aaabb.cc";
+        int[] iMatch1 = { 0, 8 };
+        string[] strGroup1 = { "aaabb.cc", "bb.c", "c" };
+        int[,] iGroup1 = { { 0, 8 }, { 3, 4 }, { 7, 1 } };
+        string[,] strGrpCap1 = { { "aaabb.cc" }, { "bb.c" }, { "c" } };
+        int[,,] iGrpCap1 = { { { 0, 8 } }, { { 3, 4 } }, { { 7, 1 } } };
 
-        ;
-        String[] strGroup1 =
-        {
-        "aaabb.cc", "bb.c", "c"
-        }
+        // Using *, +, ?, {} : Actual - "a+\\.?b*\\.?c{2}"
+        // "ab.cc"
+        Regex result = new Regex(@"a+\.?b*\.+c{2}");
+        Match match = result.Match("ab.cc");
+        Assert.True(match.Success);
 
-        ;
-        Int32[,] iGroup1 =
-        {
-        {
-        0, 8
-        }
+        // Using |, (), ^, $, .: Actual - "^aaa(bb.+)(d|c)$"
+        // "aaabb.cc"
+        result = new Regex("^aaa(bb.+)(d|c)$");
+        match = result.Match("aaabb.cc");
+        Assert.True(match.Success);
 
-        , {
-        3, 4
-        }
+        Assert.Equal(strMatch1, match.Value);
+        Assert.Equal(iMatch1[0], match.Index);
+        Assert.Equal(iMatch1[1], match.Length);
 
-        , {
-        7, 1
-        }
-        }
+        Assert.Equal(1, match.Captures.Count);
+        Assert.Equal(strMatch1, match.Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Captures[0].Length);
 
-        ;
-        //This could be a rectangular array
-        String[,] strGrpCap1 =
-        {
-        {
-        "aaabb.cc"
-        }
+        Assert.Equal(3, match.Groups.Count);
 
-        , {
-        "bb.c"
-        }
+        // Group 0 always is the Match
+        Assert.Equal(strMatch1, match.Groups[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Length);
 
-        , {
-        "c"
-        }
-        }
+        //Group 0's Capture is always the Match
+        Assert.Equal(1, match.Groups[0].Captures.Count);
+        Assert.Equal(strMatch1, match.Groups[0].Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Captures[0].Length);
 
-        ;
-        Int32[,,] iGrpCap1 =
+        for (int i = 1; i < match.Groups.Count; i++)
         {
-        {
-        {
-        0, 8
-        }
-        }
+            Assert.Equal(strGroup1[i], match.Groups[i].Value);
+            Assert.Equal(iGroup1[i, 0], match.Groups[i].Index);
+            Assert.Equal(iGroup1[i, 1], match.Groups[i].Length);
 
-        , {
-        {
-        3, 4
-        }
-        }
+            Assert.Equal(1, match.Groups[i].Captures.Count);
 
-        , {
-        {
-        7, 1
-        }
-        }
-        }
-
-        ;
-        Regex r;
-        Match match;
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] public static Match Match(string input);     Using *, +, ?, {} : Actual - "a+\\.?b*\\.?c{2}"
-            //"ab.cc"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            r = new Regex(@"a+\.?b*\.+c{2}");
-            match = r.Match("ab.cc");
-            if (!match.Success)
+            for (int j = 0; j < match.Groups[i].Captures.Count; j++)
             {
-                iCountErrors++;
-                Console.WriteLine("Err_4532gvfs! 1 do not match");
+                Assert.Equal(strGrpCap1[i, j], match.Groups[i].Captures[j].Value);
+                Assert.Equal(iGrpCap1[i, j, 0], match.Groups[i].Captures[j].Index);
+                Assert.Equal(iGrpCap1[i, j, 1], match.Groups[i].Captures[j].Length);
             }
-
-            // [] public static Match Match(string input);     Using |, (), ^, $, .: Actual - "^aaa(bb.+)(d|c)$"
-            //"aaabb.cc"
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            r = new Regex("^aaa(bb.+)(d|c)$");
-            match = r.Match("aaabb.cc");
-            if (!match.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_7563rfsgf! 2 do not match");
-            }
-            else
-            {
-                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_98275dsg: unexpected return result");
-                }
-
-                //Match.Captures always is Match
-                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                if (match.Groups.Count != 3)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_75324sg! unexpected return result");
-                }
-
-                //Group 0 always is the Match
-                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                //Group 0's Capture is always the Match
-                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2975edg!! unexpected return result");
-                }
-
-                for (int i = 1; i < match.Groups.Count; i++)
-                {
-                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != 1))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1]);
-                    }
-
-                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
-                    {
-                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i, j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i, j, 0]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i, j, 1]))
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i, j], iGrpCap1[i, j, 0], iGrpCap1[i, j, 1]);
-                        }
-                    }
-                }
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
         }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
     }
 }

--- a/src/System.Text.RegularExpressions/tests/RightToLeft.cs
+++ b/src/System.Text.RegularExpressions/tests/RightToLeft.cs
@@ -12,364 +12,111 @@ public class RightToLeft
     [Fact]
     public static void RightToLeftTests()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo"; // 000ooOooo spooky
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        Regex r;
-        String s;
-        Match m;
-        MatchCollection mCollection;
-        string replace, actualResult, expectedResult;
-        string[] splitResult, expectedSplitResult;
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            //[]IsMatch(string) with RightToLeft
-            strLoc = "Loc_sdfa9849";
-            r = new Regex(@"\s+\d+", RegexOptions.RightToLeft);
-            s = @"sdf 12sad";
-            if (!r.IsMatch(s))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_16891dfa Expected match");
-            }
+        // IsMatch(string) with RightToLeft
+        Regex regex = new Regex(@"\s+\d+", RegexOptions.RightToLeft);
+        string input = "sdf 12sad";
+        Assert.True(regex.IsMatch(input));
 
-            s = @" asdf12 ";
-            if (r.IsMatch(s))
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_16891dafes Did not expect match");
-            }
+        input = " asdf12 ";
+        Assert.False(regex.IsMatch(input));
 
-            //[]Match(string, int, int) with RightToLeft
-            strLoc = "Loc_6589aead";
-            r = new Regex(@"foo\d+", RegexOptions.RightToLeft);
-            s = @"0123456789foo4567890foo         ";
-            m = r.Match(s, 0, s.Length);
-            if (!m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_86847sdae Expected match");
-            }
+        // Match(string, int, int) with RightToLeft
+        regex = new Regex(@"foo\d+", RegexOptions.RightToLeft);
+        input = "0123456789foo4567890foo         ";
+        Match match = regex.Match(input, 0, input.Length);
+        Assert.True(match.Success);
+        Assert.Equal("foo4567890", match.Value);
 
-            if (m.Value != "foo4567890")
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_4988awea Expected Value={0} actual={1}", "foo4567890", m.Value);
-            }
+        match = regex.Match(input, 10, input.Length - 10);
+        Assert.True(match.Success);
+        Assert.Equal("foo4567890", match.Value);
 
-            m = r.Match(s, 10, s.Length - 10);
-            if (!m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_658asea Expected match");
-            }
+        match = regex.Match(input, 10, 4);
+        Assert.True(match.Success);
+        Assert.Equal("foo4", match.Value);
 
-            if (m.Value != "foo4567890")
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_6488ead Expected Value={0} actual={1}", "foo4567890", m.Value);
-            }
+        match = regex.Match(input, 10, 3);
+        Assert.False(match.Success);
 
-            m = r.Match(s, 10, 4);
-            if (!m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_2389eads Expected match");
-            }
+        match = regex.Match(input, 11, input.Length - 11);
+        Assert.False(match.Success);
 
-            if (m.Value != "foo4")
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_65489asdead Expected Value={0} actual={1}", "foo4", m.Value);
-            }
+        // Matches(string) with RightToLeft
+        regex = new Regex(@"foo\d+", RegexOptions.RightToLeft);
+        input = "0123456789foo4567890foo1foo  0987";
 
-            m = r.Match(s, 10, 3);
-            if (m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_6489sdfwa Did not expect match");
-            }
+        MatchCollection collection = regex.Matches(input);
+        Assert.Equal(2, collection.Count);
+        Assert.Equal("foo1", collection[0].Value);
+        Assert.Equal("foo4567890", collection[1].Value);
 
-            m = r.Match(s, 11, s.Length - 11);
-            if (m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_64542adesa Did not expect match");
-            }
+        // Replace(string, string) with RightToLeft
+        regex = new Regex(@"foo\s+", RegexOptions.RightToLeft);
+        input = "0123456789foo4567890foo         ";
+        string replace = "bar";
+        string replaceResult = regex.Replace(input, replace);
+        Assert.Equal("0123456789foo4567890bar", replaceResult);
 
-            //[]Matches(string) with RightToLeft
-            strLoc = "Loc_49487depmz";
-            r = new Regex(@"foo\d+", RegexOptions.RightToLeft);
-            s = @"0123456789foo4567890foo1foo  0987";
-            mCollection = r.Matches(s);
-            if (mCollection.Count != 2)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_49889eadf Expected match");
-            }
-            else
-            {
-                if (mCollection[0].Value != "foo1")
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_8977eade Expected Value={0} actual={1}", "foo1", mCollection[0].Value);
-                }
+        // Replace(string, string, int count) with RightToLeft
+        regex = new Regex(@"\d", RegexOptions.RightToLeft);
+        input = "0123456789foo4567890foo         ";
+        replace = "#";
+        replaceResult = regex.Replace(input, replace, 17);
+        Assert.Equal("##########foo#######foo         ", replaceResult);
 
-                if (mCollection[1].Value != "foo4567890")
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_97884dsae Expected Value={0} actual={1}", "foo4567890", mCollection[0].Value);
-                }
-            }
+        replaceResult = regex.Replace(input, replace, 7);
+        Assert.Equal("0123456789foo#######foo         ", replaceResult);
 
-            //[]Replace(string, string) with RightToLeft
-            strLoc = "Loc_3215dsfg";
-            r = new Regex(@"foo\s+", RegexOptions.RightToLeft);
-            s = @"0123456789foo4567890foo         ";
-            replace = "bar";
-            actualResult = r.Replace(s, replace);
-            expectedResult = "0123456789foo4567890bar";
-            if (actualResult != expectedResult)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_65489asdead Expected Result={0} actual={1}", expectedResult, actualResult);
-            }
+        replaceResult = regex.Replace(input, replace, 0);
+        Assert.Equal("0123456789foo4567890foo         ", replaceResult);
 
-            //[]Replace(string, string, int count) with RightToLeft
-            strLoc = "Loc_90822safwe";
-            r = new Regex(@"\d", RegexOptions.RightToLeft);
-            s = @"0123456789foo4567890foo         ";
-            replace = "#";
-            actualResult = r.Replace(s, replace, 17);
-            expectedResult = "##########foo#######foo         ";
-            if (actualResult != expectedResult)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_1658asead Expected Result='{0}' actual='{1}'", expectedResult, actualResult);
-            }
+        replaceResult = regex.Replace(input, replace, -1);
+        Assert.Equal("##########foo#######foo         ", replaceResult);
 
-            actualResult = r.Replace(s, replace, 7);
-            expectedResult = "0123456789foo#######foo         ";
-            if (actualResult != expectedResult)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_1238jhioa Expected Result='{0}' actual='{1}'", expectedResult, actualResult);
-            }
+        // Replace(string, MatchEvaluator) with RightToLeft
+        regex = new Regex(@"foo\s+", RegexOptions.RightToLeft);
+        input = "0123456789foo4567890foo         ";
+        replace = "bar";
+        replaceResult = regex.Replace(input, new MatchEvaluator(MyBarMatchEvaluator));
+        Assert.Equal("0123456789foo4567890bar", replaceResult);
 
-            actualResult = r.Replace(s, replace, 0);
-            expectedResult = "0123456789foo4567890foo         ";
-            if (actualResult != expectedResult)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_56498dafe Expected Result='{0}' actual='{1}'", expectedResult, actualResult);
-            }
+        // Replace(string, string, int count) with RightToLeft
+        regex = new Regex(@"\d", RegexOptions.RightToLeft);
+        input = "0123456789foo4567890foo         ";
+        replaceResult = regex.Replace(input, new MatchEvaluator(MyPoundMatchEvaluator), 17);
+        Assert.Equal("##########foo#######foo         ", replaceResult);
 
-            actualResult = r.Replace(s, replace, -1);
-            expectedResult = "##########foo#######foo         ";
-            if (actualResult != expectedResult)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_80972jnklase Expected Result='{0}' actual='{1}'", expectedResult, actualResult);
-            }
+        replaceResult = regex.Replace(input, new MatchEvaluator(MyPoundMatchEvaluator), 7);
+        Assert.Equal("0123456789foo#######foo         ", replaceResult);
 
-            //[]Replace(string, MatchEvaluator) with RightToLeft
-            strLoc = "Loc_5645eade";
-            r = new Regex(@"foo\s+", RegexOptions.RightToLeft);
-            s = @"0123456789foo4567890foo         ";
-            replace = "bar";
-            actualResult = r.Replace(s, new MatchEvaluator(MyBarMatchEvaluator));
-            expectedResult = "0123456789foo4567890bar";
-            if (actualResult != expectedResult)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_489894sead Expected Result={0} actual={1}", expectedResult, actualResult);
-            }
+        replaceResult = regex.Replace(input, new MatchEvaluator(MyPoundMatchEvaluator), 0);
+        Assert.Equal("0123456789foo4567890foo         ", replaceResult);
 
-            //[]Replace(string, string, int count) with RightToLeft
-            strLoc = "Loc_6548eada";
-            r = new Regex(@"\d", RegexOptions.RightToLeft);
-            s = @"0123456789foo4567890foo         ";
-            actualResult = r.Replace(s, new MatchEvaluator(MyPoundMatchEvaluator), 17);
-            expectedResult = "##########foo#######foo         ";
-            if (actualResult != expectedResult)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_6589adsfe Expected Result='{0}' actual='{1}'", expectedResult, actualResult);
-            }
+        replaceResult = regex.Replace(input, new MatchEvaluator(MyPoundMatchEvaluator), -1);
+        Assert.Equal("##########foo#######foo         ", replaceResult);
 
-            actualResult = r.Replace(s, new MatchEvaluator(MyPoundMatchEvaluator), 7);
-            expectedResult = "0123456789foo#######foo         ";
-            if (actualResult != expectedResult)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_65489eadea Expected Result='{0}' actual='{1}'", expectedResult, actualResult);
-            }
+        // Split(string) with RightToLeft
+        regex = new Regex("foo", RegexOptions.RightToLeft);
+        input = "0123456789foo4567890foo         ";
+        string[] splitResult = regex.Split(input);
+        Assert.Equal(new string[] { "0123456789", "4567890", "         " }, splitResult);
 
-            actualResult = r.Replace(s, new MatchEvaluator(MyPoundMatchEvaluator), 0);
-            expectedResult = "0123456789foo4567890foo         ";
-            if (actualResult != expectedResult)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_56489eafd Expected Result='{0}' actual='{1}'", expectedResult, actualResult);
-            }
+        // Split(string, int) with RightToLeft
+        regex = new Regex(@"\d", RegexOptions.RightToLeft);
+        input = "1a2b3c4d5e6f7g8h9i0k";
+        splitResult = regex.Split(input, 11);
+        Assert.Equal(new string[] { "", "a", "b", "c", "d", "e", "f", "g", "h", "i", "k" }, splitResult);
 
-            actualResult = r.Replace(s, new MatchEvaluator(MyPoundMatchEvaluator), -1);
-            expectedResult = "##########foo#######foo         ";
-            if (actualResult != expectedResult)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_6487eafd Expected Result='{0}' actual='{1}'", expectedResult, actualResult);
-            }
+        splitResult = regex.Split(input, 10);
+        Assert.Equal(new string[] { "1a", "b", "c", "d", "e", "f", "g", "h", "i", "k" }, splitResult);
 
-            //[]Split(string) with RightToLeft
-            strLoc = "Loc_5645eade";
-            r = new Regex(@"foo", RegexOptions.RightToLeft);
-            s = @"0123456789foo4567890foo         ";
-            splitResult = r.Split(s);
-            expectedSplitResult = new string[]
-            {
-            "0123456789", "4567890", "         "
-            }
+        splitResult = regex.Split(input, 2);
+        Assert.Equal(new string[] { "1a2b3c4d5e6f7g8h9i", "k" }, splitResult);
 
-            ;
-            if (splitResult.Length != expectedSplitResult.Length)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_65489aeee Expected {0} string actual={1}", expectedSplitResult.Length, splitResult.Length);
-            }
-            else
-            {
-                for (int i = 0; i < expectedSplitResult.Length; i++)
-                {
-                    if (splitResult[i] != expectedSplitResult[i])
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_0232jkoas Expected Result={0} actual={1}", expectedSplitResult[i], splitResult[i]);
-                    }
-                }
-            }
-
-            //[]Split(string, int) with RightToLeft
-            strLoc = "Loc_5645eade";
-            r = new Regex(@"\d", RegexOptions.RightToLeft);
-            s = @"1a2b3c4d5e6f7g8h9i0k";
-            splitResult = r.Split(s, 11);
-            expectedSplitResult = new string[]
-            {
-            "", "a", "b", "c", "d", "e", "f", "g", "h", "i", "k"
-            }
-
-            ;
-            if (splitResult.Length != expectedSplitResult.Length)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_68ead Expected {0} string actual={1}", expectedSplitResult.Length, splitResult.Length);
-            }
-            else
-            {
-                for (int i = 0; i < expectedSplitResult.Length; i++)
-                {
-                    if (splitResult[i] != expectedSplitResult[i])
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_1235eas Expected Result={0} actual={1}", expectedSplitResult[i], splitResult[i]);
-                    }
-                }
-            }
-
-            splitResult = r.Split(s, 10);
-            expectedSplitResult = new string[]
-            {
-            "1a", "b", "c", "d", "e", "f", "g", "h", "i", "k"
-            }
-
-            ;
-            if (splitResult.Length != expectedSplitResult.Length)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_66898adejl Expected {0} string actual={1}", expectedSplitResult.Length, splitResult.Length);
-            }
-            else
-            {
-                for (int i = 0; i < expectedSplitResult.Length; i++)
-                {
-                    if (splitResult[i] != expectedSplitResult[i])
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_9648kojk Expected Result={0} actual={1}", expectedSplitResult[i], splitResult[i]);
-                    }
-                }
-            }
-
-            splitResult = r.Split(s, 2);
-            expectedSplitResult = new string[]
-            {
-            "1a2b3c4d5e6f7g8h9i", "k"
-            }
-
-            ;
-            if (splitResult.Length != expectedSplitResult.Length)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_66898adejl Expected {0} string actual={1}", expectedSplitResult.Length, splitResult.Length);
-            }
-            else
-            {
-                for (int i = 0; i < expectedSplitResult.Length; i++)
-                {
-                    if (splitResult[i] != expectedSplitResult[i])
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_9648kojk Expected Result={0} actual={1}", expectedSplitResult[i], splitResult[i]);
-                    }
-                }
-            }
-
-            splitResult = r.Split(s, 1);
-            expectedSplitResult = new string[]
-            {
-            "1a2b3c4d5e6f7g8h9i0k"
-            }
-
-            ;
-            if (splitResult.Length != expectedSplitResult.Length)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_56987dellp Expected {0} string actual={1}", expectedSplitResult.Length, splitResult.Length);
-            }
-            else
-            {
-                for (int i = 0; i < expectedSplitResult.Length; i++)
-                {
-                    if (splitResult[i] != expectedSplitResult[i])
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_13678jhuy Expected Result={0} actual={1}", expectedSplitResult[i], splitResult[i]);
-                    }
-                }
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
-        }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-
-        Assert.Equal(0, iCountErrors);
+        splitResult = regex.Split(input, 1);
+        Assert.Equal(new string[] { "1a2b3c4d5e6f7g8h9i0k" }, splitResult);
     }
 
-    private static string MyBarMatchEvaluator(Match m)
-    {
-        return "bar";
-    }
-
-    private static string MyPoundMatchEvaluator(Match m)
-    {
-        return "#";
-    }
+    private static string MyBarMatchEvaluator(Match match) => "bar";
+    private static string MyPoundMatchEvaluator(Match match) => "#";
 }

--- a/src/System.Text.RegularExpressions/tests/RightToLeftMatchStartAtTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RightToLeftMatchStartAtTests.cs
@@ -9,203 +9,67 @@ using Xunit;
 public class RightToLeftMatchStartAtTests
 {
     /*
-    Tested Methods:
-
-        public static Boolean RightToLeft;
-
-        public static Match Match(string input, Int32 startat);     "aaa"
-            "aaabbb", 3
-
-        public static Match Match(string input, Int32 startat);     "aaa", "r"
-            "aaabbb", 3
-
-        public static Match Match(string input, Int32 startat);     "AAA", "i"
-            "aaabbb", 3
+    public Boolean RightToLeft;
+    public Match Match(string input, int start);
+        - "aaa", "aaabbb", 3
+        - "aaa", "r", "aaabbb", 3
+        - "AAA", "i", "aaabbb", 3
     */
-
     [Fact]
     public static void RightToLeftMatchStartAt()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
-        Regex r;
-        String s;
-        Match m;
-        Match match;
-        String strMatch1 = "aaa";
-        Int32[] iMatch1 =
-        {
-        0, 3
-        }
+        string strMatch1 = "aaa";
+        int[] iMatch1 = { 0, 3 };
+        string[] strGroup1 = { "aaa" };
+        int[,] iGroup1 = { { 0, 3 } };
+        string[][] strGrpCap1 = new string[1][];
+        strGrpCap1[0] = new string[] { "aaa" };
+        int[][] iGrpCap1 = new int[1][];
+        iGrpCap1[0] = new int[] { 5, 9, 3, 3 };
+        int[] iGrpCapCnt1 = { 1, 1 };
+        
+        // public Boolean RightToLeft;
+        Regex regex = new Regex("aaa");
+        Assert.False(regex.RightToLeft); 
+        
+        regex = new Regex("aaa", RegexOptions.RightToLeft);
+        Assert.True(regex.RightToLeft);
 
-        ;
-        String[] strGroup1 =
-        {
-        "aaa"
-        }
+        // public Match Match(string input, int start); "aaa", "aaabbb", 3
+        regex = new Regex("aaa");
+        Match match = regex.Match("aaabbb", 3);
+        Assert.False(match.Success);
 
-        ;
-        Int32[,] iGroup1 =
-        {
-        {
-        0, 3
-        }
-        }
+        // [] public static Match Match(string input, Int32 startat); "aaa", "r", "aaabbb", 3
+        regex = new Regex("aaa", RegexOptions.RightToLeft);
+        match = regex.Match("aaabbb", 3);
+        Assert.True(match.Success);
 
-        ;
-        String[][] strGrpCap1 = new String[1][];
-        strGrpCap1[0] = new String[]
-        {
-        "aaa"
-        }
+        Assert.Equal(strMatch1, match.Value);
+        Assert.Equal(iMatch1[0], match.Index);
+        Assert.Equal(iMatch1[1], match.Length);
 
-        ;
-        Int32[][] iGrpCap1 = new Int32[1][];
-        iGrpCap1[0] = new Int32[]
-        {
-        5, 9, 3, 3
-        }
+        Assert.Equal(1, match.Captures.Count);
 
-        ; //This is ignored
-        Int32[] iGrpCapCnt1 =
-        {
-        1, 1
-        }
+        Assert.Equal(strMatch1, match.Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Captures[0].Length);
 
-        ; //0 is ignored
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            // [] public static Boolean RightToLeft;
-            //-----------------------------------------------------------------
-            strLoc = "Loc_498yg";
-            iCountTestcases++;
-            r = new Regex("aaa");
-            if (r.RightToLeft)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_234fsadg! doesnot match");
-            }
+        Assert.Equal(1, match.Groups.Count);
 
-            // [] public static Boolean RightToLeft
-            //-----------------------------------------------------------------
-            strLoc = "Loc_746tegd";
-            iCountTestcases++;
-            r = new Regex("aaa", RegexOptions.RightToLeft);
-            if (!r.RightToLeft)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_452wfdf! doesnot match");
-            }
+        // Group 0 always is the Match
+        Assert.Equal(strMatch1, match.Groups[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Length);
 
-            // [] public static Match Match(string input, Int32 startat);     "aaa"
-            //"aaabbb", 3
-            //-----------------------------------------------------------------
-            strLoc = "Loc_298vy";
-            iCountTestcases++;
-            s = "aaabbb";
-            r = new Regex("aaa");
-            m = r.Match(s, 3);
-            if (m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_87543! doesnot match");
-            }
+        Assert.Equal(1, match.Groups[0].Captures.Count);
+        Assert.Equal(strMatch1, match.Groups[0].Captures[0].Value);
+        Assert.Equal(iMatch1[0], match.Groups[0].Captures[0].Index);
+        Assert.Equal(iMatch1[1], match.Groups[0].Captures[0].Length);
 
-            // [] public static Match Match(string input, Int32 startat);     "aaa", "r"
-            //"aaabbb", 3
-            //-----------------------------------------------------------------
-            strLoc = "Loc_563rfg";
-            iCountTestcases++;
-            s = "aaabbb";
-            r = new Regex("aaa", RegexOptions.RightToLeft);
-            match = r.Match(s, 3);
-            if (!match.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_865rfsg! doesnot match");
-            }
-            else
-            {
-                if (!match.Value.Equals(strMatch1) || (match.Index != iMatch1[0]) || (match.Length != iMatch1[1]) || (match.Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_98275dsg: unexpected return result");
-                }
-
-                //Match.Captures always is Match
-                if (!match.Captures[0].Value.Equals(strMatch1) || (match.Captures[0].Index != iMatch1[0]) || (match.Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                if (match.Groups.Count != 1)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_75324sg! unexpected return result");
-                }
-
-                //Group 0 always is the Match
-                if (!match.Groups[0].Value.Equals(strMatch1) || (match.Groups[0].Index != iMatch1[0]) || (match.Groups[0].Length != iMatch1[1]) || (match.Groups[0].Captures.Count != 1))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2046gsg! unexpected return result");
-                }
-
-                //Group 0's Capture is always the Match
-                if (!match.Groups[0].Captures[0].Value.Equals(strMatch1) || (match.Groups[0].Captures[0].Index != iMatch1[0]) || (match.Groups[0].Captures[0].Length != iMatch1[1]))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_2975edg!! unexpected return result");
-                }
-
-                for (int i = 1; i < match.Groups.Count; i++)
-                {
-                    if (!match.Groups[i].Value.Equals(strGroup1[i]) || (match.Groups[i].Index != iGroup1[i, 0]) || (match.Groups[i].Length != iGroup1[i, 1]) || (match.Groups[i].Captures.Count != iGrpCapCnt1[i]))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_1954eg_" + i + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>, CaptureCount = <{6}:{7}>", match.Groups[i].Value, match.Groups[i].Index, match.Groups[i].Length, strGroup1[i], iGroup1[i, 0], iGroup1[i, 1], match.Groups[i].Captures.Count, iGrpCapCnt1[i]);
-                    }
-
-                    for (int j = 0; j < match.Groups[i].Captures.Count; j++)
-                    {
-                        if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap1[i][j]) || (match.Groups[i].Captures[j].Index != iGrpCap1[i][j]) || (match.Groups[i].Captures[j].Length != iGrpCap1[i][match.Groups[i].Captures.Count + j]))
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_5072dn_" + i + "_" + j + "! unexpected return result, Value = <{0}:{3}>, Index = <{1}:{4}>, Length = <{2}:{5}>", match.Groups[i].Captures[j].Value, match.Groups[i].Captures[j].Index, match.Groups[i].Captures[j].Length, strGrpCap1[i][j], iGrpCap1[i][j], iGrpCap1[i][match.Groups[i].Captures.Count + j]);
-                        }
-                    }
-                }
-            }
-
-            // []     public static Match Match(string input);     "AAA", "i"
-            //"aaabbb", 3
-            //-----------------------------------------------------------------
-            strLoc = "Loc_3452sdg";
-            iCountTestcases++;
-            s = "aaabbb";
-            r = new Regex("AAA", RegexOptions.IgnoreCase);
-            m = r.Match(s);
-            if (!m.Success)
-            {
-                iCountErrors++;
-                Console.WriteLine("Err_fsdfxcvz! doesnot match");
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
-        }
-        catch (Exception exc_general)
-        {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
-
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+        // public Match Match(string input); "AAA", "i", "aaabbb", 3
+        regex = new Regex("AAA", RegexOptions.IgnoreCase);
+        match = regex.Match("aaabbb");
+        Assert.True(match.Success);
     }
 }

--- a/src/System.Text.RegularExpressions/tests/SplitMatchIsMatchTests.cs
+++ b/src/System.Text.RegularExpressions/tests/SplitMatchIsMatchTests.cs
@@ -9,284 +9,91 @@ using Xunit;
 public class SplitMatchIsMatchTests
 {
     /*
-        Class: Regex
-        Tested Methods:
-
-            public static string[] Split(string input, string pattern);
-                very simple
-
-            public static bool IsMatch(string input, string pattern, string options);
-                "m" option with 5 patterns
-
-            public static bool IsMatch(string input, string pattern);
-                "abc", "^b"
-
-            public static Match Match(string input, string pattern);     ???
-                "XSP_TEST_FAILURE SUCCESS", ".*\\b(\\w+)\\b"
+        public static string[] Split(string input, string pattern); very simple
+        public static bool IsMatch(string input, string pattern, string options); "m" option with 5 patterns
+        public static bool IsMatch(string input, string pattern); "abc", "^b"
+        public static Match Match(string input, string pattern); ???, "XSP_TEST_FAILURE SUCCESS", ".*\\b(\\w+)\\b"
     */
-
     [Fact]
     public static void SplitMatchIsMatch()
     {
-        //////////// Global Variables used for all tests
-        String strLoc = "Loc_000oo";
-        String strValue = String.Empty;
-        int iCountErrors = 0;
-        int iCountTestcases = 0;
+        string[] strMatch1 = { "line2\nline3", "line2\nline3", "line3\n\nline4", "line3\n\nline4", "line2\nline3" };
+        int[,] iMatch1 = { { 6, 11 }, { 6, 11 }, { 12, 12 }, { 12, 12 }, { 6, 11 } };
+        string[] strGroup1 = { };
+        string[] strGrpCap1 = { };
+
+        string strMatch2 = "XSP_TEST_FAILURE SUCCESS";
+        int[] iMatch2 = { 0, 24 };
+        string[] strGroup2 = { "XSP_TEST_FAILURE SUCCESS", "SUCCESS" };
+        int[] iGroup2 = { 17, 7 };
+        string[] strGrpCap2 = { "SUCCESS" };
+        int[] iGrpCap2 = { 17, 7 };
+        
+        // public static string[] Split(string input, string pattern); very simple
+        string[] sa = Regex.Split("word0    word1    word2    word3", "    ");
+        Assert.Equal(new string[] { "word0", "word1", "word2", "word3" }, sa);
+
+        // public static bool IsMatch(string input, string pattern, string options); "m" option with 5 patterns
         Match match;
-        String[] sa;
-        String[] strMatch1 =
+        sa = new string[] { "(line2$\n)line3", "(line2\n^)line3", "(line3\n$\n)line4", "(line3\n^\n)line4", "(line2$\n^)line3" };
+        for (int i = 0; i < sa.Length; i++)
         {
-        "line2\nline3", "line2\nline3", "line3\n\nline4", "line3\n\nline4", "line2\nline3"
-        }
+            Assert.True(Regex.IsMatch("line1\nline2\nline3\n\nline4", sa[i], RegexOptions.Multiline));
+            match = Regex.Match("line1\nline2\nline3\n\nline4", sa[i], RegexOptions.Multiline);
 
-        ;
-        Int32[,] iMatch1 =
-        {
-        {
-        6, 11
-        }
+            Assert.Equal(strMatch1[i], match.Value);
+            Assert.Equal(iMatch1[i, 0], match.Index);
+            Assert.Equal(iMatch1[i, 1], match.Length);
 
-        , {
-        6, 11
-        }
-
-        , {
-        12, 12
-        }
-
-        , {
-        12, 12
-        }
-
-        , {
-        6, 11
-        }
-        }
-
-        ;
-        String[] strGroup1 =
-        {
-        }
-
-        ;
-        String[] strGrpCap1 =
-        {
-        }
-
-        ;
-        String strMatch2 = "XSP_TEST_FAILURE SUCCESS";
-        Int32[] iMatch2 =
-        {
-        0, 24
-        }
-
-        ;
-        String[] strGroup2 =
-        {
-        "XSP_TEST_FAILURE SUCCESS", "SUCCESS"
-        }
-
-        ;
-        Int32[] iGroup2 =
-        {
-        17, 7
-        }
-
-        ;
-        String[] strGrpCap2 =
-        {
-        "SUCCESS"
-        }
-
-        ;
-        Int32[] iGrpCap2 =
-        {
-        17, 7
-        }
-
-        ;
-        try
-        {
-            /////////////////////////  START TESTS ////////////////////////////
-            ///////////////////////////////////////////////////////////////////
-            try
+            Assert.Equal(1, match.Captures.Count);
+            for (int j = 0; j < match.Captures.Count; j++)
             {
-                // []     public static string[] Split(string input, string pattern);
-                //    very simple
-                //-----------------------------------------------------------------
-                strLoc = "Loc_498yg";
-                iCountTestcases++;
-                sa = Regex.Split("word0    word1    word2    word3", "    ");
-                for (int i = 0; i < sa.Length; i++)
-                {
-                    String s = "word" + i;
-                    if (String.Compare(sa[i], s) != 0)
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_7654fdgd! Fail : [" + s + "] not equal [" + sa[i] + "]");
-                    }
-                }
-                //-----------------------------------------------------------------
+                Assert.Equal(strMatch1[i], match.Captures[j].Value);
+                Assert.Equal(iMatch1[i, 0], match.Captures[j].Index);
+                Assert.Equal(iMatch1[i, 1], match.Captures[j].Length);
             }
-            catch
-            {
-            }
-
-            try
-            {
-                // [] public static bool IsMatch(string input, string pattern, string options);
-                //"m" option with 5 patterns
-                //-----------------------------------------------------------------
-                strLoc = "Loc_298vy";
-                iCountTestcases++;
-                sa = new String[5];
-                sa[0] = "(line2$\n)line3";
-                sa[1] = "(line2\n^)line3";
-                sa[2] = "(line3\n$\n)line4";
-                sa[3] = "(line3\n^\n)line4";
-                sa[4] = "(line2$\n^)line3";
-                for (int ii = 0; ii < sa.Length; ii++)
-                {
-                    strLoc = "Loc_0002." + ii.ToString();
-                    if (!Regex.IsMatch("line1\nline2\nline3\n\nline4", sa[ii], RegexOptions.Multiline))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Fail : " + strLoc + " : Pattern not match");
-                    }
-                    else
-                    {
-                        match = Regex.Match("line1\nline2\nline3\n\nline4", sa[ii], RegexOptions.Multiline);
-                        if (!match.Value.Equals(strMatch1[ii]) || (match.Index != iMatch1[ii, 0]) || (match.Length != iMatch1[ii, 1]) || (match.Captures.Count != 1))
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_75234_" + ii + " : unexpected return result");
-                        }
-
-                        for (int i = 0; i < match.Captures.Count; i++)
-                        {
-                            if (!match.Captures[i].Value.Equals(strMatch1[ii]) || (match.Captures[i].Index != iMatch1[ii, 0]) || (match.Captures[i].Length != iMatch1[ii, 1]))
-                            {
-                                iCountErrors++;
-                                Console.WriteLine("Err_8743fsgd_" + ii + "_" + i + " : unexpected return result");
-                            }
-                        }
-
-                        if (match.Groups.Count != 2)
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_3976dffd! unexpected return result");
-                        }
-                    }
-                }
-                //-----------------------------------------------------------------
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex);
-            }
-
-            try
-            {
-                // [] public static bool IsMatch(string input, string pattern);
-                //"abc", "^b"
-                //-----------------------------------------------------------------
-                strLoc = "Loc_75rfds";
-                iCountTestcases++;
-                if (Regex.IsMatch("abc", "^b"))
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_7356wgd! Fail : " + strLoc + " : unexpected match");
-                }
-                //-----------------------------------------------------------------
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex);
-            }
-
-            try
-            {
-                // [] public static Match Match(string input, string pattern);     ???
-                //"XSP_TEST_FAILURE SUCCESS", ".*\\b(\\w+)\\b"
-                //-----------------------------------------------------------------
-                strLoc = "Loc_87423fs";
-                iCountTestcases++;
-                match = Regex.Match("XSP_TEST_FAILURE SUCCESS", @".*\b(\w+)\b");
-                if (!match.Success)
-                {
-                    iCountErrors++;
-                    Console.WriteLine("Err_753rwef! Unexpected results returned");
-                }
-                else
-                {
-                    if (!match.Value.Equals(strMatch2) || (match.Index != iMatch2[0]) || (match.Length != iMatch2[1]) || (match.Captures.Count != 1))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_98275dsg: unexpected return result");
-                    }
-
-                    //Match.Captures always is Match
-                    if (!match.Captures[0].Value.Equals(strMatch2) || (match.Captures[0].Index != iMatch2[0]) || (match.Captures[0].Length != iMatch2[1]))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_2046gsg! unexpected return result");
-                    }
-
-                    if (match.Groups.Count != 2)
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_75324sg! unexpected return result");
-                    }
-
-                    //Group 0 always is the Match
-                    if (!match.Groups[0].Value.Equals(strMatch2) || (match.Groups[0].Index != iMatch2[0]) || (match.Groups[0].Length != iMatch2[1]) || (match.Groups[0].Captures.Count != 1))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_2046gsg! unexpected return result");
-                    }
-
-                    //Group 0's Capture is always the Match
-                    if (!match.Groups[0].Captures[0].Value.Equals(strMatch2) || (match.Groups[0].Captures[0].Index != iMatch2[0]) || (match.Groups[0].Captures[0].Length != iMatch2[1]))
-                    {
-                        iCountErrors++;
-                        Console.WriteLine("Err_2975edg!! unexpected return result");
-                    }
-
-                    for (int i = 1; i < match.Groups.Count; i++)
-                    {
-                        if (!match.Groups[i].Value.Equals(strGroup2[i]) || (match.Groups[i].Index != iGroup2[0]) || (match.Groups[i].Length != iGroup2[1]) || (match.Groups[i].Captures.Count != 1))
-                        {
-                            iCountErrors++;
-                            Console.WriteLine("Err_1954eg_" + i + "! unexpected return result");
-                        }
-
-                        for (int j = 0; j < match.Groups[i].Captures.Count; j++)
-                        {
-                            if (!match.Groups[i].Captures[j].Value.Equals(strGrpCap2[j]) || (match.Groups[i].Captures[j].Index != iGrpCap2[0]) || (match.Groups[i].Captures[j].Length != iGrpCap2[1]))
-                            {
-                                iCountErrors++;
-                                Console.WriteLine("Err_5072dn_" + i + "_" + j + "!! unexpected return result");
-                            }
-                        }
-                    }
-                }
-                //-----------------------------------------------------------------
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex);
-            }
-            ///////////////////////////////////////////////////////////////////
-            /////////////////////////// END TESTS /////////////////////////////
+            Assert.Equal(2, match.Groups.Count);
         }
-        catch (Exception exc_general)
+
+        // public static bool IsMatch(string input, string pattern); "abc", "^b"
+        Assert.False(Regex.IsMatch("abc", "^b"));
+        
+        // public static Match Match(string input, string pattern); ???, "XSP_TEST_FAILURE SUCCESS", ".*\\b(\\w+)\\b"
+        match = Regex.Match("XSP_TEST_FAILURE SUCCESS", @".*\b(\w+)\b");
+        Assert.True(match.Success);
+
+        Assert.Equal(strMatch2, match.Value);
+        Assert.Equal(iMatch2[0], match.Index);
+        Assert.Equal(iMatch2[1], match.Length);
+
+        Assert.Equal(1, match.Captures.Count);
+        Assert.Equal(strMatch2, match.Captures[0].Value);
+        Assert.Equal(iMatch2[0], match.Captures[0].Index);
+        Assert.Equal(iMatch2[1], match.Captures[0].Length);
+
+        Assert.Equal(2, match.Groups.Count);
+        Assert.Equal(strMatch2, match.Groups[0].Value);
+        Assert.Equal(iMatch2[0], match.Groups[0].Index);
+        Assert.Equal(iMatch2[1], match.Groups[0].Length);
+
+        Assert.Equal(1, match.Groups[0].Captures.Count);
+        Assert.Equal(strMatch2, match.Groups[0].Captures[0].Value);
+        Assert.Equal(iMatch2[0], match.Groups[0].Captures[0].Index);
+        Assert.Equal(iMatch2[1], match.Groups[0].Captures[0].Length);
+
+        for (int i = 1; i < match.Groups.Count; i++)
         {
-            ++iCountErrors;
-            Console.WriteLine("Error Err_8888yyy!  strLoc==" + strLoc + ", exc_general==" + exc_general.ToString());
-        }
+            Assert.Equal(strGroup2[i], match.Groups[i].Value);
+            Assert.Equal(iGroup2[0], match.Groups[i].Index);
+            Assert.Equal(iGroup2[1], match.Groups[i].Length);
 
-        ////  Finish Diagnostics
-        Assert.Equal(0, iCountErrors);
+            Assert.Equal(1, match.Groups[i].Captures.Count);
+            for (int j = 0; j < match.Groups[i].Captures.Count; j++)
+            {
+                Assert.Equal(strGroup2[i], match.Groups[i].Captures[j].Value);
+                Assert.Equal(iGroup2[0], match.Groups[i].Captures[j].Index);
+                Assert.Equal(iGroup2[1], match.Groups[i].Captures[j].Length);
+            }
+        }
     }
 }


### PR DESCRIPTION
This commit moves the tests for System.Text.RegularExpressions to use
xunit, instead of Console.WriteLine and really obfuscated error messages.
I have not added or removed any tests. I did, however, remove some obsolete test code for branches that would never occur.

Already, this test suite looks nicer. There is more to be done, however:
If/when this is merged, I will submit another PR consolidating common test code, and further modernizations including:
- Renaming tests and test files to make sense
- Splitting test data and test code
- Consolidating tests into various helper methods.

This PR contributes to #516 and #915