### PR TITLE
Remove DNXCore50 mentions from packages

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-1.0.25-prerelease-00177
+1.0.25-prerelease-00180

--- a/src/Microsoft.CSharp/pkg/Microsoft.CSharp.pkgproj
+++ b/src/Microsoft.CSharp/pkg/Microsoft.CSharp.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\Microsoft.CSharp.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\Microsoft.CSharp.builds" />
 

--- a/src/Microsoft.CSharp/pkg/Microsoft.CSharp.pkgproj
+++ b/src/Microsoft.CSharp/pkg/Microsoft.CSharp.pkgproj
@@ -1,13 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\Microsoft.CSharp.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\Microsoft.CSharp.builds" />
-
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45">
@@ -18,7 +16,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/Microsoft.VisualBasic/pkg/Microsoft.VisualBasic.pkgproj
+++ b/src/Microsoft.VisualBasic/pkg/Microsoft.VisualBasic.pkgproj
@@ -4,7 +4,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\Microsoft.VisualBasic.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\Microsoft.VisualBasic.builds" />
     

--- a/src/Microsoft.Win32.Primitives/pkg/Microsoft.Win32.Primitives.pkgproj
+++ b/src/Microsoft.Win32.Primitives/pkg/Microsoft.Win32.Primitives.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\Microsoft.Win32.Primitives.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\Microsoft.Win32.Primitives.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>

--- a/src/Microsoft.Win32.Primitives/pkg/Microsoft.Win32.Primitives.pkgproj
+++ b/src/Microsoft.Win32.Primitives/pkg/Microsoft.Win32.Primitives.pkgproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\Microsoft.Win32.Primitives.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
@@ -9,16 +8,16 @@
     <ProjectReference Include="..\src\Microsoft.Win32.Primitives.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </ProjectReference>
-
     <ProjectReference Include="win\Microsoft.Win32.Primitives.pkgproj" />
     <ProjectReference Include="unix\Microsoft.Win32.Primitives.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/Microsoft.Win32.Registry.AccessControl/pkg/Microsoft.Win32.Registry.AccessControl.pkgproj
+++ b/src/Microsoft.Win32.Registry.AccessControl/pkg/Microsoft.Win32.Registry.AccessControl.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\Microsoft.Win32.Registry.AccessControl.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\Microsoft.Win32.Registry.AccessControl.builds" />
 
@@ -12,10 +12,10 @@
       <PackageTargetRuntime>win</PackageTargetRuntime>
     </NotSupportedOnTargetFramework>
 
-    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
     <!-- Only supported on windows, so overriding
          the validation RID's -->
-    <ValidateFramework Include="dnxcore50"> 
+    <ValidateFramework Include="netstandardapp1.5"> 
       <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
     </ValidateFramework> 
   </ItemGroup>

--- a/src/Microsoft.Win32.Registry.AccessControl/pkg/Microsoft.Win32.Registry.AccessControl.pkgproj
+++ b/src/Microsoft.Win32.Registry.AccessControl/pkg/Microsoft.Win32.Registry.AccessControl.pkgproj
@@ -7,6 +7,17 @@
       <SupportedFramework>net46;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\Microsoft.Win32.Registry.AccessControl.builds" />
+
+    <NotSupportedOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>win</PackageTargetRuntime>
+    </NotSupportedOnTargetFramework>
+
+    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <!-- Only supported on windows, so overriding
+         the validation RID's -->
+    <ValidateFramework Include="dnxcore50"> 
+      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
+    </ValidateFramework> 
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Microsoft.Win32.Registry.AccessControl/src/Microsoft.Win32.Registry.AccessControl.csproj
+++ b/src/Microsoft.Win32.Registry.AccessControl/src/Microsoft.Win32.Registry.AccessControl.csproj
@@ -9,7 +9,8 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net46'">None</ResourcesSourceOutputDirectory>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework> 
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net46'">win</PackageTargetRuntime>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />

--- a/src/Microsoft.Win32.Registry/pkg/Microsoft.Win32.Registry.pkgproj
+++ b/src/Microsoft.Win32.Registry/pkg/Microsoft.Win32.Registry.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\Microsoft.Win32.Registry.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\Microsoft.Win32.Registry.builds" />
     
@@ -12,10 +12,10 @@
       <PackageTargetRuntime>win</PackageTargetRuntime>
     </NotSupportedOnTargetFramework>
 
-    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
     <!-- Only supported on windows, so overriding
          the validation RID's -->
-    <ValidateFramework Include="dnxcore50"> 
+    <ValidateFramework Include="netstandardapp1.5"> 
       <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
     </ValidateFramework> 
   </ItemGroup>

--- a/src/Microsoft.Win32.Registry/pkg/Microsoft.Win32.Registry.pkgproj
+++ b/src/Microsoft.Win32.Registry/pkg/Microsoft.Win32.Registry.pkgproj
@@ -7,6 +7,17 @@
       <SupportedFramework>net46;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\Microsoft.Win32.Registry.builds" />
+    
+    <NotSupportedOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>win</PackageTargetRuntime>
+    </NotSupportedOnTargetFramework>
+
+    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <!-- Only supported on windows, so overriding
+         the validation RID's -->
+    <ValidateFramework Include="dnxcore50"> 
+      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
+    </ValidateFramework> 
   </ItemGroup>
   
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
+++ b/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
@@ -10,7 +10,8 @@
     <AssemblyName>Microsoft.Win32.Registry</AssemblyName>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework> 
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net46'">win</PackageTargetRuntime>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->

--- a/src/System.AppContext/pkg/System.AppContext.pkgproj
+++ b/src/System.AppContext/pkg/System.AppContext.pkgproj
@@ -7,7 +7,7 @@
       <SupportedFramework>net46</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.AppContext.csproj">
-      <SupportedFramework>netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\redist\System.AppContext.depproj">
       <TargetGroup>net46</TargetGroup>

--- a/src/System.AppContext/pkg/System.AppContext.pkgproj
+++ b/src/System.AppContext/pkg/System.AppContext.pkgproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\4.0.0\System.AppContext.depproj">
       <SupportedFramework>net46</SupportedFramework>
@@ -17,13 +16,13 @@
     </ProjectReference>
     <ProjectReference Include="any\System.AppContext.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.AppContext/pkg/System.AppContext.pkgproj
+++ b/src/System.AppContext/pkg/System.AppContext.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net46</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.AppContext.csproj">
-      <SupportedFramework>netcore50;netstandardapp1.5</SupportedFramework>
+      <SupportedFramework>net462;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\redist\System.AppContext.depproj">
       <TargetGroup>net46</TargetGroup>

--- a/src/System.AppContext/pkg/any/System.AppContext.pkgproj
+++ b/src/System.AppContext/pkg/any/System.AppContext.pkgproj
@@ -14,6 +14,8 @@
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.AppContext/src/System.AppContext.csproj
+++ b/src/System.AppContext/src/System.AppContext.csproj
@@ -9,19 +9,8 @@
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'!='netcore50'">true</IsPartialFacadeAssembly>
     <!-- The following line needs to be removed once we have a targeting pack for 4.6.2 -->
     <TargetingPackNugetPackageId Condition="'$(TargetGroup)'=='net462'">Microsoft.TargetingPack.NETFramework.v4.6</TargetingPackNugetPackageId>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.5</PackageTargetFramework>
   </PropertyGroup>
-  <ItemGroup Condition="'$(PackageTargetFramework)' == ''">
-    <!-- Remove when resolving https://github.com/dotnet/corefx/issues/5471 
-         And replace with property 
-         <PackageTargetFramework >netstandard1.5</PackageTargetFramework>
-    -->
-    <PackageDestination Include="lib/netstandard1.5">
-      <TargetFramework>netstandard1.5</TargetFramework>
-    </PackageDestination>
-    <PackageDestination Include="lib/dnxcore50">
-      <TargetFramework>dnxcore50</TargetFramework>
-    </PackageDestination>
-  </ItemGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/System.Buffers/pkg/System.Buffers.pkgproj
+++ b/src/System.Buffers/pkg/System.Buffers.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\src\System.Buffers.builds">
-      <SupportedFramework>net45;netcore45;dnxcore50;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
     </ProjectReference>
   </ItemGroup>
 

--- a/src/System.Collections.Concurrent/pkg/System.Collections.Concurrent.pkgproj
+++ b/src/System.Collections.Concurrent/pkg/System.Collections.Concurrent.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Collections.Concurrent.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <!-- reference .CSProj rather than .builds since we don't need the desktop facade -->
     <ProjectReference Include="..\src\System.Collections.Concurrent.csproj"/>

--- a/src/System.Collections.Concurrent/pkg/System.Collections.Concurrent.pkgproj
+++ b/src/System.Collections.Concurrent/pkg/System.Collections.Concurrent.pkgproj
@@ -9,8 +9,7 @@
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <!-- reference .CSProj rather than .builds since we don't need the desktop facade -->
-    <ProjectReference Include="..\src\System.Collections.Concurrent.csproj"/>
-
+    <ProjectReference Include="..\src\System.Collections.Concurrent.csproj" />
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />
@@ -18,6 +17,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Collections.Immutable/pkg/System.Collections.Immutable.pkgproj
+++ b/src/System.Collections.Immutable/pkg/System.Collections.Immutable.pkgproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\src\System.Collections.Immutable.builds">
-      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
   </ItemGroup>
 

--- a/src/System.Collections.NonGeneric/pkg/System.Collections.NonGeneric.pkgproj
+++ b/src/System.Collections.NonGeneric/pkg/System.Collections.NonGeneric.pkgproj
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Collections.NonGeneric.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Collections.NonGeneric.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Collections.NonGeneric/pkg/System.Collections.NonGeneric.pkgproj
+++ b/src/System.Collections.NonGeneric/pkg/System.Collections.NonGeneric.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Collections.NonGeneric.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Collections.NonGeneric.builds" />
   </ItemGroup>

--- a/src/System.Collections.Specialized/pkg/System.Collections.Specialized.pkgproj
+++ b/src/System.Collections.Specialized/pkg/System.Collections.Specialized.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Collections.Specialized.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Collections.Specialized.builds" />
   </ItemGroup>

--- a/src/System.Collections.Specialized/pkg/System.Collections.Specialized.pkgproj
+++ b/src/System.Collections.Specialized/pkg/System.Collections.Specialized.pkgproj
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Collections.Specialized.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Collections.Specialized.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Collections/pkg/System.Collections.pkgproj
+++ b/src/System.Collections/pkg/System.Collections.pkgproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
@@ -10,7 +10,6 @@
     </ProjectReference>
     <ProjectReference Include="any\System.Collections.pkgproj" />
     <ProjectReference Include="aot\System.Collections.pkgproj" />
-    
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />
@@ -19,6 +18,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Collections/pkg/System.Collections.pkgproj
+++ b/src/System.Collections/pkg/System.Collections.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Collections.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Collections.pkgproj" />
     <ProjectReference Include="aot\System.Collections.pkgproj" />

--- a/src/System.Collections/pkg/any/System.Collections.pkgproj
+++ b/src/System.Collections/pkg/any/System.Collections.pkgproj
@@ -24,6 +24,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ComponentModel.Annotations/pkg/System.ComponentModel.Annotations.pkgproj
+++ b/src/System.ComponentModel.Annotations/pkg/System.ComponentModel.Annotations.pkgproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
@@ -13,12 +13,13 @@
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ComponentModel.Annotations.builds" />
-
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
-    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ComponentModel.Annotations/pkg/System.ComponentModel.Annotations.pkgproj
+++ b/src/System.ComponentModel.Annotations/pkg/System.ComponentModel.Annotations.pkgproj
@@ -10,7 +10,7 @@
       <SupportedFramework>net46;netcore50</SupportedFramework>
     </ProjectReference -->
     <ProjectReference Include="..\ref\System.ComponentModel.Annotations.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ComponentModel.Annotations.builds" />
 

--- a/src/System.ComponentModel.Annotations/pkg/System.ComponentModel.Annotations.pkgproj
+++ b/src/System.ComponentModel.Annotations/pkg/System.ComponentModel.Annotations.pkgproj
@@ -5,12 +5,11 @@
     <ProjectReference Include="..\ref\4.0.0\System.ComponentModel.Annotations.depproj">
       <SupportedFramework>net45</SupportedFramework>
     </ProjectReference>
-    <!-- TODO: Add back once nuget maps UAP to 5.5 https://github.com/nuget/home/1709 -->
-    <!-- ProjectReference Include="..\ref\4.0.10\System.ComponentModel.Annotations.depproj">
-      <SupportedFramework>net46;netcore50</SupportedFramework>
-    </ProjectReference -->
+    <ProjectReference Include="..\ref\4.0.10\System.ComponentModel.Annotations.depproj">
+      <SupportedFramework>net46</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\ref\System.ComponentModel.Annotations.csproj">
-      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
+      <SupportedFramework>net461;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ComponentModel.Annotations.builds" />
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.csproj
+++ b/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.csproj
@@ -4,9 +4,8 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <!-- TODO: Update to 5.5 once nuget maps UAP to 5.5 https://github.com/nuget/home/1709 -->
-    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.4</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.ComponentModel.Annotations.cs" />

--- a/src/System.ComponentModel.Annotations/ref/project.json
+++ b/src/System.ComponentModel.Annotations/ref/project.json
@@ -4,9 +4,9 @@
     "System.ComponentModel": "4.0.0"
   },
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.4": {
       "imports": [
-        "dotnet5.4"
+        "dotnet5.5"
       ]
     }
   }

--- a/src/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.builds
+++ b/src/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.builds
@@ -4,7 +4,7 @@
   <ItemGroup>
     <Project Include="System.ComponentModel.Annotations.csproj" />
     <Project Include="System.ComponentModel.Annotations.csproj">
-      <TargetGroup>net46</TargetGroup>
+      <TargetGroup>net461</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.csproj
+++ b/src/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.csproj
@@ -6,9 +6,9 @@
     <RootNamespace>System.ComponentModel.Annotations</RootNamespace>
     <AssemblyName>System.ComponentModel.Annotations</AssemblyName>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.3</PackageTargetFramework>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46'">true</IsPartialFacadeAssembly>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.4</PackageTargetFramework>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net461'">true</IsPartialFacadeAssembly>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.4</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -64,7 +64,7 @@
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='net46'">
+  <ItemGroup Condition="'$(TargetGroup)'=='net461'">
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>

--- a/src/System.ComponentModel.Annotations/src/project.json
+++ b/src/System.ComponentModel.Annotations/src/project.json
@@ -1,6 +1,6 @@
 {
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.4": {
       "dependencies": {
         "System.Collections": "4.0.10",
         "System.ComponentModel": "4.0.0",
@@ -18,12 +18,12 @@
         "System.Threading": "4.0.10"
       },
       "imports": [
-        "dotnet5.4"
+        "dotnet5.5"
       ]
     },
-    "net46": {
+    "net461": {
       "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+        "Microsoft.TargetingPack.NETFramework.v4.6.1": "1.0.1"
       }
     }
   }

--- a/src/System.ComponentModel.EventBasedAsync/pkg/System.ComponentModel.EventBasedAsync.pkgproj
+++ b/src/System.ComponentModel.EventBasedAsync/pkg/System.ComponentModel.EventBasedAsync.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.ComponentModel.EventBasedAsync.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ComponentModel.EventBasedAsync.builds" />
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/System.ComponentModel.EventBasedAsync/pkg/System.ComponentModel.EventBasedAsync.pkgproj
+++ b/src/System.ComponentModel.EventBasedAsync/pkg/System.ComponentModel.EventBasedAsync.pkgproj
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <ProjectReference Include="..\ref\4.0.0\System.ComponentModel.EventBasedAsync.depproj" >
+    <ProjectReference Include="..\ref\4.0.0\System.ComponentModel.EventBasedAsync.depproj">
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.ComponentModel.EventBasedAsync.csproj">
@@ -17,6 +17,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ComponentModel.Primitives/pkg/System.ComponentModel.Primitives.pkgproj
+++ b/src/System.ComponentModel.Primitives/pkg/System.ComponentModel.Primitives.pkgproj
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.ComponentModel.Primitives.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ComponentModel.Primitives.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ComponentModel.Primitives/pkg/System.ComponentModel.Primitives.pkgproj
+++ b/src/System.ComponentModel.Primitives/pkg/System.ComponentModel.Primitives.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.ComponentModel.Primitives.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ComponentModel.Primitives.builds" />
   </ItemGroup>

--- a/src/System.ComponentModel.TypeConverter/pkg/System.ComponentModel.TypeConverter.pkgproj
+++ b/src/System.ComponentModel.TypeConverter/pkg/System.ComponentModel.TypeConverter.pkgproj
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.ComponentModel.TypeConverter.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ComponentModel.TypeConverter.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ComponentModel.TypeConverter/pkg/System.ComponentModel.TypeConverter.pkgproj
+++ b/src/System.ComponentModel.TypeConverter/pkg/System.ComponentModel.TypeConverter.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.ComponentModel.TypeConverter.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ComponentModel.TypeConverter.builds" />
   </ItemGroup>

--- a/src/System.ComponentModel/pkg/System.ComponentModel.pkgproj
+++ b/src/System.ComponentModel/pkg/System.ComponentModel.pkgproj
@@ -1,22 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
   <ItemGroup>
     <ProjectReference Include="..\ref\System.ComponentModel.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ComponentModel.builds" />
-
-    <InboxOnTargetFramework Include="MonoAndroid10"/>
-    <InboxOnTargetFramework Include="MonoTouch10"/>
-    <InboxOnTargetFramework Include="net45"/>
-    <InboxOnTargetFramework Include="win8"/>
-    <InboxOnTargetFramework Include="wp80"/>
-    <InboxOnTargetFramework Include="wpa81"/>
-    <InboxOnTargetFramework Include="xamarinios10"/>
-    <InboxOnTargetFramework Include="xamarinmac20"/>
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ComponentModel/pkg/System.ComponentModel.pkgproj
+++ b/src/System.ComponentModel/pkg/System.ComponentModel.pkgproj
@@ -4,7 +4,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.ComponentModel.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ComponentModel.builds" />
 

--- a/src/System.Console/pkg/System.Console.pkgproj
+++ b/src/System.Console/pkg/System.Console.pkgproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Console.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
@@ -9,17 +8,16 @@
     <ProjectReference Include="..\src\System.Console.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </ProjectReference>
-
     <ProjectReference Include="win\System.Console.pkgproj" />
     <ProjectReference Include="unix\System.Console.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Console/pkg/System.Console.pkgproj
+++ b/src/System.Console/pkg/System.Console.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Console.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Console.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>

--- a/src/System.Data.Common/pkg/System.Data.Common.pkgproj
+++ b/src/System.Data.Common/pkg/System.Data.Common.pkgproj
@@ -1,21 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Data.Common.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
- 
     <ProjectReference Include="..\src\System.Data.Common.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Data.Common/pkg/System.Data.Common.pkgproj
+++ b/src/System.Data.Common/pkg/System.Data.Common.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Data.Common.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
  
     <ProjectReference Include="..\src\System.Data.Common.builds" />

--- a/src/System.Data.SqlClient/pkg/System.Data.SqlClient.pkgproj
+++ b/src/System.Data.SqlClient/pkg/System.Data.SqlClient.pkgproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\4.0.0\System.Data.SqlClient.csproj">
       <SupportedFramework>net45;</SupportedFramework>
@@ -9,15 +8,13 @@
     <ProjectReference Include="..\src\System.Data.SqlClient.csproj">
       <AdditionalProperties>TargetGroup=net45</AdditionalProperties>
     </ProjectReference>
-	<ProjectReference Include="..\ref\System.Data.SqlClient.csproj">
+    <ProjectReference Include="..\ref\System.Data.SqlClient.csproj">
       <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
-    
-	<ProjectReference Include="win\System.Data.SqlClient.pkgproj">
-        <PackageAlias>win.System.Data.SqlClient</PackageAlias>
+    <ProjectReference Include="win\System.Data.SqlClient.pkgproj">
+      <PackageAlias>win.System.Data.SqlClient</PackageAlias>
     </ProjectReference>
     <ProjectReference Include="unix\System.Data.SqlClient.pkgproj" />
-
     <!-- Ideally we'd place these in the windows project, but nuget cannot handle
          recursive runtime runtime dependencies -->
     <ProjectReference Include="win\native\System.Data.SqlClient.sni.pkgproj">
@@ -29,13 +26,13 @@
       <Platform>x86</Platform>
     </ProjectReference>
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Data.SqlClient/pkg/System.Data.SqlClient.pkgproj
+++ b/src/System.Data.SqlClient/pkg/System.Data.SqlClient.pkgproj
@@ -10,7 +10,7 @@
       <AdditionalProperties>TargetGroup=net45</AdditionalProperties>
     </ProjectReference>
 	<ProjectReference Include="..\ref\System.Data.SqlClient.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     
 	<ProjectReference Include="win\System.Data.SqlClient.pkgproj">

--- a/src/System.Diagnostics.Contracts/pkg/System.Diagnostics.Contracts.pkgproj
+++ b/src/System.Diagnostics.Contracts/pkg/System.Diagnostics.Contracts.pkgproj
@@ -4,7 +4,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Diagnostics.Contracts.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Diagnostics.Contracts.builds" />
 

--- a/src/System.Diagnostics.Contracts/pkg/System.Diagnostics.Contracts.pkgproj
+++ b/src/System.Diagnostics.Contracts/pkg/System.Diagnostics.Contracts.pkgproj
@@ -1,22 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Diagnostics.Contracts.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Diagnostics.Contracts.builds" />
-
-    <InboxOnTargetFramework Include="MonoAndroid10"/>
-    <InboxOnTargetFramework Include="MonoTouch10"/>
-    <InboxOnTargetFramework Include="net45"/>
-    <InboxOnTargetFramework Include="win8"/>
-    <InboxOnTargetFramework Include="wp80"/>
-    <InboxOnTargetFramework Include="wpa81"/>
-    <InboxOnTargetFramework Include="xamarinios10"/>
-    <InboxOnTargetFramework Include="xamarinmac20"/>
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.Debug/pkg/System.Diagnostics.Debug.pkgproj
+++ b/src/System.Diagnostics.Debug/pkg/System.Diagnostics.Debug.pkgproj
@@ -1,17 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <ProjectReference Include="..\ref\4.0.0\System.Diagnostics.Debug.depproj" >
+    <ProjectReference Include="..\ref\4.0.0\System.Diagnostics.Debug.depproj">
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Diagnostics.Debug.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
-
     <ProjectReference Include="win\System.Diagnostics.Debug.pkgproj" />
     <ProjectReference Include="unix\System.Diagnostics.Debug.pkgproj" />
-
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />
@@ -20,6 +18,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.Debug/pkg/System.Diagnostics.Debug.pkgproj
+++ b/src/System.Diagnostics.Debug/pkg/System.Diagnostics.Debug.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Diagnostics.Debug.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
 
     <ProjectReference Include="win\System.Diagnostics.Debug.pkgproj" />

--- a/src/System.Diagnostics.DiagnosticSource/pkg/System.Diagnostics.DiagnosticSource.pkgproj
+++ b/src/System.Diagnostics.DiagnosticSource/pkg/System.Diagnostics.DiagnosticSource.pkgproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\src\System.Diagnostics.DiagnosticSource.builds">
-      <SupportedFramework>net45;netcore45;dnxcore50;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
     </ProjectReference>
   </ItemGroup>
 

--- a/src/System.Diagnostics.FileVersionInfo/pkg/System.Diagnostics.FileVersionInfo.pkgproj
+++ b/src/System.Diagnostics.FileVersionInfo/pkg/System.Diagnostics.FileVersionInfo.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Diagnostics.FileVersionInfo.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Diagnostics.FileVersionInfo.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>

--- a/src/System.Diagnostics.FileVersionInfo/pkg/System.Diagnostics.FileVersionInfo.pkgproj
+++ b/src/System.Diagnostics.FileVersionInfo/pkg/System.Diagnostics.FileVersionInfo.pkgproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Diagnostics.FileVersionInfo.csproj">
       <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
@@ -9,17 +8,16 @@
     <ProjectReference Include="..\src\System.Diagnostics.FileVersionInfo.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </ProjectReference>
-    
     <ProjectReference Include="win\System.Diagnostics.FileVersionInfo.pkgproj" />
     <ProjectReference Include="unix\System.Diagnostics.FileVersionInfo.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.Process/pkg/System.Diagnostics.Process.pkgproj
+++ b/src/System.Diagnostics.Process/pkg/System.Diagnostics.Process.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Diagnostics.Process.csproj">
-      <SupportedFramework>net461;dnxcore50</SupportedFramework>
+      <SupportedFramework>net461;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\4.0\System.Diagnostics.Process.csproj" >
       <SupportedFramework>net46</SupportedFramework>

--- a/src/System.Diagnostics.Process/pkg/System.Diagnostics.Process.pkgproj
+++ b/src/System.Diagnostics.Process/pkg/System.Diagnostics.Process.pkgproj
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Diagnostics.Process.csproj">
       <SupportedFramework>net461;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\ref\4.0\System.Diagnostics.Process.csproj" >
+    <ProjectReference Include="..\ref\4.0\System.Diagnostics.Process.csproj">
       <SupportedFramework>net46</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Diagnostics.Process.csproj">
@@ -15,18 +14,17 @@
     <ProjectReference Include="..\src\System.Diagnostics.Process.csproj">
       <TargetGroup>net461</TargetGroup>
     </ProjectReference>
-    
     <ProjectReference Include="win\System.Diagnostics.Process.pkgproj" />
     <ProjectReference Include="linux\System.Diagnostics.Process.pkgproj" />
     <ProjectReference Include="osx\System.Diagnostics.Process.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.StackTrace/pkg/System.Diagnostics.StackTrace.pkgproj
+++ b/src/System.Diagnostics.StackTrace/pkg/System.Diagnostics.StackTrace.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Diagnostics.StackTrace.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Diagnostics.StackTrace.builds" />
   </ItemGroup>

--- a/src/System.Diagnostics.StackTrace/pkg/System.Diagnostics.StackTrace.pkgproj
+++ b/src/System.Diagnostics.StackTrace/pkg/System.Diagnostics.StackTrace.pkgproj
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Diagnostics.StackTrace.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Diagnostics.StackTrace.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.TextWriterTraceListener/pkg/System.Diagnostics.TextWriterTraceListener.pkgproj
+++ b/src/System.Diagnostics.TextWriterTraceListener/pkg/System.Diagnostics.TextWriterTraceListener.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Diagnostics.TextWriterTraceListener.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Diagnostics.TextWriterTraceListener.builds" />
   </ItemGroup>

--- a/src/System.Diagnostics.TextWriterTraceListener/pkg/System.Diagnostics.TextWriterTraceListener.pkgproj
+++ b/src/System.Diagnostics.TextWriterTraceListener/pkg/System.Diagnostics.TextWriterTraceListener.pkgproj
@@ -1,21 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Diagnostics.TextWriterTraceListener.csproj">
       <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Diagnostics.TextWriterTraceListener.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <NotSupportedOnTargetFramework Include="netcore50" />
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.TextWriterTraceListener/pkg/System.Diagnostics.TextWriterTraceListener.pkgproj
+++ b/src/System.Diagnostics.TextWriterTraceListener/pkg/System.Diagnostics.TextWriterTraceListener.pkgproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <NotSupportedOnTargetFramework Include="netcore50" />
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />

--- a/src/System.Diagnostics.TextWriterTraceListener/src/System.Diagnostics.TextWriterTraceListener.csproj
+++ b/src/System.Diagnostics.TextWriterTraceListener/src/System.Diagnostics.TextWriterTraceListener.csproj
@@ -7,7 +7,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <ProjectGuid>{315929D9-D76E-47E9-BE82-C787FB3A7876}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework> 
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Diagnostics.Tools/pkg/System.Diagnostics.Tools.pkgproj
+++ b/src/System.Diagnostics.Tools/pkg/System.Diagnostics.Tools.pkgproj
@@ -4,7 +4,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Diagnostics.Tools.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Diagnostics.Tools.pkgproj" />
     <ProjectReference Include="aot\System.Diagnostics.Tools.pkgproj" />

--- a/src/System.Diagnostics.Tools/pkg/System.Diagnostics.Tools.pkgproj
+++ b/src/System.Diagnostics.Tools/pkg/System.Diagnostics.Tools.pkgproj
@@ -1,23 +1,22 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Diagnostics.Tools.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Diagnostics.Tools.pkgproj" />
     <ProjectReference Include="aot\System.Diagnostics.Tools.pkgproj" />
-
-    <InboxOnTargetFramework Include="MonoAndroid10"/>
-    <InboxOnTargetFramework Include="MonoTouch10"/>
-    <InboxOnTargetFramework Include="net45"/>
-    <InboxOnTargetFramework Include="win8"/>
-    <InboxOnTargetFramework Include="wp80"/>
-    <InboxOnTargetFramework Include="wpa81"/>
-    <InboxOnTargetFramework Include="xamarinios10"/>
-    <InboxOnTargetFramework Include="xamarinmac20"/>
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.Tools/pkg/any/System.Diagnostics.Tools.pkgproj
+++ b/src/System.Diagnostics.Tools/pkg/any/System.Diagnostics.Tools.pkgproj
@@ -24,6 +24,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.TraceSource/pkg/System.Diagnostics.TraceSource.pkgproj
+++ b/src/System.Diagnostics.TraceSource/pkg/System.Diagnostics.TraceSource.pkgproj
@@ -1,26 +1,23 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Diagnostics.TraceSource.csproj">
       <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
-    
     <ProjectReference Include="..\src\System.Diagnostics.TraceSource.csproj">
       <TargetGroup>net46</TargetGroup>
     </ProjectReference>
-
     <ProjectReference Include="win\System.Diagnostics.TraceSource.pkgproj" />
     <ProjectReference Include="unix\System.Diagnostics.TraceSource.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.TraceSource/pkg/System.Diagnostics.TraceSource.pkgproj
+++ b/src/System.Diagnostics.TraceSource/pkg/System.Diagnostics.TraceSource.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Diagnostics.TraceSource.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     
     <ProjectReference Include="..\src\System.Diagnostics.TraceSource.csproj">

--- a/src/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.pkgproj
+++ b/src/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.pkgproj
@@ -12,7 +12,7 @@
       <SupportedFramework>net46</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Diagnostics.Tracing.csproj">
-      <SupportedFramework>netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Diagnostics.Tracing.csproj">
       <TargetGroup>net462</TargetGroup>

--- a/src/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.pkgproj
+++ b/src/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.pkgproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
@@ -26,6 +26,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.pkgproj
+++ b/src/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.pkgproj
@@ -12,7 +12,7 @@
       <SupportedFramework>net46</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Diagnostics.Tracing.csproj">
-      <SupportedFramework>netcore50;netstandardapp1.5</SupportedFramework>
+      <SupportedFramework>net462;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Diagnostics.Tracing.csproj">
       <TargetGroup>net462</TargetGroup>

--- a/src/System.Diagnostics.Tracing/pkg/any/System.Diagnostics.Tracing.pkgproj
+++ b/src/System.Diagnostics.Tracing/pkg/any/System.Diagnostics.Tracing.pkgproj
@@ -23,6 +23,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
+++ b/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
@@ -8,6 +8,7 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <!-- The following line needs to be removed once we have a targeting pack for 4.6.2 -->
     <TargetingPackNugetPackageId Condition="'$(TargetGroup)'=='net462'">Microsoft.TargetingPack.NETFramework.v4.6.1</TargetingPackNugetPackageId>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.5</PackageTargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)'!='netcore50aot'">
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
@@ -18,18 +19,6 @@
     which is included transitively via System.Reflection -->
     <OmitTransitiveCompileReferences>true</OmitTransitiveCompileReferences>
   </PropertyGroup>
-  <ItemGroup Condition="'$(PackageTargetFramework)' == ''">
-    <!-- Remove when resolving https://github.com/dotnet/corefx/issues/5471 
-         And replace with property 
-         <PackageTargetFramework >netstandard1.5</PackageTargetFramework>
-    -->
-    <PackageDestination Include="lib/netstandard1.5">
-      <TargetFramework>netstandard1.5</TargetFramework>
-    </PackageDestination>
-    <PackageDestination Include="lib/dnxcore50">
-      <TargetFramework>dnxcore50</TargetFramework>
-    </PackageDestination>
-  </ItemGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/System.Dynamic.Runtime/pkg/System.Dynamic.Runtime.pkgproj
+++ b/src/System.Dynamic.Runtime/pkg/System.Dynamic.Runtime.pkgproj
@@ -1,15 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <ProjectReference Include="..\ref\4.0.0\System.Dynamic.Runtime.depproj" >
+    <ProjectReference Include="..\ref\4.0.0\System.Dynamic.Runtime.depproj">
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Dynamic.Runtime.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Dynamic.Runtime.builds" />
-
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />
@@ -18,6 +17,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Dynamic.Runtime/pkg/System.Dynamic.Runtime.pkgproj
+++ b/src/System.Dynamic.Runtime/pkg/System.Dynamic.Runtime.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Dynamic.Runtime.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Dynamic.Runtime.builds" />
 

--- a/src/System.Globalization.Calendars/pkg/System.Globalization.Calendars.pkgproj
+++ b/src/System.Globalization.Calendars/pkg/System.Globalization.Calendars.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Globalization.Calendars.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Globalization.Calendars.csproj">
       <TargetGroup>net46</TargetGroup>

--- a/src/System.Globalization.Calendars/pkg/System.Globalization.Calendars.pkgproj
+++ b/src/System.Globalization.Calendars/pkg/System.Globalization.Calendars.pkgproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Globalization.Calendars.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
@@ -12,13 +11,13 @@
     <ProjectReference Include="any\System.Globalization.Calendars.pkgproj" />
     <ProjectReference Include="aot\System.Globalization.Calendars.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Globalization.Calendars/pkg/any/System.Globalization.Calendars.pkgproj
+++ b/src/System.Globalization.Calendars/pkg/any/System.Globalization.Calendars.pkgproj
@@ -25,6 +25,8 @@
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Globalization.Extensions/pkg/System.Globalization.Extensions.pkgproj
+++ b/src/System.Globalization.Extensions/pkg/System.Globalization.Extensions.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Globalization.Extensions.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
 
     <ProjectReference Include="..\src\System.Globalization.Extensions.csproj">

--- a/src/System.Globalization.Extensions/pkg/System.Globalization.Extensions.pkgproj
+++ b/src/System.Globalization.Extensions/pkg/System.Globalization.Extensions.pkgproj
@@ -1,26 +1,23 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Globalization.Extensions.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
-
     <ProjectReference Include="..\src\System.Globalization.Extensions.csproj">
       <TargetGroup>net46</TargetGroup>
     </ProjectReference>
-    
     <ProjectReference Include="win\System.Globalization.Extensions.pkgproj" />
-    <ProjectReference Include="unix\System.Globalization.Extensions.pkgproj" />    
+    <ProjectReference Include="unix\System.Globalization.Extensions.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Globalization/pkg/System.Globalization.pkgproj
+++ b/src/System.Globalization/pkg/System.Globalization.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Globalization.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Globalization.pkgproj" />
     <ProjectReference Include="aot\System.Globalization.pkgproj" />

--- a/src/System.Globalization/pkg/System.Globalization.pkgproj
+++ b/src/System.Globalization/pkg/System.Globalization.pkgproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
@@ -18,6 +18,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Globalization/pkg/any/System.Globalization.pkgproj
+++ b/src/System.Globalization/pkg/any/System.Globalization.pkgproj
@@ -26,6 +26,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Compression.ZipFile/pkg/System.IO.Compression.ZipFile.pkgproj
+++ b/src/System.IO.Compression.ZipFile/pkg/System.IO.Compression.ZipFile.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.Compression.ZipFile.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.Compression.ZipFile.builds" />
   </ItemGroup>

--- a/src/System.IO.Compression.ZipFile/pkg/System.IO.Compression.ZipFile.pkgproj
+++ b/src/System.IO.Compression.ZipFile/pkg/System.IO.Compression.ZipFile.pkgproj
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.Compression.ZipFile.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.Compression.ZipFile.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Compression/pkg/System.IO.Compression.pkgproj
+++ b/src/System.IO.Compression/pkg/System.IO.Compression.pkgproj
@@ -8,7 +8,7 @@
       <SupportedFramework>net45;netcore45;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.IO.Compression.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.Compression.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>

--- a/src/System.IO.Compression/pkg/System.IO.Compression.pkgproj
+++ b/src/System.IO.Compression/pkg/System.IO.Compression.pkgproj
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
-
   <ItemGroup>
-    <ProjectReference Include="..\ref\4.0.0\System.IO.Compression.depproj" >
+    <ProjectReference Include="..\ref\4.0.0\System.IO.Compression.depproj">
       <SupportedFramework>net45;netcore45;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.IO.Compression.csproj">
@@ -13,7 +11,6 @@
     <ProjectReference Include="..\src\System.IO.Compression.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </ProjectReference>
-
     <InboxOnTargetFramework Include="net45" />
     <InboxOnTargetFramework Include="win8" />
     <InboxOnTargetFramework Include="wpa81" />
@@ -21,10 +18,10 @@
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
-
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
     <ProjectReference Include="win\System.IO.Compression.pkgproj" />
-    <ProjectReference Include="unix\System.IO.Compression.pkgproj"/>
+    <ProjectReference Include="unix\System.IO.Compression.pkgproj" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.FileSystem.AccessControl/pkg/System.IO.FileSystem.AccessControl.pkgproj
+++ b/src/System.IO.FileSystem.AccessControl/pkg/System.IO.FileSystem.AccessControl.pkgproj
@@ -7,6 +7,16 @@
       <SupportedFramework>net46;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.FileSystem.AccessControl.builds" />
+
+    <NotSupportedOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>win</PackageTargetRuntime>
+    </NotSupportedOnTargetFramework>
+    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <!-- Only supported on windows, so overriding
+         the validation RID's -->
+    <ValidateFramework Include="dnxcore50"> 
+      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
+    </ValidateFramework> 
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.IO.FileSystem.AccessControl/pkg/System.IO.FileSystem.AccessControl.pkgproj
+++ b/src/System.IO.FileSystem.AccessControl/pkg/System.IO.FileSystem.AccessControl.pkgproj
@@ -4,17 +4,17 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.FileSystem.AccessControl.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.FileSystem.AccessControl.builds" />
 
     <NotSupportedOnTargetFramework Include="netcore50">
       <PackageTargetRuntime>win</PackageTargetRuntime>
     </NotSupportedOnTargetFramework>
-    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
     <!-- Only supported on windows, so overriding
          the validation RID's -->
-    <ValidateFramework Include="dnxcore50"> 
+    <ValidateFramework Include="netstandardapp1.5"> 
       <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
     </ValidateFramework> 
   </ItemGroup>

--- a/src/System.IO.FileSystem.AccessControl/src/System.IO.FileSystem.AccessControl.csproj
+++ b/src/System.IO.FileSystem.AccessControl/src/System.IO.FileSystem.AccessControl.csproj
@@ -6,7 +6,8 @@
     <AssemblyName>System.IO.FileSystem.AccessControl</AssemblyName>
     <ProjectGuid>{D77FBA6C-1AA6-45A4-93E2-97A370672C53}</ProjectGuid>
     <AllowUnsafeBlocks Condition="'$(TargetGroup)'==''">true</AllowUnsafeBlocks>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">dnxcore50</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.3</PackageTargetFramework>
+    <PackageTargetRuntime  Condition="'$(TargetGroup)' == ''">win</PackageTargetRuntime>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>

--- a/src/System.IO.FileSystem.DriveInfo/pkg/System.IO.FileSystem.DriveInfo.pkgproj
+++ b/src/System.IO.FileSystem.DriveInfo/pkg/System.IO.FileSystem.DriveInfo.pkgproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.FileSystem.DriveInfo.csproj">
       <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
@@ -9,18 +8,17 @@
     <ProjectReference Include="..\src\System.IO.FileSystem.DriveInfo.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </ProjectReference>
-    
     <ProjectReference Include="win\System.IO.FileSystem.DriveInfo.pkgproj" />
     <ProjectReference Include="linux\System.IO.FileSystem.DriveInfo.pkgproj" />
     <ProjectReference Include="osx\System.IO.FileSystem.DriveInfo.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.FileSystem.DriveInfo/pkg/System.IO.FileSystem.DriveInfo.pkgproj
+++ b/src/System.IO.FileSystem.DriveInfo/pkg/System.IO.FileSystem.DriveInfo.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.FileSystem.DriveInfo.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.FileSystem.DriveInfo.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>

--- a/src/System.IO.FileSystem.Primitives/pkg/System.IO.FileSystem.Primitives.pkgproj
+++ b/src/System.IO.FileSystem.Primitives/pkg/System.IO.FileSystem.Primitives.pkgproj
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.FileSystem.Primitives.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.FileSystem.Primitives.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.FileSystem.Primitives/pkg/System.IO.FileSystem.Primitives.pkgproj
+++ b/src/System.IO.FileSystem.Primitives/pkg/System.IO.FileSystem.Primitives.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.FileSystem.Primitives.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.FileSystem.Primitives.builds" />
   </ItemGroup>

--- a/src/System.IO.FileSystem.Watcher/pkg/System.IO.FileSystem.Watcher.pkgproj
+++ b/src/System.IO.FileSystem.Watcher/pkg/System.IO.FileSystem.Watcher.pkgproj
@@ -1,12 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.FileSystem.Watcher.csproj">
       <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
-    
     <ProjectReference Include="..\src\System.IO.FileSystem.Watcher.csproj">
       <TargetGroup>net46</TargetGroup>
     </ProjectReference>
@@ -14,13 +12,13 @@
     <ProjectReference Include="linux\System.IO.FileSystem.Watcher.pkgproj" />
     <ProjectReference Include="osx\System.IO.FileSystem.Watcher.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.FileSystem.Watcher/pkg/System.IO.FileSystem.Watcher.pkgproj
+++ b/src/System.IO.FileSystem.Watcher/pkg/System.IO.FileSystem.Watcher.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.FileSystem.Watcher.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     
     <ProjectReference Include="..\src\System.IO.FileSystem.Watcher.csproj">

--- a/src/System.IO.FileSystem/pkg/System.IO.FileSystem.pkgproj
+++ b/src/System.IO.FileSystem/pkg/System.IO.FileSystem.pkgproj
@@ -10,11 +10,12 @@
     </ProjectReference>
     <ProjectReference Include="win\System.IO.FileSystem.pkgproj" />
     <ProjectReference Include="unix\System.IO.FileSystem.pkgproj" />
-
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.FileSystem/pkg/System.IO.FileSystem.pkgproj
+++ b/src/System.IO.FileSystem/pkg/System.IO.FileSystem.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.FileSystem.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.FileSystem.csproj">
       <TargetGroup>net46</TargetGroup>

--- a/src/System.IO.IsolatedStorage/pkg/System.IO.IsolatedStorage.pkgproj
+++ b/src/System.IO.IsolatedStorage/pkg/System.IO.IsolatedStorage.pkgproj
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.IsolatedStorage.csproj">
       <SupportedFramework>netcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.IsolatedStorage.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.MemoryMappedFiles/pkg/System.IO.MemoryMappedFiles.pkgproj
+++ b/src/System.IO.MemoryMappedFiles/pkg/System.IO.MemoryMappedFiles.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.MemoryMappedFiles.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.MemoryMappedFiles.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>

--- a/src/System.IO.MemoryMappedFiles/pkg/System.IO.MemoryMappedFiles.pkgproj
+++ b/src/System.IO.MemoryMappedFiles/pkg/System.IO.MemoryMappedFiles.pkgproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.MemoryMappedFiles.csproj">
       <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
@@ -9,18 +8,17 @@
     <ProjectReference Include="..\src\System.IO.MemoryMappedFiles.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </ProjectReference>
-    
     <ProjectReference Include="win\System.IO.MemoryMappedFiles.pkgproj" />
     <ProjectReference Include="linux\System.IO.MemoryMappedFiles.pkgproj" />
     <ProjectReference Include="osx\System.IO.MemoryMappedFiles.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Packaging/pkg/System.IO.Packaging.pkgproj
+++ b/src/System.IO.Packaging/pkg/System.IO.Packaging.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.Packaging.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.Packaging.builds" />
   </ItemGroup>

--- a/src/System.IO.Pipes/pkg/System.IO.Pipes.pkgproj
+++ b/src/System.IO.Pipes/pkg/System.IO.Pipes.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.Pipes.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.Pipes.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>

--- a/src/System.IO.UnmanagedMemoryStream/pkg/System.IO.UnmanagedMemoryStream.pkgproj
+++ b/src/System.IO.UnmanagedMemoryStream/pkg/System.IO.UnmanagedMemoryStream.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.UnmanagedMemoryStream.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.UnmanagedMemoryStream.builds" />
   </ItemGroup>

--- a/src/System.IO.UnmanagedMemoryStream/pkg/System.IO.UnmanagedMemoryStream.pkgproj
+++ b/src/System.IO.UnmanagedMemoryStream/pkg/System.IO.UnmanagedMemoryStream.pkgproj
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.IO.UnmanagedMemoryStream.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.UnmanagedMemoryStream.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO/pkg/System.IO.pkgproj
+++ b/src/System.IO/pkg/System.IO.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.IO.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.csproj">
       <TargetGroup>net46</TargetGroup>

--- a/src/System.IO/pkg/System.IO.pkgproj
+++ b/src/System.IO/pkg/System.IO.pkgproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
@@ -21,6 +21,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO/pkg/any/System.IO.pkgproj
+++ b/src/System.IO/pkg/any/System.IO.pkgproj
@@ -23,6 +23,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Linq.Expressions/pkg/System.Linq.Expressions.pkgproj
+++ b/src/System.Linq.Expressions/pkg/System.Linq.Expressions.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp80;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Linq.Expressions.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
 
     <!-- not yet needed

--- a/src/System.Linq.Expressions/pkg/System.Linq.Expressions.pkgproj
+++ b/src/System.Linq.Expressions/pkg/System.Linq.Expressions.pkgproj
@@ -8,16 +8,13 @@
     <ProjectReference Include="..\ref\System.Linq.Expressions.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
-
     <!-- not yet needed
     <ProjectReference Include="..\src\Facade\System.Linq.Expressions.csproj">
       <TargetGroup>net46</TargetGroup>
     </ProjectReference>
     -->
-
     <ProjectReference Include="any\System.Linq.Expressions.pkgproj" />
     <ProjectReference Include="aot\System.Linq.Expressions.pkgproj" />
-
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />
@@ -26,6 +23,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Linq.Expressions/pkg/any/System.Linq.Expressions.pkgproj
+++ b/src/System.Linq.Expressions/pkg/any/System.Linq.Expressions.pkgproj
@@ -26,6 +26,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Linq.Parallel/pkg/System.Linq.Parallel.pkgproj
+++ b/src/System.Linq.Parallel/pkg/System.Linq.Parallel.pkgproj
@@ -1,21 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Linq.Parallel.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Linq.Parallel.builds" />
-
-    <InboxOnTargetFramework Include="MonoAndroid10"/>
-    <InboxOnTargetFramework Include="MonoTouch10"/>
-    <InboxOnTargetFramework Include="net45"/>
-    <InboxOnTargetFramework Include="win8"/>
-    <InboxOnTargetFramework Include="wpa81"/>
-    <InboxOnTargetFramework Include="xamarinios10"/>
-    <InboxOnTargetFramework Include="xamarinmac20"/>
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Linq.Parallel/pkg/System.Linq.Parallel.pkgproj
+++ b/src/System.Linq.Parallel/pkg/System.Linq.Parallel.pkgproj
@@ -4,7 +4,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Linq.Parallel.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Linq.Parallel.builds" />
 

--- a/src/System.Linq.Queryable/pkg/System.Linq.Queryable.pkgproj
+++ b/src/System.Linq.Queryable/pkg/System.Linq.Queryable.pkgproj
@@ -1,22 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Linq.Queryable.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Linq.Queryable.builds" />
-    
-    <InboxOnTargetFramework Include="monoandroid1"/>
-    <InboxOnTargetFramework Include="monotouch1"/>
-    <InboxOnTargetFramework Include="net45"/>
-    <InboxOnTargetFramework Include="win8"/>
-    <InboxOnTargetFramework Include="wp80"/>
-    <InboxOnTargetFramework Include="wpa81"/>
-    <InboxOnTargetFramework Include="xamarinios1"/>
-    <InboxOnTargetFramework Include="xamarinmac2"/>
+    <InboxOnTargetFramework Include="monoandroid10" />
+    <InboxOnTargetFramework Include="monotouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Linq.Queryable/pkg/System.Linq.Queryable.pkgproj
+++ b/src/System.Linq.Queryable/pkg/System.Linq.Queryable.pkgproj
@@ -4,7 +4,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Linq.Queryable.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Linq.Queryable.builds" />
     

--- a/src/System.Linq/pkg/System.Linq.pkgproj
+++ b/src/System.Linq/pkg/System.Linq.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Linq.csproj">
-      <SupportedFramework>netcore50;netstandardapp1.5</SupportedFramework>
+      <SupportedFramework>net462;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Linq.builds" />
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/System.Linq/pkg/System.Linq.pkgproj
+++ b/src/System.Linq/pkg/System.Linq.pkgproj
@@ -7,7 +7,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Linq.csproj">
-      <SupportedFramework>netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Linq.builds" />
     

--- a/src/System.Linq/pkg/System.Linq.pkgproj
+++ b/src/System.Linq/pkg/System.Linq.pkgproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
   <ItemGroup>
     <ProjectReference Include="..\ref\4.0.0\System.Linq.depproj">
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
@@ -10,16 +9,16 @@
       <SupportedFramework>netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Linq.builds" />
-    
-    <InboxOnTargetFramework Include="MonoAndroid10"/>
-    <InboxOnTargetFramework Include="MonoTouch10"/>
-    <InboxOnTargetFramework Include="net45"/>
-    <InboxOnTargetFramework Include="win8"/>
-    <InboxOnTargetFramework Include="wp80"/>
-    <InboxOnTargetFramework Include="wpa81"/>
-    <InboxOnTargetFramework Include="xamarinios10"/>
-    <InboxOnTargetFramework Include="xamarinmac20"/>
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Linq/src/System.Linq.csproj
+++ b/src/System.Linq/src/System.Linq.csproj
@@ -9,19 +9,8 @@
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net462'">true</IsPartialFacadeAssembly>
     <!-- The following line needs to be removed once we have a targeting pack for 4.6.2 -->
     <TargetingPackNugetPackageId Condition="'$(TargetGroup)' == 'net462'">Microsoft.TargetingPack.NETFramework.v4.6.1</TargetingPackNugetPackageId>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.5</PackageTargetFramework>
   </PropertyGroup>
-  <ItemGroup Condition="'$(PackageTargetFramework)' == ''">
-    <!-- Remove when resolving https://github.com/dotnet/corefx/issues/5471 
-         And replace with property 
-         <PackageTargetFramework >netstandard1.5</PackageTargetFramework>
-    -->
-    <PackageDestination Include="lib/netstandard1.5">
-      <TargetFramework>netstandard1.5</TargetFramework>
-    </PackageDestination>
-    <PackageDestination Include="lib/dnxcore50">
-      <TargetFramework>dnxcore50</TargetFramework>
-    </PackageDestination>
-  </ItemGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/System.Net.Http.WinHttpHandler/pkg/System.Net.Http.WinHttpHandler.pkgproj
+++ b/src/System.Net.Http.WinHttpHandler/pkg/System.Net.Http.WinHttpHandler.pkgproj
@@ -4,17 +4,17 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.Http.WinHttpHandler.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Net.Http.WinHttpHandler.builds" />
 
     <NotSupportedOnTargetFramework Include="netcore50">
       <PackageTargetRuntime>win</PackageTargetRuntime>
     </NotSupportedOnTargetFramework>
-    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
     <!-- Only supported on windows, so overriding
          the validation RID's -->
-    <ValidateFramework Include="dnxcore50"> 
+    <ValidateFramework Include="netstandardapp1.5"> 
       <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
     </ValidateFramework> 
   </ItemGroup>

--- a/src/System.Net.Http.WinHttpHandler/pkg/System.Net.Http.WinHttpHandler.pkgproj
+++ b/src/System.Net.Http.WinHttpHandler/pkg/System.Net.Http.WinHttpHandler.pkgproj
@@ -7,6 +7,16 @@
       <SupportedFramework>net46;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Net.Http.WinHttpHandler.builds" />
+
+    <NotSupportedOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>win</PackageTargetRuntime>
+    </NotSupportedOnTargetFramework>
+    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <!-- Only supported on windows, so overriding
+         the validation RID's -->
+    <ValidateFramework Include="dnxcore50"> 
+      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
+    </ValidateFramework> 
   </ItemGroup>
   
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
@@ -10,8 +10,9 @@
     <ProjectGuid>{F75E3008-0562-42DF-BE72-C1384F12157E}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Net.Http.WinHttpHandler</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>    
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework> 
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
+    <PackageTargetRuntime Condition="'$(PackageTargetFramework)' == ''">win</PackageTargetRuntime> 
   </PropertyGroup>
   
   <!-- Help VS understand available configurations -->

--- a/src/System.Net.Http/pkg/System.Net.Http.pkgproj
+++ b/src/System.Net.Http/pkg/System.Net.Http.pkgproj
@@ -1,26 +1,27 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.Http.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
     </ProjectReference>
-    
     <ProjectReference Include="win\System.Net.Http.pkgproj" />
     <ProjectReference Include="linux\System.Net.Http.pkgproj" />
     <ProjectReference Include="osx\System.Net.Http.pkgproj" />
   </ItemGroup>
-  
   <ItemGroup>
+    <InboxOnTargetFramework Include="monoandroid10" />
+    <InboxOnTargetFramework Include="monotouch10" />
     <InboxOnTargetFramework Include="net45">
       <AsFrameworkReference>true</AsFrameworkReference>
     </InboxOnTargetFramework>
-    <InboxOnTargetFramework Include="win8"/>
-    <InboxOnTargetFramework Include="wpa81"/>
-
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="Xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
     <!-- TODO: Bring in Microsoft.Net.Http on older platforms -->
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.Http/pkg/System.Net.Http.pkgproj
+++ b/src/System.Net.Http/pkg/System.Net.Http.pkgproj
@@ -4,7 +4,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.Http.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
     </ProjectReference>
     
     <ProjectReference Include="win\System.Net.Http.pkgproj" />

--- a/src/System.Net.Http/pkg/win/System.Net.Http.pkgproj
+++ b/src/System.Net.Http/pkg/win/System.Net.Http.pkgproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\..\src\System.Net.Http.builds" >
       <AdditionalProperties>FilterToOSGroup=Windows_NT</AdditionalProperties>
     </ProjectReference>
+    <ExternalOnTargetFramework Include="net" />
   </ItemGroup>
   
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>System.Net.Http</AssemblyName>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework> 
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
     <PackageTargetRuntime Condition="'$(TargetsWindows)' == 'true'">win7</PackageTargetRuntime> 
     <PackageTargetRuntime Condition="'$(TargetsLinux)' == 'true'">linux</PackageTargetRuntime> 
     <PackageTargetRuntime Condition="'$(TargetsOSX)' == 'true'">osx</PackageTargetRuntime> 

--- a/src/System.Net.NameResolution/pkg/System.Net.NameResolution.pkgproj
+++ b/src/System.Net.NameResolution/pkg/System.Net.NameResolution.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.NameResolution.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
 
     <ProjectReference Include="..\src\System.Net.NameResolution.csproj">

--- a/src/System.Net.NameResolution/pkg/System.Net.NameResolution.pkgproj
+++ b/src/System.Net.NameResolution/pkg/System.Net.NameResolution.pkgproj
@@ -1,26 +1,23 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.NameResolution.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
-
     <ProjectReference Include="..\src\System.Net.NameResolution.csproj">
       <TargetGroup>net46</TargetGroup>
     </ProjectReference>
-
     <ProjectReference Include="win\System.Net.NameResolution.pkgproj" />
     <ProjectReference Include="unix\System.Net.NameResolution.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.NetworkInformation/pkg/System.Net.NetworkInformation.pkgproj
+++ b/src/System.Net.NetworkInformation/pkg/System.Net.NetworkInformation.pkgproj
@@ -7,7 +7,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Net.NetworkInformation.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
 
     <ProjectReference Include="..\src\System.Net.NetworkInformation.csproj">

--- a/src/System.Net.NetworkInformation/pkg/System.Net.NetworkInformation.pkgproj
+++ b/src/System.Net.NetworkInformation/pkg/System.Net.NetworkInformation.pkgproj
@@ -1,15 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
-    <ProjectReference Include="..\ref\4.0.0\System.Net.NetworkInformation.depproj" >
+    <ProjectReference Include="..\ref\4.0.0\System.Net.NetworkInformation.depproj">
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Net.NetworkInformation.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
-
     <ProjectReference Include="..\src\System.Net.NetworkInformation.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </ProjectReference>
@@ -17,7 +15,6 @@
     <ProjectReference Include="linux\System.Net.NetworkInformation.pkgproj" />
     <ProjectReference Include="osx\System.Net.NetworkInformation.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
@@ -27,6 +24,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.Ping/pkg/System.Net.Ping.pkgproj
+++ b/src/System.Net.Ping/pkg/System.Net.Ping.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.Ping.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Net.Ping.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>

--- a/src/System.Net.Ping/pkg/win/System.Net.Ping.pkgproj
+++ b/src/System.Net.Ping/pkg/win/System.Net.Ping.pkgproj
@@ -12,6 +12,7 @@
       <AdditionalProperties>FilterToOSGroup=Windows_NT</AdditionalProperties>
     </ProjectReference>
 
+    <NotSupportedOnTargetFramework Include="netcore50" />
     <!-- don't use the dotnet implementation for any version of desktop, it's implementation comes from the reference package -->
     <ExternalOnTargetFramework Include="net" />
   </ItemGroup>

--- a/src/System.Net.Ping/src/System.Net.Ping.csproj
+++ b/src/System.Net.Ping/src/System.Net.Ping.csproj
@@ -12,7 +12,8 @@
     <DefineConstants>$(DefineConstants);FEATURE_CORECLR</DefineConstants>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net46'">None</ResourcesSourceOutputDirectory>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NugetTargetMoniker>
     <UsePackageTargetRuntimeDefaults Condition="'$(TargetGroup)' == ''">true</UsePackageTargetRuntimeDefaults>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->

--- a/src/System.Net.Ping/src/project.json
+++ b/src/System.Net.Ping/src/project.json
@@ -1,14 +1,28 @@
 {
   "frameworks": {
-    "dnxcore50": {
+    "netstandard1.3": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23829",
+        "Microsoft.Win32.Primitives": "4.0.0",
+        "System.Collections": "4.0.10",
+        "System.Diagnostics.Debug" : "4.0.10",
         "System.Diagnostics.Process": "4.1.0-rc3-23829",
+        "System.Diagnostics.Tracing" : "4.0.20",
+        "System.IO.FileSystem" : "4.0.0",
         "System.Net.NameResolution": "4.0.0-rc3-23829",
         "System.Net.Primitives": "4.0.10",
         "System.Net.Sockets": "4.1.0-rc3-23829",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Extensions": "4.0.10",
+        "System.Runtime.InteropServices": "4.0.20",
+        "System.Threading": "4.0.10",
+        "System.Threading.Tasks": "4.0.10",
         "System.Threading.ThreadPool": "4.0.10-rc3-23829"
-      }
+      },
+      "imports": [
+        "dotnet5.4"
+      ]
     },
     "net46": {
       "dependencies": {

--- a/src/System.Net.Primitives/pkg/System.Net.Primitives.pkgproj
+++ b/src/System.Net.Primitives/pkg/System.Net.Primitives.pkgproj
@@ -1,17 +1,16 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <ProjectReference Include="..\ref\3.9.0\System.Net.Primitives.depproj" >
+    <ProjectReference Include="..\ref\3.9.0\System.Net.Primitives.depproj">
       <SupportedFramework>wp8</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\ref\4.0.0\System.Net.Primitives.depproj" >
+    <ProjectReference Include="..\ref\4.0.0\System.Net.Primitives.depproj">
       <SupportedFramework>net45;netcore45;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Net.Primitives.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
-
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />
@@ -20,6 +19,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
     <ProjectReference Include="win\System.Net.Primitives.pkgproj" />
     <ProjectReference Include="unix\System.Net.Primitives.pkgproj" />
   </ItemGroup>

--- a/src/System.Net.Primitives/pkg/System.Net.Primitives.pkgproj
+++ b/src/System.Net.Primitives/pkg/System.Net.Primitives.pkgproj
@@ -9,7 +9,7 @@
       <SupportedFramework>net45;netcore45;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Net.Primitives.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
 
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -12,7 +12,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableWinRT Condition="'$(TargetGroup)' == 'netcore50'">true</EnableWinRT>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
     <PackageTargetFramework Condition="'$(TargetsWindows)' == 'true' AND '$(EnableWinRT)' == 'true'">netcore50</PackageTargetFramework>
     <PackageTargetRuntime Condition="'$(TargetsWindows)' == 'true' and '$(TargetGroup)' == ''">win7</PackageTargetRuntime>
     <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true' and '$(TargetGroup)' == ''">unix</PackageTargetRuntime>

--- a/src/System.Net.Requests/pkg/System.Net.Requests.pkgproj
+++ b/src/System.Net.Requests/pkg/System.Net.Requests.pkgproj
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\3.9.0\System.Net.Requests.depproj">
       <SupportedFramework>wp8</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\ref\4.0.0\System.Net.Requests.depproj" >
+    <ProjectReference Include="..\ref\4.0.0\System.Net.Requests.depproj">
       <SupportedFramework>net45;netcore45;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Net.Requests.csproj">
@@ -23,6 +23,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.Requests/pkg/System.Net.Requests.pkgproj
+++ b/src/System.Net.Requests/pkg/System.Net.Requests.pkgproj
@@ -9,7 +9,7 @@
       <SupportedFramework>net45;netcore45;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Net.Requests.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="win\System.Net.Requests.pkgproj" />
     <ProjectReference Include="unix\System.Net.Requests.pkgproj" />

--- a/src/System.Net.Security/pkg/System.Net.Security.pkgproj
+++ b/src/System.Net.Security/pkg/System.Net.Security.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.Security.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Net.Security.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>

--- a/src/System.Net.Security/pkg/System.Net.Security.pkgproj
+++ b/src/System.Net.Security/pkg/System.Net.Security.pkgproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.Security.csproj">
       <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
@@ -9,17 +8,16 @@
     <ProjectReference Include="..\src\System.Net.Security.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </ProjectReference>
-    
     <ProjectReference Include="$(MSBuildThisFileDirectory)win\System.Net.Security.pkgproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)unix\System.Net.Security.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.Security/pkg/win/System.Net.Security.pkgproj
+++ b/src/System.Net.Security/pkg/win/System.Net.Security.pkgproj
@@ -12,6 +12,8 @@
       <AdditionalProperties>FilterToOSGroup=Windows_NT</AdditionalProperties>
     </ProjectReference>
 
+    <NotSupportedOnTargetFramework Include="netcore50" />
+
     <!-- don't use the dotnet implementation for any version of desktop, it's implementation comes from the reference package -->
     <ExternalOnTargetFramework Include="net" />
   </ItemGroup>

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -12,7 +12,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_CORECLR</DefineConstants>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net46'">None</ResourcesSourceOutputDirectory>
-    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">dnxcore50</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.3</PackageTargetFramework>
     <UsePackageTargetRuntimeDefaults Condition="'$(TargetGroup)' == ''">true</UsePackageTargetRuntimeDefaults>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetsWindows)' == 'true' and '$(ProjectJson)' == '' ">

--- a/src/System.Net.Sockets/pkg/System.Net.Sockets.pkgproj
+++ b/src/System.Net.Sockets/pkg/System.Net.Sockets.pkgproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.Sockets.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
@@ -12,13 +11,13 @@
     <ProjectReference Include="win\System.Net.Sockets.pkgproj" />
     <ProjectReference Include="unix\System.Net.Sockets.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.Sockets/pkg/System.Net.Sockets.pkgproj
+++ b/src/System.Net.Sockets/pkg/System.Net.Sockets.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.Sockets.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Net.Sockets.csproj">
       <TargetGroup>net46</TargetGroup>

--- a/src/System.Net.WebHeaderCollection/pkg/System.Net.WebHeaderCollection.pkgproj
+++ b/src/System.Net.WebHeaderCollection/pkg/System.Net.WebHeaderCollection.pkgproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.WebHeaderCollection.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
@@ -9,13 +8,13 @@
     <ProjectReference Include="..\src\System.Net.WebHeaderCollection.builds">
       <AdditionalProperties>FilterToOSGroup=Windows_NT</AdditionalProperties>
     </ProjectReference>
-
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net46" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.WebHeaderCollection/pkg/System.Net.WebHeaderCollection.pkgproj
+++ b/src/System.Net.WebHeaderCollection/pkg/System.Net.WebHeaderCollection.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.WebHeaderCollection.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Net.WebHeaderCollection.builds">
       <AdditionalProperties>FilterToOSGroup=Windows_NT</AdditionalProperties>

--- a/src/System.Net.WebSockets.Client/pkg/System.Net.WebSockets.Client.pkgproj
+++ b/src/System.Net.WebSockets.Client/pkg/System.Net.WebSockets.Client.pkgproj
@@ -1,25 +1,23 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.WebSockets.Client.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
-    
     <ProjectReference Include="..\src\System.Net.WebSockets.Client.csproj">
       <TargetGroup>net46</TargetGroup>
     </ProjectReference>
     <ProjectReference Include="win\System.Net.WebSockets.Client.pkgproj" />
     <ProjectReference Include="unix\System.Net.WebSockets.Client.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.WebSockets.Client/pkg/System.Net.WebSockets.Client.pkgproj
+++ b/src/System.Net.WebSockets.Client/pkg/System.Net.WebSockets.Client.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.WebSockets.Client.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     
     <ProjectReference Include="..\src\System.Net.WebSockets.Client.csproj">

--- a/src/System.Net.WebSockets/pkg/System.Net.WebSockets.pkgproj
+++ b/src/System.Net.WebSockets/pkg/System.Net.WebSockets.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.WebSockets.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Net.WebSockets.builds" />
   </ItemGroup>

--- a/src/System.Net.WebSockets/pkg/System.Net.WebSockets.pkgproj
+++ b/src/System.Net.WebSockets/pkg/System.Net.WebSockets.pkgproj
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Net.WebSockets.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Net.WebSockets.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Numerics.Vectors/pkg/System.Numerics.Vectors.pkgproj
+++ b/src/System.Numerics.Vectors/pkg/System.Numerics.Vectors.pkgproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Numerics.Vectors.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Numerics.Vectors.builds" />
   </ItemGroup>

--- a/src/System.Numerics.Vectors/pkg/System.Numerics.Vectors.pkgproj
+++ b/src/System.Numerics.Vectors/pkg/System.Numerics.Vectors.pkgproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -17,7 +17,8 @@
     <InboxOnTargetFramework Include="net46" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ObjectModel/pkg/System.ObjectModel.pkgproj
+++ b/src/System.ObjectModel/pkg/System.ObjectModel.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.ObjectModel.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ObjectModel.builds" />
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/System.ObjectModel/pkg/System.ObjectModel.pkgproj
+++ b/src/System.ObjectModel/pkg/System.ObjectModel.pkgproj
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <ProjectReference Include="..\ref\4.0.0\System.ObjectModel.depproj" >
+    <ProjectReference Include="..\ref\4.0.0\System.ObjectModel.depproj">
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.ObjectModel.csproj">
@@ -17,6 +17,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -12,7 +12,7 @@
     <DebugSymbols>true</DebugSymbols>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DefineConstants Condition="'$(TargetGroup)'=='netcore50aot'">$(DefineConstants);NET_NATIVE</DefineConstants>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework> 
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
     
     <!-- We do not want to block reflection for this assembly -->
     <BlockReflectionAttribute Condition="'$(TargetGroup)'=='netcore50aot'">false</BlockReflectionAttribute>

--- a/src/System.Private.Uri/pkg/System.Private.Uri.pkgproj
+++ b/src/System.Private.Uri/pkg/System.Private.Uri.pkgproj
@@ -8,17 +8,10 @@
     <!-- The Unix implementations place the asset in a generation folder,
          however the assembly won't reference any generation-based contracts -->
     <SkipGenerationCheck>true</SkipGenerationCheck>
+    <PreventImplementationReference>true</PreventImplementationReference>
   </PropertyGroup>
   
   <ItemGroup>
-    <!-- Implementation only package -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/dnxcore50</TargetPath>
-    </File>
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netcore50</TargetPath>
-    </File>
-
     <ProjectReference Include="win\System.Private.Uri.pkgproj" />
     <ProjectReference Include="unix\System.Private.Uri.pkgproj" />
   </ItemGroup>

--- a/src/System.Reflection.DispatchProxy/pkg/System.Reflection.DispatchProxy.pkgproj
+++ b/src/System.Reflection.DispatchProxy/pkg/System.Reflection.DispatchProxy.pkgproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Reflection.DispatchProxy.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
@@ -9,12 +8,13 @@
     <ProjectReference Include="any\System.Reflection.DispatchProxy.pkgproj" />
     <ProjectReference Include="aot\System.Reflection.DispatchProxy.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.DispatchProxy/pkg/System.Reflection.DispatchProxy.pkgproj
+++ b/src/System.Reflection.DispatchProxy/pkg/System.Reflection.DispatchProxy.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Reflection.DispatchProxy.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Reflection.DispatchProxy.pkgproj" />
     <ProjectReference Include="aot\System.Reflection.DispatchProxy.pkgproj" />

--- a/src/System.Reflection.DispatchProxy/pkg/any/System.Reflection.DispatchProxy.pkgproj
+++ b/src/System.Reflection.DispatchProxy/pkg/any/System.Reflection.DispatchProxy.pkgproj
@@ -23,6 +23,8 @@
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.Emit.ILGeneration/pkg/System.Reflection.Emit.ILGeneration.pkgproj
+++ b/src/System.Reflection.Emit.ILGeneration/pkg/System.Reflection.Emit.ILGeneration.pkgproj
@@ -4,7 +4,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Reflection.Emit.ILGeneration.csproj">
-      <SupportedFramework>net45;dnxcore50;wp8</SupportedFramework>
+      <SupportedFramework>net45;netstandardapp1.5;wp8</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Reflection.Emit.ILGeneration.builds" />
     

--- a/src/System.Reflection.Emit.Lightweight/pkg/System.Reflection.Emit.Lightweight.pkgproj
+++ b/src/System.Reflection.Emit.Lightweight/pkg/System.Reflection.Emit.Lightweight.pkgproj
@@ -4,7 +4,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Reflection.Emit.Lightweight.csproj">
-      <SupportedFramework>net45;dnxcore50;wp8</SupportedFramework>
+      <SupportedFramework>net45;netstandardapp1.5;wp8</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Reflection.Emit.Lightweight.builds"/>
 

--- a/src/System.Reflection.Emit/pkg/System.Reflection.Emit.pkgproj
+++ b/src/System.Reflection.Emit/pkg/System.Reflection.Emit.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Reflection.Emit.csproj">
-      <SupportedFramework>net45;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net45;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
 
     <ProjectReference Include="..\src\System.Reflection.Emit.builds" />

--- a/src/System.Reflection.Emit/src/System.Reflection.Emit.csproj
+++ b/src/System.Reflection.Emit/src/System.Reflection.Emit.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>System.Reflection.Emit</AssemblyName>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework> 
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->

--- a/src/System.Reflection.Extensions/pkg/System.Reflection.Extensions.pkgproj
+++ b/src/System.Reflection.Extensions/pkg/System.Reflection.Extensions.pkgproj
@@ -4,7 +4,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Reflection.Extensions.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Reflection.Extensions.pkgproj" />
     <ProjectReference Include="aot\System.Reflection.Extensions.pkgproj" />

--- a/src/System.Reflection.Extensions/pkg/System.Reflection.Extensions.pkgproj
+++ b/src/System.Reflection.Extensions/pkg/System.Reflection.Extensions.pkgproj
@@ -1,23 +1,22 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Reflection.Extensions.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Reflection.Extensions.pkgproj" />
     <ProjectReference Include="aot\System.Reflection.Extensions.pkgproj" />
-
-    <InboxOnTargetFramework Include="MonoAndroid10"/>
-    <InboxOnTargetFramework Include="MonoTouch10"/>
-    <InboxOnTargetFramework Include="net45"/>
-    <InboxOnTargetFramework Include="win8"/>
-    <InboxOnTargetFramework Include="wp80"/>
-    <InboxOnTargetFramework Include="wpa81"/>
-    <InboxOnTargetFramework Include="xamarinios10"/>
-    <InboxOnTargetFramework Include="xamarinmac20"/>
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.Extensions/pkg/any/System.Reflection.Extensions.pkgproj
+++ b/src/System.Reflection.Extensions/pkg/any/System.Reflection.Extensions.pkgproj
@@ -23,6 +23,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.Metadata/pkg/System.Reflection.Metadata.pkgproj
+++ b/src/System.Reflection.Metadata/pkg/System.Reflection.Metadata.pkgproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\src\System.Reflection.Metadata.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
     </ProjectReference>
     <Dependency Include="System.Collections.Immutable">
       <TargetFramework>portable-net45+win8</TargetFramework>

--- a/src/System.Reflection.Metadata/pkg/future/System.Reflection.Metadata.pkgproj
+++ b/src/System.Reflection.Metadata/pkg/future/System.Reflection.Metadata.pkgproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Reflection.Metadata.csproj">
       <AdditionalProperties>future=true</AdditionalProperties>
-      <SupportedFramework>net45;netcore45;dnxcore50;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
     </ProjectReference>
     <Dependency Include="System.Collections.Immutable">
       <TargetFramework>portable-net45+win8</TargetFramework>

--- a/src/System.Reflection.Primitives/pkg/System.Reflection.Primitives.pkgproj
+++ b/src/System.Reflection.Primitives/pkg/System.Reflection.Primitives.pkgproj
@@ -1,22 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Reflection.Primitives.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Reflection.Primitives.pkgproj" />
-
-    <InboxOnTargetFramework Include="MonoAndroid10"/>
-    <InboxOnTargetFramework Include="MonoTouch10"/>
-    <InboxOnTargetFramework Include="net45"/>
-    <InboxOnTargetFramework Include="win8"/>
-    <InboxOnTargetFramework Include="wp80"/>
-    <InboxOnTargetFramework Include="wpa81"/>
-    <InboxOnTargetFramework Include="xamarinios10"/>
-    <InboxOnTargetFramework Include="xamarinmac20"/>
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.Primitives/pkg/System.Reflection.Primitives.pkgproj
+++ b/src/System.Reflection.Primitives/pkg/System.Reflection.Primitives.pkgproj
@@ -4,7 +4,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Reflection.Primitives.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Reflection.Primitives.pkgproj" />
 

--- a/src/System.Reflection.Primitives/pkg/any/System.Reflection.Primitives.pkgproj
+++ b/src/System.Reflection.Primitives/pkg/any/System.Reflection.Primitives.pkgproj
@@ -17,6 +17,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
+++ b/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Reflection.TypeExtensions.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
@@ -12,13 +11,13 @@
     <ProjectReference Include="any\System.Reflection.TypeExtensions.pkgproj" />
     <ProjectReference Include="aot\System.Reflection.TypeExtensions.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
+++ b/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Reflection.TypeExtensions.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Reflection.TypeExtensions.csproj">
       <TargetGroup>net46</TargetGroup>

--- a/src/System.Reflection.TypeExtensions/pkg/any/System.Reflection.TypeExtensions.pkgproj
+++ b/src/System.Reflection.TypeExtensions/pkg/any/System.Reflection.TypeExtensions.pkgproj
@@ -22,6 +22,8 @@
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection/pkg/System.Reflection.pkgproj
+++ b/src/System.Reflection/pkg/System.Reflection.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Reflection.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Reflection.csproj">
       <TargetGroup>net46</TargetGroup>

--- a/src/System.Reflection/pkg/System.Reflection.pkgproj
+++ b/src/System.Reflection/pkg/System.Reflection.pkgproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
@@ -21,6 +21,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection/pkg/any/System.Reflection.pkgproj
+++ b/src/System.Reflection/pkg/any/System.Reflection.pkgproj
@@ -26,6 +26,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Resources.Reader/pkg/System.Resources.Reader.pkgproj
+++ b/src/System.Resources.Reader/pkg/System.Resources.Reader.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\src\System.Resources.Reader.builds">
-      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
   </ItemGroup>
 

--- a/src/System.Resources.ReaderWriter/pkg/System.Resources.ReaderWriter.pkgproj
+++ b/src/System.Resources.ReaderWriter/pkg/System.Resources.ReaderWriter.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Resources.ReaderWriter.csproj">
-      <SupportedFramework>net46;dnxcore50;netcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5;netcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Resources.ReaderWriter.builds" />
   </ItemGroup>

--- a/src/System.Resources.ReaderWriter/pkg/System.Resources.ReaderWriter.pkgproj
+++ b/src/System.Resources.ReaderWriter/pkg/System.Resources.ReaderWriter.pkgproj
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Resources.ReaderWriter.csproj">
       <SupportedFramework>net46;netstandardapp1.5;netcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Resources.ReaderWriter.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Resources.ReaderWriter/pkg/System.Resources.ReaderWriter.pkgproj
+++ b/src/System.Resources.ReaderWriter/pkg/System.Resources.ReaderWriter.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Resources.ReaderWriter.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;dnxcore50;netcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Resources.ReaderWriter.builds" />
   </ItemGroup>

--- a/src/System.Resources.ReaderWriter/src/System.Resources.ReaderWriter.csproj
+++ b/src/System.Resources.ReaderWriter/src/System.Resources.ReaderWriter.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>System.Resources</RootNamespace>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net46'">None</ResourcesSourceOutputDirectory>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework> 
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Resources.ResourceManager/pkg/System.Resources.ResourceManager.pkgproj
+++ b/src/System.Resources.ResourceManager/pkg/System.Resources.ResourceManager.pkgproj
@@ -4,7 +4,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Resources.ResourceManager.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
 
     <ProjectReference Include="any\System.Resources.ResourceManager.pkgproj" />

--- a/src/System.Resources.ResourceManager/pkg/System.Resources.ResourceManager.pkgproj
+++ b/src/System.Resources.ResourceManager/pkg/System.Resources.ResourceManager.pkgproj
@@ -1,24 +1,22 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Resources.ResourceManager.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
-
     <ProjectReference Include="any\System.Resources.ResourceManager.pkgproj" />
     <ProjectReference Include="aot\System.Resources.ResourceManager.pkgproj" />
-
-    <InboxOnTargetFramework Include="MonoAndroid10"/>
-    <InboxOnTargetFramework Include="MonoTouch10"/>
-    <InboxOnTargetFramework Include="net45"/>
-    <InboxOnTargetFramework Include="win8"/>
-    <InboxOnTargetFramework Include="wp80"/>
-    <InboxOnTargetFramework Include="wpa81"/>
-    <InboxOnTargetFramework Include="xamarinios10"/>
-    <InboxOnTargetFramework Include="xamarinmac20"/>
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Resources.ResourceManager/pkg/any/System.Resources.ResourceManager.pkgproj
+++ b/src/System.Resources.ResourceManager/pkg/any/System.Resources.ResourceManager.pkgproj
@@ -24,6 +24,8 @@
     <InboxOnTargetFramework Include="wpa81"/>
     <InboxOnTargetFramework Include="xamarinios10"/>
     <InboxOnTargetFramework Include="xamarinmac20"/>
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Resources.Writer/pkg/System.Resources.Writer.pkgproj
+++ b/src/System.Resources.Writer/pkg/System.Resources.Writer.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\src\System.Resources.Writer.builds">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
   </ItemGroup>
 

--- a/src/System.Runtime.CompilerServices.VisualC/pkg/System.Runtime.CompilerServices.VisualC.pkgproj
+++ b/src/System.Runtime.CompilerServices.VisualC/pkg/System.Runtime.CompilerServices.VisualC.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Runtime.CompilerServices.VisualC.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.CompilerServices.VisualC.builds" />
   </ItemGroup>

--- a/src/System.Runtime.CompilerServices.VisualC/pkg/System.Runtime.CompilerServices.VisualC.pkgproj
+++ b/src/System.Runtime.CompilerServices.VisualC/pkg/System.Runtime.CompilerServices.VisualC.pkgproj
@@ -1,21 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Runtime.CompilerServices.VisualC.csproj">
       <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.CompilerServices.VisualC.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <NotSupportedOnTargetFramework Include="netcore50" />
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.CompilerServices.VisualC/pkg/System.Runtime.CompilerServices.VisualC.pkgproj
+++ b/src/System.Runtime.CompilerServices.VisualC/pkg/System.Runtime.CompilerServices.VisualC.pkgproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <NotSupportedOnTargetFramework Include="netcore50" />
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />

--- a/src/System.Runtime.CompilerServices.VisualC/src/System.Runtime.CompilerServices.VisualC.csproj
+++ b/src/System.Runtime.CompilerServices.VisualC/src/System.Runtime.CompilerServices.VisualC.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>System.Runtime.CompilerServices.VisualC</AssemblyName>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework> 
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->
@@ -15,7 +15,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
 
   <ItemGroup>
-    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="mscorlib" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Runtime.Extensions/pkg/System.Runtime.Extensions.pkgproj
+++ b/src/System.Runtime.Extensions/pkg/System.Runtime.Extensions.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp80;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Runtime.Extensions.csproj">
-      <SupportedFramework>netcore50;dnxcore50;net46;</SupportedFramework>
+      <SupportedFramework>netcore50;netstandardapp1.5;net46;</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.Extensions.csproj" >
       <TargetGroup>net46</TargetGroup>

--- a/src/System.Runtime.Extensions/pkg/System.Runtime.Extensions.pkgproj
+++ b/src/System.Runtime.Extensions/pkg/System.Runtime.Extensions.pkgproj
@@ -8,12 +8,11 @@
     <ProjectReference Include="..\ref\System.Runtime.Extensions.csproj">
       <SupportedFramework>netcore50;netstandardapp1.5;net46;</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Runtime.Extensions.csproj" >
+    <ProjectReference Include="..\src\System.Runtime.Extensions.csproj">
       <TargetGroup>net46</TargetGroup>
     </ProjectReference>
     <ProjectReference Include="win\System.Runtime.Extensions.pkgproj" />
     <ProjectReference Include="unix\System.Runtime.Extensions.pkgproj" />
-
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />
@@ -22,6 +21,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Handles/pkg/System.Runtime.Handles.pkgproj
+++ b/src/System.Runtime.Handles/pkg/System.Runtime.Handles.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Runtime.Handles.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Runtime.Handles.pkgproj" />
     <ProjectReference Include="aot\System.Runtime.Handles.pkgproj" />

--- a/src/System.Runtime.Handles/pkg/System.Runtime.Handles.pkgproj
+++ b/src/System.Runtime.Handles/pkg/System.Runtime.Handles.pkgproj
@@ -1,19 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Runtime.Handles.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Runtime.Handles.pkgproj" />
     <ProjectReference Include="aot\System.Runtime.Handles.pkgproj" />
-
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net46" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Handles/pkg/any/System.Runtime.Handles.pkgproj
+++ b/src/System.Runtime.Handles/pkg/any/System.Runtime.Handles.pkgproj
@@ -20,6 +20,8 @@
     <InboxOnTargetFramework Include="net46" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.InteropServices.PInvoke/pkg/System.Runtime.InteropServices.PInvoke.pkgproj
+++ b/src/System.Runtime.InteropServices.PInvoke/pkg/System.Runtime.InteropServices.PInvoke.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Runtime.InteropServices.PInvoke.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.InteropServices.PInvoke.builds" />
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/System.Runtime.InteropServices.RuntimeInformation/pkg/System.Runtime.InteropServices.RuntimeInformation.pkgproj
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/pkg/System.Runtime.InteropServices.RuntimeInformation.pkgproj
@@ -1,22 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Runtime.InteropServices.RuntimeInformation.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
-    
     <ProjectReference Include="win/System.Runtime.InteropServices.RuntimeInformation.pkgproj" />
     <ProjectReference Include="unix/System.Runtime.InteropServices.RuntimeInformation.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.InteropServices.RuntimeInformation/pkg/System.Runtime.InteropServices.RuntimeInformation.pkgproj
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/pkg/System.Runtime.InteropServices.RuntimeInformation.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Runtime.InteropServices.RuntimeInformation.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     
     <ProjectReference Include="win/System.Runtime.InteropServices.RuntimeInformation.pkgproj" />

--- a/src/System.Runtime.InteropServices.WindowsRuntime/pkg/System.Runtime.InteropServices.WindowsRuntime.pkgproj
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/pkg/System.Runtime.InteropServices.WindowsRuntime.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Runtime.InteropServices.WindowsRuntime.csproj">
-      <SupportedFramework>net45;dnxcore50;netcore45;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netstandardapp1.5;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.InteropServices.WindowsRuntime.builds" />
 
@@ -13,11 +13,11 @@
     <InboxOnTargetFramework Include="wp80"/>
     <InboxOnTargetFramework Include="wpa81"/>
 
-    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
 
     <!-- Only supported on win8 and higher, so overriding
          the validation RID's -->
-    <ValidateFramework Include="dnxcore50"> 
+    <ValidateFramework Include="netstandardapp1.5"> 
       <RuntimeIDs>win8-x86;win8-x64</RuntimeIDs> 
     </ValidateFramework> 
 

--- a/src/System.Runtime.InteropServices/pkg/System.Runtime.InteropServices.pkgproj
+++ b/src/System.Runtime.InteropServices/pkg/System.Runtime.InteropServices.pkgproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
@@ -23,6 +23,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.InteropServices/pkg/System.Runtime.InteropServices.pkgproj
+++ b/src/System.Runtime.InteropServices/pkg/System.Runtime.InteropServices.pkgproj
@@ -9,7 +9,7 @@
       <SupportedFramework>net451;netcore451;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Runtime.InteropServices.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.InteropServices.csproj">
       <TargetGroup>net46</TargetGroup>

--- a/src/System.Runtime.InteropServices/pkg/any/System.Runtime.InteropServices.pkgproj
+++ b/src/System.Runtime.InteropServices/pkg/any/System.Runtime.InteropServices.pkgproj
@@ -22,6 +22,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Loader/pkg/System.Runtime.Loader.pkgproj
+++ b/src/System.Runtime.Loader/pkg/System.Runtime.Loader.pkgproj
@@ -7,6 +7,9 @@
       <SupportedFramework>dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.Loader.builds"/>
+    
+    <NotSupportedOnTargetFramework Include="netcore50" />
+    <NotSupportedOnTargetFramework Include="net462" />
   </ItemGroup>
   
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Runtime.Loader/pkg/System.Runtime.Loader.pkgproj
+++ b/src/System.Runtime.Loader/pkg/System.Runtime.Loader.pkgproj
@@ -4,7 +4,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Runtime.Loader.csproj">
-      <SupportedFramework>dnxcore50</SupportedFramework>
+      <SupportedFramework>netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.Loader.builds"/>
     

--- a/src/System.Runtime.Loader/src/System.Runtime.Loader.csproj
+++ b/src/System.Runtime.Loader/src/System.Runtime.Loader.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>System.Runtime.Loader</AssemblyName>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework> 
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.5</PackageTargetFramework> 
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->

--- a/src/System.Runtime.Numerics/pkg/System.Runtime.Numerics.pkgproj
+++ b/src/System.Runtime.Numerics/pkg/System.Runtime.Numerics.pkgproj
@@ -1,21 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Runtime.Numerics.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.Numerics.builds" />
-
-    <InboxOnTargetFramework Include="MonoAndroid10"/>
-    <InboxOnTargetFramework Include="MonoTouch10"/>
-    <InboxOnTargetFramework Include="net45"/>
-    <InboxOnTargetFramework Include="win8"/>
-    <InboxOnTargetFramework Include="wpa81"/>
-    <InboxOnTargetFramework Include="xamarinios10"/>
-    <InboxOnTargetFramework Include="xamarinmac20"/>
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Numerics/pkg/System.Runtime.Numerics.pkgproj
+++ b/src/System.Runtime.Numerics/pkg/System.Runtime.Numerics.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Runtime.Numerics.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.Numerics.builds" />
 

--- a/src/System.Runtime.Serialization.Json/pkg/System.Runtime.Serialization.Json.pkgproj
+++ b/src/System.Runtime.Serialization.Json/pkg/System.Runtime.Serialization.Json.pkgproj
@@ -4,7 +4,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Runtime.Serialization.Json.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
 
     <ProjectReference Include="..\src\System.Runtime.Serialization.Json.builds" />
@@ -19,7 +19,7 @@
     <InboxOnTargetFramework Include="xamarinmac20"/>
 
     <ProjectReference Include="..\..\System.Private.DataContractSerialization\pkg\System.Private.DataContractSerialization.pkgproj">
-      <PackageTargetFramework>dnxcore50</PackageTargetFramework>
+      <PackageTargetFramework>netstandardapp1.5</PackageTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Private.DataContractSerialization\pkg\System.Private.DataContractSerialization.pkgproj">
       <PackageTargetFramework>netcore50</PackageTargetFramework>

--- a/src/System.Runtime.Serialization.Json/pkg/System.Runtime.Serialization.Json.pkgproj
+++ b/src/System.Runtime.Serialization.Json/pkg/System.Runtime.Serialization.Json.pkgproj
@@ -1,31 +1,27 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Runtime.Serialization.Json.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
-
     <ProjectReference Include="..\src\System.Runtime.Serialization.Json.builds" />
-
-    <InboxOnTargetFramework Include="MonoAndroid10"/>
-    <InboxOnTargetFramework Include="MonoTouch10"/>
-    <InboxOnTargetFramework Include="net45"/>
-    <InboxOnTargetFramework Include="win8"/>
-    <InboxOnTargetFramework Include="wp80"/>
-    <InboxOnTargetFramework Include="wpa81"/>
-    <InboxOnTargetFramework Include="xamarinios10"/>
-    <InboxOnTargetFramework Include="xamarinmac20"/>
-
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
     <ProjectReference Include="..\..\System.Private.DataContractSerialization\pkg\System.Private.DataContractSerialization.pkgproj">
       <PackageTargetFramework>netstandardapp1.5</PackageTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Private.DataContractSerialization\pkg\System.Private.DataContractSerialization.pkgproj">
       <PackageTargetFramework>netcore50</PackageTargetFramework>
     </ProjectReference>
-
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Json/src/System.Runtime.Serialization.Json.csproj
+++ b/src/System.Runtime.Serialization.Json/src/System.Runtime.Serialization.Json.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>System.Runtime.Serialization.Json</AssemblyName>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework> 
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' == 'net46'" />
     <TargetingPackReference Include="System.Runtime.Serialization" Condition="'$(TargetGroup)' == 'net46'" />
     <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
     <TargetingPackReference Include="System.Private.DataContractSerialization" Condition="'$(TargetGroup)' == 'netcore50aot'" />

--- a/src/System.Runtime.Serialization.Json/src/project.json
+++ b/src/System.Runtime.Serialization.Json/src/project.json
@@ -2,7 +2,11 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23829"
+        "Microsoft.NETCore.Platforms": "1.0.1-rc3-23829",
+        "System.Runtime": "4.0.20",
+        "System.Reflection": "4.0.10",
+        "System.Reflection.TypeExtensions": "4.0.0",
+        "System.Xml.XmlDocument": "4.0.0"
       }
     },
     "netcore50": {

--- a/src/System.Runtime.Serialization.Primitives/pkg/System.Runtime.Serialization.Primitives.pkgproj
+++ b/src/System.Runtime.Serialization.Primitives/pkg/System.Runtime.Serialization.Primitives.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Runtime.Serialization.Primitives.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.Serialization.Primitives.csproj">
       <TargetGroup>net46</TargetGroup>

--- a/src/System.Runtime.Serialization.Primitives/pkg/System.Runtime.Serialization.Primitives.pkgproj
+++ b/src/System.Runtime.Serialization.Primitives/pkg/System.Runtime.Serialization.Primitives.pkgproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
@@ -15,8 +15,6 @@
     <ProjectReference Include="aot\System.Runtime.Serialization.Primitives.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
     </ProjectReference>
-
-
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />
@@ -25,6 +23,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Primitives/pkg/any/System.Runtime.Serialization.Primitives.pkgproj
+++ b/src/System.Runtime.Serialization.Primitives/pkg/any/System.Runtime.Serialization.Primitives.pkgproj
@@ -26,6 +26,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Xml/pkg/System.Runtime.Serialization.Xml.pkgproj
+++ b/src/System.Runtime.Serialization.Xml/pkg/System.Runtime.Serialization.Xml.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Runtime.Serialization.Xml.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.Serialization.Xml.builds" />
     <InboxOnTargetFramework Include="MonoAndroid10" />
@@ -18,7 +18,7 @@
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
     <ProjectReference Include="..\..\System.Private.DataContractSerialization\pkg\System.Private.DataContractSerialization.pkgproj">
-      <PackageTargetFramework>dnxcore50</PackageTargetFramework>
+      <PackageTargetFramework>netstandardapp1.5</PackageTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Private.DataContractSerialization\pkg\System.Private.DataContractSerialization.pkgproj">
       <PackageTargetFramework>netcore50</PackageTargetFramework>

--- a/src/System.Runtime.Serialization.Xml/pkg/System.Runtime.Serialization.Xml.pkgproj
+++ b/src/System.Runtime.Serialization.Xml/pkg/System.Runtime.Serialization.Xml.pkgproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
@@ -17,6 +17,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
     <ProjectReference Include="..\..\System.Private.DataContractSerialization\pkg\System.Private.DataContractSerialization.pkgproj">
       <PackageTargetFramework>netstandardapp1.5</PackageTargetFramework>
     </ProjectReference>

--- a/src/System.Runtime.Serialization.Xml/src/System.Runtime.Serialization.Xml.csproj
+++ b/src/System.Runtime.Serialization.Xml/src/System.Runtime.Serialization.Xml.csproj
@@ -5,7 +5,8 @@
     <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework> 
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->

--- a/src/System.Runtime.Serialization.Xml/src/project.json
+++ b/src/System.Runtime.Serialization.Xml/src/project.json
@@ -2,7 +2,11 @@
   "frameworks": {
     "netstandard1.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23829"
+        "Microsoft.NETCore.Platforms": "1.0.1-rc3-23829",
+        "System.Runtime": "4.0.20",
+        "System.Reflection": "4.0.10",
+        "System.Reflection.TypeExtensions": "4.0.0",
+        "System.Xml.XmlDocument": "4.0.0"
       },
       "imports": [
         "dotnet5.4"

--- a/src/System.Runtime/pkg/System.Runtime.pkgproj
+++ b/src/System.Runtime/pkg/System.Runtime.pkgproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
@@ -14,10 +14,8 @@
     <ProjectReference Include="..\src\System.Runtime.csproj">
       <TargetGroup>net46</TargetGroup>
     </ProjectReference>
-
     <ProjectReference Include="any\System.Runtime.pkgproj" />
     <ProjectReference Include="aot\System.Runtime.pkgproj" />
-
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />
@@ -26,6 +24,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime/pkg/System.Runtime.pkgproj
+++ b/src/System.Runtime/pkg/System.Runtime.pkgproj
@@ -9,7 +9,7 @@
       <SupportedFramework>net451;netcore451;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Runtime.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.csproj">
       <TargetGroup>net46</TargetGroup>

--- a/src/System.Runtime/pkg/any/System.Runtime.pkgproj
+++ b/src/System.Runtime/pkg/any/System.Runtime.pkgproj
@@ -25,6 +25,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.AccessControl/pkg/System.Security.AccessControl.pkgproj
+++ b/src/System.Security.AccessControl/pkg/System.Security.AccessControl.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.AccessControl.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.AccessControl.builds" />
 
@@ -11,10 +11,10 @@
       <PackageTargetRuntime>win</PackageTargetRuntime>
     </NotSupportedOnTargetFramework>
 
-    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
     <!-- Only supported on windows, so overriding
          the validation RID's -->
-    <ValidateFramework Include="dnxcore50"> 
+    <ValidateFramework Include="netstandardapp1.5"> 
       <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
     </ValidateFramework> 
   </ItemGroup>

--- a/src/System.Security.AccessControl/pkg/System.Security.AccessControl.pkgproj
+++ b/src/System.Security.AccessControl/pkg/System.Security.AccessControl.pkgproj
@@ -6,6 +6,17 @@
       <SupportedFramework>net46;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.AccessControl.builds" />
+
+    <NotSupportedOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>win</PackageTargetRuntime>
+    </NotSupportedOnTargetFramework>
+
+    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <!-- Only supported on windows, so overriding
+         the validation RID's -->
+    <ValidateFramework Include="dnxcore50"> 
+      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
+    </ValidateFramework> 
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Security.AccessControl/src/System.Security.AccessControl.csproj
+++ b/src/System.Security.AccessControl/src/System.Security.AccessControl.csproj
@@ -6,7 +6,8 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46'" >true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework> 
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
+    <PackageTargetRuntime Condition="'$(TargetGroup)' == ''">win</PackageTargetRuntime>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
 

--- a/src/System.Security.Claims/pkg/System.Security.Claims.pkgproj
+++ b/src/System.Security.Claims/pkg/System.Security.Claims.pkgproj
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Claims.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Claims.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Claims/pkg/System.Security.Claims.pkgproj
+++ b/src/System.Security.Claims/pkg/System.Security.Claims.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Claims.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Claims.builds" />
   </ItemGroup>

--- a/src/System.Security.Cryptography.Algorithms/pkg/System.Security.Cryptography.Algorithms.pkgproj
+++ b/src/System.Security.Cryptography.Algorithms/pkg/System.Security.Cryptography.Algorithms.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.Algorithms.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Algorithms.csproj">
       <TargetGroup>net46</TargetGroup>

--- a/src/System.Security.Cryptography.Algorithms/pkg/System.Security.Cryptography.Algorithms.pkgproj
+++ b/src/System.Security.Cryptography.Algorithms/pkg/System.Security.Cryptography.Algorithms.pkgproj
@@ -10,11 +10,12 @@
     </ProjectReference>
     <ProjectReference Include="win\System.Security.Cryptography.Algorithms.pkgproj" />
     <ProjectReference Include="unix\System.Security.Cryptography.Algorithms.pkgproj" />
-
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
+++ b/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.Cng.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Cng.builds" />
   </ItemGroup>

--- a/src/System.Security.Cryptography.Csp/pkg/System.Security.Cryptography.Csp.pkgproj
+++ b/src/System.Security.Cryptography.Csp/pkg/System.Security.Cryptography.Csp.pkgproj
@@ -7,6 +7,17 @@
       <SupportedFramework>net46;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Csp.builds" />
+    
+    <NotSupportedOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>win</PackageTargetRuntime>
+    </NotSupportedOnTargetFramework>
+
+    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <!-- Only supported on windows, so overriding
+         the validation RID's -->
+    <ValidateFramework Include="dnxcore50"> 
+      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
+    </ValidateFramework> 
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Security.Cryptography.Csp/pkg/System.Security.Cryptography.Csp.pkgproj
+++ b/src/System.Security.Cryptography.Csp/pkg/System.Security.Cryptography.Csp.pkgproj
@@ -1,31 +1,28 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.Csp.csproj">
       <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Csp.builds" />
-    
     <NotSupportedOnTargetFramework Include="netcore50">
       <PackageTargetRuntime>win</PackageTargetRuntime>
     </NotSupportedOnTargetFramework>
-
     <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
     <!-- Only supported on windows, so overriding
          the validation RID's -->
-    <ValidateFramework Include="netstandardapp1.5"> 
-      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
-    </ValidateFramework> 
+    <ValidateFramework Include="netstandardapp1.5">
+      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs>
+    </ValidateFramework>
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Csp/pkg/System.Security.Cryptography.Csp.pkgproj
+++ b/src/System.Security.Cryptography.Csp/pkg/System.Security.Cryptography.Csp.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.Csp.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Csp.builds" />
     
@@ -12,10 +12,10 @@
       <PackageTargetRuntime>win</PackageTargetRuntime>
     </NotSupportedOnTargetFramework>
 
-    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
     <!-- Only supported on windows, so overriding
          the validation RID's -->
-    <ValidateFramework Include="dnxcore50"> 
+    <ValidateFramework Include="netstandardapp1.5"> 
       <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
     </ValidateFramework> 
   </ItemGroup>

--- a/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
+++ b/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
@@ -9,7 +9,8 @@
     <CLSCompliant>false</CLSCompliant>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net46'">None</ResourcesSourceOutputDirectory>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' == ''">win</PackageTargetRuntime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/System.Security.Cryptography.Encoding/pkg/System.Security.Cryptography.Encoding.pkgproj
+++ b/src/System.Security.Cryptography.Encoding/pkg/System.Security.Cryptography.Encoding.pkgproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.Encoding.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
@@ -9,17 +8,16 @@
     <ProjectReference Include="..\src\System.Security.Cryptography.Encoding.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </ProjectReference>
-    
     <ProjectReference Include="win\System.Security.Cryptography.Encoding.pkgproj" />
     <ProjectReference Include="unix\System.Security.Cryptography.Encoding.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Encoding/pkg/System.Security.Cryptography.Encoding.pkgproj
+++ b/src/System.Security.Cryptography.Encoding/pkg/System.Security.Cryptography.Encoding.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.Encoding.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Encoding.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>

--- a/src/System.Security.Cryptography.OpenSsl/pkg/System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/System.Security.Cryptography.OpenSsl/pkg/System.Security.Cryptography.OpenSsl.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.OpenSsl.csproj">
-      <SupportedFramework>dnxcore50</SupportedFramework>
+      <SupportedFramework>netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.OpenSsl.builds" >
       <AdditionalProperties>FilterToOSGroup=Linux</AdditionalProperties>

--- a/src/System.Security.Cryptography.Primitives/pkg/System.Security.Cryptography.Primitives.pkgproj
+++ b/src/System.Security.Cryptography.Primitives/pkg/System.Security.Cryptography.Primitives.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.Primitives.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Primitives.builds" />
   </ItemGroup>

--- a/src/System.Security.Cryptography.Primitives/pkg/System.Security.Cryptography.Primitives.pkgproj
+++ b/src/System.Security.Cryptography.Primitives/pkg/System.Security.Cryptography.Primitives.pkgproj
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.Primitives.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Primitives.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.X509Certificates/pkg/System.Security.Cryptography.X509Certificates.pkgproj
+++ b/src/System.Security.Cryptography.X509Certificates/pkg/System.Security.Cryptography.X509Certificates.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.X509Certificates.csproj">
-      <SupportedFramework>net461;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net461;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.X509Certificates.csproj">
       <AdditionalProperties>TargetGroup=net461</AdditionalProperties>

--- a/src/System.Security.Cryptography.X509Certificates/pkg/System.Security.Cryptography.X509Certificates.pkgproj
+++ b/src/System.Security.Cryptography.X509Certificates/pkg/System.Security.Cryptography.X509Certificates.pkgproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.X509Certificates.csproj">
       <SupportedFramework>net461;netcore50;netstandardapp1.5</SupportedFramework>
@@ -9,17 +8,16 @@
     <ProjectReference Include="..\src\System.Security.Cryptography.X509Certificates.csproj">
       <AdditionalProperties>TargetGroup=net461</AdditionalProperties>
     </ProjectReference>
-    
     <ProjectReference Include="win\System.Security.Cryptography.X509Certificates.pkgproj" />
     <ProjectReference Include="unix\System.Security.Cryptography.X509Certificates.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Principal.Windows/pkg/System.Security.Principal.Windows.pkgproj
+++ b/src/System.Security.Principal.Windows/pkg/System.Security.Principal.Windows.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Principal.Windows.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Principal.Windows.builds" />
   </ItemGroup>

--- a/src/System.Security.Principal/pkg/System.Security.Principal.pkgproj
+++ b/src/System.Security.Principal/pkg/System.Security.Principal.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Principal.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Principal.builds" />
 

--- a/src/System.Security.Principal/pkg/System.Security.Principal.pkgproj
+++ b/src/System.Security.Principal/pkg/System.Security.Principal.pkgproj
@@ -1,22 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Principal.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Principal.builds" />
-
-    <InboxOnTargetFramework Include="MonoAndroid10"/>
-    <InboxOnTargetFramework Include="MonoTouch10"/>
-    <InboxOnTargetFramework Include="net45"/>
-    <InboxOnTargetFramework Include="win8"/>
-    <InboxOnTargetFramework Include="wp80"/>
-    <InboxOnTargetFramework Include="wpa81"/>
-    <InboxOnTargetFramework Include="xamarinios10"/>
-    <InboxOnTargetFramework Include="xamarinmac20"/>
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.ServiceProcess.ServiceController/pkg/System.ServiceProcess.ServiceController.pkgproj
+++ b/src/System.ServiceProcess.ServiceController/pkg/System.ServiceProcess.ServiceController.pkgproj
@@ -4,17 +4,17 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.ServiceProcess.ServiceController.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ServiceProcess.ServiceController.builds" />
 
     <NotSupportedOnTargetFramework Include="netcore50">
       <PackageTargetRuntime>win</PackageTargetRuntime>
     </NotSupportedOnTargetFramework>
-    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
     <!-- Only supported on windows, so overriding
          the validation RID's -->
-    <ValidateFramework Include="dnxcore50"> 
+    <ValidateFramework Include="netstandardapp1.5"> 
       <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
     </ValidateFramework>
   </ItemGroup>

--- a/src/System.ServiceProcess.ServiceController/pkg/System.ServiceProcess.ServiceController.pkgproj
+++ b/src/System.ServiceProcess.ServiceController/pkg/System.ServiceProcess.ServiceController.pkgproj
@@ -7,6 +7,16 @@
       <SupportedFramework>net46;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ServiceProcess.ServiceController.builds" />
+
+    <NotSupportedOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>win</PackageTargetRuntime>
+    </NotSupportedOnTargetFramework>
+    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <!-- Only supported on windows, so overriding
+         the validation RID's -->
+    <ValidateFramework Include="dnxcore50"> 
+      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
+    </ValidateFramework>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.ServiceProcess.ServiceController/src/System.ServiceProcess.ServiceController.csproj
+++ b/src/System.ServiceProcess.ServiceController/src/System.ServiceProcess.ServiceController.csproj
@@ -12,7 +12,8 @@
     <ProjectGuid>{F4821CB6-91A3-4546-BC4F-E00DBFBDAA05}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net46'">None</ResourcesSourceOutputDirectory>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.5</PackageTargetFramework>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net46'">win</PackageTargetRuntime>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />

--- a/src/System.Text.Encoding.CodePages/pkg/System.Text.Encoding.CodePages.pkgproj
+++ b/src/System.Text.Encoding.CodePages/pkg/System.Text.Encoding.CodePages.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Text.Encoding.CodePages.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
 
     <ProjectReference Include="win\System.Text.Encoding.CodePages.pkgproj" />

--- a/src/System.Text.Encoding.CodePages/pkg/System.Text.Encoding.CodePages.pkgproj
+++ b/src/System.Text.Encoding.CodePages/pkg/System.Text.Encoding.CodePages.pkgproj
@@ -1,22 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Text.Encoding.CodePages.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
-
     <ProjectReference Include="win\System.Text.Encoding.CodePages.pkgproj" />
     <ProjectReference Include="unix\System.Text.Encoding.CodePages.pkgproj" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Text.Encoding.Extensions/pkg/System.Text.Encoding.Extensions.pkgproj
+++ b/src/System.Text.Encoding.Extensions/pkg/System.Text.Encoding.Extensions.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Text.Encoding.Extensions.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Text.Encoding.Extensions.pkgproj" />
     <ProjectReference Include="aot\System.Text.Encoding.Extensions.pkgproj" />

--- a/src/System.Text.Encoding.Extensions/pkg/System.Text.Encoding.Extensions.pkgproj
+++ b/src/System.Text.Encoding.Extensions/pkg/System.Text.Encoding.Extensions.pkgproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
@@ -18,6 +18,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Text.Encoding.Extensions/pkg/any/System.Text.Encoding.Extensions.pkgproj
+++ b/src/System.Text.Encoding.Extensions/pkg/any/System.Text.Encoding.Extensions.pkgproj
@@ -25,6 +25,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Text.Encoding/pkg/System.Text.Encoding.pkgproj
+++ b/src/System.Text.Encoding/pkg/System.Text.Encoding.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Text.Encoding.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Text.Encoding.pkgproj" />
     <ProjectReference Include="aot\System.Text.Encoding.pkgproj" />

--- a/src/System.Text.Encoding/pkg/System.Text.Encoding.pkgproj
+++ b/src/System.Text.Encoding/pkg/System.Text.Encoding.pkgproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
@@ -18,6 +18,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Text.Encoding/pkg/any/System.Text.Encoding.pkgproj
+++ b/src/System.Text.Encoding/pkg/any/System.Text.Encoding.pkgproj
@@ -25,6 +25,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Text.Encodings.Web/pkg/System.Text.Encodings.Web.pkgproj
+++ b/src/System.Text.Encodings.Web/pkg/System.Text.Encodings.Web.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\src\System.Text.Encodings.Web.builds">
-      <SupportedFramework>net45;netcore45;wp8;wpa81;dnxcore50</SupportedFramework>
+      <SupportedFramework>net45;netcore45;wp8;wpa81;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
   </ItemGroup>
 

--- a/src/System.Text.RegularExpressions/pkg/System.Text.RegularExpressions.pkgproj
+++ b/src/System.Text.RegularExpressions/pkg/System.Text.RegularExpressions.pkgproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
@@ -17,6 +17,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Text.RegularExpressions/pkg/System.Text.RegularExpressions.pkgproj
+++ b/src/System.Text.RegularExpressions/pkg/System.Text.RegularExpressions.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Text.RegularExpressions.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Text.RegularExpressions.builds" />
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/System.Threading.AccessControl/pkg/System.Threading.AccessControl.pkgproj
+++ b/src/System.Threading.AccessControl/pkg/System.Threading.AccessControl.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Threading.AccessControl.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Threading.AccessControl.builds" />
 
@@ -12,10 +12,10 @@
       <PackageTargetRuntime>win</PackageTargetRuntime>
     </NotSupportedOnTargetFramework>
 
-    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
     <!-- Only supported on windows, so overriding
          the validation RID's -->
-    <ValidateFramework Include="dnxcore50"> 
+    <ValidateFramework Include="netstandardapp1.5"> 
       <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
     </ValidateFramework> 
   </ItemGroup>

--- a/src/System.Threading.AccessControl/pkg/System.Threading.AccessControl.pkgproj
+++ b/src/System.Threading.AccessControl/pkg/System.Threading.AccessControl.pkgproj
@@ -7,6 +7,17 @@
       <SupportedFramework>net46;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Threading.AccessControl.builds" />
+
+    <NotSupportedOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>win</PackageTargetRuntime>
+    </NotSupportedOnTargetFramework>
+
+    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <!-- Only supported on windows, so overriding
+         the validation RID's -->
+    <ValidateFramework Include="dnxcore50"> 
+      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
+    </ValidateFramework> 
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Threading.AccessControl/src/System.Threading.AccessControl.csproj
+++ b/src/System.Threading.AccessControl/src/System.Threading.AccessControl.csproj
@@ -5,7 +5,8 @@
     <AssemblyName>System.Threading.AccessControl</AssemblyName>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <ProjectGuid>{E3ED83FD-3015-4BD8-A1B8-6294986E6CFA}</ProjectGuid>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">dnxcore50</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' == ''">win</PackageTargetRuntime>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>

--- a/src/System.Threading.Overlapped/pkg/System.Threading.Overlapped.pkgproj
+++ b/src/System.Threading.Overlapped/pkg/System.Threading.Overlapped.pkgproj
@@ -7,6 +7,13 @@
       <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Threading.Overlapped.builds" />
+
+    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <!-- Only supported on windows, so overriding
+         the validation RID's -->
+    <ValidateFramework Include="dnxcore50"> 
+      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
+    </ValidateFramework> 
   </ItemGroup>
   
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Threading.Overlapped/pkg/System.Threading.Overlapped.pkgproj
+++ b/src/System.Threading.Overlapped/pkg/System.Threading.Overlapped.pkgproj
@@ -4,14 +4,14 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Threading.Overlapped.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Threading.Overlapped.builds" />
 
-    <ExcludeDefaultValidateFramework Include="dnxcore50" />
+    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
     <!-- Only supported on windows, so overriding
          the validation RID's -->
-    <ValidateFramework Include="dnxcore50"> 
+    <ValidateFramework Include="netstandardapp1.5"> 
       <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
     </ValidateFramework> 
   </ItemGroup>

--- a/src/System.Threading.Overlapped/src/System.Threading.Overlapped.csproj
+++ b/src/System.Threading.Overlapped/src/System.Threading.Overlapped.csproj
@@ -10,8 +10,9 @@
     <ProjectGuid>{6A07CCB8-3E59-47e7-B3DD-DB1F6FC501D5}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='' OR '$(TargetGroup)'=='net46'">true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework> 
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.0</NuGetTargetMoniker>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
+    <PackageTargetRuntime Condition="'$(TargetGroup)' == ''">win</PackageTargetRuntime>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />

--- a/src/System.Threading.Overlapped/src/project.json
+++ b/src/System.Threading.Overlapped/src/project.json
@@ -1,6 +1,6 @@
 {
   "frameworks": {
-    "netstandard1.0": {
+    "netstandard1.3": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23829",
         "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23829"

--- a/src/System.Threading.Tasks.Dataflow/pkg/System.Threading.Tasks.Dataflow.pkgproj
+++ b/src/System.Threading.Tasks.Dataflow/pkg/System.Threading.Tasks.Dataflow.pkgproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\src\System.Threading.Tasks.Dataflow.csproj">
-      <SupportedFramework>net45;netcore45;wp8;wpa81;dnxcore50</SupportedFramework>
+      <SupportedFramework>net45;netcore45;wp8;wpa81;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Threading.Tasks.Dataflow.WP8.csproj" />
   </ItemGroup>

--- a/src/System.Threading.Tasks.Extensions/pkg/System.Threading.Tasks.Extensions.pkgproj
+++ b/src/System.Threading.Tasks.Extensions/pkg/System.Threading.Tasks.Extensions.pkgproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\src\System.Threading.Tasks.Extensions.builds" >
-      <SupportedFramework>net45;netcore45;dnxcore50;wpa81;wp8</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81;wp8</SupportedFramework>
     </ProjectReference>
   </ItemGroup>
 

--- a/src/System.Threading.Tasks.Parallel/pkg/System.Threading.Tasks.Parallel.pkgproj
+++ b/src/System.Threading.Tasks.Parallel/pkg/System.Threading.Tasks.Parallel.pkgproj
@@ -4,7 +4,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Threading.Tasks.Parallel.csproj">
-      <SupportedFramework>net45;netcore45;dnxcore50;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Threading.Tasks.Parallel.builds" />
 

--- a/src/System.Threading.Tasks.Parallel/pkg/System.Threading.Tasks.Parallel.pkgproj
+++ b/src/System.Threading.Tasks.Parallel/pkg/System.Threading.Tasks.Parallel.pkgproj
@@ -1,21 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Threading.Tasks.Parallel.csproj">
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Threading.Tasks.Parallel.builds" />
-
-    <InboxOnTargetFramework Include="MonoAndroid10"/>
-    <InboxOnTargetFramework Include="MonoTouch10"/>
-    <InboxOnTargetFramework Include="net45"/>
-    <InboxOnTargetFramework Include="win8"/>
-    <InboxOnTargetFramework Include="wpa81"/>
-    <InboxOnTargetFramework Include="xamarinios10"/>
-    <InboxOnTargetFramework Include="xamarinmac20"/>
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading.Tasks/pkg/System.Threading.Tasks.pkgproj
+++ b/src/System.Threading.Tasks/pkg/System.Threading.Tasks.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Threading.Tasks.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Threading.Tasks.pkgproj" />
     <ProjectReference Include="aot\System.Threading.Tasks.pkgproj" />

--- a/src/System.Threading.Tasks/pkg/System.Threading.Tasks.pkgproj
+++ b/src/System.Threading.Tasks/pkg/System.Threading.Tasks.pkgproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
@@ -18,6 +18,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading.Tasks/pkg/any/System.Threading.Tasks.pkgproj
+++ b/src/System.Threading.Tasks/pkg/any/System.Threading.Tasks.pkgproj
@@ -23,6 +23,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading.Thread/pkg/System.Threading.Thread.pkgproj
+++ b/src/System.Threading.Thread/pkg/System.Threading.Thread.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Threading.Thread.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Threading.Thread.builds" />
 

--- a/src/System.Threading.Thread/pkg/System.Threading.Thread.pkgproj
+++ b/src/System.Threading.Thread/pkg/System.Threading.Thread.pkgproj
@@ -1,22 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Threading.Thread.csproj">
       <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Threading.Thread.builds" />
-
     <NotSupportedOnTargetFramework Include="netcore50" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading.Thread/pkg/System.Threading.Thread.pkgproj
+++ b/src/System.Threading.Thread/pkg/System.Threading.Thread.pkgproj
@@ -7,6 +7,8 @@
       <SupportedFramework>net46;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Threading.Thread.builds" />
+
+    <NotSupportedOnTargetFramework Include="netcore50" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Threading.Thread/src/System.Threading.Thread.csproj
+++ b/src/System.Threading.Thread/src/System.Threading.Thread.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>System.Threading.Thread</AssemblyName>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework> 
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->

--- a/src/System.Threading.ThreadPool/pkg/System.Threading.ThreadPool.pkgproj
+++ b/src/System.Threading.ThreadPool/pkg/System.Threading.ThreadPool.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Threading.ThreadPool.csproj">
-      <SupportedFramework>net46;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Threading.ThreadPool.builds" />
   </ItemGroup>

--- a/src/System.Threading.ThreadPool/pkg/System.Threading.ThreadPool.pkgproj
+++ b/src/System.Threading.ThreadPool/pkg/System.Threading.ThreadPool.pkgproj
@@ -1,22 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Threading.ThreadPool.csproj">
       <SupportedFramework>net46;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Threading.ThreadPool.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <NotSupportedOnTargetFramework Include="netcore50" />
-
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading.ThreadPool/pkg/System.Threading.ThreadPool.pkgproj
+++ b/src/System.Threading.ThreadPool/pkg/System.Threading.ThreadPool.pkgproj
@@ -10,6 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <NotSupportedOnTargetFramework Include="netcore50" />
+
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />

--- a/src/System.Threading.ThreadPool/src/System.Threading.ThreadPool.csproj
+++ b/src/System.Threading.ThreadPool/src/System.Threading.ThreadPool.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>System.Threading.ThreadPool</AssemblyName>
     <AssemblyVersion>4.0.10.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dnxcore50</PackageTargetFramework> 
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->

--- a/src/System.Threading.Timer/pkg/System.Threading.Timer.pkgproj
+++ b/src/System.Threading.Timer/pkg/System.Threading.Timer.pkgproj
@@ -4,7 +4,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Threading.Timer.csproj">
-      <SupportedFramework>net451;netcore451;dnxcore50;wpa81</SupportedFramework>
+      <SupportedFramework>net451;netcore451;netstandardapp1.5;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Threading.Timer.pkgproj" />
     <ProjectReference Include="aot\System.Threading.Timer.pkgproj" />

--- a/src/System.Threading.Timer/pkg/System.Threading.Timer.pkgproj
+++ b/src/System.Threading.Timer/pkg/System.Threading.Timer.pkgproj
@@ -1,22 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Threading.Timer.csproj">
       <SupportedFramework>net451;netcore451;netstandardapp1.5;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Threading.Timer.pkgproj" />
     <ProjectReference Include="aot\System.Threading.Timer.pkgproj" />
-
-    <InboxOnTargetFramework Include="MonoAndroid10"/>
-    <InboxOnTargetFramework Include="MonoTouch10"/>
-    <InboxOnTargetFramework Include="net451"/>
-    <InboxOnTargetFramework Include="win81"/>
-    <InboxOnTargetFramework Include="wpa81"/>
-    <InboxOnTargetFramework Include="xamarinios10"/>
-    <InboxOnTargetFramework Include="xamarinmac20"/>
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net451" />
+    <InboxOnTargetFramework Include="win81" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading.Timer/pkg/any/System.Threading.Timer.pkgproj
+++ b/src/System.Threading.Timer/pkg/any/System.Threading.Timer.pkgproj
@@ -25,6 +25,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading/pkg/System.Threading.pkgproj
+++ b/src/System.Threading/pkg/System.Threading.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Threading.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Threading.builds" />
   </ItemGroup>

--- a/src/System.Threading/pkg/System.Threading.pkgproj
+++ b/src/System.Threading/pkg/System.Threading.pkgproj
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <ProjectReference Include="..\ref\4.0.0\System.Threading.depproj" >
+    <ProjectReference Include="..\ref\4.0.0\System.Threading.depproj">
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Threading.csproj">
@@ -19,6 +19,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Xml.ReaderWriter/pkg/System.Xml.ReaderWriter.pkgproj
+++ b/src/System.Xml.ReaderWriter/pkg/System.Xml.ReaderWriter.pkgproj
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <ProjectReference Include="..\ref\4.0.0\System.Xml.ReaderWriter.depproj" >
+    <ProjectReference Include="..\ref\4.0.0\System.Xml.ReaderWriter.depproj">
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Xml.ReaderWriter.csproj">
@@ -17,6 +17,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Xml.ReaderWriter/pkg/System.Xml.ReaderWriter.pkgproj
+++ b/src/System.Xml.ReaderWriter/pkg/System.Xml.ReaderWriter.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Xml.ReaderWriter.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Xml.ReaderWriter.builds" />
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/System.Xml.XDocument/pkg/System.Xml.XDocument.pkgproj
+++ b/src/System.Xml.XDocument/pkg/System.Xml.XDocument.pkgproj
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <ProjectReference Include="..\ref\4.0.0\System.Xml.XDocument.depproj" >
+    <ProjectReference Include="..\ref\4.0.0\System.Xml.XDocument.depproj">
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Xml.XDocument.csproj">
@@ -17,6 +17,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Xml.XDocument/pkg/System.Xml.XDocument.pkgproj
+++ b/src/System.Xml.XDocument/pkg/System.Xml.XDocument.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Xml.XDocument.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Xml.XDocument.builds" />
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/System.Xml.XPath.XDocument/pkg/System.Xml.XPath.XDocument.pkgproj
+++ b/src/System.Xml.XPath.XDocument/pkg/System.Xml.XPath.XDocument.pkgproj
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Xml.XPath.XDocument.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Xml.XPath.XDocument.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Xml.XPath.XDocument/pkg/System.Xml.XPath.XDocument.pkgproj
+++ b/src/System.Xml.XPath.XDocument/pkg/System.Xml.XPath.XDocument.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Xml.XPath.XDocument.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Xml.XPath.XDocument.builds" />
   </ItemGroup>

--- a/src/System.Xml.XPath.XmlDocument/pkg/System.Xml.XPath.XmlDocument.pkgproj
+++ b/src/System.Xml.XPath.XmlDocument/pkg/System.Xml.XPath.XmlDocument.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Xml.XPath.XmlDocument.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Xml.XPath.XmlDocument.builds" />
     <!-- nothing special required for desktop - pure plib with no type conflicts. -->

--- a/src/System.Xml.XPath.XmlDocument/pkg/System.Xml.XPath.XmlDocument.pkgproj
+++ b/src/System.Xml.XPath.XmlDocument/pkg/System.Xml.XPath.XmlDocument.pkgproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Xml.XPath.XmlDocument.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
@@ -9,13 +8,13 @@
     <ProjectReference Include="..\src\System.Xml.XPath.XmlDocument.builds" />
     <!-- nothing special required for desktop - pure plib with no type conflicts. -->
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Xml.XPath/pkg/System.Xml.XPath.pkgproj
+++ b/src/System.Xml.XPath/pkg/System.Xml.XPath.pkgproj
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Xml.XPath.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Xml.XPath.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Xml.XPath/pkg/System.Xml.XPath.pkgproj
+++ b/src/System.Xml.XPath/pkg/System.Xml.XPath.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Xml.XPath.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Xml.XPath.builds" />
   </ItemGroup>

--- a/src/System.Xml.XmlDocument/pkg/System.Xml.XmlDocument.pkgproj
+++ b/src/System.Xml.XmlDocument/pkg/System.Xml.XmlDocument.pkgproj
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Xml.XmlDocument.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Xml.XmlDocument.builds" />
   </ItemGroup>
-
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Xml.XmlDocument/pkg/System.Xml.XmlDocument.pkgproj
+++ b/src/System.Xml.XmlDocument/pkg/System.Xml.XmlDocument.pkgproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Xml.XmlDocument.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Xml.XmlDocument.builds" />
   </ItemGroup>

--- a/src/System.Xml.XmlSerializer/pkg/System.Xml.XmlSerializer.pkgproj
+++ b/src/System.Xml.XmlSerializer/pkg/System.Xml.XmlSerializer.pkgproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
@@ -8,10 +8,8 @@
     <ProjectReference Include="..\ref\System.Xml.XmlSerializer.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
-
     <ProjectReference Include="any\System.Xml.XmlSerializer.pkgproj" />
     <ProjectReference Include="aot\System.Xml.XmlSerializer.pkgproj" />
-
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />
@@ -20,6 +18,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Xml.XmlSerializer/pkg/System.Xml.XmlSerializer.pkgproj
+++ b/src/System.Xml.XmlSerializer/pkg/System.Xml.XmlSerializer.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Xml.XmlSerializer.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
 
     <ProjectReference Include="any\System.Xml.XmlSerializer.pkgproj" />

--- a/src/System.Xml.XmlSerializer/pkg/any/System.Xml.XmlSerializer.pkgproj
+++ b/src/System.Xml.XmlSerializer/pkg/any/System.Xml.XmlSerializer.pkgproj
@@ -25,6 +25,8 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
This change is best reviewed by individual commits.

https://github.com/ericstj/corefx/commit/6008326984df7bddff751d0fec678ee29d821a59

- This is the bulk of the change.  Any package that previously included a DNXCore50 asset now packages that asset as NETStandard.  None of our API actually were tied to DNXCore50 and usually they were only packaged that way because we didn't support them on UWP due to the WACK.  In order to model this better we are packaging as NETStandard and disabling the implemenation on UWP with a placeholder.

https://github.com/ericstj/corefx/commit/7c50768be0a2008480aa22ddb8038fdcb0e8039b

- Updates the version of build tools and updates all cases where we were using DNXCore50 in validation to NETstandardApp.

https://github.com/ericstj/corefx/commit/baf425fa935f4ecd32712448be627604067cf1d3

 - The new version of buildtools from above brought down the new Xamarin frameworks.  This updates all packages supported by those new frameworks to add placeholders to indicate that the impl on those frameworks is an inbox facade.

https://github.com/ericstj/corefx/commit/c5e9a0bbfd1472f8abb3c2e35140b83ac1bcdcef

 - Cleanup.  Originally I did this as part of the 4.6.2 validation commit, but then pulled it out since this is actually supported by 4.6.1.

https://github.com/ericstj/corefx/commit/3a2ac29245c7bfa04950e268b7165c38c879ea2f

- The new version of buildtools from above started validating for .NET 4.6.2 as well so we needed to markup the packages that had a specific version of their API supported starting in 4.6.2.

/cc @weshaggard @chcosta 
