### PR TITLE
Fix Directory.CreateDirectory permissions mask on Unix

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -160,7 +160,9 @@ namespace System.IO
                     throw new PathTooLongException(SR.IO_PathTooLong);
                 }
 
-                result = Interop.Sys.MkDir(name, (int)Interop.Sys.Permissions.S_IRWXU);
+                // The mkdir command uses 0777 by default (it'll be AND'd with the process umask internally).
+                // We do the same.
+                result = Interop.Sys.MkDir(name, (int)Interop.Sys.Permissions.Mask);
                 if (result < 0 && firstError.Error == 0)
                 {
                     Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();


### PR DESCRIPTION
The mkdir utility by default uses 777 (automatically and'd with the process umask) as the permissions for new directory.  Directory.CreateDirectory should do the same, but it's currently using 700.  This fixes it to match.

cc: @ianhays, @ericstj, @mmitche 
Fixes https://github.com/dotnet/corefx/issues/6494 (we think)