### PR TITLE
Update netci and run-test to use the IgnoreForCI trait in Jenkins

### DIFF
--- a/src/Common/tests/project.json
+++ b/src/Common/tests/project.json
@@ -17,7 +17,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Threading.Tasks.Parallel": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/Microsoft.CSharp/tests/project.json
+++ b/src/Microsoft.CSharp/tests/project.json
@@ -20,7 +20,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/Microsoft.VisualBasic/tests/project.json
+++ b/src/Microsoft.VisualBasic/tests/project.json
@@ -22,7 +22,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/Microsoft.Win32.Primitives/tests/project.json
+++ b/src/Microsoft.Win32.Primitives/tests/project.json
@@ -4,7 +4,7 @@
     "System.Runtime": "4.0.20",
     "System.Runtime.InteropServices": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/Microsoft.Win32.Registry.AccessControl/tests/project.json
+++ b/src/Microsoft.Win32.Registry.AccessControl/tests/project.json
@@ -10,7 +10,7 @@
     "System.Security.AccessControl": "4.0.0-rc3-23829",
     "System.Security.Principal.Windows": "4.0.0-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/Microsoft.Win32.Registry/tests/project.json
+++ b/src/Microsoft.Win32.Registry/tests/project.json
@@ -8,7 +8,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/Scenarios/tests/InterProcessCommunication/project.json
+++ b/src/Scenarios/tests/InterProcessCommunication/project.json
@@ -12,7 +12,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.AppContext/tests/project.json
+++ b/src/System.AppContext/tests/project.json
@@ -4,7 +4,7 @@
     "System.AppContext": "4.0.0",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Buffers/tests/project.json
+++ b/src/System.Buffers/tests/project.json
@@ -7,7 +7,7 @@
     "System.Resources.ResourceManager": "4.0.1-rc3-23829",
     "System.Threading": "4.0.11-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Collections.Concurrent/tests/project.json
+++ b/src/System.Collections.Concurrent/tests/project.json
@@ -13,7 +13,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Collections.Immutable/tests/project.json
+++ b/src/System.Collections.Immutable/tests/project.json
@@ -7,7 +7,7 @@
     "System.Reflection.TypeExtensions": "4.0.0",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Collections.NonGeneric/tests/project.json
+++ b/src/System.Collections.NonGeneric/tests/project.json
@@ -14,7 +14,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Collections.Specialized/tests/project.json
+++ b/src/System.Collections.Specialized/tests/project.json
@@ -11,7 +11,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -12,7 +12,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.ComponentModel.Annotations/tests/project.json
+++ b/src/System.ComponentModel.Annotations/tests/project.json
@@ -9,7 +9,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.ComponentModel.EventBasedAsync/tests/project.json
+++ b/src/System.ComponentModel.EventBasedAsync/tests/project.json
@@ -5,7 +5,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.ComponentModel.Primitives/tests/project.json
+++ b/src/System.ComponentModel.Primitives/tests/project.json
@@ -4,7 +4,7 @@
     "System.ComponentModel": "4.0.0",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.ComponentModel.TypeConverter/tests/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/project.json
@@ -8,7 +8,7 @@
     "System.Runtime": "4.0.20",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.ComponentModel/tests/project.json
+++ b/src/System.ComponentModel/tests/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23829",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Composition.Convention/tests/project.json
+++ b/src/System.Composition.Convention/tests/project.json
@@ -4,7 +4,7 @@
     "System.Linq.Expressions": "4.0.10",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Composition/tests/project.json
+++ b/src/System.Composition/tests/project.json
@@ -4,7 +4,7 @@
     "System.Linq.Expressions": "4.0.10",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Console/tests/project.json
+++ b/src/System.Console/tests/project.json
@@ -13,7 +13,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Threading.Tasks.Parallel": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Data.Common/tests/project.json
+++ b/src/System.Data.Common/tests/project.json
@@ -12,7 +12,7 @@
     "System.Text.RegularExpressions": "4.0.0",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Data.SqlClient/tests/FunctionalTests/project.json
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/project.json
@@ -5,7 +5,7 @@
     "System.Data.Common": "4.0.1-rc3-23829",
     "System.Text.RegularExpressions": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Data.SqlClient/tests/ManualTests/project.json
+++ b/src/System.Data.SqlClient/tests/ManualTests/project.json
@@ -51,6 +51,6 @@
     "System.Xml.ReaderWriter": "4.0.11-rc3-23829",
     "System.Xml.XmlDocument": "4.0.1-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   }
 }

--- a/src/System.Diagnostics.Contracts/tests/project.json
+++ b/src/System.Diagnostics.Contracts/tests/project.json
@@ -6,7 +6,7 @@
     "System.Runtime": "4.0.20",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Diagnostics.Debug/tests/project.json
+++ b/src/System.Diagnostics.Debug/tests/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23829",
     "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Diagnostics.DiagnosticSource/tests/project.json
+++ b/src/System.Diagnostics.DiagnosticSource/tests/project.json
@@ -7,7 +7,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
@@ -8,7 +8,7 @@
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc3-23829",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Diagnostics.Process/tests/project.json
+++ b/src/System.Diagnostics.Process/tests/project.json
@@ -22,7 +22,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Threading.Thread": "4.0.0-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/project.json
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/project.json
@@ -10,7 +10,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Diagnostics.Tools/tests/project.json
+++ b/src/System.Diagnostics.Tools/tests/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23829",
     "System.Diagnostics.Tools": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Diagnostics.TraceSource/tests/project.json
+++ b/src/System.Diagnostics.TraceSource/tests/project.json
@@ -8,7 +8,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
@@ -8,7 +8,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Diagnostics.Tracing/tests/project.json
+++ b/src/System.Diagnostics.Tracing/tests/project.json
@@ -15,7 +15,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Threading.Thread": "4.0.0-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Drawing.Primitives/tests/project.json
+++ b/src/System.Drawing.Primitives/tests/project.json
@@ -4,7 +4,7 @@
     "System.Globalization": "4.0.0",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Dynamic.Runtime/tests/project.json
+++ b/src/System.Dynamic.Runtime/tests/project.json
@@ -18,7 +18,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Globalization.Calendars/tests/project.json
+++ b/src/System.Globalization.Calendars/tests/project.json
@@ -6,7 +6,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Globalization.Extensions/tests/project.json
+++ b/src/System.Globalization.Extensions/tests/project.json
@@ -9,7 +9,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Globalization/tests/project.json
+++ b/src/System.Globalization/tests/project.json
@@ -8,7 +8,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.IO.Compression.ZipFile/tests/project.json
+++ b/src/System.IO.Compression.ZipFile/tests/project.json
@@ -17,7 +17,7 @@
     "System.Text.Encoding": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -17,7 +17,7 @@
     "System.Text.Encoding": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.IO.FileSystem.AccessControl/tests/project.json
+++ b/src/System.IO.FileSystem.AccessControl/tests/project.json
@@ -16,7 +16,7 @@
     "System.Security.Principal": "4.0.0",
     "System.Security.Principal.Windows": "4.0.0-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.IO.FileSystem.DriveInfo/tests/project.json
+++ b/src/System.IO.FileSystem.DriveInfo/tests/project.json
@@ -8,7 +8,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.IO.FileSystem.Primitives/tests/project.json
+++ b/src/System.IO.FileSystem.Primitives/tests/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23829",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.IO.FileSystem.Watcher/tests/project.json
+++ b/src/System.IO.FileSystem.Watcher/tests/project.json
@@ -12,7 +12,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.IO.FileSystem/tests/project.json
+++ b/src/System.IO.FileSystem/tests/project.json
@@ -20,7 +20,7 @@
     "System.Text.Encoding.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.IO.MemoryMappedFiles/tests/project.json
+++ b/src/System.IO.MemoryMappedFiles/tests/project.json
@@ -12,7 +12,7 @@
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc3-23829",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.IO.Packaging/tests/project.json
+++ b/src/System.IO.Packaging/tests/project.json
@@ -10,7 +10,7 @@
     "System.Xml.ReaderWriter": "4.0.0",
     "System.Xml.XDocument": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.IO.Pipes/tests/project.json
+++ b/src/System.IO.Pipes/tests/project.json
@@ -14,7 +14,7 @@
     "System.Threading.Overlapped": "4.0.0",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.IO.UnmanagedMemoryStream/tests/project.json
+++ b/src/System.IO.UnmanagedMemoryStream/tests/project.json
@@ -11,7 +11,7 @@
     "System.Runtime.InteropServices": "4.0.20",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.IO/tests/project.json
+++ b/src/System.IO/tests/project.json
@@ -5,7 +5,7 @@
     "System.IO": "4.1.0-rc3-23829",
     "System.Text.Encoding.CodePages": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Linq.Expressions/tests/project.json
+++ b/src/System.Linq.Expressions/tests/project.json
@@ -15,7 +15,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Linq.Parallel/tests/project.json
+++ b/src/System.Linq.Parallel/tests/project.json
@@ -12,7 +12,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Linq.Queryable/tests/project.json
+++ b/src/System.Linq.Queryable/tests/project.json
@@ -8,7 +8,7 @@
     "System.Runtime": "4.0.20",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Linq/tests/project.json
+++ b/src/System.Linq/tests/project.json
@@ -8,7 +8,7 @@
     "System.Runtime": "4.0.20",
     "System.Runtime.Extensions": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
@@ -9,7 +9,7 @@
     "System.Security.Cryptography.X509Certificates": "4.0.0-rc3-23829",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
@@ -18,7 +18,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Threading.Thread": "4.0.0-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.Http/tests/FunctionalTests/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/project.json
@@ -13,7 +13,7 @@
     "System.Text.Encoding": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.Http/tests/UnitTests/project.json
+++ b/src/System.Net.Http/tests/UnitTests/project.json
@@ -8,7 +8,7 @@
     "System.Reflection": "4.0.10",
     "System.Reflection.TypeExtensions": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.NameResolution/tests/FunctionalTests/project.json
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/project.json
@@ -8,7 +8,7 @@
     "System.Runtime": "4.0.20",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.NameResolution/tests/PalTests/project.json
+++ b/src/System.Net.NameResolution/tests/PalTests/project.json
@@ -23,7 +23,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/project.json
@@ -4,7 +4,7 @@
     "System.Net.Primitives": "4.0.10",
     "Microsoft.Win32.Primitives": "4.0.1-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.NetworkInformation/tests/UnitTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/UnitTests/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23829",
     "System.Net.Primitives": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.Ping/tests/FunctionalTests/project.json
+++ b/src/System.Net.Ping/tests/FunctionalTests/project.json
@@ -4,7 +4,7 @@
     "System.Diagnostics.Process": "4.1.0-rc3-23829",
     "System.Net.Primitives": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.Primitives/tests/FunctionalTests/project.json
+++ b/src/System.Net.Primitives/tests/FunctionalTests/project.json
@@ -5,7 +5,7 @@
     "System.Runtime": "4.0.20",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.Primitives/tests/PalTests/project.json
+++ b/src/System.Net.Primitives/tests/PalTests/project.json
@@ -13,7 +13,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.Primitives/tests/UnitTests/project.json
+++ b/src/System.Net.Primitives/tests/UnitTests/project.json
@@ -14,7 +14,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.Requests/tests/project.json
+++ b/src/System.Net.Requests/tests/project.json
@@ -6,7 +6,7 @@
     "System.Net.Primitives": "4.0.11-rc3-23829",
     "System.Net.Requests": "4.0.11-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.Security/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/unix/project.json
@@ -7,7 +7,7 @@
     "System.Security.Cryptography.X509Certificates": "4.0.0-rc3-23829",
     "System.Security.Principal": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.Security/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/win/project.json
@@ -8,7 +8,7 @@
     "System.Security.Principal": "4.0.0",
     "System.Security.Principal.Windows": "4.0.0-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.Security/tests/UnitTests/project.json
+++ b/src/System.Net.Security/tests/UnitTests/project.json
@@ -6,7 +6,7 @@
     "System.Net.TestData": "1.0.0-prerelease",
     "System.Security.Cryptography.X509Certificates": "4.0.0-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/project.json
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/project.json
@@ -12,7 +12,7 @@
     "System.Threading.Thread": "4.0.0-rc3-23829",
     "System.Threading.ThreadPool": "4.0.10-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.Sockets.Legacy/tests/PerformanceTests/project.json
+++ b/src/System.Net.Sockets.Legacy/tests/PerformanceTests/project.json
@@ -9,7 +9,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Threading.Tasks.Parallel": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.Sockets/tests/FunctionalTests/project.json
+++ b/src/System.Net.Sockets/tests/FunctionalTests/project.json
@@ -9,7 +9,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Threading.Tasks.Parallel": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.Sockets/tests/PerformanceTests/project.json
+++ b/src/System.Net.Sockets/tests/PerformanceTests/project.json
@@ -9,7 +9,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Threading.Tasks.Parallel": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.WebHeaderCollection/tests/project.json
+++ b/src/System.Net.WebHeaderCollection/tests/project.json
@@ -4,7 +4,7 @@
     "System.Collections.Specialized": "4.0.0",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.WebSockets.Client/tests/project.json
+++ b/src/System.Net.WebSockets.Client/tests/project.json
@@ -6,7 +6,7 @@
     "System.Reflection.Extensions": "4.0.0",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Net.WebSockets/tests/project.json
+++ b/src/System.Net.WebSockets/tests/project.json
@@ -4,7 +4,7 @@
     "System.Net.WebSockets": "4.0.0-rc3-23829",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Numerics.Vectors/tests/project.json
+++ b/src/System.Numerics.Vectors/tests/project.json
@@ -14,7 +14,7 @@
     "System.Runtime.InteropServices": "4.0.20",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.ObjectModel/tests/project.json
+++ b/src/System.ObjectModel/tests/project.json
@@ -10,7 +10,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Reflection.Context/tests/project.json
+++ b/src/System.Reflection.Context/tests/project.json
@@ -5,7 +5,7 @@
     "System.Reflection.Primitives": "4.0.0",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Reflection.DispatchProxy/tests/project.json
+++ b/src/System.Reflection.DispatchProxy/tests/project.json
@@ -7,7 +7,7 @@
     "System.Reflection": "4.0.10",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Reflection.Emit.ILGeneration/tests/project.json
+++ b/src/System.Reflection.Emit.ILGeneration/tests/project.json
@@ -10,7 +10,7 @@
     "System.Runtime": "4.0.20",
     "System.Runtime.Extensions": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Reflection.Emit.Lightweight/tests/project.json
+++ b/src/System.Reflection.Emit.Lightweight/tests/project.json
@@ -6,7 +6,7 @@
     "System.Reflection.TypeExtensions": "4.0.0",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Reflection.Emit/tests/project.json
+++ b/src/System.Reflection.Emit/tests/project.json
@@ -9,7 +9,7 @@
     "System.Runtime": "4.0.20",
     "System.Runtime.Extensions": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Reflection.Extensions/tests/project.json
+++ b/src/System.Reflection.Extensions/tests/project.json
@@ -7,7 +7,7 @@
     "System.Runtime": "4.0.20",
     "System.Threading": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Reflection.Metadata/tests/project.json
+++ b/src/System.Reflection.Metadata/tests/project.json
@@ -18,7 +18,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Threading.Tasks.Parallel": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Reflection.TypeExtensions/tests/CoreCLR/project.json
+++ b/src/System.Reflection.TypeExtensions/tests/CoreCLR/project.json
@@ -12,7 +12,7 @@
     "System.Runtime": "4.0.20",
     "System.Runtime.Extensions": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Reflection.TypeExtensions/tests/project.json
+++ b/src/System.Reflection.TypeExtensions/tests/project.json
@@ -8,7 +8,7 @@
     "System.Runtime": "4.0.20",
     "System.Runtime.Extensions": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Reflection/tests/CoreCLR/project.json
+++ b/src/System.Reflection/tests/CoreCLR/project.json
@@ -9,7 +9,7 @@
     "System.Runtime": "4.0.20",
     "System.Runtime.Loader": "4.0.0-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Reflection/tests/project.json
+++ b/src/System.Reflection/tests/project.json
@@ -11,7 +11,7 @@
     "System.Runtime.InteropServices": "4.0.20",
     "System.Threading": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Resources.Reader/tests/project.json
+++ b/src/System.Resources.Reader/tests/project.json
@@ -7,7 +7,7 @@
     "System.Runtime": "4.0.20",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Resources.ReaderWriter/tests/project.json
+++ b/src/System.Resources.ReaderWriter/tests/project.json
@@ -7,7 +7,7 @@
     "System.Runtime": "4.0.20",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Resources.ResourceManager/tests/project.json
+++ b/src/System.Resources.ResourceManager/tests/project.json
@@ -5,7 +5,7 @@
     "System.Globalization": "4.0.10",
     "System.Resources.ResourceManager": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Resources.Writer/tests/project.json
+++ b/src/System.Resources.Writer/tests/project.json
@@ -7,7 +7,7 @@
     "System.Runtime": "4.0.20",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Runtime.Extensions/tests/project.json
+++ b/src/System.Runtime.Extensions/tests/project.json
@@ -11,7 +11,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Runtime.Handles/tests/project.json
+++ b/src/System.Runtime.Handles/tests/project.json
@@ -4,7 +4,7 @@
     "System.Runtime.Handles": "4.0.0",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Runtime.InteropServices.PInvoke/tests/project.json
+++ b/src/System.Runtime.InteropServices.PInvoke/tests/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/project.json
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/project.json
@@ -5,7 +5,7 @@
     "System.Runtime": "4.0.20",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Runtime.InteropServices/tests/project.json
+++ b/src/System.Runtime.InteropServices/tests/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23829",
     "System.Runtime.InteropServices": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Runtime.Loader/tests/DefaultContext/project.json
+++ b/src/System.Runtime.Loader/tests/DefaultContext/project.json
@@ -12,7 +12,7 @@
     "System.Runtime.Loader": "4.0.0-rc3-23829",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Runtime.Loader/tests/project.json
+++ b/src/System.Runtime.Loader/tests/project.json
@@ -12,7 +12,7 @@
     "System.Runtime.Loader": "4.0.0-rc3-23829",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Runtime.Numerics/tests/project.json
+++ b/src/System.Runtime.Numerics/tests/project.json
@@ -8,7 +8,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Runtime.Serialization.Json/tests/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/project.json
@@ -16,7 +16,7 @@
     "System.Xml.XDocument": "4.0.10",
     "System.Xml.XmlDocument": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Runtime.Serialization.Xml/tests/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/project.json
@@ -18,7 +18,7 @@
     "System.Xml.XDocument": "4.0.10",
     "System.Xml.XmlDocument": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Runtime/tests/project.json
+++ b/src/System.Runtime/tests/project.json
@@ -12,7 +12,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Security.Claims/tests/project.json
+++ b/src/System.Security.Claims/tests/project.json
@@ -10,7 +10,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Security.Principal": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Security.Cryptography.Algorithms/tests/project.json
+++ b/src/System.Security.Cryptography.Algorithms/tests/project.json
@@ -8,7 +8,7 @@
     "System.Security.Cryptography.Primitives": "4.0.0-rc3-23829",
     "System.Text.Encoding.Extensions": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Security.Cryptography.Cng/tests/project.json
+++ b/src/System.Security.Cryptography.Cng/tests/project.json
@@ -9,7 +9,7 @@
     "System.Security.Cryptography.Algorithms": "4.0.0-rc3-23829",
     "System.Text.Encoding.Extensions": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Security.Cryptography.Csp/tests/project.json
+++ b/src/System.Security.Cryptography.Csp/tests/project.json
@@ -7,7 +7,7 @@
     "System.Security.Cryptography.Algorithms": "4.0.0-rc3-23829",
     "System.Text.Encoding.Extensions": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Security.Cryptography.Encoding/tests/project.json
+++ b/src/System.Security.Cryptography.Encoding/tests/project.json
@@ -5,7 +5,7 @@
     "System.Runtime.Numerics": "4.0.0",
     "System.Security.Cryptography.Primitives": "4.0.0-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Security.Cryptography.OpenSsl/tests/project.json
+++ b/src/System.Security.Cryptography.OpenSsl/tests/project.json
@@ -8,7 +8,7 @@
     "System.Security.Cryptography.Algorithms": "4.0.0-rc3-23829",
     "System.Text.Encoding.Extensions": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Security.Cryptography.Primitives/tests/project.json
+++ b/src/System.Security.Cryptography.Primitives/tests/project.json
@@ -4,7 +4,7 @@
     "System.Runtime": "4.0.20",
     "System.Runtime.Extensions": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Security.Cryptography.X509Certificates/tests/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/tests/project.json
@@ -11,7 +11,7 @@
     "System.Security.Cryptography.Encoding": "4.0.0-rc3-23829",
     "System.Security.Cryptography.X509Certificates.TestData": "1.0.0-prerelease",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Security.Principal.Windows/tests/project.json
+++ b/src/System.Security.Principal.Windows/tests/project.json
@@ -5,7 +5,7 @@
     "System.Runtime.Handles": "4.0.0",
     "System.Security.Claims": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Security.Principal/tests/project.json
+++ b/src/System.Security.Principal/tests/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23829",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/project.json
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/project.json
@@ -7,7 +7,7 @@
     "System.Security.Principal.Windows": "4.0.0-rc3-23829",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Text.Encoding.CodePages/tests/project.json
+++ b/src/System.Text.Encoding.CodePages/tests/project.json
@@ -6,7 +6,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Text.Encoding": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Text.Encoding.Extensions/tests/project.json
+++ b/src/System.Text.Encoding.Extensions/tests/project.json
@@ -5,7 +5,7 @@
     "System.Text.Encoding": "4.0.10",
     "System.Text.Encoding.Extensions": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Text.Encoding/tests/project.json
+++ b/src/System.Text.Encoding/tests/project.json
@@ -9,7 +9,7 @@
     "System.Text.Encoding.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Text.Encodings.Web/tests/project.json
+++ b/src/System.Text.Encodings.Web/tests/project.json
@@ -8,7 +8,7 @@
     "System.Text.Encoding.Extensions": "4.0.0",
     "System.Threading": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Text.RegularExpressions/tests/project.json
+++ b/src/System.Text.RegularExpressions/tests/project.json
@@ -8,7 +8,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Threading.AccessControl/tests/project.json
+++ b/src/System.Threading.AccessControl/tests/project.json
@@ -11,7 +11,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Threading.Overlapped/tests/project.json
+++ b/src/System.Threading.Overlapped/tests/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23829",
     "System.Threading.Overlapped": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Threading.Tasks.Dataflow/tests/project.json
+++ b/src/System.Threading.Tasks.Dataflow/tests/project.json
@@ -13,7 +13,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Threading.Tasks.Parallel": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Threading.Tasks.Extensions/tests/project.json
+++ b/src/System.Threading.Tasks.Extensions/tests/project.json
@@ -4,7 +4,7 @@
     "System.Runtime": "4.0.20",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Threading.Tasks.Parallel/tests/project.json
+++ b/src/System.Threading.Tasks.Parallel/tests/project.json
@@ -11,7 +11,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Threading.Tasks/tests/project.json
+++ b/src/System.Threading.Tasks/tests/project.json
@@ -11,7 +11,7 @@
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Threading.Timer/tests/project.json
+++ b/src/System.Threading.Timer/tests/project.json
@@ -6,7 +6,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Threading.Timer": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Threading/tests/project.json
+++ b/src/System.Threading/tests/project.json
@@ -10,7 +10,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Threading.Thread": "4.0.0-rc3-23829",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/project.json
@@ -5,7 +5,7 @@
     "System.IO": "4.0.10",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/project.json
@@ -5,7 +5,7 @@
     "System.IO": "4.0.10",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/project.json
@@ -5,7 +5,7 @@
     "System.IO": "4.0.10",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.ReaderWriter/tests/Readers/NameTable/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/NameTable/project.json
@@ -7,7 +7,7 @@
     "System.Runtime": "4.0.20",
     "System.Runtime.Extensions": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/project.json
@@ -8,7 +8,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Text.Encoding": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/project.json
@@ -5,7 +5,7 @@
     "System.IO": "4.0.10",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/project.json
@@ -5,7 +5,7 @@
     "System.Runtime": "4.0.20",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/project.json
@@ -10,7 +10,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Text.Encoding": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/project.json
@@ -10,7 +10,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Text.Encoding": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/project.json
@@ -5,7 +5,7 @@
     "System.Runtime": "4.0.20",
     "System.Runtime.Extensions": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/project.json
@@ -6,7 +6,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/project.json
@@ -7,7 +7,7 @@
     "System.Text.Encoding": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/project.json
@@ -9,7 +9,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/project.json
@@ -8,7 +8,7 @@
     "System.Text.Encoding": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.ReaderWriter/tests/XmlWriter/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlWriter/project.json
@@ -10,7 +10,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.XDocument/tests/Properties/project.json
+++ b/src/System.Xml.XDocument/tests/Properties/project.json
@@ -11,7 +11,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.XDocument/tests/SDMSample/project.json
+++ b/src/System.Xml.XDocument/tests/SDMSample/project.json
@@ -10,7 +10,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.XDocument/tests/Streaming/project.json
+++ b/src/System.Xml.XDocument/tests/Streaming/project.json
@@ -9,7 +9,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.XDocument/tests/TreeManipulation/project.json
+++ b/src/System.Xml.XDocument/tests/TreeManipulation/project.json
@@ -10,7 +10,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.XDocument/tests/XDocument.Common/project.json
+++ b/src/System.Xml.XDocument/tests/XDocument.Common/project.json
@@ -11,7 +11,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/project.json
+++ b/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/project.json
@@ -10,7 +10,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.XDocument/tests/axes/project.json
+++ b/src/System.Xml.XDocument/tests/axes/project.json
@@ -7,7 +7,7 @@
     "System.Xml.ReaderWriter": "4.0.10",
     "System.Xml.XDocument": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.XDocument/tests/events/project.json
+++ b/src/System.Xml.XDocument/tests/events/project.json
@@ -8,7 +8,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.XDocument/tests/misc/project.json
+++ b/src/System.Xml.XDocument/tests/misc/project.json
@@ -9,7 +9,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.XDocument/tests/xNodeBuilder/project.json
+++ b/src/System.Xml.XDocument/tests/xNodeBuilder/project.json
@@ -12,7 +12,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.XDocument/tests/xNodeReader/project.json
+++ b/src/System.Xml.XDocument/tests/xNodeReader/project.json
@@ -10,7 +10,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.XPath.XDocument/tests/project.json
+++ b/src/System.Xml.XPath.XDocument/tests/project.json
@@ -13,7 +13,7 @@
     "System.Xml.XDocument": "4.0.10",
     "System.Xml.XmlDocument": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.XPath.XmlDocument/tests/project.json
+++ b/src/System.Xml.XPath.XmlDocument/tests/project.json
@@ -13,7 +13,7 @@
     "System.Xml.XmlDocument": "4.0.0",
     "System.Xml.XPath": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.XPath/tests/project.json
+++ b/src/System.Xml.XPath/tests/project.json
@@ -11,7 +11,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.XmlDocument/tests/project.json
+++ b/src/System.Xml.XmlDocument/tests/project.json
@@ -6,7 +6,7 @@
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/System.Xml.XmlSerializer/tests/project.json
+++ b/src/System.Xml.XmlSerializer/tests/project.json
@@ -17,7 +17,7 @@
     "System.Xml.XDocument": "4.0.10",
     "System.Xml.XmlDocument": "4.0.0",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-00169"
   },
   "frameworks": {
     "dnxcore50": {


### PR DESCRIPTION
Updates the netci.groovy and runtest.sh files to pass  ```-notrait Category=IgnoreForCI``` to ```build.cmd``` and ```run-test.sh``` in Jenkins so that we can disable tests from running when they're being run in Jenkins.

@dotnet-bot test ci please

@Priya91 would you mind checking (or showing me how to check) that the generated jobs are correctly passing the -notrait / WithoutCategories?

replaces part of #6145