### PR TITLE
Support setting outgoing interface for multicast on Socket

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.MulticastOption.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MulticastOption.cs
@@ -13,7 +13,8 @@ internal static partial class Interop
         internal enum MulticastOption : int
         {
             MULTICAST_ADD = 0,
-            MULTICAST_DROP = 1
+            MULTICAST_DROP = 1,
+            MULTICAST_IF = 2
         }
 
         internal struct IPv4MulticastOption

--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -1344,6 +1344,10 @@ static bool GetMulticastOptionName(int32_t multicastOption, bool isIPv6, int& op
             optionName = isIPv6 ? IPV6_DROP_MEMBERSHIP : IP_DROP_MEMBERSHIP;
             return true;
 
+        case PAL_MULTICAST_IF:
+            optionName = IP_MULTICAST_IF;
+            return true;
+
         default:
             return false;
     }
@@ -1405,6 +1409,10 @@ extern "C" Error SystemNative_SetIPv4MulticastOption(int32_t socket, int32_t mul
 #else
     ip_mreq opt = {.imr_multiaddr = {.s_addr = option->MulticastAddress},
                    .imr_interface = {.s_addr = option->LocalAddress}};
+    if (option->InterfaceIndex != 0)
+    {
+        return PAL_ENOPROTOOPT;
+    }
 #endif
     int err = setsockopt(socket, IPPROTO_IP, optionName, &opt, sizeof(opt));
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);

--- a/src/Native/System.Native/pal_networking.h
+++ b/src/Native/System.Native/pal_networking.h
@@ -91,8 +91,9 @@ enum ProtocolType : int32_t
 
 enum MulticastOption : int32_t
 {
-    PAL_MULTICAST_ADD = 0, // IP{,V6}_ADD_MEMBERSHIP
-    PAL_MULTICAST_DROP = 1 // IP{,V6}_DROP_MEMBERSHIP
+    PAL_MULTICAST_ADD = 0,  // IP{,V6}_ADD_MEMBERSHIP
+    PAL_MULTICAST_DROP = 1, // IP{,V6}_DROP_MEMBERSHIP
+    PAL_MULTICAST_IF = 2    // IP_MULTICAST_IF
 };
 
 /*

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -963,6 +963,26 @@ namespace System.Net.Sockets
                     return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
                 }
             }
+            else if (optionLevel == SocketOptionLevel.IP)
+            {
+                if (optionName == SocketOptionName.MulticastInterface)
+                {
+                    // if the value of the IP_MULTICAST_IF is an address in the 0.x.x.x block
+                    // the value is interpreted as an interface index
+                    int interfaceIndex = IPAddress.NetworkToHostOrder(optionValue);
+                    if ((interfaceIndex & 0xff000000) == 0)
+                    {
+                        var opt = new Interop.Sys.IPv4MulticastOption {
+                            MulticastAddress = 0,
+                            LocalAddress = 0,
+                            InterfaceIndex = interfaceIndex
+                        };
+
+                        err = Interop.Sys.SetIPv4MulticastOption(handle, Interop.Sys.MulticastOption.MULTICAST_IF, &opt);
+                        return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
+                    }
+                }
+            }
 
             err = Interop.Sys.SetSockOpt(handle, optionLevel, optionName, (byte*)&optionValue, sizeof(int));
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);

--- a/src/System.Net.Sockets/tests/FunctionalTests/project.json
+++ b/src/System.Net.Sockets/tests/FunctionalTests/project.json
@@ -3,6 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23818",
     "System.Collections": "4.0.10",
     "System.Diagnostics.Debug": "4.0.10",
+    "System.Text.Encoding": "4.0.10",
     "System.Net.Primitives": "4.0.10",
     "System.Runtime": "4.0.20",
     "System.Threading": "4.0.10",


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/6486

pal_networking: support specifying the network interface for outgoing multicast traffic via SocketOptionName.MulticastInterface on non-Windows platforms

The interface for outgoing multicast traffic can be set as follows:
	socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastInterface, IPAddress.HostToNetworkOrder(interfaceIndex))