### PR TITLE
Enable ResourceManager fallback in AOT

### DIFF
--- a/src/System.Resources.ResourceManager/src/System.Resources.ResourceManager.csproj
+++ b/src/System.Resources.ResourceManager/src/System.Resources.ResourceManager.csproj
@@ -43,6 +43,7 @@
       <Link>Common\System\SR.Core.cs</Link>
     </Compile>
     <TargetingPackReference Include="System.Private.CoreLib.WinRTInterop" />
+    <ProjectReference Include="$(SourceDir)/mscorlib.WinRT-Facade/mscorlib.WinRT-Facade.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Resources.ResourceManager/src/System/Resources/ResourceManager.cs
+++ b/src/System.Resources.ResourceManager/src/System/Resources/ResourceManager.cs
@@ -6,12 +6,16 @@ using System.Globalization;
 using System.Reflection;
 using Internal.Runtime.Augments;
 
+using Windows.ApplicationModel;
+using Windows.ApplicationModel.Resources.Core;
+
 namespace System.Resources
 {
     public class ResourceManager
     {
-        private readonly object _resourceMap;
+        private readonly ResourceMap _resourceMap;
         private readonly string _resourcesSubtree;
+        private readonly string _neutralResourcesCultureName;
 
         public ResourceManager(Type resourceSource)
         {
@@ -22,7 +26,7 @@ namespace System.Resources
 
             // Portable libraries resources are indexed under the the type full name 
             _resourcesSubtree = resourceSource.FullName;
-            _resourceMap = WinRTInterop.Callbacks.GetResourceMap(_resourcesSubtree);
+            _resourceMap = GetResourceMap(_resourcesSubtree);
         }
 
         public ResourceManager(string baseName, Assembly assembly)
@@ -37,13 +41,14 @@ namespace System.Resources
             }
 
             _resourcesSubtree = baseName;
-            _resourceMap = WinRTInterop.Callbacks.GetResourceMap(_resourcesSubtree);
+            _resourceMap = GetResourceMap(_resourcesSubtree);
+            _neutralResourcesCultureName = GetNeutralLanguageForAssembly(assembly);
         }
 
         public ResourceManager(string resourcesName)
         {
             _resourcesSubtree = resourcesName;
-            _resourceMap = WinRTInterop.Callbacks.GetResourceMap(_resourcesSubtree);
+            _resourceMap = GetResourceMap(_resourcesSubtree);
         }
 
         public string GetString(string name)
@@ -74,7 +79,68 @@ namespace System.Resources
                 throw new MissingManifestResourceException(SR.Format(SR.MissingManifestResource_ResWFileNotLoaded, _resourcesSubtree));
             }
 
-            return WinRTInterop.Callbacks.GetResourceString(_resourceMap, name, culture == null ? null : culture.Name);
+            return GetResourceString(name, culture == null ? null : culture.Name);
+        }
+        
+        private static string GetNeutralLanguageForAssembly(Assembly assembly)
+        {
+            foreach (CustomAttributeData cad in assembly.CustomAttributes)
+            {
+                if (cad.AttributeType.FullName.Equals("System.Resources.NeutralResourcesLanguageAttribute"))
+                {
+                    foreach (CustomAttributeTypedArgument cata in cad.ConstructorArguments)
+                    {
+                        if (cata.ArgumentType.Equals(typeof(System.String)))
+                        {
+                            return (string) cata.Value;
+                        }
+                    }
+                }
+            }
+            
+            // The assembly is not tagged with NeutralResourcesLanguageAttribute
+            return null;
+        }
+        
+        //
+        // WinRT Wrappers
+        //
+
+        private ResourceMap GetResourceMap(string subtreeName)
+        {
+            if (WinRTInterop.Callbacks.IsAppxModel())
+                return Windows.ApplicationModel.Resources.Core.ResourceManager.Current.MainResourceMap.GetSubtree(subtreeName);
+
+            return null;
+        }
+
+        private string GetResourceString(string resourceName, string languageName)
+        {
+            if (!WinRTInterop.Callbacks.IsAppxModel())
+            {
+                // on desktop we usually don't have resource strings. so we just return the key name
+                return resourceName;
+            }
+
+            if (_resourceMap == null)
+                return null;
+
+            ResourceContext context;
+            ResourceCandidate candidate;
+
+            if (languageName == null && _neutralResourcesCultureName == null)
+            {
+                candidate = _resourceMap.GetValue(resourceName);
+            }
+            else
+            {
+                context = new ResourceContext();
+                context.QualifierValues["language"] = (languageName != null ? languageName + ";" : "") + 
+                                                      (_neutralResourcesCultureName != null ? _neutralResourcesCultureName : ""); 
+                candidate = _resourceMap.GetValue(resourceName, context);
+            }
+
+            return candidate == null ? null : candidate.ValueAsString;
         }
     }
 }

--- a/src/System.Resources.ResourceManager/src/netcore50aot/project.json
+++ b/src/System.Resources.ResourceManager/src/netcore50aot/project.json
@@ -4,6 +4,7 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23829",
         "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23829",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
         "System.Diagnostics.Debug": "4.0.0",
         "System.Diagnostics.Tools": "4.0.0",
         "System.Diagnostics.Tracing": "4.0.0",


### PR DESCRIPTION
This change is to have the resource manager fallback to the assembly neutral
language when couldn't get the resource string using the input culture.
Also there is small change moving some code from System.Private.CoreLib,WinRtInterop
to minimize the dependency between these 2 libraries so eventually we can fully
get rid of this dependency for the sake of flexibility changing any of them without
worrying of change the other