### PR TITLE
Use sysconf(_SC_OPEN_MAX) instead of OPEN_MAX in an assert

### DIFF
--- a/src/Native/Common/pal_config.h.in
+++ b/src/Native/Common/pal_config.h.in
@@ -53,7 +53,6 @@
 #cmakedefine01 HAVE_CURLPIPE_MULTIPLEX
 #cmakedefine01 HAVE_TCP_H_TCPSTATE_ENUM
 #cmakedefine01 HAVE_TCP_FSM_H
-#cmakedefine01 HAVE_OPEN_MAX
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/Native/Common/pal_utilities.h
+++ b/src/Native/Common/pal_utilities.h
@@ -14,10 +14,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <type_traits>
-
-#if HAVE_OPEN_MAX
-#include <sys/syslimits.h>
-#endif
+#include <unistd.h>
 
 /**
  * ResultOf<T> is shorthand for typename std::result_of<T>::type.
@@ -123,11 +120,7 @@ inline void SafeStringCopy(char* destination, int32_t destinationSize, const cha
 */
 inline static int ToFileDescriptor(intptr_t fd)
 {
-#if HAVE_OPEN_MAX
-    assert(0 <= fd && fd <= OPEN_MAX);
-#else
-    assert(0 <= fd && fd <= INT32_MAX);
-#endif
+    assert(0 <= fd && fd < sysconf(_SC_OPEN_MAX));
 
     return static_cast<int>(fd);
 }

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -418,11 +418,6 @@ check_cxx_source_compiles(
     "
     HAVE_CURLPIPE_MULTIPLEX)
 
-check_symbol_exists(
-    OPEN_MAX
-    "sys/syslimits.h"
-    HAVE_OPEN_MAX)
-
 set (CMAKE_REQUIRED_LIBRARIES)
 
 configure_file(


### PR DESCRIPTION
Use the actual limit rather than one hardcoded in a .h file.

cc: @krytarowski, @eerhardt 
Fixes #6531 