### PR TITLE
Reduce some allocations in WebUtility.UrlDecode

### DIFF
--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -176,6 +176,7 @@
   <ItemGroup Condition="'$(TargetGroup)' == ''">
     <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.csproj" />
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj" />
+    <ProjectReference Include="..\..\System.Buffers\src\System.Buffers.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -176,7 +176,6 @@
   <ItemGroup Condition="'$(TargetGroup)' == ''">
     <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.csproj" />
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj" />
-    <ProjectReference Include="..\..\System.Buffers\src\System.Buffers.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -670,9 +670,20 @@ namespace System.Net
 
             internal void Dispose()
             {
-                ArrayPool<char>.Shared.Return(_charBuffer);
-                if (_byteBuffer != null)
-                    ArrayPool<byte>.Shared.Return(_byteBuffer);
+                var charBuffer = _charBuffer;
+                var byteBuffer = _byteBuffer;
+                
+                if (charBuffer != null)
+                {
+                    ArrayPool<char>.Shared.Return(charBuffer);
+                    _charBuffer = null;
+                }
+                
+                if (byteBuffer != null)
+                {
+                    ArrayPool<byte>.Shared.Return(byteBuffer);
+                    _byteBuffer = null;
+                }
             }
         }
 

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -601,13 +601,13 @@ namespace System.Net
 
         #endregion
 
-        #region UrlDecoder nested class
+        #region UrlDecoder nested struct
 
         // *** Source: alm/tfs_core/Framework/Common/UriUtility/HttpUtility.cs
         // This specific code was copied from above ASP.NET codebase.
 
-        // Internal class to facilitate URL decoding -- keeps char buffer and byte buffer, allows appending of either chars or bytes
-        private class UrlDecoder
+        // Internal struct to facilitate URL decoding -- keeps char buffer and byte buffer, allows appending of either chars or bytes
+        private struct UrlDecoder
         {
             private int _bufferSize;
 

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -283,9 +283,6 @@ namespace System.Net
 
         #region UrlEncode implementation
 
-        // *** Source: alm/tfs_core/Framework/Common/UriUtility/HttpUtility.cs
-        // This specific code was copied from above ASP.NET codebase.
-
         private static byte[] UrlEncode(byte[] bytes, int offset, int count, bool alwaysCreateNewReturnValue)
         {
             byte[] encoded = UrlEncode(bytes, offset, count);
@@ -371,10 +368,6 @@ namespace System.Net
         #endregion
 
         #region UrlDecode implementation
-
-        // *** Source: alm/tfs_core/Framework/Common/UriUtility/HttpUtility.cs
-        // This specific code was copied from above ASP.NET codebase.
-        // Changes done - Removed the logic to handle %Uxxxx as it is not standards compliant.
 
         private static string UrlDecodeInternal(string value, Encoding encoding)
         {
@@ -612,9 +605,6 @@ namespace System.Net
         #endregion
 
         #region UrlDecoder nested struct
-
-        // *** Source: alm/tfs_core/Framework/Common/UriUtility/HttpUtility.cs
-        // This specific code was copied from above ASP.NET codebase.
 
         // Internal struct to facilitate URL decoding -- keeps char buffer and byte buffer, allows appending of either chars or bytes
         private struct UrlDecoder

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -355,8 +355,8 @@ namespace System.Net
         [SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "Already shipped public API; code moved here as part of API consolidation")]
         public static string UrlEncode(string value)
         {
-            if (value == null)
-                return null;
+            if (string.IsNullOrEmpty(value))
+                return value;
 
             byte[] bytes = Encoding.UTF8.GetBytes(value);
             byte[] encodedBytes = UrlEncode(bytes, 0, bytes.Length, false /* alwaysCreateNewReturnValue */);
@@ -378,9 +378,9 @@ namespace System.Net
 
         private static string UrlDecodeInternal(string value, Encoding encoding)
         {
-            if (value == null)
+            if (string.IsNullOrEmpty(value))
             {
-                return null;
+                return value;
             }
 
             int count = value.Length;

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -419,8 +419,9 @@ namespace System.Net
             }
             finally
             {
-                // We don't use `using` since UrlDecoder is a struct
-                // and we want to avoid a boxing conversion
+                // We don't use `using` since UrlDecoder doesn't
+                // implement IDisposable (since we want to avoid
+                // accidental boxing b/c it's a value type)
                 helper.Dispose();
             }
         }

--- a/src/System.Runtime.Extensions/src/project.json
+++ b/src/System.Runtime.Extensions/src/project.json
@@ -1,4 +1,7 @@
 {
+  "dependencies": {
+    "System.Buffers": "4.0.0-rc3-23829"
+  },
   "frameworks": {
     "dnxcore50": {
       "dependencies": {


### PR DESCRIPTION
This partially addresses issue #5888. It makes `UrlDecoder` a struct (and fixes the associated comments), and adds a dependency on `System.Buffers` so it can pool arrays.

I'll go again and submit the `StringBuilder` changes in another PR, since from my understanding they seem to be an API change.