### PR TITLE
Short-circuit in UrlEncode/Decode for WebUtility

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -624,8 +624,6 @@ namespace System.Net
                     return true;
                 if (c == '%' && i < s.Length - 2) // things like %20 are transformed into space
                     return true;
-                if ((c & 0xFF80) == 0) // 7 bit Unicode
-                    return true;
             }
             return false;
         }

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -602,7 +602,7 @@ namespace System.Net
             return false;
         }
         
-        private static bool NeedsUrlDecoding(string s)
+        private static bool NeedsUrlEncoding(string s)
         {
             for (int i = 0; i < s.Length; i++)
             {

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -385,6 +385,9 @@ namespace System.Net
                 return null;
             }
 
+            if (!NeedsUrlDecoding(value))
+                return value;
+            
             int count = value.Length;
             UrlDecoder helper = new UrlDecoder(count, encoding);
 
@@ -475,9 +478,6 @@ namespace System.Net
         [SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "Already shipped public API; code moved here as part of API consolidation")]
         public static string UrlDecode(string encodedValue)
         {
-            if (!NeedsUrlDecoding(encodedValue))
-                return encodedValue;
-            
             return UrlDecodeInternal(encodedValue, Encoding.UTF8);
         }
 

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -356,6 +356,9 @@ namespace System.Net
         {
             if (value == null)
                 return null;
+            
+            if (!NeedsUrlEncoding(value))
+                return value;
 
             byte[] bytes = Encoding.UTF8.GetBytes(value);
             byte[] encodedBytes = UrlEncode(bytes, 0, bytes.Length, alwaysCreateNewReturnValue: false);
@@ -595,6 +598,16 @@ namespace System.Net
                 {
                     return true;
                 }
+            }
+            return false;
+        }
+        
+        private static bool NeedsUrlDecoding(string s)
+        {
+            for (int i = 0; i < s.Length; i++)
+            {
+                if (!IsUrlSafeChar(s[i]))
+                    return true;
             }
             return false;
         }

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -358,13 +358,13 @@ namespace System.Net
                 return null;
 
             byte[] bytes = Encoding.UTF8.GetBytes(value);
-            byte[] encodedBytes = UrlEncode(bytes, 0, bytes.Length, false /* alwaysCreateNewReturnValue */);
+            byte[] encodedBytes = UrlEncode(bytes, 0, bytes.Length, alwaysCreateNewReturnValue: false);
             return Encoding.UTF8.GetString(encodedBytes, 0, encodedBytes.Length);
         }
 
         public static byte[] UrlEncodeToBytes(byte[] value, int offset, int count)
         {
-            return UrlEncode(value, offset, count, true /* alwaysCreateNewReturnValue */);
+            return UrlEncode(value, offset, count, alwaysCreateNewReturnValue: true);
         }
 
         #endregion

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -475,6 +475,9 @@ namespace System.Net
         [SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "Already shipped public API; code moved here as part of API consolidation")]
         public static string UrlDecode(string encodedValue)
         {
+            if (!NeedsUrlDecoding(encodedValue))
+                return encodedValue;
+            
             return UrlDecodeInternal(encodedValue, Encoding.UTF8);
         }
 
@@ -607,6 +610,21 @@ namespace System.Net
             for (int i = 0; i < s.Length; i++)
             {
                 if (!IsUrlSafeChar(s[i]))
+                    return true;
+            }
+            return false;
+        }
+        
+        private static bool NeedsUrlDecoding(string s)
+        {
+            for (int i = 0; i < s.Length; i++)
+            {
+                char c = s[i];
+                if (c == '+') // space
+                    return true;
+                if (c == '%' && i < s.Length - 2) // things like %20 are transformed into space
+                    return true;
+                if ((c & 0xFF80) == 0) // 7 bit Unicode
                     return true;
             }
             return false;


### PR DESCRIPTION
Partially fixes #6542 by short-circuiting in `UrlEncode` if no encoding is required. It uses the already-existing `IsUrlSafeChar` helper method to do this.

I think this may break in the case where a UTF-8 encoded string doesn't pass as 'safe' (and needs to be encoded), but its UTF-16 counterpart does. I'm not sure such a case could exist though, since all of the chars validated by `IsUrlSafeChar` should have the same representation when converted to UTF-8 and cast back to `char`.

cc @stephentoub @davidsh 

**edit:** Added commits to deal with this for `UrlDecode` as well.