### PR TITLE
Slightly improve RuntimeInformation coverage

### DIFF
--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Reflection;
 
 namespace System.Runtime.InteropServices
@@ -17,11 +16,13 @@ namespace System.Runtime.InteropServices
         private const string FrameworkName = ".NET Core";
 #endif
 
+        private static string s_frameworkDescription;
+
         public static string FrameworkDescription
         {
             get
             {
-                return string.Format("{0} {1}", FrameworkName, typeof(object).GetTypeInfo().Assembly.GetName().Version);
+                return s_frameworkDescription ?? (s_frameworkDescription = $"{FrameworkName} {typeof(object).GetTypeInfo().Assembly.GetName().Version}");
             }
         }
     }

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/CheckArchitectureTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/CheckArchitectureTests.cs
@@ -37,6 +37,9 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
                     Assert.False(true, "Unexpected Architecture.");
                     break;
             }
+
+            Assert.Equal(osArch, RuntimeInformation.OSArchitecture);
+            Assert.Equal(processArch, RuntimeInformation.ProcessArchitecture);
         }
     }
 }

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -15,6 +15,14 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         {
             string expected = string.Format(".NET Core {0}", typeof(object).GetTypeInfo().Assembly.GetName().Version);
             Assert.Equal(expected, RuntimeInformation.FrameworkDescription);
+            Assert.Same(RuntimeInformation.FrameworkDescription, RuntimeInformation.FrameworkDescription);
+        }
+
+        [Fact]
+        public void VerifyOSDescription()
+        {
+            Assert.NotNull(RuntimeInformation.OSDescription);
+            Assert.Same(RuntimeInformation.OSDescription, RuntimeInformation.OSDescription);
         }
 
         [Fact, PlatformSpecific(PlatformID.Windows)]


### PR DESCRIPTION
- Add coverage of a few branches.  Everything else that's uncovered can only be covered by running on different platforms, architectures, etc.
- Add caching of the framework description string.

Fixes https://github.com/dotnet/corefx/issues/6446
cc: @ianhays, @Priya91 