### PR TITLE
Add a test for remove_CancelKeyPress

### DIFF
--- a/src/System.Console/tests/CancelKeyPress.cs
+++ b/src/System.Console/tests/CancelKeyPress.cs
@@ -13,7 +13,7 @@ public class CancelKeyPressTests : RemoteExecutorTestBase
     private const int WaitFailTestTimeoutSeconds = 30;
 
     [Fact]
-    public void CanAddAndRemoveHandler()
+    public static void CanAddAndRemoveHandler()
     {
         ConsoleCancelEventHandler handler = (sender, e) =>
         {
@@ -23,6 +23,19 @@ public class CancelKeyPressTests : RemoteExecutorTestBase
         };
         Console.CancelKeyPress += handler;
         Console.CancelKeyPress -= handler;
+    }
+
+    [Fact]
+    public void CanAddAndRemoveHandler_Remote()
+    {
+        // xunit registers a CancelKeyPress handler at the beginning of the test run and never 
+        // unregisters it, thus we can't execute all of the removal code in the same process.
+        RemoteInvoke(() =>
+        {
+            CanAddAndRemoveHandler();
+            CanAddAndRemoveHandler(); // add and remove again
+            return SuccessExitCode;
+        }).Dispose();
     }
 
     [PlatformSpecific(PlatformID.AnyUnix)]

--- a/src/System.Console/tests/ReadKey.cs
+++ b/src/System.Console/tests/ReadKey.cs
@@ -39,6 +39,12 @@ public class ReadKey : RemoteExecutorTestBase
 
     private static void RunRemote(Func<int> func, ProcessStartInfo psi = null)
     {
-        using (var remote = RemoteInvoke(func, true, psi)) { }
+        var options = new RemoteInvokeOptions();
+        if (psi != null)
+        {
+            options.StartInfo = psi;
+        }
+
+        RemoteInvoke(func, options).Dispose();
     }
 }

--- a/src/System.Console/tests/RedirectedStream.cs
+++ b/src/System.Console/tests/RedirectedStream.cs
@@ -52,6 +52,12 @@ public class RedirectedStream : RemoteExecutorTestBase
 
     private static void RunRemote(Func<int> func, ProcessStartInfo psi = null)
     {
-        using (var remote = RemoteInvoke(func, true, psi)) { }
+        var options = new RemoteInvokeOptions();
+        if (psi != null)
+        {
+            options.StartInfo = psi;
+        }
+
+        RemoteInvoke(func, options).Dispose();
     }
 }

--- a/src/System.Diagnostics.Process/tests/ProcessTestBase.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTestBase.cs
@@ -40,7 +40,7 @@ namespace System.Diagnostics.Tests
 
         protected Process CreateProcess(Func<int> method = null)
         {
-            Process p = RemoteInvoke(method ?? (() => SuccessExitCode), start: false).Process;
+            Process p = RemoteInvoke(method ?? (() => SuccessExitCode), new RemoteInvokeOptions { Start = false }).Process;
             lock (_processes)
             {
                 _processes.Add(p);
@@ -50,7 +50,7 @@ namespace System.Diagnostics.Tests
 
         protected Process CreateProcess(Func<string, int> method, string arg)
         {
-            Process p = RemoteInvoke(method, arg, start: false).Process;
+            Process p = RemoteInvoke(method, arg, new RemoteInvokeOptions { Start = false }).Process;
             lock (_processes)
             {
                 _processes.Add(p);

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -677,8 +677,7 @@ namespace System.Diagnostics.Tests
         {
             using (var handle = RemoteInvokeRaw((Func<string, string, string, int>)ConcatThreeArguments,
                 inputArguments,
-                start: true,
-                psi: new ProcessStartInfo { RedirectStandardOutput = true }))
+                new RemoteInvokeOptions { Start = true, StartInfo = new ProcessStartInfo { RedirectStandardOutput = true } }))
             {
                 Assert.Equal(expectedArgv, handle.Process.StandardOutput.ReadToEnd());
             }


### PR DESCRIPTION
Fixes #6422 

@ianhays, my guess for why you're seeing a difference on remove_CancelKeyPress in coverage comparisons is that xunit registers a CancelKeyPress handler at the beginning of test execution and never unregisters it, so our test that does an unregister doesn't actually hit all of the unregister code paths, because it doesn't remove the last registered one.  I've added a test that adds/removes the handles in another process.

To do that, I also updated our remote invoke support to not disable profiling of the child process.  We'd done that at one point to work around some issues in OpenCover.  I believe those issues have been fixed, but if not, I've made the disabling of it optional, and we can disable just those tests/suites that end up causing problems.

cc: @ianhays, @pallavit 