### PR TITLE
Removing an assert in BitVector32

### DIFF
--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/BitVector32.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/BitVector32.cs
@@ -65,7 +65,10 @@ namespace System.Collections.Specialized
             }
             set
             {
-                Debug.Assert((value & section.Mask) == value, "Value out of bounds on BitVector32 Section Set!");
+                // The code should really have originally validated "(value & section.Mask) == value" with 
+                // an exception (it instead validated it with a Debug.Assert, which does little good in a
+                // public method when in a Release build).  We don't include such a check now as it would
+                // likely break things and for little benefit.
 
                 value <<= section.Offset;
                 int offsetMask = (0xFFFF & (int)section.Mask) << section.Offset;

--- a/src/System.Collections.Specialized/tests/BitVector32Tests.cs
+++ b/src/System.Collections.Specialized/tests/BitVector32Tests.cs
@@ -368,33 +368,21 @@ namespace System.Collections.Specialized.Tests
                 BitVector32 data = new BitVector32();
                 BitVector32.Section section = BitVector32.CreateSection(maximum);
 
-                // In debug mode, attempting to set a value to a section that is too large triggers an assert.
-                // There is no accompanying check in release mode, however, allowing invalid values to be set.
-#if DEBUG
-                Exception e = Assert.ThrowsAny<Exception>(() => data[section] = value);
-                Assert.Equal("DebugAssertException", e.GetType().Name);
-#else
                 data[section] = value;
                 Assert.Equal(maximum & value, data.Data);
                 Assert.NotEqual(value, data.Data);
                 Assert.Equal(maximum & value, data[section]);
                 Assert.NotEqual(value, data[section]);
-#endif
             }
             {
                 BitVector32 data = new BitVector32();
                 BitVector32.Section nested = BitVector32.CreateSection(maximum, BitVector32.CreateSection(short.MaxValue));
-#if DEBUG
 
-                Exception e = Assert.ThrowsAny<Exception>(() => data[nested] = value);
-                Assert.Equal("DebugAssertException", e.GetType().Name);
-#else
                 data[nested] = value;
                 Assert.Equal((maximum & value) << 15, data.Data);
                 Assert.NotEqual(value << 15, data.Data);
                 Assert.Equal(maximum & value, data[nested]);
                 Assert.NotEqual(value, data[nested]);
-#endif
             }
         }
 


### PR DESCRIPTION
This assert came over from the full framework source.  This should really have been a check-and-throw-exception, as the assert will be compiled out in release code and this is a public method.  We can't add that exception now, and we have tests that are explicitly calling this method, which is triggering debug assert failures and causing unnecessary failure details in our CI logs.  I'm just removing it.

cc: @ellismg, @ianhays 