### PR TITLE
Fix race in several Sockets tests

### DIFF
--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendReceive.cs
@@ -122,33 +122,40 @@ namespace System.Net.Sockets.Tests
             Action<int, EndPoint> receiveHandler = null;
             receiveHandler = (received, remote) =>
             {
-                if (receivedDatagrams != -1)
+                try
                 {
-                    Assert.Equal(DatagramSize, received);
-                    Assert.Equal(rightEndpoint, remote);
-
-                    int datagramId = (int)receiveBuffer[0];
-                    Assert.Null(receivedChecksums[datagramId]);
-                    receivedChecksums[datagramId] = Fletcher32.Checksum(receiveBuffer, 0, received);
-
-                    receiverAck.Set();
-                    Assert.True(senderAck.Wait(AckTimeout));
-                    senderAck.Reset();
-
-                    receivedDatagrams++;
-                    if (receivedDatagrams == DatagramsToSend)
+                    if (receivedDatagrams != -1)
                     {
-                        left.Dispose();
-                        receiverFinished.SetResult(true);
-                        return;
-                    }
-                }
-                else
-                {
-                    receivedDatagrams = 0;
-                }
+                        Assert.Equal(DatagramSize, received);
+                        Assert.Equal(rightEndpoint, remote);
 
-                left.ReceiveFromAPM(receiveBuffer, 0, receiveBuffer.Length, SocketFlags.None, receiveRemote, receiveHandler);
+                        int datagramId = (int)receiveBuffer[0];
+                        Assert.Null(receivedChecksums[datagramId]);
+                        receivedChecksums[datagramId] = Fletcher32.Checksum(receiveBuffer, 0, received);
+
+                        receiverAck.Set();
+                        Assert.True(senderAck.Wait(AckTimeout));
+                        senderAck.Reset();
+
+                        receivedDatagrams++;
+                        if (receivedDatagrams == DatagramsToSend)
+                        {
+                            left.Dispose();
+                            receiverFinished.SetResult(true);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        receivedDatagrams = 0;
+                    }
+
+                    left.ReceiveFromAPM(receiveBuffer, 0, receiveBuffer.Length, SocketFlags.None, receiveRemote, receiveHandler);
+                }
+                catch (Exception ex)
+                {
+                    receiverFinished.SetException(ex);
+                }
             };
 
             receiveHandler(0, null);
@@ -162,31 +169,38 @@ namespace System.Net.Sockets.Tests
             Action<int> sendHandler = null;
             sendHandler = sent =>
             {
-                if (sentDatagrams != -1)
+                try
                 {
-                    Assert.True(receiverAck.Wait(AckTimeout));
-                    receiverAck.Reset();
-                    senderAck.Set();
-
-                    Assert.Equal(DatagramSize, sent);
-                    sentChecksums[sentDatagrams] = Fletcher32.Checksum(sendBuffer, 0, sent);
-
-                    sentDatagrams++;
-                    if (sentDatagrams == DatagramsToSend)
+                    if (sentDatagrams != -1)
                     {
-                        right.Dispose();
-                        senderFinished.SetResult(true);
-                        return;
-                    }
-                }
-                else
-                {
-                    sentDatagrams = 0;
-                }
+                        Assert.True(receiverAck.Wait(AckTimeout));
+                        receiverAck.Reset();
+                        senderAck.Set();
 
-                random.NextBytes(sendBuffer);
-                sendBuffer[0] = (byte)sentDatagrams;
-                right.SendToAPM(sendBuffer, 0, sendBuffer.Length, SocketFlags.None, leftEndpoint, sendHandler);
+                        Assert.Equal(DatagramSize, sent);
+                        sentChecksums[sentDatagrams] = Fletcher32.Checksum(sendBuffer, 0, sent);
+
+                        sentDatagrams++;
+                        if (sentDatagrams == DatagramsToSend)
+                        {
+                            right.Dispose();
+                            senderFinished.SetResult(true);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        sentDatagrams = 0;
+                    }
+
+                    random.NextBytes(sendBuffer);
+                    sendBuffer[0] = (byte)sentDatagrams;
+                    right.SendToAPM(sendBuffer, 0, sendBuffer.Length, SocketFlags.None, leftEndpoint, sendHandler);
+                }
+                catch (Exception ex)
+                {
+                    senderFinished.SetException(ex);
+                }
             };
 
             sendHandler(0);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendReceive.cs
@@ -154,6 +154,7 @@ namespace System.Net.Sockets.Tests
             receiveHandler(0, null);
 
             var random = new Random();
+            var senderFinished = new TaskCompletionSource<bool>();
             var sentChecksums = new uint[DatagramsToSend];
             var sendBuffer = new byte[DatagramSize];
             int sentDatagrams = -1;
@@ -174,6 +175,7 @@ namespace System.Net.Sockets.Tests
                     if (sentDatagrams == DatagramsToSend)
                     {
                         right.Dispose();
+                        senderFinished.SetResult(true);
                         return;
                     }
                 }
@@ -190,6 +192,8 @@ namespace System.Net.Sockets.Tests
             sendHandler(0);
 
             Assert.True(receiverFinished.Task.Wait(TestTimeout));
+            Assert.True(senderFinished.Task.Wait(TestTimeout));
+
             for (int i = 0; i < DatagramsToSend; i++)
             {
                 Assert.NotNull(receivedChecksums[i]);

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -50,34 +50,41 @@ namespace System.Net.Sockets.Tests
             Action<int, EndPoint> receiveHandler = null;
             receiveHandler = (received, remote) =>
             {
-                if (receivedDatagrams != -1)
+                try
                 {
-                    Assert.Equal(DatagramSize, received);
-                    Assert.Equal(rightEndpoint, remote);
-
-                    int datagramId = (int)receiveBuffer[0];
-                    Assert.Null(receivedChecksums[datagramId]);
-
-                    receivedChecksums[datagramId] = Fletcher32.Checksum(receiveBuffer, 0, received);
-
-                    receiverAck.Set();
-                    Assert.True(senderAck.Wait(AckTimeout));
-                    senderAck.Reset();
-
-                    receivedDatagrams++;
-                    if (receivedDatagrams == DatagramsToSend)
+                    if (receivedDatagrams != -1)
                     {
-                        left.Dispose();
-                        receiverFinished.SetResult(true);
-                        return;
-                    }
-                }
-                else
-                {
-                    receivedDatagrams = 0;
-                }
+                        Assert.Equal(DatagramSize, received);
+                        Assert.Equal(rightEndpoint, remote);
 
-                left.ReceiveFromAsync(leftEventArgs, receiveBuffer, 0, receiveBuffer.Length, SocketFlags.None, receiveRemote, receiveHandler);
+                        int datagramId = (int)receiveBuffer[0];
+                        Assert.Null(receivedChecksums[datagramId]);
+
+                        receivedChecksums[datagramId] = Fletcher32.Checksum(receiveBuffer, 0, received);
+
+                        receiverAck.Set();
+                        Assert.True(senderAck.Wait(AckTimeout));
+                        senderAck.Reset();
+
+                        receivedDatagrams++;
+                        if (receivedDatagrams == DatagramsToSend)
+                        {
+                            left.Dispose();
+                            receiverFinished.SetResult(true);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        receivedDatagrams = 0;
+                    }
+
+                    left.ReceiveFromAsync(leftEventArgs, receiveBuffer, 0, receiveBuffer.Length, SocketFlags.None, receiveRemote, receiveHandler);
+                }
+                catch (Exception ex)
+                {
+                    receiverFinished.SetException(ex);
+                }
             };
 
             receiveHandler(0, null);
@@ -91,31 +98,38 @@ namespace System.Net.Sockets.Tests
             Action<int> sendHandler = null;
             sendHandler = sent =>
             {
-                if (sentDatagrams != -1)
+                try
                 {
-                    Assert.True(receiverAck.Wait(AckTimeout));
-                    receiverAck.Reset();
-                    senderAck.Set();
-
-                    Assert.Equal(DatagramSize, sent);
-                    sentChecksums[sentDatagrams] = Fletcher32.Checksum(sendBuffer, 0, sent);
-
-                    sentDatagrams++;
-                    if (sentDatagrams == DatagramsToSend)
+                    if (sentDatagrams != -1)
                     {
-                        right.Dispose();
-                        senderFinished.SetResult(true);
-                        return;
-                    }
-                }
-                else
-                {
-                    sentDatagrams = 0;
-                }
+                        Assert.True(receiverAck.Wait(AckTimeout));
+                        receiverAck.Reset();
+                        senderAck.Set();
 
-                random.NextBytes(sendBuffer);
-                sendBuffer[0] = (byte)sentDatagrams;
-                right.SendToAsync(rightEventArgs, sendBuffer, 0, sendBuffer.Length, SocketFlags.None, leftEndpoint, sendHandler);
+                        Assert.Equal(DatagramSize, sent);
+                        sentChecksums[sentDatagrams] = Fletcher32.Checksum(sendBuffer, 0, sent);
+
+                        sentDatagrams++;
+                        if (sentDatagrams == DatagramsToSend)
+                        {
+                            right.Dispose();
+                            senderFinished.SetResult(true);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        sentDatagrams = 0;
+                    }
+
+                    random.NextBytes(sendBuffer);
+                    sendBuffer[0] = (byte)sentDatagrams;
+                    right.SendToAsync(rightEventArgs, sendBuffer, 0, sendBuffer.Length, SocketFlags.None, leftEndpoint, sendHandler);
+                }
+                catch (Exception ex)
+                {
+                    senderFinished.SetException(ex);
+                }
             };
 
             sendHandler(0);

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -383,14 +383,12 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
         }
 
-        [ActiveIssue(5234, PlatformID.Windows)]
         [Fact]
         public void SendToRecvFromAsync_Single_Datagram_UDP_IPv6()
         {
             SendToRecvFromAsync_Datagram_UDP(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
         }
 
-        [ActiveIssue(5234, PlatformID.Windows)]
         [Fact]
         public void SendToRecvFromAsync_Single_Datagram_UDP_IPv4()
         {
@@ -428,7 +426,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue(5234, PlatformID.Windows)]
         public void SendRecvAsync_TcpListener_TcpClient_IPv4()
         {
             SendRecvAsync_TcpListener_TcpClient(IPAddress.Loopback);

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -83,6 +83,7 @@ namespace System.Net.Sockets.Tests
             receiveHandler(0, null);
 
             var random = new Random();
+            var senderFinished = new TaskCompletionSource<bool>();
             var sentChecksums = new uint[DatagramsToSend];
             var sendBuffer = new byte[DatagramSize];
             int sentDatagrams = -1;
@@ -103,6 +104,7 @@ namespace System.Net.Sockets.Tests
                     if (sentDatagrams == DatagramsToSend)
                     {
                         right.Dispose();
+                        senderFinished.SetResult(true);
                         return;
                     }
                 }
@@ -119,6 +121,8 @@ namespace System.Net.Sockets.Tests
             sendHandler(0);
 
             Assert.True(receiverFinished.Task.Wait(TestTimeout));
+            Assert.True(senderFinished.Task.Wait(TestTimeout));
+
             for (int i = 0; i < DatagramsToSend; i++)
             {
                 Assert.NotNull(receivedChecksums[i]);


### PR DESCRIPTION
These tests were comparing against some checksum values without waiting until those values were actually generated/stored.  This change adds synchronization to ensure that the "sender" side of the test is done before validating the received data.  A nice side benefit of this is that any assertions and cleanup in the sender will also complete before we return from the test case, keeping it better isolated from other tests.

Fixes #5234 

@CIPop