### PR TITLE
Add MANAGED_SNI tags to ManualTests to suppress version-difference errors between managed and native SNI

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
@@ -54,7 +54,9 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         {
             BasicConnectionPoolingTest(tcpConnectionString);
             ClearAllPoolsTest(tcpConnectionString);
+#if MANAGED_SNI
             KillConnectionTest(tcpConnectionString);
+#endif
             ReclaimEmancipatedOnOpenTest(tcpConnectionString);
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNamedPipesTest/SqlNamedPipesTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlNamedPipesTest/SqlNamedPipesTest.cs
@@ -35,7 +35,11 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void InvalidConnStringTest()
         {
+#if MANAGED_SNI
             const string invalidConnStringError = "A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections. (provider: Named Pipes Provider, error: 25 - Connection string is not valid)";
+#else
+            const string invalidConnStringError = "A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections.";
+#endif
 
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestClass.SQL2008_Northwind_NamedPipes);
             builder.ConnectTimeout = 2;

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -9,6 +9,9 @@
     <OutputType>Library</OutputType>
     <UnsupportedPlatforms>Linux;NetBSD;OSX;Windows_NT</UnsupportedPlatforms>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetsWindows)' != 'true' ">
+    <DefineConstants>$(DefineConstants);MANAGED_SNI</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />


### PR DESCRIPTION
1) Using KillConnection with native SNI would require native test code, which doesn't fit our XPlat model. So ConnectionPoolTest.KillConnectionTest should only be run with managed SNI.

2) Native SNI has various differing error messages for named pipes parsing errors. Trying to clean these up is definitely a no go, so I've added basic error message verification with NamedPipeTest.InvalidConnStringTest on native SNI.
