### PR TITLE
Split Cryptography contracts into 4.0 (net46) and 4.1 (net461) as needed.

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/pkg/System.Security.Cryptography.Algorithms.pkgproj
+++ b/src/System.Security.Cryptography.Algorithms/pkg/System.Security.Cryptography.Algorithms.pkgproj
@@ -2,11 +2,17 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <ProjectReference Include="..\ref\4.0\System.Security.Cryptography.Algorithms.csproj">
+      <SupportedFramework>net46</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\ref\System.Security.Cryptography.Algorithms.csproj">
-      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
+      <SupportedFramework>net461;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Algorithms.csproj">
       <TargetGroup>net46</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Security.Cryptography.Algorithms.csproj">
+      <TargetGroup>net461</TargetGroup>
     </ProjectReference>
     <ProjectReference Include="win\System.Security.Cryptography.Algorithms.pkgproj" />
     <ProjectReference Include="unix\System.Security.Cryptography.Algorithms.pkgproj" />

--- a/src/System.Security.Cryptography.Algorithms/pkg/unix/System.Security.Cryptography.Algorithms.pkgproj
+++ b/src/System.Security.Cryptography.Algorithms/pkg/unix/System.Security.Cryptography.Algorithms.pkgproj
@@ -16,7 +16,7 @@
   <!-- The runtime.native.System.Security.Cryptography package hasn't moved to open yet-->
   <ItemGroup>
     <_FilePackageReference Include="runtime.native.System.Security.Cryptography">
-      <TargetFramework>netstandard1.3</TargetFramework>
+      <TargetFramework>netstandard1.4</TargetFramework>
       <Version>4.0.0</Version>
     </_FilePackageReference>
   </ItemGroup>

--- a/src/System.Security.Cryptography.Algorithms/ref/4.0/System.Security.Cryptography.Algorithms.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/4.0/System.Security.Cryptography.Algorithms.cs
@@ -1,0 +1,219 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+
+namespace System.Security.Cryptography
+{
+    public abstract partial class Aes : System.Security.Cryptography.SymmetricAlgorithm
+    {
+        protected Aes() { }
+        public override System.Security.Cryptography.KeySizes[] LegalBlockSizes { get { return default(System.Security.Cryptography.KeySizes[]); } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { return default(System.Security.Cryptography.KeySizes[]); } }
+        public static System.Security.Cryptography.Aes Create() { return default(System.Security.Cryptography.Aes); }
+    }
+    public abstract partial class DeriveBytes : System.IDisposable
+    {
+        protected DeriveBytes() { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public abstract byte[] GetBytes(int cb);
+        public abstract void Reset();
+    }
+    public partial class HMACMD5 : System.Security.Cryptography.HMAC
+    {
+        public HMACMD5() { }
+        public HMACMD5(byte[] key) { }
+        public override int HashSize { get { return default(int); } }
+        public override byte[] Key { get { return default(byte[]); } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { return default(byte[]); }
+        public override void Initialize() { }
+    }
+    public partial class HMACSHA1 : System.Security.Cryptography.HMAC
+    {
+        public HMACSHA1() { }
+        public HMACSHA1(byte[] key) { }
+        public override int HashSize { get { return default(int); } }
+        public override byte[] Key { get { return default(byte[]); } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { return default(byte[]); }
+        public override void Initialize() { }
+    }
+    public partial class HMACSHA256 : System.Security.Cryptography.HMAC
+    {
+        public HMACSHA256() { }
+        public HMACSHA256(byte[] key) { }
+        public override int HashSize { get { return default(int); } }
+        public override byte[] Key { get { return default(byte[]); } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { return default(byte[]); }
+        public override void Initialize() { }
+    }
+    public partial class HMACSHA384 : System.Security.Cryptography.HMAC
+    {
+        public HMACSHA384() { }
+        public HMACSHA384(byte[] key) { }
+        public override int HashSize { get { return default(int); } }
+        public override byte[] Key { get { return default(byte[]); } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { return default(byte[]); }
+        public override void Initialize() { }
+    }
+    public partial class HMACSHA512 : System.Security.Cryptography.HMAC
+    {
+        public HMACSHA512() { }
+        public HMACSHA512(byte[] key) { }
+        public override int HashSize { get { return default(int); } }
+        public override byte[] Key { get { return default(byte[]); } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { return default(byte[]); }
+        public override void Initialize() { }
+    }
+    public sealed partial class IncrementalHash : System.IDisposable
+    {
+        internal IncrementalHash() { }
+        public System.Security.Cryptography.HashAlgorithmName AlgorithmName { get { return default(System.Security.Cryptography.HashAlgorithmName); } }
+        public void AppendData(byte[] data) { }
+        public void AppendData(byte[] data, int offset, int count) { }
+        public static System.Security.Cryptography.IncrementalHash CreateHash(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { return default(System.Security.Cryptography.IncrementalHash); }
+        public static System.Security.Cryptography.IncrementalHash CreateHMAC(System.Security.Cryptography.HashAlgorithmName hashAlgorithm, byte[] key) { return default(System.Security.Cryptography.IncrementalHash); }
+        public void Dispose() { }
+        public byte[] GetHashAndReset() { return default(byte[]); }
+    }
+    public abstract partial class MD5 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected MD5() { }
+        public static System.Security.Cryptography.MD5 Create() { return default(System.Security.Cryptography.MD5); }
+    }
+    public abstract partial class RandomNumberGenerator : System.IDisposable
+    {
+        protected RandomNumberGenerator() { }
+        public static System.Security.Cryptography.RandomNumberGenerator Create() { return default(System.Security.Cryptography.RandomNumberGenerator); }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public abstract void GetBytes(byte[] data);
+    }
+    public partial class Rfc2898DeriveBytes : System.Security.Cryptography.DeriveBytes
+    {
+        public Rfc2898DeriveBytes(byte[] password, byte[] salt, int iterations) { }
+        public Rfc2898DeriveBytes(string password, byte[] salt) { }
+        public Rfc2898DeriveBytes(string password, byte[] salt, int iterations) { }
+        public Rfc2898DeriveBytes(string password, int saltSize) { }
+        public Rfc2898DeriveBytes(string password, int saltSize, int iterations) { }
+        public int IterationCount { get { return default(int); } set { } }
+        public byte[] Salt { get { return default(byte[]); } set { } }
+        protected override void Dispose(bool disposing) { }
+        public override byte[] GetBytes(int cb) { return default(byte[]); }
+        public override void Reset() { }
+    }
+    public abstract partial class RSA : System.Security.Cryptography.AsymmetricAlgorithm
+    {
+        protected RSA() { }
+        public static RSA Create() { return default(RSA); }
+        public abstract byte[] Decrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding);
+        public abstract byte[] Encrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding);
+        public abstract System.Security.Cryptography.RSAParameters ExportParameters(bool includePrivateParameters);
+        protected abstract byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm);
+        protected abstract byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm);
+        public abstract void ImportParameters(System.Security.Cryptography.RSAParameters parameters);
+        public virtual byte[] SignData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { return default(byte[]); }
+        public byte[] SignData(byte[] data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { return default(byte[]); }
+        public virtual byte[] SignData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { return default(byte[]); }
+        public abstract byte[] SignHash(byte[] hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding);
+        public bool VerifyData(byte[] data, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { return default(bool); }
+        public virtual bool VerifyData(byte[] data, int offset, int count, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { return default(bool); }
+        public bool VerifyData(System.IO.Stream data, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { return default(bool); }
+        public abstract bool VerifyHash(byte[] hash, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding);
+    }
+    public sealed partial class RSAEncryptionPadding : System.IEquatable<System.Security.Cryptography.RSAEncryptionPadding>
+    {
+        internal RSAEncryptionPadding() { }
+        public System.Security.Cryptography.RSAEncryptionPaddingMode Mode { get { return default(System.Security.Cryptography.RSAEncryptionPaddingMode); } }
+        public System.Security.Cryptography.HashAlgorithmName OaepHashAlgorithm { get { return default(System.Security.Cryptography.HashAlgorithmName); } }
+        public static System.Security.Cryptography.RSAEncryptionPadding OaepSHA1 { get { return default(System.Security.Cryptography.RSAEncryptionPadding); } }
+        public static System.Security.Cryptography.RSAEncryptionPadding OaepSHA256 { get { return default(System.Security.Cryptography.RSAEncryptionPadding); } }
+        public static System.Security.Cryptography.RSAEncryptionPadding OaepSHA384 { get { return default(System.Security.Cryptography.RSAEncryptionPadding); } }
+        public static System.Security.Cryptography.RSAEncryptionPadding OaepSHA512 { get { return default(System.Security.Cryptography.RSAEncryptionPadding); } }
+        public static System.Security.Cryptography.RSAEncryptionPadding Pkcs1 { get { return default(System.Security.Cryptography.RSAEncryptionPadding); } }
+        public static System.Security.Cryptography.RSAEncryptionPadding CreateOaep(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { return default(System.Security.Cryptography.RSAEncryptionPadding); }
+        public override bool Equals(object obj) { return default(bool); }
+        public bool Equals(System.Security.Cryptography.RSAEncryptionPadding other) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public static bool operator ==(System.Security.Cryptography.RSAEncryptionPadding left, System.Security.Cryptography.RSAEncryptionPadding right) { return default(bool); }
+        public static bool operator !=(System.Security.Cryptography.RSAEncryptionPadding left, System.Security.Cryptography.RSAEncryptionPadding right) { return default(bool); }
+        public override string ToString() { return default(string); }
+    }
+    public enum RSAEncryptionPaddingMode
+    {
+        Oaep = 1,
+        Pkcs1 = 0,
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct RSAParameters
+    {
+        public byte[] D;
+        public byte[] DP;
+        public byte[] DQ;
+        public byte[] Exponent;
+        public byte[] InverseQ;
+        public byte[] Modulus;
+        public byte[] P;
+        public byte[] Q;
+    }
+    public sealed partial class RSASignaturePadding : System.IEquatable<System.Security.Cryptography.RSASignaturePadding>
+    {
+        internal RSASignaturePadding() { }
+        public System.Security.Cryptography.RSASignaturePaddingMode Mode { get { return default(System.Security.Cryptography.RSASignaturePaddingMode); } }
+        public static System.Security.Cryptography.RSASignaturePadding Pkcs1 { get { return default(System.Security.Cryptography.RSASignaturePadding); } }
+        public static System.Security.Cryptography.RSASignaturePadding Pss { get { return default(System.Security.Cryptography.RSASignaturePadding); } }
+        public override bool Equals(object obj) { return default(bool); }
+        public bool Equals(System.Security.Cryptography.RSASignaturePadding other) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public static bool operator ==(System.Security.Cryptography.RSASignaturePadding left, System.Security.Cryptography.RSASignaturePadding right) { return default(bool); }
+        public static bool operator !=(System.Security.Cryptography.RSASignaturePadding left, System.Security.Cryptography.RSASignaturePadding right) { return default(bool); }
+        public override string ToString() { return default(string); }
+    }
+    public enum RSASignaturePaddingMode
+    {
+        Pkcs1 = 0,
+        Pss = 1,
+    }
+    public abstract partial class SHA1 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected SHA1() { }
+        public static System.Security.Cryptography.SHA1 Create() { return default(System.Security.Cryptography.SHA1); }
+    }
+    public abstract partial class SHA256 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected SHA256() { }
+        public static System.Security.Cryptography.SHA256 Create() { return default(System.Security.Cryptography.SHA256); }
+    }
+    public abstract partial class SHA384 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected SHA384() { }
+        public static System.Security.Cryptography.SHA384 Create() { return default(System.Security.Cryptography.SHA384); }
+    }
+    public abstract partial class SHA512 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected SHA512() { }
+        public static System.Security.Cryptography.SHA512 Create() { return default(System.Security.Cryptography.SHA512); }
+    }
+    public abstract partial class TripleDES : System.Security.Cryptography.SymmetricAlgorithm
+    {
+        protected TripleDES() { }
+        public override byte[] Key { get { return default(byte[]); } set { } }
+        public override System.Security.Cryptography.KeySizes[] LegalBlockSizes { get { return default(System.Security.Cryptography.KeySizes[]); } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { return default(System.Security.Cryptography.KeySizes[]); } }
+        public static System.Security.Cryptography.TripleDES Create() { return default(System.Security.Cryptography.TripleDES); }
+        public static bool IsWeakKey(byte[] rgbKey) { return default(bool); }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/ref/4.0/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/ref/4.0/System.Security.Cryptography.Algorithms.csproj
@@ -1,15 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.4</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.4</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="System.Security.Cryptography.Cng.cs" />
-    <Compile Include="System.Security.Cryptography.Cng.Manual.cs" />
+    <Compile Include="System.Security.Cryptography.Algorithms.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Security.Cryptography.Algorithms/ref/4.0/project.json
+++ b/src/System.Security.Cryptography.Algorithms/ref/4.0/project.json
@@ -2,14 +2,12 @@
   "dependencies": {
     "System.Runtime": "4.0.0",
     "System.IO": "4.0.0",
-    "System.Runtime.Handles": "4.0.0",
-    "System.Security.Cryptography.Algorithms": "4.0.0-rc3-23901",
     "System.Security.Cryptography.Primitives": "4.0.0-rc3-23901"
   },
   "frameworks": {
-    "netstandard1.4": {
+    "netstandard1.3": {
       "imports": [
-        "dotnet5.5"
+        "dotnet5.4"
       ]
     }
   }

--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.csproj
@@ -2,10 +2,10 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.4</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Security.Cryptography.Algorithms.cs" />

--- a/src/System.Security.Cryptography.Algorithms/ref/project.json
+++ b/src/System.Security.Cryptography.Algorithms/ref/project.json
@@ -5,9 +5,9 @@
     "System.Security.Cryptography.Primitives": "4.0.0-rc3-23901"
   },
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.4": {
       "imports": [
-        "dotnet5.4"
+        "dotnet5.5"
       ]
     }
   }

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.builds
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.builds
@@ -17,6 +17,9 @@
     <Project Include="System.Security.Cryptography.Algorithms.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project>
+    <Project Include="System.Security.Cryptography.Algorithms.csproj">
+      <TargetGroup>net461</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -10,16 +10,15 @@
     <ProjectGuid>{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.Algorithms</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)'=='net46'">4.0.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>false</CLSCompliant>
     <DefineConstants>INTERNAL_ASYMMETRIC_IMPLEMENTATIONS</DefineConstants>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.3</PackageTargetFramework>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46'">true</IsPartialFacadeAssembly>
-    <PackageTargetRuntime Condition=" '$(TargetsWindows)' == 'true'">win7</PackageTargetRuntime>
-    <PackageTargetRuntime Condition=" '$(TargetGroup)' == 'net46'"></PackageTargetRuntime>
-    <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.4</PackageTargetFramework>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46' OR '$(TargetGroup)'=='net461'">true</IsPartialFacadeAssembly>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.4</NuGetTargetMoniker>
+    <UsePackageTargetRuntimeDefaults Condition=" '$(IsPartialFacadeAssembly)' != 'true' ">true</UsePackageTargetRuntimeDefaults>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Release|AnyCPU'" />
@@ -258,7 +257,7 @@
       <Link>Common\System\Security\Cryptography\RSAOpenSsl.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='net46'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)'=='true'">
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Core" />

--- a/src/System.Security.Cryptography.Algorithms/src/project.json
+++ b/src/System.Security.Cryptography.Algorithms/src/project.json
@@ -1,6 +1,6 @@
 {
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.4": {
       "dependencies": {
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
@@ -13,12 +13,17 @@
         "System.Text.Encoding.Extensions": "4.0.0"
       },
       "imports": [
-        "dotnet5.4"
+        "dotnet5.5"
       ]
     },
     "net46": {
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
+    },
+    "net461": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NetFramework.v4.6.1": "1.0.1"
       }
     }
   }

--- a/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
+++ b/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
@@ -3,8 +3,11 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <ItemGroup>
+    <ProjectReference Include="..\ref\4.0\System.Security.Cryptography.Cng.csproj">
+      <SupportedFramework>net46</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\ref\System.Security.Cryptography.Cng.csproj">
-      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
+      <SupportedFramework>net461;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Cng.builds" />
   </ItemGroup>

--- a/src/System.Security.Cryptography.Cng/ref/4.0/System.Security.Cryptography.Cng.Manual.cs
+++ b/src/System.Security.Cryptography.Cng/ref/4.0/System.Security.Cryptography.Cng.Manual.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+namespace Microsoft.Win32.SafeHandles
+{
+    public abstract partial class SafeNCryptHandle : System.Runtime.InteropServices.SafeHandle
+    {
+        public override bool IsInvalid { get { return default(bool); } }
+    }
+}

--- a/src/System.Security.Cryptography.Cng/ref/4.0/System.Security.Cryptography.Cng.cs
+++ b/src/System.Security.Cryptography.Cng/ref/4.0/System.Security.Cryptography.Cng.cs
@@ -1,0 +1,251 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+
+namespace Microsoft.Win32.SafeHandles
+{
+    public abstract partial class SafeNCryptHandle : System.Runtime.InteropServices.SafeHandle
+    {
+        protected SafeNCryptHandle() : base(default(System.IntPtr), default(bool)) { }
+        protected override bool ReleaseHandle() { return default(bool); }
+        protected abstract bool ReleaseNativeHandle();
+    }
+    public sealed partial class SafeNCryptKeyHandle : Microsoft.Win32.SafeHandles.SafeNCryptHandle
+    {
+        public SafeNCryptKeyHandle() { }
+        protected override bool ReleaseNativeHandle() { return default(bool); }
+    }
+    public sealed partial class SafeNCryptProviderHandle : Microsoft.Win32.SafeHandles.SafeNCryptHandle
+    {
+        public SafeNCryptProviderHandle() { }
+        protected override bool ReleaseNativeHandle() { return default(bool); }
+    }
+    public sealed partial class SafeNCryptSecretHandle : Microsoft.Win32.SafeHandles.SafeNCryptHandle
+    {
+        public SafeNCryptSecretHandle() { }
+        protected override bool ReleaseNativeHandle() { return default(bool); }
+    }
+}
+namespace System.Security.Cryptography
+{
+    public sealed partial class CngAlgorithm : System.IEquatable<System.Security.Cryptography.CngAlgorithm>
+    {
+        public CngAlgorithm(string algorithm) { }
+        public string Algorithm { get { return default(string); } }
+        public static System.Security.Cryptography.CngAlgorithm ECDiffieHellmanP256 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
+        public static System.Security.Cryptography.CngAlgorithm ECDiffieHellmanP384 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
+        public static System.Security.Cryptography.CngAlgorithm ECDiffieHellmanP521 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
+        public static System.Security.Cryptography.CngAlgorithm ECDsaP256 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
+        public static System.Security.Cryptography.CngAlgorithm ECDsaP384 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
+        public static System.Security.Cryptography.CngAlgorithm ECDsaP521 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
+        public static System.Security.Cryptography.CngAlgorithm MD5 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
+        public static System.Security.Cryptography.CngAlgorithm Rsa { get { return default(System.Security.Cryptography.CngAlgorithm); } }
+        public static System.Security.Cryptography.CngAlgorithm Sha1 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
+        public static System.Security.Cryptography.CngAlgorithm Sha256 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
+        public static System.Security.Cryptography.CngAlgorithm Sha384 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
+        public static System.Security.Cryptography.CngAlgorithm Sha512 { get { return default(System.Security.Cryptography.CngAlgorithm); } }
+        public override bool Equals(object obj) { return default(bool); }
+        public bool Equals(System.Security.Cryptography.CngAlgorithm other) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public static bool operator ==(System.Security.Cryptography.CngAlgorithm left, System.Security.Cryptography.CngAlgorithm right) { return default(bool); }
+        public static bool operator !=(System.Security.Cryptography.CngAlgorithm left, System.Security.Cryptography.CngAlgorithm right) { return default(bool); }
+        public override string ToString() { return default(string); }
+    }
+    public sealed partial class CngAlgorithmGroup : System.IEquatable<System.Security.Cryptography.CngAlgorithmGroup>
+    {
+        public CngAlgorithmGroup(string algorithmGroup) { }
+        public string AlgorithmGroup { get { return default(string); } }
+        public static System.Security.Cryptography.CngAlgorithmGroup DiffieHellman { get { return default(System.Security.Cryptography.CngAlgorithmGroup); } }
+        public static System.Security.Cryptography.CngAlgorithmGroup Dsa { get { return default(System.Security.Cryptography.CngAlgorithmGroup); } }
+        public static System.Security.Cryptography.CngAlgorithmGroup ECDiffieHellman { get { return default(System.Security.Cryptography.CngAlgorithmGroup); } }
+        public static System.Security.Cryptography.CngAlgorithmGroup ECDsa { get { return default(System.Security.Cryptography.CngAlgorithmGroup); } }
+        public static System.Security.Cryptography.CngAlgorithmGroup Rsa { get { return default(System.Security.Cryptography.CngAlgorithmGroup); } }
+        public override bool Equals(object obj) { return default(bool); }
+        public bool Equals(System.Security.Cryptography.CngAlgorithmGroup other) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public static bool operator ==(System.Security.Cryptography.CngAlgorithmGroup left, System.Security.Cryptography.CngAlgorithmGroup right) { return default(bool); }
+        public static bool operator !=(System.Security.Cryptography.CngAlgorithmGroup left, System.Security.Cryptography.CngAlgorithmGroup right) { return default(bool); }
+        public override string ToString() { return default(string); }
+    }
+    [System.FlagsAttribute]
+    public enum CngExportPolicies
+    {
+        AllowArchiving = 4,
+        AllowExport = 1,
+        AllowPlaintextArchiving = 8,
+        AllowPlaintextExport = 2,
+        None = 0,
+    }
+    public sealed partial class CngKey : System.IDisposable
+    {
+        internal CngKey() { }
+        public System.Security.Cryptography.CngAlgorithm Algorithm { get { return default(System.Security.Cryptography.CngAlgorithm); } }
+        public System.Security.Cryptography.CngAlgorithmGroup AlgorithmGroup { get { return default(System.Security.Cryptography.CngAlgorithmGroup); } }
+        public System.Security.Cryptography.CngExportPolicies ExportPolicy { get { return default(System.Security.Cryptography.CngExportPolicies); } }
+        public Microsoft.Win32.SafeHandles.SafeNCryptKeyHandle Handle { get { return default(Microsoft.Win32.SafeHandles.SafeNCryptKeyHandle); } }
+        public bool IsEphemeral { get { return default(bool); } }
+        public bool IsMachineKey { get { return default(bool); } }
+        public string KeyName { get { return default(string); } }
+        public int KeySize { get { return default(int); } }
+        public System.Security.Cryptography.CngKeyUsages KeyUsage { get { return default(System.Security.Cryptography.CngKeyUsages); } }
+        public System.IntPtr ParentWindowHandle { get { return default(System.IntPtr); } set { } }
+        public System.Security.Cryptography.CngProvider Provider { get { return default(System.Security.Cryptography.CngProvider); } }
+        public Microsoft.Win32.SafeHandles.SafeNCryptProviderHandle ProviderHandle { get { return default(Microsoft.Win32.SafeHandles.SafeNCryptProviderHandle); } }
+        public System.Security.Cryptography.CngUIPolicy UIPolicy { get { return default(System.Security.Cryptography.CngUIPolicy); } }
+        public string UniqueName { get { return default(string); } }
+        public static System.Security.Cryptography.CngKey Create(System.Security.Cryptography.CngAlgorithm algorithm) { return default(System.Security.Cryptography.CngKey); }
+        public static System.Security.Cryptography.CngKey Create(System.Security.Cryptography.CngAlgorithm algorithm, string keyName) { return default(System.Security.Cryptography.CngKey); }
+        public static System.Security.Cryptography.CngKey Create(System.Security.Cryptography.CngAlgorithm algorithm, string keyName, System.Security.Cryptography.CngKeyCreationParameters creationParameters) { return default(System.Security.Cryptography.CngKey); }
+        public void Delete() { }
+        public void Dispose() { }
+        public static bool Exists(string keyName) { return default(bool); }
+        public static bool Exists(string keyName, System.Security.Cryptography.CngProvider provider) { return default(bool); }
+        public static bool Exists(string keyName, System.Security.Cryptography.CngProvider provider, System.Security.Cryptography.CngKeyOpenOptions options) { return default(bool); }
+        public byte[] Export(System.Security.Cryptography.CngKeyBlobFormat format) { return default(byte[]); }
+        public System.Security.Cryptography.CngProperty GetProperty(string name, System.Security.Cryptography.CngPropertyOptions options) { return default(System.Security.Cryptography.CngProperty); }
+        public bool HasProperty(string name, System.Security.Cryptography.CngPropertyOptions options) { return default(bool); }
+        public static System.Security.Cryptography.CngKey Import(byte[] keyBlob, System.Security.Cryptography.CngKeyBlobFormat format) { return default(System.Security.Cryptography.CngKey); }
+        public static System.Security.Cryptography.CngKey Import(byte[] keyBlob, System.Security.Cryptography.CngKeyBlobFormat format, System.Security.Cryptography.CngProvider provider) { return default(System.Security.Cryptography.CngKey); }
+        public static System.Security.Cryptography.CngKey Open(Microsoft.Win32.SafeHandles.SafeNCryptKeyHandle keyHandle, System.Security.Cryptography.CngKeyHandleOpenOptions keyHandleOpenOptions) { return default(System.Security.Cryptography.CngKey); }
+        public static System.Security.Cryptography.CngKey Open(string keyName) { return default(System.Security.Cryptography.CngKey); }
+        public static System.Security.Cryptography.CngKey Open(string keyName, System.Security.Cryptography.CngProvider provider) { return default(System.Security.Cryptography.CngKey); }
+        public static System.Security.Cryptography.CngKey Open(string keyName, System.Security.Cryptography.CngProvider provider, System.Security.Cryptography.CngKeyOpenOptions openOptions) { return default(System.Security.Cryptography.CngKey); }
+        public void SetProperty(System.Security.Cryptography.CngProperty property) { }
+    }
+    public sealed partial class CngKeyBlobFormat : System.IEquatable<System.Security.Cryptography.CngKeyBlobFormat>
+    {
+        public CngKeyBlobFormat(string format) { }
+        public static System.Security.Cryptography.CngKeyBlobFormat EccPrivateBlob { get { return default(System.Security.Cryptography.CngKeyBlobFormat); } }
+        public static System.Security.Cryptography.CngKeyBlobFormat EccPublicBlob { get { return default(System.Security.Cryptography.CngKeyBlobFormat); } }
+        public string Format { get { return default(string); } }
+        public static System.Security.Cryptography.CngKeyBlobFormat GenericPrivateBlob { get { return default(System.Security.Cryptography.CngKeyBlobFormat); } }
+        public static System.Security.Cryptography.CngKeyBlobFormat GenericPublicBlob { get { return default(System.Security.Cryptography.CngKeyBlobFormat); } }
+        public static System.Security.Cryptography.CngKeyBlobFormat OpaqueTransportBlob { get { return default(System.Security.Cryptography.CngKeyBlobFormat); } }
+        public static System.Security.Cryptography.CngKeyBlobFormat Pkcs8PrivateBlob { get { return default(System.Security.Cryptography.CngKeyBlobFormat); } }
+        public override bool Equals(object obj) { return default(bool); }
+        public bool Equals(System.Security.Cryptography.CngKeyBlobFormat other) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public static bool operator ==(System.Security.Cryptography.CngKeyBlobFormat left, System.Security.Cryptography.CngKeyBlobFormat right) { return default(bool); }
+        public static bool operator !=(System.Security.Cryptography.CngKeyBlobFormat left, System.Security.Cryptography.CngKeyBlobFormat right) { return default(bool); }
+        public override string ToString() { return default(string); }
+    }
+    [System.FlagsAttribute]
+    public enum CngKeyCreationOptions
+    {
+        MachineKey = 32,
+        None = 0,
+        OverwriteExistingKey = 128,
+    }
+    public sealed partial class CngKeyCreationParameters
+    {
+        public CngKeyCreationParameters() { }
+        public System.Nullable<System.Security.Cryptography.CngExportPolicies> ExportPolicy { get { return default(System.Nullable<System.Security.Cryptography.CngExportPolicies>); } set { } }
+        public System.Security.Cryptography.CngKeyCreationOptions KeyCreationOptions { get { return default(System.Security.Cryptography.CngKeyCreationOptions); } set { } }
+        public System.Nullable<System.Security.Cryptography.CngKeyUsages> KeyUsage { get { return default(System.Nullable<System.Security.Cryptography.CngKeyUsages>); } set { } }
+        public System.Security.Cryptography.CngPropertyCollection Parameters { get { return default(System.Security.Cryptography.CngPropertyCollection); } }
+        public System.IntPtr ParentWindowHandle { get { return default(System.IntPtr); } set { } }
+        public System.Security.Cryptography.CngProvider Provider { get { return default(System.Security.Cryptography.CngProvider); } set { } }
+        public System.Security.Cryptography.CngUIPolicy UIPolicy { get { return default(System.Security.Cryptography.CngUIPolicy); } set { } }
+    }
+    [System.FlagsAttribute]
+    public enum CngKeyHandleOpenOptions
+    {
+        EphemeralKey = 1,
+        None = 0,
+    }
+    [System.FlagsAttribute]
+    public enum CngKeyOpenOptions
+    {
+        MachineKey = 32,
+        None = 0,
+        Silent = 64,
+        UserKey = 0,
+    }
+    [System.FlagsAttribute]
+    public enum CngKeyUsages
+    {
+        AllUsages = 16777215,
+        Decryption = 1,
+        KeyAgreement = 4,
+        None = 0,
+        Signing = 2,
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct CngProperty : System.IEquatable<System.Security.Cryptography.CngProperty>
+    {
+        public CngProperty(string name, byte[] value, System.Security.Cryptography.CngPropertyOptions options) { throw new System.NotImplementedException(); }
+        public string Name { get { return default(string); } }
+        public System.Security.Cryptography.CngPropertyOptions Options { get { return default(System.Security.Cryptography.CngPropertyOptions); } }
+        public override bool Equals(object obj) { return default(bool); }
+        public bool Equals(System.Security.Cryptography.CngProperty other) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public byte[] GetValue() { return default(byte[]); }
+        public static bool operator ==(System.Security.Cryptography.CngProperty left, System.Security.Cryptography.CngProperty right) { return default(bool); }
+        public static bool operator !=(System.Security.Cryptography.CngProperty left, System.Security.Cryptography.CngProperty right) { return default(bool); }
+    }
+    public sealed partial class CngPropertyCollection : System.Collections.ObjectModel.Collection<System.Security.Cryptography.CngProperty>
+    {
+        public CngPropertyCollection() { }
+    }
+    [System.FlagsAttribute]
+    public enum CngPropertyOptions
+    {
+        CustomProperty = 1073741824,
+        None = 0,
+        Persist = -2147483648,
+    }
+    public sealed partial class CngProvider : System.IEquatable<System.Security.Cryptography.CngProvider>
+    {
+        public CngProvider(string provider) { }
+        public static System.Security.Cryptography.CngProvider MicrosoftSmartCardKeyStorageProvider { get { return default(System.Security.Cryptography.CngProvider); } }
+        public static System.Security.Cryptography.CngProvider MicrosoftSoftwareKeyStorageProvider { get { return default(System.Security.Cryptography.CngProvider); } }
+        public string Provider { get { return default(string); } }
+        public override bool Equals(object obj) { return default(bool); }
+        public bool Equals(System.Security.Cryptography.CngProvider other) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public static bool operator ==(System.Security.Cryptography.CngProvider left, System.Security.Cryptography.CngProvider right) { return default(bool); }
+        public static bool operator !=(System.Security.Cryptography.CngProvider left, System.Security.Cryptography.CngProvider right) { return default(bool); }
+        public override string ToString() { return default(string); }
+    }
+    public sealed partial class CngUIPolicy
+    {
+        public CngUIPolicy(System.Security.Cryptography.CngUIProtectionLevels protectionLevel) { }
+        public CngUIPolicy(System.Security.Cryptography.CngUIProtectionLevels protectionLevel, string friendlyName) { }
+        public CngUIPolicy(System.Security.Cryptography.CngUIProtectionLevels protectionLevel, string friendlyName, string description) { }
+        public CngUIPolicy(System.Security.Cryptography.CngUIProtectionLevels protectionLevel, string friendlyName, string description, string useContext) { }
+        public CngUIPolicy(System.Security.Cryptography.CngUIProtectionLevels protectionLevel, string friendlyName, string description, string useContext, string creationTitle) { }
+        public string CreationTitle { get { return default(string); } }
+        public string Description { get { return default(string); } }
+        public string FriendlyName { get { return default(string); } }
+        public System.Security.Cryptography.CngUIProtectionLevels ProtectionLevel { get { return default(System.Security.Cryptography.CngUIProtectionLevels); } }
+        public string UseContext { get { return default(string); } }
+    }
+    [System.FlagsAttribute]
+    public enum CngUIProtectionLevels
+    {
+        ForceHighProtection = 2,
+        None = 0,
+        ProtectKey = 1,
+    }
+    public sealed partial class RSACng : System.Security.Cryptography.RSA
+    {
+        public RSACng() { }
+        public RSACng(int keySize) { }
+        public RSACng(System.Security.Cryptography.CngKey key) { }
+        public System.Security.Cryptography.CngKey Key { get { return default(System.Security.Cryptography.CngKey); } }
+        public override byte[] Decrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding) { return default(byte[]); }
+        protected override void Dispose(bool disposing) { }
+        public override byte[] Encrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding) { return default(byte[]); }
+        public override System.Security.Cryptography.RSAParameters ExportParameters(bool includePrivateParameters) { return default(System.Security.Cryptography.RSAParameters); }
+        protected override byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { return default(byte[]); }
+        protected override byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { return default(byte[]); }
+        public override void ImportParameters(System.Security.Cryptography.RSAParameters parameters) { }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { return default(System.Security.Cryptography.KeySizes[]); } }
+        public override byte[] SignHash(byte[] hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { return default(byte[]); }
+        public override bool VerifyHash(byte[] hash, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { return default(bool); }
+    }
+}

--- a/src/System.Security.Cryptography.Cng/ref/4.0/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/ref/4.0/System.Security.Cryptography.Cng.csproj
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.4</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.4</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Security.Cryptography.Cng.cs" />

--- a/src/System.Security.Cryptography.Cng/ref/4.0/project.json
+++ b/src/System.Security.Cryptography.Cng/ref/4.0/project.json
@@ -7,9 +7,9 @@
     "System.Security.Cryptography.Primitives": "4.0.0-rc3-23901"
   },
   "frameworks": {
-    "netstandard1.4": {
+    "netstandard1.3": {
       "imports": [
-        "dotnet5.5"
+        "dotnet5.4"
       ]
     }
   }

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.builds
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.builds
@@ -6,6 +6,9 @@
     <Project Include="System.Security.Cryptography.Cng.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project>
+    <Project Include="System.Security.Cryptography.Cng.csproj">
+      <TargetGroup>net461</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -5,18 +5,19 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>System.Security.Cryptography.Cng</AssemblyName>
     <ProjectGuid>{4C1BD451-6A99-45E7-9339-79C77C42EE9E}</ProjectGuid>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)'=='net46'">4.0.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>false</CLSCompliant>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
-    <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net46'">None</ResourcesSourceOutputDirectory>
-    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.3</PackageTargetFramework>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'net461'">true</IsPartialFacadeAssembly>
+    <ResourcesSourceOutputDirectory Condition="'$(IsPartialFacadeAssembly)' == 'true'">None</ResourcesSourceOutputDirectory>
+    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.4</PackageTargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Security\Cryptography\AesCng.cs" />
     <Compile Include="System\Security\Cryptography\CngAlgorithm.cs" />
     <Compile Include="System\Security\Cryptography\CngAlgorithmGroup.cs" />
@@ -202,7 +203,7 @@
       <Link>Common\System\Security\Cryptography\RSACng.SignVerify.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System.Core" />
   </ItemGroup>

--- a/src/System.Security.Cryptography.Cng/src/project.json
+++ b/src/System.Security.Cryptography.Cng/src/project.json
@@ -16,6 +16,11 @@
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }
+    },
+    "net461": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6.1": "1.0.1"
+      }
     }
   }
 }

--- a/src/System.Security.Cryptography.X509Certificates/ref/4.0/System.Security.Cryptography.X509Certificates.Manual.cs
+++ b/src/System.Security.Cryptography.X509Certificates/ref/4.0/System.Security.Cryptography.X509Certificates.Manual.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Win32.SafeHandles
+{
+    // Members from SafeHandleMinusOneOrZeroIsInvalid needed after removing base
+    public sealed partial class SafeX509ChainHandle
+    {
+        public override bool IsInvalid {[System.Security.SecurityCriticalAttribute]get { return default(bool); } }
+    }
+}
+
+namespace System.Security.Cryptography.X509Certificates
+{
+    // Declaring members from stripped base class CollectionBase
+    public partial class X509CertificateCollection : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+    {
+        public int Count { get { return default(int); } }
+        bool System.Collections.ICollection.IsSynchronized { get { return default(bool); } }
+        object System.Collections.ICollection.SyncRoot { get { return default(object); } }
+        bool System.Collections.IList.IsFixedSize { get { return default(bool); } }
+        bool System.Collections.IList.IsReadOnly { get { return default(bool); } }
+        object System.Collections.IList.this[int index] { get { return default(object); } set { } }
+        public void Clear() { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return default(System.Collections.IEnumerator); }
+        public void RemoveAt(int index) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        int System.Collections.IList.Add(object value) { return default(int); }
+        bool System.Collections.IList.Contains(object value) { return default(bool); }
+        int System.Collections.IList.IndexOf(object value) { return default(int); }
+        void System.Collections.IList.Insert(int index, object value) { }
+        void System.Collections.IList.Remove(object value) { }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/ref/4.0/System.Security.Cryptography.X509Certificates.cs
+++ b/src/System.Security.Cryptography.X509Certificates/ref/4.0/System.Security.Cryptography.X509Certificates.cs
@@ -1,0 +1,469 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+
+namespace Microsoft.Win32.SafeHandles
+{
+    public sealed partial class SafeX509ChainHandle : System.Runtime.InteropServices.SafeHandle
+    {
+        internal SafeX509ChainHandle() : base(default(System.IntPtr), default(bool)) { }
+        protected override bool ReleaseHandle() { return default(bool); }
+    }
+}
+namespace System.Security.Cryptography.X509Certificates
+{
+    [System.FlagsAttribute]
+    public enum OpenFlags
+    {
+        IncludeArchived = 8,
+        MaxAllowed = 2,
+        OpenExistingOnly = 4,
+        ReadOnly = 0,
+        ReadWrite = 1,
+    }
+    public sealed partial class PublicKey
+    {
+        public PublicKey(System.Security.Cryptography.Oid oid, System.Security.Cryptography.AsnEncodedData parameters, System.Security.Cryptography.AsnEncodedData keyValue) { }
+        public System.Security.Cryptography.AsnEncodedData EncodedKeyValue { get { return default(System.Security.Cryptography.AsnEncodedData); } }
+        public System.Security.Cryptography.AsnEncodedData EncodedParameters { get { return default(System.Security.Cryptography.AsnEncodedData); } }
+        public System.Security.Cryptography.Oid Oid { get { return default(System.Security.Cryptography.Oid); } }
+    }
+    public static partial class RSACertificateExtensions
+    {
+        public static System.Security.Cryptography.RSA GetRSAPrivateKey(this System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { return default(System.Security.Cryptography.RSA); }
+        public static System.Security.Cryptography.RSA GetRSAPublicKey(this System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { return default(System.Security.Cryptography.RSA); }
+    }
+    public enum StoreLocation
+    {
+        CurrentUser = 1,
+        LocalMachine = 2,
+    }
+    public enum StoreName
+    {
+        AddressBook = 1,
+        AuthRoot = 2,
+        CertificateAuthority = 3,
+        Disallowed = 4,
+        My = 5,
+        Root = 6,
+        TrustedPeople = 7,
+        TrustedPublisher = 8,
+    }
+    public sealed partial class X500DistinguishedName : System.Security.Cryptography.AsnEncodedData
+    {
+        public X500DistinguishedName(byte[] encodedDistinguishedName) { }
+        public X500DistinguishedName(System.Security.Cryptography.AsnEncodedData encodedDistinguishedName) { }
+        public X500DistinguishedName(System.Security.Cryptography.X509Certificates.X500DistinguishedName distinguishedName) { }
+        public X500DistinguishedName(string distinguishedName) { }
+        public X500DistinguishedName(string distinguishedName, System.Security.Cryptography.X509Certificates.X500DistinguishedNameFlags flag) { }
+        public string Name { get { return default(string); } }
+        public string Decode(System.Security.Cryptography.X509Certificates.X500DistinguishedNameFlags flag) { return default(string); }
+        public override string Format(bool multiLine) { return default(string); }
+    }
+    [System.FlagsAttribute]
+    public enum X500DistinguishedNameFlags
+    {
+        DoNotUsePlusSign = 32,
+        DoNotUseQuotes = 64,
+        ForceUTF8Encoding = 16384,
+        None = 0,
+        Reversed = 1,
+        UseCommas = 128,
+        UseNewLines = 256,
+        UseSemicolons = 16,
+        UseT61Encoding = 8192,
+        UseUTF8Encoding = 4096,
+    }
+    public sealed partial class X509BasicConstraintsExtension : System.Security.Cryptography.X509Certificates.X509Extension
+    {
+        public X509BasicConstraintsExtension() { }
+        public X509BasicConstraintsExtension(bool certificateAuthority, bool hasPathLengthConstraint, int pathLengthConstraint, bool critical) { }
+        public X509BasicConstraintsExtension(System.Security.Cryptography.AsnEncodedData encodedBasicConstraints, bool critical) { }
+        public bool CertificateAuthority { get { return default(bool); } }
+        public bool HasPathLengthConstraint { get { return default(bool); } }
+        public int PathLengthConstraint { get { return default(int); } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public partial class X509Certificate : System.IDisposable
+    {
+        public X509Certificate() { }
+        public X509Certificate(byte[] data) { }
+        public X509Certificate(byte[] rawData, string password) { }
+        public X509Certificate(byte[] rawData, string password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
+        [System.Security.SecurityCriticalAttribute]
+        public X509Certificate(System.IntPtr handle) { }
+        public X509Certificate(string fileName) { }
+        public X509Certificate(string fileName, string password) { }
+        public X509Certificate(string fileName, string password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
+        public System.IntPtr Handle {[System.Security.SecurityCriticalAttribute]get { return default(System.IntPtr); } }
+        public string Issuer { get { return default(string); } }
+        public string Subject { get { return default(string); } }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public override bool Equals(object obj) { return default(bool); }
+        public virtual bool Equals(System.Security.Cryptography.X509Certificates.X509Certificate other) { return default(bool); }
+        public virtual byte[] Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType) { return default(byte[]); }
+        public virtual byte[] Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType, string password) { return default(byte[]); }
+        public virtual byte[] GetCertHash() { return default(byte[]); }
+        public virtual string GetFormat() { return default(string); }
+        public override int GetHashCode() { return default(int); }
+        public virtual string GetKeyAlgorithm() { return default(string); }
+        public virtual byte[] GetKeyAlgorithmParameters() { return default(byte[]); }
+        public virtual string GetKeyAlgorithmParametersString() { return default(string); }
+        public virtual byte[] GetPublicKey() { return default(byte[]); }
+        public virtual byte[] GetSerialNumber() { return default(byte[]); }
+        public override string ToString() { return default(string); }
+        public virtual string ToString(bool fVerbose) { return default(string); }
+    }
+    public partial class X509Certificate2 : System.Security.Cryptography.X509Certificates.X509Certificate
+    {
+        public X509Certificate2() { }
+        public X509Certificate2(byte[] rawData) { }
+        public X509Certificate2(byte[] rawData, string password) { }
+        public X509Certificate2(byte[] rawData, string password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
+        public X509Certificate2(System.IntPtr handle) { }
+        public X509Certificate2(string fileName) { }
+        public X509Certificate2(string fileName, string password) { }
+        public X509Certificate2(string fileName, string password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
+        public bool Archived { get { return default(bool); } set { } }
+        public System.Security.Cryptography.X509Certificates.X509ExtensionCollection Extensions { get { return default(System.Security.Cryptography.X509Certificates.X509ExtensionCollection); } }
+        public string FriendlyName { get { return default(string); } set { } }
+        public bool HasPrivateKey { get { return default(bool); } }
+        public System.Security.Cryptography.X509Certificates.X500DistinguishedName IssuerName { get { return default(System.Security.Cryptography.X509Certificates.X500DistinguishedName); } }
+        public System.DateTime NotAfter { get { return default(System.DateTime); } }
+        public System.DateTime NotBefore { get { return default(System.DateTime); } }
+        public System.Security.Cryptography.X509Certificates.PublicKey PublicKey { get { return default(System.Security.Cryptography.X509Certificates.PublicKey); } }
+        public byte[] RawData { get { return default(byte[]); } }
+        public string SerialNumber { get { return default(string); } }
+        public System.Security.Cryptography.Oid SignatureAlgorithm { get { return default(System.Security.Cryptography.Oid); } }
+        public System.Security.Cryptography.X509Certificates.X500DistinguishedName SubjectName { get { return default(System.Security.Cryptography.X509Certificates.X500DistinguishedName); } }
+        public string Thumbprint { get { return default(string); } }
+        public int Version { get { return default(int); } }
+        public static System.Security.Cryptography.X509Certificates.X509ContentType GetCertContentType(byte[] rawData) { return default(System.Security.Cryptography.X509Certificates.X509ContentType); }
+        public static System.Security.Cryptography.X509Certificates.X509ContentType GetCertContentType(string fileName) { return default(System.Security.Cryptography.X509Certificates.X509ContentType); }
+        public string GetNameInfo(System.Security.Cryptography.X509Certificates.X509NameType nameType, bool forIssuer) { return default(string); }
+        public override string ToString() { return default(string); }
+        public override string ToString(bool verbose) { return default(string); }
+    }
+    public partial class X509Certificate2Collection : System.Security.Cryptography.X509Certificates.X509CertificateCollection
+    {
+        public X509Certificate2Collection() { }
+        public X509Certificate2Collection(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public X509Certificate2Collection(System.Security.Cryptography.X509Certificates.X509Certificate2[] certificates) { }
+        public X509Certificate2Collection(System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+        public new System.Security.Cryptography.X509Certificates.X509Certificate2 this[int index] { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate2); } set { } }
+        public int Add(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { return default(int); }
+        public void AddRange(System.Security.Cryptography.X509Certificates.X509Certificate2[] certificates) { }
+        public void AddRange(System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+        public bool Contains(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { return default(bool); }
+        public byte[] Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType) { return default(byte[]); }
+        public byte[] Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType, string password) { return default(byte[]); }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Find(System.Security.Cryptography.X509Certificates.X509FindType findType, object findValue, bool validOnly) { return default(System.Security.Cryptography.X509Certificates.X509Certificate2Collection); }
+        public new System.Security.Cryptography.X509Certificates.X509Certificate2Enumerator GetEnumerator() { return default(System.Security.Cryptography.X509Certificates.X509Certificate2Enumerator); }
+        public void Import(byte[] rawData) { }
+        public void Import(byte[] rawData, string password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
+        public void Import(string fileName) { }
+        public void Import(string fileName, string password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
+        public void Insert(int index, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public void Remove(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public void RemoveRange(System.Security.Cryptography.X509Certificates.X509Certificate2[] certificates) { }
+        public void RemoveRange(System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+    }
+    public sealed partial class X509Certificate2Enumerator : System.Collections.IEnumerator
+    {
+        internal X509Certificate2Enumerator() { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Current { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate2); } }
+        object System.Collections.IEnumerator.Current { get { return default(object); } }
+        public bool MoveNext() { return default(bool); }
+        public void Reset() { }
+        bool System.Collections.IEnumerator.MoveNext() { return default(bool); }
+        void System.Collections.IEnumerator.Reset() { }
+    }
+    public partial class X509CertificateCollection
+    {
+        public X509CertificateCollection() { }
+        public X509CertificateCollection(System.Security.Cryptography.X509Certificates.X509Certificate[] value) { }
+        public X509CertificateCollection(System.Security.Cryptography.X509Certificates.X509CertificateCollection value) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate this[int index] { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate); } set { } }
+        public int Add(System.Security.Cryptography.X509Certificates.X509Certificate value) { return default(int); }
+        public void AddRange(System.Security.Cryptography.X509Certificates.X509Certificate[] value) { }
+        public void AddRange(System.Security.Cryptography.X509Certificates.X509CertificateCollection value) { }
+        public bool Contains(System.Security.Cryptography.X509Certificates.X509Certificate value) { return default(bool); }
+        public void CopyTo(System.Security.Cryptography.X509Certificates.X509Certificate[] array, int index) { }
+        public System.Security.Cryptography.X509Certificates.X509CertificateCollection.X509CertificateEnumerator GetEnumerator() { return default(System.Security.Cryptography.X509Certificates.X509CertificateCollection.X509CertificateEnumerator); }
+        public override int GetHashCode() { return default(int); }
+        public int IndexOf(System.Security.Cryptography.X509Certificates.X509Certificate value) { return default(int); }
+        public void Insert(int index, System.Security.Cryptography.X509Certificates.X509Certificate value) { }
+        public void Remove(System.Security.Cryptography.X509Certificates.X509Certificate value) { }
+        public partial class X509CertificateEnumerator : System.Collections.IEnumerator
+        {
+            public X509CertificateEnumerator(System.Security.Cryptography.X509Certificates.X509CertificateCollection mappings) { }
+            public System.Security.Cryptography.X509Certificates.X509Certificate Current { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate); } }
+            object System.Collections.IEnumerator.Current { get { return default(object); } }
+            public bool MoveNext() { return default(bool); }
+            public void Reset() { }
+            bool System.Collections.IEnumerator.MoveNext() { return default(bool); }
+            void System.Collections.IEnumerator.Reset() { }
+        }
+    }
+    public partial class X509Chain : System.IDisposable
+    {
+        public X509Chain() { }
+        public System.Security.Cryptography.X509Certificates.X509ChainElementCollection ChainElements { get { return default(System.Security.Cryptography.X509Certificates.X509ChainElementCollection); } }
+        public System.Security.Cryptography.X509Certificates.X509ChainPolicy ChainPolicy { get { return default(System.Security.Cryptography.X509Certificates.X509ChainPolicy); } set { } }
+        public System.Security.Cryptography.X509Certificates.X509ChainStatus[] ChainStatus { get { return default(System.Security.Cryptography.X509Certificates.X509ChainStatus[]); } }
+        public Microsoft.Win32.SafeHandles.SafeX509ChainHandle SafeHandle { get { return default(Microsoft.Win32.SafeHandles.SafeX509ChainHandle); } }
+        public bool Build(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { return default(bool); }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+    }
+    public partial class X509ChainElement
+    {
+        internal X509ChainElement() { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate2); } }
+        public System.Security.Cryptography.X509Certificates.X509ChainStatus[] ChainElementStatus { get { return default(System.Security.Cryptography.X509Certificates.X509ChainStatus[]); } }
+        public string Information { get { return default(string); } }
+    }
+    public sealed partial class X509ChainElementCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal X509ChainElementCollection() { }
+        public int Count { get { return default(int); } }
+        bool System.Collections.ICollection.IsSynchronized { get { return default(bool); } }
+        public System.Security.Cryptography.X509Certificates.X509ChainElement this[int index] { get { return default(System.Security.Cryptography.X509Certificates.X509ChainElement); } }
+        object System.Collections.ICollection.SyncRoot { get { return default(object); } }
+        public void CopyTo(System.Security.Cryptography.X509Certificates.X509ChainElement[] array, int index) { }
+        public System.Security.Cryptography.X509Certificates.X509ChainElementEnumerator GetEnumerator() { return default(System.Security.Cryptography.X509Certificates.X509ChainElementEnumerator); }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return default(System.Collections.IEnumerator); }
+    }
+    public sealed partial class X509ChainElementEnumerator : System.Collections.IEnumerator
+    {
+        internal X509ChainElementEnumerator() { }
+        public System.Security.Cryptography.X509Certificates.X509ChainElement Current { get { return default(System.Security.Cryptography.X509Certificates.X509ChainElement); } }
+        object System.Collections.IEnumerator.Current { get { return default(object); } }
+        public bool MoveNext() { return default(bool); }
+        public void Reset() { }
+    }
+    public sealed partial class X509ChainPolicy
+    {
+        public X509ChainPolicy() { }
+        public System.Security.Cryptography.OidCollection ApplicationPolicy { get { return default(System.Security.Cryptography.OidCollection); } }
+        public System.Security.Cryptography.OidCollection CertificatePolicy { get { return default(System.Security.Cryptography.OidCollection); } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection ExtraStore { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate2Collection); } }
+        public System.Security.Cryptography.X509Certificates.X509RevocationFlag RevocationFlag { get { return default(System.Security.Cryptography.X509Certificates.X509RevocationFlag); } set { } }
+        public System.Security.Cryptography.X509Certificates.X509RevocationMode RevocationMode { get { return default(System.Security.Cryptography.X509Certificates.X509RevocationMode); } set { } }
+        public System.TimeSpan UrlRetrievalTimeout { get { return default(System.TimeSpan); } set { } }
+        public System.Security.Cryptography.X509Certificates.X509VerificationFlags VerificationFlags { get { return default(System.Security.Cryptography.X509Certificates.X509VerificationFlags); } set { } }
+        public System.DateTime VerificationTime { get { return default(System.DateTime); } set { } }
+        public void Reset() { }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct X509ChainStatus
+    {
+        public System.Security.Cryptography.X509Certificates.X509ChainStatusFlags Status { get { return default(System.Security.Cryptography.X509Certificates.X509ChainStatusFlags); } set { } }
+        public string StatusInformation { get { return default(string); } set { } }
+    }
+    [System.FlagsAttribute]
+    public enum X509ChainStatusFlags
+    {
+        CtlNotSignatureValid = 262144,
+        CtlNotTimeValid = 131072,
+        CtlNotValidForUsage = 524288,
+        Cyclic = 128,
+        ExplicitDistrust = 67108864,
+        HasExcludedNameConstraint = 32768,
+        HasNotDefinedNameConstraint = 8192,
+        HasNotPermittedNameConstraint = 16384,
+        HasNotSupportedCriticalExtension = 134217728,
+        HasNotSupportedNameConstraint = 4096,
+        HasWeakSignature = 1048576,
+        InvalidBasicConstraints = 1024,
+        InvalidExtension = 256,
+        InvalidNameConstraints = 2048,
+        InvalidPolicyConstraints = 512,
+        NoError = 0,
+        NoIssuanceChainPolicy = 33554432,
+        NotSignatureValid = 8,
+        NotTimeNested = 2,
+        NotTimeValid = 1,
+        NotValidForUsage = 16,
+        OfflineRevocation = 16777216,
+        PartialChain = 65536,
+        RevocationStatusUnknown = 64,
+        Revoked = 4,
+        UntrustedRoot = 32,
+    }
+    public enum X509ContentType
+    {
+        Authenticode = 6,
+        Cert = 1,
+        Pfx = 3,
+        Pkcs12 = 3,
+        Pkcs7 = 5,
+        SerializedCert = 2,
+        SerializedStore = 4,
+        Unknown = 0,
+    }
+    public sealed partial class X509EnhancedKeyUsageExtension : System.Security.Cryptography.X509Certificates.X509Extension
+    {
+        public X509EnhancedKeyUsageExtension() { }
+        public X509EnhancedKeyUsageExtension(System.Security.Cryptography.AsnEncodedData encodedEnhancedKeyUsages, bool critical) { }
+        public X509EnhancedKeyUsageExtension(System.Security.Cryptography.OidCollection enhancedKeyUsages, bool critical) { }
+        public System.Security.Cryptography.OidCollection EnhancedKeyUsages { get { return default(System.Security.Cryptography.OidCollection); } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public partial class X509Extension : System.Security.Cryptography.AsnEncodedData
+    {
+        protected X509Extension() { }
+        public X509Extension(System.Security.Cryptography.AsnEncodedData encodedExtension, bool critical) { }
+        public X509Extension(System.Security.Cryptography.Oid oid, byte[] rawData, bool critical) { }
+        public X509Extension(string oid, byte[] rawData, bool critical) { }
+        public bool Critical { get { return default(bool); } set { } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class X509ExtensionCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public X509ExtensionCollection() { }
+        public int Count { get { return default(int); } }
+        bool System.Collections.ICollection.IsSynchronized { get { return default(bool); } }
+        public System.Security.Cryptography.X509Certificates.X509Extension this[int index] { get { return default(System.Security.Cryptography.X509Certificates.X509Extension); } }
+        public System.Security.Cryptography.X509Certificates.X509Extension this[string oid] { get { return default(System.Security.Cryptography.X509Certificates.X509Extension); } }
+        object System.Collections.ICollection.SyncRoot { get { return default(object); } }
+        public int Add(System.Security.Cryptography.X509Certificates.X509Extension extension) { return default(int); }
+        public void CopyTo(System.Security.Cryptography.X509Certificates.X509Extension[] array, int index) { }
+        public System.Security.Cryptography.X509Certificates.X509ExtensionEnumerator GetEnumerator() { return default(System.Security.Cryptography.X509Certificates.X509ExtensionEnumerator); }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return default(System.Collections.IEnumerator); }
+    }
+    public sealed partial class X509ExtensionEnumerator : System.Collections.IEnumerator
+    {
+        internal X509ExtensionEnumerator() { }
+        public System.Security.Cryptography.X509Certificates.X509Extension Current { get { return default(System.Security.Cryptography.X509Certificates.X509Extension); } }
+        object System.Collections.IEnumerator.Current { get { return default(object); } }
+        public bool MoveNext() { return default(bool); }
+        public void Reset() { }
+    }
+    public enum X509FindType
+    {
+        FindByApplicationPolicy = 10,
+        FindByCertificatePolicy = 11,
+        FindByExtension = 12,
+        FindByIssuerDistinguishedName = 4,
+        FindByIssuerName = 3,
+        FindByKeyUsage = 13,
+        FindBySerialNumber = 5,
+        FindBySubjectDistinguishedName = 2,
+        FindBySubjectKeyIdentifier = 14,
+        FindBySubjectName = 1,
+        FindByTemplateName = 9,
+        FindByThumbprint = 0,
+        FindByTimeExpired = 8,
+        FindByTimeNotYetValid = 7,
+        FindByTimeValid = 6,
+    }
+    [System.FlagsAttribute]
+    public enum X509KeyStorageFlags
+    {
+        DefaultKeySet = 0,
+        Exportable = 4,
+        MachineKeySet = 2,
+        PersistKeySet = 16,
+        UserKeySet = 1,
+        UserProtected = 8,
+    }
+    public sealed partial class X509KeyUsageExtension : System.Security.Cryptography.X509Certificates.X509Extension
+    {
+        public X509KeyUsageExtension() { }
+        public X509KeyUsageExtension(System.Security.Cryptography.AsnEncodedData encodedKeyUsage, bool critical) { }
+        public X509KeyUsageExtension(System.Security.Cryptography.X509Certificates.X509KeyUsageFlags keyUsages, bool critical) { }
+        public System.Security.Cryptography.X509Certificates.X509KeyUsageFlags KeyUsages { get { return default(System.Security.Cryptography.X509Certificates.X509KeyUsageFlags); } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    [System.FlagsAttribute]
+    public enum X509KeyUsageFlags
+    {
+        CrlSign = 2,
+        DataEncipherment = 16,
+        DecipherOnly = 32768,
+        DigitalSignature = 128,
+        EncipherOnly = 1,
+        KeyAgreement = 8,
+        KeyCertSign = 4,
+        KeyEncipherment = 32,
+        None = 0,
+        NonRepudiation = 64,
+    }
+    public enum X509NameType
+    {
+        DnsFromAlternativeName = 4,
+        DnsName = 3,
+        EmailName = 1,
+        SimpleName = 0,
+        UpnName = 2,
+        UrlName = 5,
+    }
+    public enum X509RevocationFlag
+    {
+        EndCertificateOnly = 0,
+        EntireChain = 1,
+        ExcludeRoot = 2,
+    }
+    public enum X509RevocationMode
+    {
+        NoCheck = 0,
+        Offline = 2,
+        Online = 1,
+    }
+    public sealed partial class X509Store : System.IDisposable
+    {
+        public X509Store() { }
+        public X509Store(System.Security.Cryptography.X509Certificates.StoreName storeName, System.Security.Cryptography.X509Certificates.StoreLocation storeLocation) { }
+        public X509Store(string storeName, System.Security.Cryptography.X509Certificates.StoreLocation storeLocation) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate2Collection); } }
+        public System.Security.Cryptography.X509Certificates.StoreLocation Location { get { return default(System.Security.Cryptography.X509Certificates.StoreLocation); } }
+        public string Name { get { return default(string); } }
+        public void Add(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public void Dispose() { }
+        public void Open(System.Security.Cryptography.X509Certificates.OpenFlags flags) { }
+        public void Remove(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+    }
+    public sealed partial class X509SubjectKeyIdentifierExtension : System.Security.Cryptography.X509Certificates.X509Extension
+    {
+        public X509SubjectKeyIdentifierExtension() { }
+        public X509SubjectKeyIdentifierExtension(byte[] subjectKeyIdentifier, bool critical) { }
+        public X509SubjectKeyIdentifierExtension(System.Security.Cryptography.AsnEncodedData encodedSubjectKeyIdentifier, bool critical) { }
+        public X509SubjectKeyIdentifierExtension(System.Security.Cryptography.X509Certificates.PublicKey key, bool critical) { }
+        public X509SubjectKeyIdentifierExtension(System.Security.Cryptography.X509Certificates.PublicKey key, System.Security.Cryptography.X509Certificates.X509SubjectKeyIdentifierHashAlgorithm algorithm, bool critical) { }
+        public X509SubjectKeyIdentifierExtension(string subjectKeyIdentifier, bool critical) { }
+        public string SubjectKeyIdentifier { get { return default(string); } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public enum X509SubjectKeyIdentifierHashAlgorithm
+    {
+        CapiSha1 = 2,
+        Sha1 = 0,
+        ShortSha1 = 1,
+    }
+    [System.FlagsAttribute]
+    public enum X509VerificationFlags
+    {
+        AllFlags = 4095,
+        AllowUnknownCertificateAuthority = 16,
+        IgnoreCertificateAuthorityRevocationUnknown = 1024,
+        IgnoreCtlNotTimeValid = 2,
+        IgnoreCtlSignerRevocationUnknown = 512,
+        IgnoreEndRevocationUnknown = 256,
+        IgnoreInvalidBasicConstraints = 8,
+        IgnoreInvalidName = 64,
+        IgnoreInvalidPolicy = 128,
+        IgnoreNotTimeNested = 4,
+        IgnoreNotTimeValid = 1,
+        IgnoreRootRevocationUnknown = 2048,
+        IgnoreWrongUsage = 32,
+        NoFlag = 0,
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/ref/4.0/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/ref/4.0/System.Security.Cryptography.X509Certificates.csproj
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.4</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.4</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="System.Security.Cryptography.Cng.cs" />
-    <Compile Include="System.Security.Cryptography.Cng.Manual.cs" />
+    <Compile Include="System.Security.Cryptography.X509Certificates.cs" />
+    <Compile Include="System.Security.Cryptography.X509Certificates.Manual.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Security.Cryptography.X509Certificates/ref/4.0/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/ref/4.0/project.json
@@ -1,15 +1,16 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.0",
     "System.IO": "4.0.0",
+    "System.Runtime": "4.0.0",
     "System.Runtime.Handles": "4.0.0",
+    "System.Security.Cryptography.Primitives": "4.0.0-rc3-23901",
     "System.Security.Cryptography.Algorithms": "4.0.0-rc3-23901",
-    "System.Security.Cryptography.Primitives": "4.0.0-rc3-23901"
+    "System.Security.Cryptography.Encoding": "4.0.0-rc3-23901"
   },
   "frameworks": {
-    "netstandard1.4": {
+    "netstandard1.3": {
       "imports": [
-        "dotnet5.5"
+        "dotnet5.4"
       ]
     }
   }

--- a/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.csproj
@@ -2,10 +2,10 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.4</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Security.Cryptography.X509Certificates.cs" />

--- a/src/System.Security.Cryptography.X509Certificates/ref/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/ref/project.json
@@ -8,9 +8,9 @@
     "System.Security.Cryptography.Encoding": "4.0.0-rc3-23901"
   },
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.4": {
       "imports": [
-        "dotnet5.4"
+        "dotnet5.5"
       ]
     }
   }

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.builds
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.builds
@@ -16,6 +16,9 @@
       <TargetGroup>netcore50</TargetGroup>
     </Project>
     <Project Include="System.Security.Cryptography.X509Certificates.csproj">
+      <TargetGroup>net46</TargetGroup>
+    </Project>
+    <Project Include="System.Security.Cryptography.X509Certificates.csproj">
       <TargetGroup>net461</TargetGroup>
     </Project>
   </ItemGroup>

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -10,23 +10,19 @@
     <ProjectGuid>{6F8576C2-6CD0-4DF3-8394-00B002D82E40}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.X509Certificates</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)'=='net46'">4.0.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>false</CLSCompliant>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
-    <PackageTargetRuntime Condition="'$(TargetsWindows)' == 'true' and '$(TargetGroup)' != 'net461'">win7</PackageTargetRuntime> 
-    <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true' and '$(TargetGroup)' != 'net461'">unix</PackageTargetRuntime> 
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net461'">true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.4</PackageTargetFramework>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46' OR '$(TargetGroup)'=='net461'">true</IsPartialFacadeAssembly>
+    <UsePackageTargetRuntimeDefaults Condition="'$(IsPartialFacadeAssembly)' != 'true'">true</UsePackageTargetRuntimeDefaults>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetGroup)' == 'netcore50' and '$(ProjectJson)' == '' ">
     <ProjectJson>netcore50/project.json</ProjectJson>
     <ProjectLockJson>netcore50/project.lock.json</ProjectLockJson>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetGroup)' == 'net461' and '$(ProjectJson)' == '' ">
-    <ProjectJson>net461\project.json</ProjectJson>
-    <ProjectLockJson>net461\project.lock.json</ProjectLockJson>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetsWindows)' == 'true' and '$(ProjectJson)' == '' ">
+  <PropertyGroup Condition=" '$(TargetsWindows)' == 'true' AND '$(IsPartialFacadeAssembly)' != 'true' AND '$(ProjectJson)' == '' ">
     <ProjectJson>win/project.json</ProjectJson>
     <ProjectLockJson>win/project.lock.json</ProjectLockJson>
   </PropertyGroup>
@@ -46,7 +42,7 @@
     <DefineConstants>$(DefineConstants);NETNATIVE</DefineConstants>
   </PropertyGroup>
   
-  <ItemGroup Condition=" '$(TargetGroup)' != 'net461'">
+  <ItemGroup Condition=" '$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="Internal\Cryptography\ICertificatePal.cs" />
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs</Link>
@@ -100,7 +96,7 @@
     <Compile Include="System\Security\Cryptography\X509Certificates\X509SubjectKeyIdentifierHashAlgorithm.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\X509VerificationFlags.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' AND '$(TargetGroup)' != 'net461'">
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' AND '$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Security\Cryptography\DSACryptoServiceProviderStub.cs" />
     <Compile Include="Internal\Cryptography\Pal.Windows\CertificatePal.cs" />
     <Compile Include="Internal\Cryptography\Pal.Windows\CertificatePal.CspParametersStub.cs" />
@@ -152,7 +148,7 @@
       <Link>Common\Microsoft\Win32\SafeHandles\SafeBCryptKeyHandle.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' AND '$(TargetGroup)' != 'net461'">
+  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' AND '$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="Internal\Cryptography\Pal.Unix\CertificateAssetDownloader.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\CertificatePal.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\CertificatePolicy.cs" />
@@ -298,7 +294,7 @@
       <Link>Common\System\Security\Cryptography\DerSequenceReader.cs</Link>
     </Compile>    
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetGroup)'=='net461'">
+  <ItemGroup Condition=" '$(IsPartialFacadeAssembly)'=='true'">
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Core" />

--- a/src/System.Security.Cryptography.X509Certificates/src/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/project.json
@@ -1,5 +1,10 @@
 {
   "frameworks": {
+    "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
+    },
     "net461": {
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6.1": "1.0.1"

--- a/src/System.Security.Cryptography.X509Certificates/src/win/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/win/project.json
@@ -13,13 +13,16 @@
     "System.Runtime.Numerics": "4.0.0",
     "System.Security.Cryptography.Algorithms": "4.0.0-rc3-23901",
     "System.Security.Cryptography.Cng": "4.0.0-rc3-23901",
-    "System.Security.Cryptography.Csp": "4.0.0-rc3-23901",
     "System.Security.Cryptography.Encoding": "4.0.0-rc3-23901",
     "System.Security.Cryptography.Primitives": "4.0.0-rc3-23901",
     "System.Text.Encoding": "4.0.10",
     "System.Threading": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "dependencies": {
+        "System.Security.Cryptography.Csp": "4.0.0-rc3-23901"
+      }
+    }
   }
 }


### PR DESCRIPTION
ECDsa support was enhanced in net461, and that API surface is what is
present in CoreFX. To allow for a net46(0)-compatible experience the
ECDsa support needs to be shaved off.

This change:
* Splits S.S.C.Algorithms 4.0 (removes ECDsa)
* Splits S.S.C.Cng 4.0 (removes ECDsaCng)
* Splits S.S.C.X509Certificates 4.0 (removes ECDsaCertificateExtensions)

Fixes #5874.
cc: @ericstj @weshaggard 