### PR TITLE
Fix System.IO.FileSystem handling of symlinks

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
@@ -2,16 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.InteropServices;
-
 namespace System.IO
 {
     partial class FileSystemInfo : IFileSystemObject
     {
         /// <summary>The last cached stat information about the file.</summary>
         private Interop.Sys.FileStatus _fileStatus;
-        /// <summary>Whether the target is a symlink.</summary>
-        private bool _isSymlink;
+        /// <summary>true if <see cref="_fileStatus"/> represents a symlink and the target of that symlink is a directory.</summary>
+        private bool _targetOfSymlinkIsDirectory;
 
         /// <summary>
         /// Whether we've successfully cached a stat structure.
@@ -39,7 +37,7 @@ namespace System.IO
 
                 FileAttributes attrs = default(FileAttributes);
 
-                if (IsDirectoryAssumesInitialized)
+                if (IsDirectoryAssumesInitialized) // this is the one attribute where we follow symlinks
                 {
                     attrs |= FileAttributes.Directory;
                 }
@@ -47,7 +45,7 @@ namespace System.IO
                 {
                     attrs |= FileAttributes.ReadOnly;
                 }
-                if (_isSymlink)
+                if (IsSymlinkAssumesInitialized)
                 {
                     attrs |= FileAttributes.ReparsePoint;
                 }
@@ -85,13 +83,13 @@ namespace System.IO
         }
 
         /// <summary>Gets whether stat reported this system object as a directory.</summary>
-        private bool IsDirectoryAssumesInitialized
-        {
-            get
-            {
-                return (_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
-            }
-        }
+        private bool IsDirectoryAssumesInitialized =>
+            (_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR ||
+            (IsSymlinkAssumesInitialized && _targetOfSymlinkIsDirectory);
+
+        /// <summary>Gets whether stat reported this system object as a symlink.</summary>
+        private bool IsSymlinkAssumesInitialized =>
+            (_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK;
 
         /// <summary>
         /// Gets or sets whether the file is read-only.  This is based on the read/write/execute
@@ -153,6 +151,7 @@ namespace System.IO
                 {
                     Refresh();
                 }
+
                 return
                     _fileStatusInitialized == 0 && // avoid throwing if Refresh failed; instead just return false
                     (this is DirectoryInfo) == IsDirectoryAssumesInitialized;
@@ -224,38 +223,27 @@ namespace System.IO
             // This should not throw, instead we store the result so that we can throw it
             // when someone actually accesses a property.
 
-            // Use LStat so that we don't follow a symlink, at least not initially.
-            // If we find that it is a symlink, we can then use Stat to get the real data
-            // but remember that this is a symlink so we can report it appropriately in the
-            // attributes we give back.  Note that this behavior differs from Windows, which
-            // always does the effective equivalent of LStat.  But that also means that functionality
-            // like EnumerateFiles would fail on a symlink to a directory, and given their prevalence 
-            // on unix systems, that would be quite problematic.
+            // Use lstat to get the details on the object, without following symlinks.
+            // If it is a symlink, then subsequently get details on the target of the symlink,
+            // storing those results separately.  We only report failure if the initial
+            // lstat fails, as a broken symlink should still report info on exists, attributs, etc.
+            _targetOfSymlinkIsDirectory = false;
             int result = Interop.Sys.LStat(FullPath, out _fileStatus);
-            if (result >= 0)
+            if (result < 0)
             {
-                // Successfully got stats.
-                if ((_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK)
-                {
-                    // If it's a symlink, get the stats for the actual target.
-                    _isSymlink = true;
-                    result = Interop.Sys.Stat(FullPath, out _fileStatus);
-                    if (result >= 0)
-                    {
-                        _fileStatusInitialized = 0;
-                        return;
-                    }
-                }
-                else
-                {
-                    _fileStatusInitialized = 0;
-                    return;
-                }
+                Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
+                _fileStatusInitialized = errorInfo.RawErrno;
+                return;
             }
 
-            // Couldn't get stats on the object.
-            var errorInfo = Interop.Sys.GetLastErrorInfo();
-            _fileStatusInitialized = errorInfo.RawErrno;
+            Interop.Sys.FileStatus targetStatus;
+            if ((_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK &&
+                Interop.Sys.Stat(FullPath, out targetStatus) >= 0)
+            {
+                _targetOfSymlinkIsDirectory = (targetStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
+            }
+
+            _fileStatusInitialized = 0;
         }
 
         private void EnsureStatInitialized()

--- a/src/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -87,6 +87,27 @@ namespace System.IO.Tests
             Assert.Throws<IOException>(() => Delete(Directory.GetCurrentDirectory()));
         }
 
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
+        public void DeletingSymLinkDoesntDeleteTarget()
+        {
+            var path = GetTestFilePath();
+            var linkPath = GetTestFilePath();
+
+            Directory.CreateDirectory(path);
+            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
+
+            // Both the symlink and the target exist
+            Assert.True(Directory.Exists(path), "path should exist");
+            Assert.True(Directory.Exists(linkPath), "linkPath should exist");
+
+            // Delete the symlink
+            Directory.Delete(linkPath);
+
+            // Target should still exist
+            Assert.True(Directory.Exists(path), "path should still exist");
+            Assert.False(Directory.Exists(linkPath), "linkPath should no longer exist");
+        }
+
         #endregion
 
         #region PlatformSpecific

--- a/src/System.IO.FileSystem/tests/Directory/GetFiles.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFiles.cs
@@ -18,8 +18,7 @@ namespace System.IO.Tests
             return Directory.GetFiles(path);
         }
 
-        [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
         public void EnumerateWithSymLinkToFile()
         {
             using (var containingFolder = new TemporaryDirectory())
@@ -30,7 +29,8 @@ namespace System.IO.Tests
                 using (var targetFile = new TemporaryFile())
                 {
                     linkPath = Path.Combine(containingFolder.Path, Path.GetRandomFileName());
-                    Assert.Equal(0, symlink(targetFile.Path, linkPath));
+                    Assert.True(MountHelper.CreateSymbolicLink(linkPath, targetFile.Path, isDirectory: false));
+
                     Assert.True(File.Exists(linkPath));
                     Assert.Equal(1, GetEntries(containingFolder.Path).Count());
                 }
@@ -43,9 +43,6 @@ namespace System.IO.Tests
                 Assert.Equal(0, GetEntries(containingFolder.Path).Count());
             }
         }
-
-        [DllImport("libc", SetLastError = true)]
-        private static extern int symlink(string path1, string path2);
     }
 
     public class Directory_GetFiles_str_str : Directory_GetFileSystemEntries_str_str

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
@@ -97,16 +97,70 @@ namespace System.IO.Tests
             Assert.False(di.Exists);
         }
 
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void FalseForNonRegularFile()
+        {
+            string fileName = GetTestFilePath();
+            Assert.Equal(0, mkfifo(fileName, 0));
+            DirectoryInfo di = new DirectoryInfo(fileName);
+            Assert.False(di.Exists);
+        }
+
         [ConditionalFact(nameof(CanCreateSymbolicLinks))]
         public void SymlinkToNewDirectoryInfo()
         {
-            string targetPath = GetTestFilePath();
-            new DirectoryInfo(targetPath).Create();
+            string path = GetTestFilePath();
+            new DirectoryInfo(path).Create();
 
             string linkPath = GetTestFilePath();
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, targetPath));
+            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
 
-            Assert.NotEqual(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), new DirectoryInfo(linkPath).Exists);
+            Assert.True(new DirectoryInfo(path).Exists);
+            Assert.True(new DirectoryInfo(linkPath).Exists);
+        }
+
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
+        public void SymLinksMayExistIndependentlyOfTarget()
+        {
+            var path = GetTestFilePath();
+            var linkPath = GetTestFilePath();
+
+            var pathFI = new DirectoryInfo(path);
+            var linkPathFI = new DirectoryInfo(linkPath);
+
+            pathFI.Create();
+            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
+
+            // Both the symlink and the target exist
+            pathFI.Refresh();
+            linkPathFI.Refresh();
+            Assert.True(pathFI.Exists, "path should exist");
+            Assert.True(linkPathFI.Exists, "linkPath should exist");
+
+            // Delete the target.  The symlink should still exist, but on Unix it'll now
+            // be considered a file and won't exist as a directory.
+            pathFI.Delete();
+            pathFI.Refresh();
+            Assert.False(pathFI.Exists, "path should now not exist");
+            linkPathFI.Refresh();
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.True(linkPathFI.Exists, "linkPath directory should still exist");
+                Assert.False(File.Exists(linkPath), "linkPath file should not exist");
+
+                Directory.Delete(linkPath);
+            }
+            else
+            {
+                Assert.False(linkPathFI.Exists, "linkPath directory should no longer exist");
+                Assert.True(File.Exists(linkPath), "linkPath file should now exist");
+
+                File.Delete(linkPath);
+            }
+
+            linkPathFI.Refresh();
+            Assert.False(linkPathFI.Exists, "linkPath should no longer exist");
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetAttributes.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/GetSetAttributes.cs
@@ -127,5 +127,39 @@ namespace System.IO.Tests
             test.Create();
             Assert.Throws<ArgumentException>(() => Set(test.FullName, attr));
         }
+
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
+        public void SymLinksAreReparsePoints()
+        {
+            var path = GetTestFilePath();
+            var linkPath = GetTestFilePath();
+
+            Directory.CreateDirectory(path);
+            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
+
+            Assert.NotEqual(FileAttributes.ReparsePoint, FileAttributes.ReparsePoint & Get(path));
+            Assert.Equal(FileAttributes.ReparsePoint, FileAttributes.ReparsePoint & Get(linkPath));
+        }
+
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
+        public void SymLinksReflectSymLinkAttributes()
+        {
+            var path = GetTestFilePath();
+            var linkPath = GetTestFilePath();
+
+            Directory.CreateDirectory(path);
+            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
+
+            Set(path, FileAttributes.ReadOnly);
+            try
+            {
+                Assert.Equal(FileAttributes.ReadOnly, FileAttributes.ReadOnly & Get(path));
+                Assert.NotEqual(FileAttributes.ReadOnly, FileAttributes.ReadOnly & Get(linkPath));
+            }
+            finally
+            {
+                Set(path, Get(path) & ~FileAttributes.ReadOnly);
+            }
+        }
     }
 }

--- a/src/System.IO.FileSystem/tests/File/Delete.cs
+++ b/src/System.IO.FileSystem/tests/File/Delete.cs
@@ -82,6 +82,27 @@ namespace System.IO.Tests
             Assert.Throws<UnauthorizedAccessException>(() => Delete(TestDirectory));
         }
 
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
+        public void DeletingSymLinkDoesntDeleteTarget()
+        {
+            var path = GetTestFilePath();
+            var linkPath = GetTestFilePath();
+
+            File.Create(path).Dispose();
+            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: false));
+
+            // Both the symlink and the target exist
+            Assert.True(File.Exists(path), "path should exist");
+            Assert.True(File.Exists(linkPath), "linkPath should exist");
+
+            // Delete the symlink
+            File.Delete(linkPath);
+
+            // Target should still exist
+            Assert.True(File.Exists(path), "path should still exist");
+            Assert.False(File.Exists(linkPath), "linkPath should no longer exist");
+        }
+
         #endregion
 
         #region PlatformSpecific

--- a/src/System.IO.FileSystem/tests/File/Exists.cs
+++ b/src/System.IO.FileSystem/tests/File/Exists.cs
@@ -112,6 +112,29 @@ namespace System.IO.Tests
             });
         }
 
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
+        public void SymLinksMayExistIndependentlyOfTarget()
+        {
+            var path = GetTestFilePath();
+            var linkPath = GetTestFilePath();
+
+            File.Create(path).Dispose();
+            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: false));
+
+            // Both the symlink and the target exist
+            Assert.True(File.Exists(path), "path should exist");
+            Assert.True(File.Exists(linkPath), "linkPath should exist");
+
+            // Delete the target.  The symlink should still exist
+            File.Delete(path);
+            Assert.False(File.Exists(path), "path should now not exist");
+            Assert.True(File.Exists(linkPath), "linkPath should still exist");
+
+            // Now delete the symlink.
+            File.Delete(linkPath);
+            Assert.False(File.Exists(linkPath), "linkPath should no longer exist");
+        }
+
         #endregion
 
         #region PlatformSpecific
@@ -200,6 +223,15 @@ namespace System.IO.Tests
             {
                 Assert.False(Exists(component));
             });
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void FalseForNonRegularFile()
+        {
+            string fileName = GetTestFilePath();
+            Assert.Equal(0, mkfifo(fileName, 0));
+            Assert.True(File.Exists(fileName));
         }
 
         #endregion

--- a/src/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -10,13 +10,16 @@ namespace System.IO.Tests
     {
         public static readonly byte[] TestBuffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
 
+        // In some cases (such as when running without elevated privileges),
+        // the symbolic link may fail to create. Only run this test if it creates
+        // links successfully.
         protected static bool CanCreateSymbolicLinks
         {
             get
             {
                 var path = Path.GetTempFileName();
                 var linkPath = path + ".link";
-                var ret = MountHelper.CreateSymbolicLink(linkPath, path);
+                var ret = MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: false);
                 try { File.Delete(path); } catch { }
                 try { File.Delete(linkPath); } catch { }
                 return ret;
@@ -25,5 +28,8 @@ namespace System.IO.Tests
 
         [DllImport("libc", SetLastError = true)]
         protected static extern int geteuid();
+
+        [DllImport("libc", SetLastError = true)]
+        protected static extern int mkfifo(string path, int mode);
     }
 }

--- a/src/System.IO.FileSystem/tests/PortedCommon/ReparsePointUtilities.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/ReparsePointUtilities.cs
@@ -32,14 +32,14 @@ public static class MountHelper
     /// <summary>Creates a symbolic link using command line tools</summary>
     /// <param name="linkPath">The existing file</param>
     /// <param name="targetPath"></param>
-    public static bool CreateSymbolicLink(string linkPath, string targetPath)
+    public static bool CreateSymbolicLink(string linkPath, string targetPath, bool isDirectory)
     {
         Process symLinkProcess = null;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            symLinkProcess = Process.Start("cmd", string.Format("/c mklink \"{0}\" \"{1}\"", linkPath, targetPath));
+            symLinkProcess = Process.Start("cmd", string.Format("/c mklink{0} \"{1}\" \"{2}\"", isDirectory ? " /D" : "", linkPath, targetPath));
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        else
         {
             symLinkProcess = Process.Start("ln", string.Format("-s \"{0}\" \"{1}\"", targetPath, linkPath));
         }


### PR DESCRIPTION
We've visited this topic a few times... hopefully this is the last.  We previously misunderstood some of how Windows handles symlinks, leading us to make some invalid choices on Unix.  This addresses those issues.

For the most part with this commit, we now match Windows behavior on Unix wherever possible, while also trying to do something sensible on the Unix side.  The only notable difference now comes into play for broken symlinks, due to a fundamental difference between symlinks on Windows and Unix: on Windows, a symlink is created as either a file or directory symlink and thus .NET can tell which it is even if it's broken... on Unix, a symlink only stores a path to its target, so when it's broken, there's no information about whether it's intended to be a file or a directory.  As a result, we fall back to always treating it as a file.

To help highlight the behavior, consider this set up:
- TargetDir - normal directory
- LinkDir - a symlink to TargetDir
- BrokenLinkDir - a symlink for a directory that's been deleted
- TargetFile.txt - normal file
- LinkFile.txt - a symlink to TargetFile.txt
- BrokenLinkFile.txt - a symlink to a file that's been deleted
- ReadonlyTargetFile.txt - a file attributed as readonly
- LinkReadonlyFile.txt - a link to ReadonlyTargetFile

With that, this program:
```C#
using System;
using System.IO;
using System.Linq;
using static System.Console;

class Program
{
    static void Main()
    {
        WritePathDetails(
            "TargetDir", "LinkDir", "BrokenLinkDir", "TargetFile.txt", 
            "LinkFile.txt", "BrokenLinkFile.txt", "ReadonlyTargetFile.txt", "LinkReadonlyFile.txt");
    }

    static void WritePathDetails(params string[] paths)
    {
        foreach (string path in paths)
        {
            WriteLine($"Path                : {Try(() => Path.GetFileName(path))}");
            WriteLine($"File.Exists         : {Try(() => File.Exists(path))}");
            WriteLine($"FileInfo.Exists     : {Try(() => new FileInfo(path).Exists)}");
            WriteLine($"Dir.Exists          : {Try(() => Directory.Exists(path))}");
            WriteLine($"DirInfo.Exists      : {Try(() => new DirectoryInfo(path).Exists)}");
            WriteLine($"FileInfo.Length     : {Try(() => new FileInfo(path).Length)}");
            WriteLine($"FileStream.Length   : {Try(() => { using (var fs = File.OpenRead(path)) return fs.Length; })}");
            WriteLine($"FileInfo.Attributes : {Try(() => new FileInfo(path).Attributes)}");
            WriteLine($"DirInfo.Attributes  : {Try(() => new DirectoryInfo(path).Attributes)}");
            WriteLine($"Dir.Enumerate       : {Try(() => Directory.EnumerateFiles(path).Count())}");
            WriteLine($"DirInfo.Enumerate   : {Try(() => new DirectoryInfo(path).EnumerateFiles().Count())}");
            WriteLine();
        }
    }

    static object Try(Func<object> func)
    {
        try { return func(); } catch (Exception e) { return $"{e.GetType().Name}: {e.Message}"; }
    }
}
```
now outputs the following:
<table>
<tr><td>Windows</td><td>Unix</td></tr>
<tr><td><pre>Path                : TargetDir
File.Exists         : False
FileInfo.Exists     : False
Dir.Exists          : True
DirInfo.Exists      : True
FileInfo.Length     : FileNotFoundException
FileStream.Length   : UnauthorizedAccessException
FileInfo.Attributes : Directory
DirInfo.Attributes  : Directory
Dir.Enumerate       : 18
DirInfo.Enumerate   : 18

Path                : LinkDir
File.Exists         : False
FileInfo.Exists     : False
Dir.Exists          : True
DirInfo.Exists      : True
FileInfo.Length     : FileNotFoundException
FileStream.Length   : UnauthorizedAccessException
FileInfo.Attributes : Directory, ReparsePoint
DirInfo.Attributes  : Directory, ReparsePoint
Dir.Enumerate       : 18
DirInfo.Enumerate   : 18

Path                : BrokenLinkDir
File.Exists         : False
FileInfo.Exists     : False
Dir.Exists          : True
DirInfo.Exists      : True
FileInfo.Length     : FileNotFoundException
FileStream.Length   : UnauthorizedAccessException
FileInfo.Attributes : Directory, ReparsePoint
DirInfo.Attributes  : Directory, ReparsePoint
Dir.Enumerate       : DirectoryNotFoundException
DirInfo.Enumerate   : DirectoryNotFoundException

Path                : TargetFile.txt
File.Exists         : True
FileInfo.Exists     : True
Dir.Exists          : False
DirInfo.Exists      : False
FileInfo.Length     : 70
FileStream.Length   : 70
FileInfo.Attributes : Archive
DirInfo.Attributes  : Archive
Dir.Enumerate       : IOException
DirInfo.Enumerate   : IOException

Path                : LinkFile.txt
File.Exists         : True
FileInfo.Exists     : True
Dir.Exists          : False
DirInfo.Exists      : False
FileInfo.Length     : 0
FileStream.Length   : 70
FileInfo.Attributes : Archive, ReparsePoint
DirInfo.Attributes  : Archive, ReparsePoint
Dir.Enumerate       : IOException
DirInfo.Enumerate   : IOException

Path                : BrokenLinkFile.txt
File.Exists         : True
FileInfo.Exists     : True
Dir.Exists          : False
DirInfo.Exists      : False
FileInfo.Length     : 0
FileStream.Length   : FileNotFoundException
FileInfo.Attributes : Archive, ReparsePoint
DirInfo.Attributes  : Archive, ReparsePoint
Dir.Enumerate       : IOException
DirInfo.Enumerate   : IOException

Path                : ReadonlyTargetFile.txt
File.Exists         : True
FileInfo.Exists     : True
Dir.Exists          : False
DirInfo.Exists      : False
FileInfo.Length     : 70
FileStream.Length   : 70
FileInfo.Attributes : ReadOnly, Archive
DirInfo.Attributes  : ReadOnly, Archive
Dir.Enumerate       : IOException
DirInfo.Enumerate   : IOException

Path                : LinkReadonlyFile.txt
File.Exists         : True
FileInfo.Exists     : True
Dir.Exists          : False
DirInfo.Exists      : False
FileInfo.Length     : 0
FileStream.Length   : 70
FileInfo.Attributes : Archive, ReparsePoint
DirInfo.Attributes  : Archive, ReparsePoint
Dir.Enumerate       : IOException
DirInfo.Enumerate   : IOException</pre></td><td><pre>Path                : TargetDir
File.Exists         : False
FileInfo.Exists     : False
Dir.Exists          : True
DirInfo.Exists      : True
FileInfo.Length     : FileNotFoundException
FileStream.Length   : UnauthorizedAccessException
FileInfo.Attributes : Directory
DirInfo.Attributes  : Directory
Dir.Enumerate       : 18
DirInfo.Enumerate   : 18

Path                : LinkDir
File.Exists         : False
FileInfo.Exists     : False
Dir.Exists          : True
DirInfo.Exists      : True
FileInfo.Length     : FileNotFoundException
FileStream.Length   : UnauthorizedAccessException
FileInfo.Attributes : Directory, ReparsePoint
DirInfo.Attributes  : Directory, ReparsePoint
Dir.Enumerate       : 18
DirInfo.Enumerate   : 18

Path                : BrokenLinkDir
File.Exists         : True
FileInfo.Exists     : True
Dir.Exists          : False
DirInfo.Exists      : False
FileInfo.Length     : 6
FileStream.Length   : FileNotFoundException
FileInfo.Attributes : ReparsePoint
DirInfo.Attributes  : ReparsePoint
Dir.Enumerate       : DirectoryNotFoundException
DirInfo.Enumerate   : DirectoryNotFoundException

Path                : TargetFile.txt
File.Exists         : True
FileInfo.Exists     : True
Dir.Exists          : False
DirInfo.Exists      : False
FileInfo.Length     : 70
FileStream.Length   : 70
FileInfo.Attributes : Normal
DirInfo.Attributes  : Normal
Dir.Enumerate       : IOException
DirInfo.Enumerate   : IOException

Path                : LinkFile.txt
File.Exists         : True
FileInfo.Exists     : True
Dir.Exists          : False
DirInfo.Exists      : False
FileInfo.Length     : 14
FileStream.Length   : 70
FileInfo.Attributes : ReparsePoint
DirInfo.Attributes  : ReparsePoint
Dir.Enumerate       : IOException
DirInfo.Enumerate   : IOException

Path                : BrokenLinkFile.txt
File.Exists         : True
FileInfo.Exists     : True
Dir.Exists          : False
DirInfo.Exists      : False
FileInfo.Length     : 7
FileStream.Length   : FileNotFoundException
FileInfo.Attributes : ReparsePoint
DirInfo.Attributes  : ReparsePoint
Dir.Enumerate       : DirectoryNotFoundException
DirInfo.Enumerate   : DirectoryNotFoundException

Path                : ReadonlyTargetFile.txt
File.Exists         : True
FileInfo.Exists     : True
Dir.Exists          : False
DirInfo.Exists      : False
FileInfo.Length     : 70
FileStream.Length   : 70
FileInfo.Attributes : ReadOnly
DirInfo.Attributes  : ReadOnly
Dir.Enumerate       : IOException
DirInfo.Enumerate   : IOException

Path                : LinkReadonlyFile.txt
File.Exists         : True
FileInfo.Exists     : True
Dir.Exists          : False
DirInfo.Exists      : False
FileInfo.Length     : 22
FileStream.Length   : 70
FileInfo.Attributes : ReparsePoint
DirInfo.Attributes  : ReparsePoint
Dir.Enumerate       : IOException
DirInfo.Enumerate   : IOException</pre></td></tr>
</table>

Interesting things to notice:
- The only meaningful differences are for the "Broken" cases.
- On Windows, symlinks are empty files and thus have 0 length.  On Unix, they contain a path and thus have a length proportional to that path.
- On Windows, files sometimes include an Archive attribute.  This is Windows-specific and we don't include that attribute on Unix.

Fixes #6556 
cc: @ianhays, @bartonjs, @joshfree, @palladia, @andschwa