### PR TITLE
Introducing netstandard13aot target group in System.IO

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -211,6 +211,7 @@
     <OSGroup Condition="'$(OSGroup)'==''">AnyOS</OSGroup>
 
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netcore50aot'))">netcore50aot</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netstandard13aot'))">netstandard13aot</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netcore50'))">netcore50</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('dnxcore50'))">dnxcore50</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net462'))">net462</TargetGroup>
@@ -309,6 +310,13 @@
         <NuGetTargetMoniker>.NETCore,Version=v5.0</NuGetTargetMoniker>
       </PropertyGroup>
     </When>
+    <When Condition="'$(TargetGroup)'=='netstandard13aot'">
+      <PropertyGroup>
+        <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+        <PackageTargetRuntime>aot</PackageTargetRuntime>
+        <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+      </PropertyGroup>
+    </When>    
     <When Condition="'$(TargetGroup)'=='dnxcore50'">
       <PropertyGroup>
         <PackageTargetFramework>dnxcore50</PackageTargetFramework>

--- a/src/Common/src/System/SR.CoreRT.cs
+++ b/src/Common/src/System/SR.CoreRT.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    // This is a placeholder for resources access implementation for corert. 
+    // At some point we’ll have the real implementation which expect to be shared between 
+    // System.IO, System.Runtime.Extensions and System.Resources.ResourceManager.   
+    
+    internal static partial class SR
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string GetResourceString(string resourceKey)
+        {
+            return resourceKey;
+        }
+
+        internal static string GetResourceString(string resourceKey, string defaultString)
+        {
+            return defaultString != null ? defaultString : resourceKey;
+        }
+
+        internal static string Format(string resourceFormat, params object[] args)
+        {
+            if (args != null)
+            {
+                return string.Format(resourceFormat, args);
+            }
+
+            return resourceFormat;
+        }
+
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string Format(string resourceFormat, object p1)
+        {
+            return string.Format(resourceFormat, p1);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string Format(string resourceFormat, object p1, object p2)
+        {
+            return string.Format(resourceFormat, p1, p2);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string Format(string resourceFormat, object p1, object p2, object p3)
+        {
+            return string.Format(resourceFormat, p1, p2, p3);
+        }
+    }
+}

--- a/src/System.IO/pkg/aot/System.IO.pkgproj
+++ b/src/System.IO/pkg/aot/System.IO.pkgproj
@@ -11,6 +11,9 @@
     <ProjectReference Include="..\..\src\System.IO.csproj">
       <TargetGroup>netcore50aot</TargetGroup>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\System.IO.csproj">
+      <TargetGroup>netstandard13aot</TargetGroup>
+    </ProjectReference>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.IO/src/System.IO.builds
+++ b/src/System.IO/src/System.IO.builds
@@ -9,6 +9,9 @@
     <Project Include="System.IO.csproj">
       <TargetGroup>netcore50aot</TargetGroup>
     </Project>
+    <Project Include="System.IO.csproj">
+      <TargetGroup>netstandard13aot</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.IO/src/System.IO.csproj
+++ b/src/System.IO/src/System.IO.csproj
@@ -16,12 +16,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard13aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard13aot_Release|AnyCPU'" />
 
   <PropertyGroup Condition="'$(TargetGroup)' == 'net46'">
     <ResourcesSourceOutputDirectory>None</ResourcesSourceOutputDirectory>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'  or '$(TargetGroup)' == 'netstandard13aot'">
     <SkipCommonResourcesIncludes>true</SkipCommonResourcesIncludes>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ExcludeAssemblyInfoPartialFile>true</ExcludeAssemblyInfoPartialFile>
@@ -41,7 +43,7 @@
     <Compile Include="System\IO\InvalidDataException.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcore50aot' or '$(TargetGroup)' == 'netstandard13aot'">
     <Compile Include="System\IO\BinaryReader.cs" />
     <Compile Include="System\IO\BinaryWriter.cs" />
     <Compile Include="System\IO\EndOfStreamException.cs" />
@@ -61,8 +63,11 @@
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
       <Link>Common\System\IO\StringBuilderCache.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\SR.Core.cs">
+    <Compile Include="$(Commonpath)\System\SR.Core.cs" Condition="'$(TargetGroup)' == 'netcore50aot'">
       <Link>Common\System\SR.Core.cs</Link>
+    </Compile>
+    <Compile Include="$(Commonpath)\System\SR.CoreRT.cs" Condition="'$(TargetGroup)' == 'netstandard13aot'"> 
+      <Link>Common\System\SR.CoreRT.cs</Link>
     </Compile>
   </ItemGroup>
 
@@ -78,6 +83,11 @@
 
   <ItemGroup>
     <None Include="project.json" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard13aot'">
+    <TargetingPackReference Include="System.Private.Interop" />
+    <ValidateIgnoreReference Include="@(TargetingPackReference)" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.IO/src/project.json
+++ b/src/System.IO/src/project.json
@@ -24,6 +24,21 @@
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }
-    }
+    },
+    "netstandard1.3": {
+        "imports": [ "netcore50" ],
+        "dependencies": {
+            "Microsoft.NETCore.Platforms": "1.0.1-rc3-23901",
+            "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23901",
+            "System.Diagnostics.Contracts": "4.0.0",
+            "System.Diagnostics.Debug": "4.0.10",
+            "System.Diagnostics.Tools": "4.0.0",
+            "System.Globalization": "4.0.0",
+            "System.Runtime.Extensions": "4.0.10",
+            "System.Text.Encoding.Extensions": "4.0.0",
+            "System.Threading": "4.0.0",
+            "System.Threading.Tasks": "4.0.10"
+        }
+    }    
   }
 }


### PR DESCRIPTION
We need to build System.IO that work with corert which we need to get rid of WinRT
dependencies and that will require to have different code in System.IO which require
creating a new target group. This change should be no-op for other target groups.