### PR TITLE
System.Net.CredentialCache: Avoid dictionary enumerator allocations

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
+++ b/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
@@ -196,12 +196,11 @@ namespace System.Net
 
             int longestMatchPrefix = -1;
             NetworkCredential mostSpecificMatch = null;
-            IDictionaryEnumerator credEnum = _cache.GetEnumerator();
 
             // Enumerate through every credential in the cache
-            while (credEnum.MoveNext())
+            foreach (KeyValuePair<CredentialKey, NetworkCredential> pair in _cache)
             {
-                CredentialKey key = (CredentialKey)credEnum.Key;
+                CredentialKey key = pair.Key;
 
                 // Determine if this credential is applicable to the current Uri/AuthType
                 if (key.Match(uriPrefix, authenticationType))
@@ -213,7 +212,7 @@ namespace System.Net
                     {
                         // Yes: update the information about currently preferred match
                         longestMatchPrefix = prefixLen;
-                        mostSpecificMatch = (NetworkCredential)credEnum.Value;
+                        mostSpecificMatch = pair.Value;
                     }
                 }
             }
@@ -252,17 +251,15 @@ namespace System.Net
 
             NetworkCredential match = null;
 
-            IDictionaryEnumerator credEnum = _cacheForHosts.GetEnumerator();
-
             // Enumerate through every credential in the cache
-            while (credEnum.MoveNext())
+            foreach (KeyValuePair<CredentialHostKey, NetworkCredential> pair in _cacheForHosts)
             {
-                CredentialHostKey key = (CredentialHostKey)credEnum.Key;
+                CredentialHostKey key = pair.Key;
 
                 // Determine if this credential is applicable to the current Uri/AuthType
                 if (key.Match(host, port, authenticationType))
                 {
-                    match = (NetworkCredential)credEnum.Value;
+                    match = pair.Value;
                 }
             }
 


### PR DESCRIPTION
Use `Dictionary`'s struct enumerator with `foreach` instead of using the enumerator as `IDictionaryEnumerator`, which boxes the struct.

Test line & branch coverage over the changed lines is 100%.

cc: @stephentoub @davidsh