### PR TITLE
Remove ProjectReferences from S.R.IS ref assembly

### DIFF
--- a/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.csproj
+++ b/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.csproj
@@ -18,13 +18,5 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="../../System.Runtime.InteropServices.PInvoke/ref/System.Runtime.InteropServices.PInvoke.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-    <ProjectReference Include="../../System.Runtime/ref/System.Runtime.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.InteropServices/ref/project.json
+++ b/src/System.Runtime.InteropServices/ref/project.json
@@ -2,8 +2,9 @@
   "dependencies": {
     "System.Reflection": "4.0.0",
     "System.Reflection.Primitives": "4.0.0",
-    "System.Runtime": "4.0.0",
-    "System.Runtime.Handles": "4.0.0"
+    "System.Runtime": "4.1.0-rc3-23901",
+    "System.Runtime.Handles": "4.0.0",
+    "System.Runtime.InteropServices.PInvoke": "4.0.0-rc3-23901",
   },
   "frameworks": {
     "netstandard1.3": {


### PR DESCRIPTION
Reference assemblies should never use project references since that will
will cause them to automatically update their dependency versions when
another reference assembly updates.

This project was using project references as a point-in-time workaround
as API was added in another contract in the same change.
/cc @botaberg