### PR TITLE
Add HttpClientHandler test for proxies

### DIFF
--- a/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -15,5 +15,6 @@ namespace System.Net.Http
         public const bool DefaultUseCookies = true;
         public const bool DefaultPreAuthenticate = false;
         public const ClientCertificateOption DefaultClientCertificateOption = ClientCertificateOption.Manual;
+        public const bool DefaultUseProxy = true;
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -69,7 +69,7 @@ namespace System.Net.Http
 
         private IWebProxy _proxy = null;
         private ICredentials _serverCredentials = null;
-        private ProxyUsePolicy _proxyPolicy = ProxyUsePolicy.UseDefaultProxy;
+        private bool _useProxy = HttpHandlerDefaults.DefaultUseProxy;
         private DecompressionMethods _automaticDecompression = HttpHandlerDefaults.DefaultAutomaticDecompression;
         private bool _preAuthenticate = HttpHandlerDefaults.DefaultPreAuthenticate;
         private CredentialCache _credentialCache = null; // protected by LockObject
@@ -140,15 +140,13 @@ namespace System.Net.Http
         {
             get
             {
-                return _proxyPolicy != ProxyUsePolicy.DoNotUseProxy;
+                return _useProxy;
             }
 
             set
             {
                 CheckDisposedOrStarted();
-                _proxyPolicy = value ?
-                    ProxyUsePolicy.UseCustomProxy :
-                    ProxyUsePolicy.DoNotUseProxy;
+                _useProxy = value;
             }
         }
 
@@ -713,13 +711,6 @@ nameof(value),
         }
 
         #endregion
-
-        private enum ProxyUsePolicy
-        {
-            DoNotUseProxy = 0, // Do not use proxy. Ignores the value set in the environment.
-            UseDefaultProxy = 1, // Do not set the proxy parameter. Use the value of environment variable, if any.
-            UseCustomProxy = 2  // Use The proxy specified by the user.
-        }
     }
 }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -916,7 +916,7 @@ namespace System.Net.Http.Functional.Tests
         {
             yield return new object[] { null };
             yield return new object[] { new PlatformNotSupportedWebProxy() };
-            yield return new object[] { new UseSpecifiedUriWebProxy(new Uri($"http://proxydoesntexist:12345"), bypass: true) };
+            yield return new object[] { new UseSpecifiedUriWebProxy(new Uri($"http://{Guid.NewGuid().ToString().Substring(0, 15)}:12345"), bypass: true) };
         }
 
         private static IEnumerable<object[]> CredentialsForProxy()

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -848,13 +848,13 @@ namespace System.Net.Http.Functional.Tests
         #region Proxy tests
         [Theory]
         [MemberData(nameof(CredentialsForProxy))]
-        public void UseCustomProxy_GetRequestGoesThroughProxy_Success(ICredentials creds)
+        public void Proxy_BypassFalse_GetRequestGoesThroughCustomProxy(ICredentials creds)
         {
             int port;
-            Task<LoopbackGetRequestHttpProxy.ProxyResult> proxyTask = LoopbackGetRequestHttpProxy.StartAsync(out port, requireAuth: creds != null);
+            Task<LoopbackGetRequestHttpProxy.ProxyResult> proxyTask = LoopbackGetRequestHttpProxy.StartAsync(out port, requireAuth: creds != null && creds != CredentialCache.DefaultCredentials);
             Uri proxyUrl = new Uri($"http://localhost:{port}");
 
-            using (var handler = new HttpClientHandler() { UseProxy = true, Proxy = new UseSpecifiedUriWebProxy(proxyUrl, creds) })
+            using (var handler = new HttpClientHandler() { Proxy = new UseSpecifiedUriWebProxy(proxyUrl, creds) })
             using (var client = new HttpClient(handler))
             {
                 Task<HttpResponseMessage> responseTask = client.GetAsync(HttpTestServers.RemoteEchoServer);
@@ -866,20 +866,57 @@ namespace System.Net.Http.Functional.Tests
 
                 NetworkCredential nc = creds != null ? creds.GetCredential(proxyUrl, "Basic") : null;
                 string expectedAuth =
-                    nc == null ? null :
+                    nc == null || nc == CredentialCache.DefaultCredentials ? null :
                     string.IsNullOrEmpty(nc.Domain) ? $"{nc.UserName}:{nc.Password}" :
                     $"{nc.Domain}\\{nc.UserName}:{nc.Password}";
                 Assert.Equal(expectedAuth, proxyTask.Result.AuthenticationHeaderValue);
             }
         }
 
+        [Theory]
+        [MemberData(nameof(BypassedProxies))]
+        public async Task Proxy_BypassTrue_GetRequestDoesntGoesThroughCustomProxy(IWebProxy proxy)
+        {
+            using (var client = new HttpClient(new HttpClientHandler() { Proxy = proxy }))
+            using (HttpResponseMessage response = await client.GetAsync(HttpTestServers.RemoteEchoServer))
+            {
+                TestHelper.VerifyResponseBody(
+                    await response.Content.ReadAsStringAsync(),
+                    response.Content.Headers.ContentMD5,
+                    false,
+                    null);
+            }
+        }
+
         private sealed class UseSpecifiedUriWebProxy : IWebProxy
         {
-            private Uri _uri;
-            public UseSpecifiedUriWebProxy(Uri uri, ICredentials credentials = null) { _uri = uri; Credentials = credentials; }
+            private readonly Uri _uri;
+            private readonly bool _bypass;
+
+            public UseSpecifiedUriWebProxy(Uri uri, ICredentials credentials = null, bool bypass = false)
+            {
+                _uri = uri;
+                _bypass = bypass;
+                Credentials = credentials;
+            }
+
             public ICredentials Credentials { get; set; }
             public Uri GetProxy(Uri destination) => _uri;
-            public bool IsBypassed(Uri host) => false;
+            public bool IsBypassed(Uri host) => _bypass;
+        }
+
+        private sealed class PlatformNotSupportedWebProxy : IWebProxy
+        {
+            public ICredentials Credentials { get; set; }
+            public Uri GetProxy(Uri destination) { throw new PlatformNotSupportedException(); }
+            public bool IsBypassed(Uri host) { throw new PlatformNotSupportedException(); }
+        }
+
+        private static IEnumerable<object[]> BypassedProxies()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new PlatformNotSupportedWebProxy() };
+            yield return new object[] { new UseSpecifiedUriWebProxy(new Uri($"http://proxydoesntexist:12345"), bypass: true) };
         }
 
         private static IEnumerable<object[]> CredentialsForProxy()
@@ -887,6 +924,7 @@ namespace System.Net.Http.Functional.Tests
             yield return new object[] { null };
             yield return new object[] { new NetworkCredential("username", "password") };
             yield return new object[] { new NetworkCredential("username", "password", "domain") };
+            yield return new object[] { CredentialCache.DefaultCredentials };
         }
         #endregion
     }

--- a/src/System.Net.Http/tests/FunctionalTests/LoopbackGetRequestHttpProxy.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/LoopbackGetRequestHttpProxy.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Net.Http.Functional.Tests
+{
+    /// <summary>
+    /// Provides a test-only, overly-simplified HTTP proxy for a single GET request.  It is not meant to be robust,
+    /// but simply for verification that a GET request is in fact getting routed through a designated proxy
+    /// and providing credentials if expected.
+    /// </summary>
+    internal sealed class LoopbackGetRequestHttpProxy
+    {
+        public struct ProxyResult
+        {
+            public byte[] ResponseContent;
+            public string AuthenticationHeaderValue;
+        }
+
+        public static Task<ProxyResult> StartAsync(out int port, bool requireAuth)
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            return StartAsync(listener, requireAuth);
+        }
+
+        private static async Task<ProxyResult> StartAsync(TcpListener listener, bool requireAuth)
+        {
+            ProxyResult result = new ProxyResult();
+            var headers = new Dictionary<string, string>();
+            Socket clientSocket = null;
+            Stream clientStream = null;
+            StreamReader clientReader = null;
+            string url = null;
+            try
+            {
+                // Get and parse the incoming request
+                Func<Task> getAndReadRequest = async () => {
+                    clientSocket = await listener.AcceptSocketAsync().ConfigureAwait(false);
+                    clientStream = new NetworkStream(clientSocket, ownsSocket: false);
+                    clientReader = new StreamReader(clientStream, Encoding.ASCII);
+                    headers.Clear();
+
+                    url = clientReader.ReadLine().Split(' ')[1];
+                    string line;
+                    while (!string.IsNullOrEmpty(line = clientReader.ReadLine()))
+                    {
+                        string[] headerParts = line.Split(':');
+                        headers.Add(headerParts[0].Trim(), headerParts[1].Trim());
+                    }
+                };
+                await getAndReadRequest().ConfigureAwait(false);
+
+                // If we're expecting credentials, look for them, and if we didn't get them, send back 
+                // a response and process a new request.
+                if (requireAuth && !headers.ContainsKey("Proxy-Authorization"))
+                {
+                    Task<Socket> secondListen = listener.AcceptSocketAsync();
+
+                    // Send back a 407
+                    await clientSocket.SendAsync(
+                        new ArraySegment<byte>(Encoding.ASCII.GetBytes("HTTP/1.1 407 Proxy Auth Required\r\nProxy-Authenticate: Basic\r\n\r\n")),
+                        SocketFlags.None).ConfigureAwait(false);
+                    clientSocket.Shutdown(SocketShutdown.Send);
+                    clientSocket.Dispose();
+
+                    // Wait for a new connection that should have an auth header this time and parse it
+                    await getAndReadRequest().ConfigureAwait(false);
+                }
+
+                // Store any auth header we may have for later comparison
+                string authValue;
+                if (headers.TryGetValue("Proxy-Authorization", out authValue))
+                {
+                    result.AuthenticationHeaderValue = Encoding.UTF8.GetString(Convert.FromBase64String(authValue.Substring("Basic ".Length)));
+                }
+
+                // Forward the request to the server
+                var request = new HttpRequestMessage(HttpMethod.Get, url);
+                foreach (var header in headers) request.Headers.Add(header.Key, header.Value);
+                using (HttpClient outboundClient = new HttpClient())
+                using (HttpResponseMessage response = await outboundClient.SendAsync(request).ConfigureAwait(false))
+                {
+                    // Transfer the response headers from the server to the client
+                    var sb = new StringBuilder($"HTTP/{response.Version.ToString(2)} {(int)response.StatusCode} {response.ReasonPhrase}\r\n");
+                    foreach (var header in response.Headers.Concat(response.Content.Headers))
+                    {
+                        sb.Append($"{header.Key}: {string.Join(", ", header.Value)}\r\n");
+                    }
+                    sb.Append("\r\n");
+                    byte[] headerBytes = Encoding.ASCII.GetBytes(sb.ToString());
+                    await clientStream.WriteAsync(headerBytes, 0, headerBytes.Length).ConfigureAwait(false);
+
+                    // Forward the content from the server, both to the client and to a memory stream which we'll use
+                    // to return the data from the proxy.
+                    var resultBody = new MemoryStream();
+                    using (Stream responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                    {
+                        byte[] buffer = new byte[0x1000];
+                        int bytesRead = 0;
+                        while ((bytesRead = responseStream.Read(buffer, 0, buffer.Length)) > 0)
+                        {
+                            await clientStream.WriteAsync(buffer, 0, bytesRead).ConfigureAwait(false);
+                            resultBody.Write(buffer, 0, bytesRead);
+                        }
+                    }
+
+                    // Return the result
+                    result.ResponseContent = resultBody.ToArray();
+                    return result;
+                }
+            }
+            finally
+            {
+                clientSocket.Dispose();
+                listener.Stop();
+            }
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/LoopbackGetRequestHttpProxy.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/LoopbackGetRequestHttpProxy.cs
@@ -14,7 +14,7 @@ namespace System.Net.Http.Functional.Tests
     /// <summary>
     /// Provides a test-only, overly-simplified HTTP proxy for a single GET request.  It is not meant to be robust,
     /// but simply for verification that a GET request is in fact getting routed through a designated proxy
-    /// and providing credentials if expected.
+    /// and providing credentials if expected.  SSL is not supported.
     /// </summary>
     internal sealed class LoopbackGetRequestHttpProxy
     {
@@ -42,7 +42,7 @@ namespace System.Net.Http.Functional.Tests
             string url = null;
             try
             {
-                // Get and parse the incoming request
+                // Get and parse the incoming request.
                 Func<Task> getAndReadRequest = async () => {
                     clientSocket = await listener.AcceptSocketAsync().ConfigureAwait(false);
                     clientStream = new NetworkStream(clientSocket, ownsSocket: false);
@@ -72,24 +72,24 @@ namespace System.Net.Http.Functional.Tests
                     clientSocket.Shutdown(SocketShutdown.Send);
                     clientSocket.Dispose();
 
-                    // Wait for a new connection that should have an auth header this time and parse it
+                    // Wait for a new connection that should have an auth header this time and parse it.
                     await getAndReadRequest().ConfigureAwait(false);
                 }
 
-                // Store any auth header we may have for later comparison
+                // Store any auth header we may have for later comparison.
                 string authValue;
                 if (headers.TryGetValue("Proxy-Authorization", out authValue))
                 {
                     result.AuthenticationHeaderValue = Encoding.UTF8.GetString(Convert.FromBase64String(authValue.Substring("Basic ".Length)));
                 }
 
-                // Forward the request to the server
+                // Forward the request to the server.
                 var request = new HttpRequestMessage(HttpMethod.Get, url);
                 foreach (var header in headers) request.Headers.Add(header.Key, header.Value);
                 using (HttpClient outboundClient = new HttpClient())
                 using (HttpResponseMessage response = await outboundClient.SendAsync(request).ConfigureAwait(false))
                 {
-                    // Transfer the response headers from the server to the client
+                    // Transfer the response headers from the server to the client.
                     var sb = new StringBuilder($"HTTP/{response.Version.ToString(2)} {(int)response.StatusCode} {response.ReasonPhrase}\r\n");
                     foreach (var header in response.Headers.Concat(response.Content.Headers))
                     {

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -40,6 +40,7 @@
     <Compile Include="HttpMethodTest.cs" />
     <Compile Include="HttpRequestMessageTest.cs" />
     <Compile Include="HttpResponseMessageTest.cs" />
+    <Compile Include="LoopbackGetRequestHttpProxy.cs" />
     <Compile Include="LoopbackServer.cs" />
     <Compile Include="MessageProcessingHandlerTest.cs" />
     <Compile Include="MultipartContentTest.cs" />


### PR DESCRIPTION
We don't currently have any functional tests in the repo for using HTTP proxies.  This commit adds a very simple loopback GET request proxy server, just enough to verify that HttpClient does go through the specified proxy and pass credentials if requested.  

(When we get better infrastructure in place for this kind of thing, we can remove the proxy implementation and replace the test, but for now, this at least provides some automated verification cross-platform.)

cc: @davidsh, @Petermarcu, @kapilash 