### PR TITLE
Add ConsoleEventListener for debugging

### DIFF
--- a/src/Common/tests/System/Diagnostics/Tracing/ConsoleEventListener.cs
+++ b/src/Common/tests/System/Diagnostics/Tracing/ConsoleEventListener.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.Diagnostics.Tracing
+{
+    internal sealed class ConsoleEventListener : EventListener
+    {
+        private readonly string _eventFilter;
+
+        public ConsoleEventListener() : this(string.Empty) { }
+
+        public ConsoleEventListener(string filter)
+        {
+            if (filter == null)
+                throw new ArgumentNullException(nameof(filter));
+
+            _eventFilter = filter;
+
+            foreach (EventSource source in EventSource.GetSources())
+                EnableEvents(source, EventLevel.LogAlways);
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            base.OnEventSourceCreated(eventSource);
+            EnableEvents(eventSource, EventLevel.LogAlways, EventKeywords.All);
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            lock (Console.Out)
+            {
+                string text = $"[{eventData.EventSource.Name}-{eventData.EventId}]{(eventData.Payload != null ? $" ({string.Join(", ", eventData.Payload)})." : "")}";
+                if (_eventFilter != null && text.Contains(_eventFilter))
+                {
+                    ConsoleColor origForeground = Console.ForegroundColor;
+                    Console.ForegroundColor = ConsoleColor.DarkYellow;
+                    Console.WriteLine(text);
+                    Console.ForegroundColor = origForeground;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit just adds a helper class that writes EventSource traces to the console, which can be very useful when debugging, especially on Linux.  This can be added to a test project and used like:
```C#
using (new ConsoleEventListener())
{
    ... // code here will have tracing to the console enabled
}
```

cc: @bartonjs 