### PR TITLE
Minor cleanup in System.Text.Encodings.Web tests

### DIFF
--- a/src/System.Text.Encodings.Web/tests/AllowedCharsBitmapTests.cs
+++ b/src/System.Text.Encodings.Web/tests/AllowedCharsBitmapTests.cs
@@ -2,23 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Text.Encodings.Web;
 using System.Text.Internal;
 using System.Text.Unicode;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public class AllowedCharsBitmapTests
     {
         [Fact]
         public void Ctor_EmptyByDefault()
         {
-            // Act
             var bitmap = AllowedCharactersBitmap.CreateNew();
-
-            // Assert
             for (int i = 0; i <= Char.MaxValue; i++)
             {
                 Assert.False(bitmap.IsCharacterAllowed((char)i));
@@ -28,26 +23,17 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void Allow_Forbid_ZigZag()
         {
-            // Arrange
             var bitmap = AllowedCharactersBitmap.CreateNew();
 
-            // Act
             // The only chars which are allowed are those whose code points are multiples of 3 or 7
             // who aren't also multiples of 5. Exception: multiples of 35 are allowed.
             for (int i = 0; i <= Char.MaxValue; i += 3)
             {
-                bitmap.AllowCharacter((char)i);
+                if (i % 3 == 0) { bitmap.AllowCharacter((char)i); }
+                if (i % 5 == 0) { bitmap.AllowCharacter((char)i); }
+                if (i % 7 == 0) { bitmap.AllowCharacter((char)i); }
             }
-            for (int i = 0; i <= Char.MaxValue; i += 5)
-            {
-                bitmap.ForbidCharacter((char)i);
-            }
-            for (int i = 0; i <= Char.MaxValue; i += 7)
-            {
-                bitmap.AllowCharacter((char)i);
-            }
-
-            // Assert
+            
             for (int i = 0; i <= Char.MaxValue; i++)
             {
                 bool isAllowed = false;
@@ -61,17 +47,13 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void Clear_ForbidsEverything()
         {
-            // Arrange
             var bitmap = AllowedCharactersBitmap.CreateNew();
             for (int i = 1; i <= Char.MaxValue; i++)
             {
                 bitmap.AllowCharacter((char)i);
             }
-
-            // Act
+            
             bitmap.Clear();
-
-            // Assert
             for (int i = 0; i <= Char.MaxValue; i++)
             {
                 Assert.False(bitmap.IsCharacterAllowed((char)i));
@@ -81,15 +63,12 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void Clone_MakesDeepCopy()
         {
-            // Arrange
             var originalBitmap = AllowedCharactersBitmap.CreateNew();
             originalBitmap.AllowCharacter('x');
-
-            // Act
+            
             var clonedBitmap = originalBitmap.Clone();
             clonedBitmap.AllowCharacter('y');
-
-            // Assert
+            
             Assert.True(originalBitmap.IsCharacterAllowed('x'));
             Assert.False(originalBitmap.IsCharacterAllowed('y'));
             Assert.True(clonedBitmap.IsCharacterAllowed('x'));
@@ -99,7 +78,6 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void ForbidUndefinedCharacters_RemovesUndefinedChars()
         {
-            // Arrange
             // We only allow odd-numbered characters in this test so that
             // we can validate that we properly merged the two bitmaps together
             // rather than simply overwriting the target.
@@ -108,11 +86,8 @@ namespace Microsoft.Framework.WebEncoders
             {
                 bitmap.AllowCharacter((char)i);
             }
-
-            // Act
+            
             bitmap.ForbidUndefinedCharacters();
-
-            // Assert
             for (int i = 0; i <= Char.MaxValue; i++)
             {
                 if (i % 2 == 0)

--- a/src/System.Text.Encodings.Web/tests/BufferInternalTests.cs
+++ b/src/System.Text.Encodings.Web/tests/BufferInternalTests.cs
@@ -5,7 +5,7 @@
 using System;
 using Xunit;
 
-namespace System.Text.Encodings.Web
+namespace System.Text.Encodings.Web.Tests
 {
     public class BufferInternalTests
     {
@@ -20,10 +20,7 @@ namespace System.Text.Encodings.Web
                 BufferInternal.MemoryCopy(pArray, pArrayPlusOne, array.Length - 1, array.Length - 1);
             }
 
-            Assert.Equal(1, array[0]);
-            Assert.Equal(1, array[1]);
-            Assert.Equal(2, array[2]);
-            Assert.Equal(3, array[3]);
+            Assert.Equal(new byte[] { 1, 1, 2, 3 }, array);
         }
 
         [Fact]
@@ -37,8 +34,7 @@ namespace System.Text.Encodings.Web
                 BufferInternal.MemoryCopy(pArray, pArrayPlusOne, array.Length - 1, array.Length - 1);
             }
 
-            Assert.Equal(1, array[0]);
-            Assert.Equal(1, array[1]);
+            Assert.Equal(new byte[] { 1, 1 }, array);
         }
 
         [Fact]
@@ -51,11 +47,7 @@ namespace System.Text.Encodings.Web
                 void* pArrayPlusOne = pArray + 1;
                 BufferInternal.MemoryCopy(pArrayPlusOne, pArray, array.Length - 1, array.Length - 1);
             }
-
-            Assert.Equal(2, array[0]);
-            Assert.Equal(3, array[1]);
-            Assert.Equal(4, array[2]);
-            Assert.Equal(4, array[3]);
+            Assert.Equal(new byte[] { 2, 3, 4, 4 }, array);
         }
     }
 }

--- a/src/System.Text.Encodings.Web/tests/CommonTestEncoder.cs
+++ b/src/System.Text.Encodings.Web/tests/CommonTestEncoder.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Text.Encodings.Web;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web
 {
     /// <summary>
     /// Dummy encoder used for unit testing.

--- a/src/System.Text.Encodings.Web/tests/EncoderCommon.cs
+++ b/src/System.Text.Encodings.Web/tests/EncoderCommon.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
-namespace System.Text.Encodings.Web
+namespace System.Text.Encodings.Web.Tests
 {
     internal static class EncoderCommon
     {

--- a/src/System.Text.Encodings.Web/tests/EncoderCommonTests.cs
+++ b/src/System.Text.Encodings.Web/tests/EncoderCommonTests.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Text.Encodings.Web;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tets
 {
     public class EncoderCommonTests
     {

--- a/src/System.Text.Encodings.Web/tests/EncoderExtensionsTests.cs
+++ b/src/System.Text.Encodings.Web/tests/EncoderExtensionsTests.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Framework.WebEncoders;
-using System;
 using System.IO;
-using Xunit;
 using System.Text.Unicode;
+using Xunit;
 
-namespace System.Text.Encodings.Web
+namespace System.Text.Encodings.Web.Tests
 {
     public class EncoderExtensionsTests
     {
@@ -21,14 +19,10 @@ namespace System.Text.Encodings.Web
         [Fact]
         public void HtmlEncode_PositiveTestCase()
         {
-            // Arrange
             HtmlEncoder encoder = HtmlEncoder.Create(UnicodeRanges.All);
             StringWriter writer = new StringWriter();
 
-            // Act
             encoder.Encode(writer, "Hello+there!");
-
-            // Assert
             Assert.Equal("Hello&#x2B;there!", writer.ToString());
         }
 
@@ -41,14 +35,10 @@ namespace System.Text.Encodings.Web
         [Fact]
         public void JavaScriptStringEncode_PositiveTestCase()
         {
-            // Arrange
             IJavaScriptStringEncoder encoder = new JavaScriptStringEncoder(UnicodeRanges.All);
             StringWriter writer = new StringWriter();
 
-            // Act
             encoder.JavaScriptStringEncode("Hello+there!", writer);
-
-            // Assert
             Assert.Equal(@"Hello\u002Bthere!", writer.ToString());
         }
 
@@ -61,14 +51,10 @@ namespace System.Text.Encodings.Web
         [Fact]
         public void UrlEncode_PositiveTestCase()
         {
-            // Arrange
             UrlEncoder encoder = UrlEncoder.Create(UnicodeRanges.All);
             StringWriter writer = new StringWriter();
-
-            // Act
+            
             encoder.Encode(writer, "Hello+there!");
-
-            // Assert
             Assert.Equal("Hello%2Bthere!", writer.ToString());
         }
     }

--- a/src/System.Text.Encodings.Web/tests/Extensions.cs
+++ b/src/System.Text.Encodings.Web/tests/Extensions.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public static class Extensions
     {

--- a/src/System.Text.Encodings.Web/tests/IHtmlEncoder.cs
+++ b/src/System.Text.Encodings.Web/tests/IHtmlEncoder.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     /// <summary>
     /// Provides services for HTML-encoding input.

--- a/src/System.Text.Encodings.Web/tests/IJavaScriptStringEncoder.cs
+++ b/src/System.Text.Encodings.Web/tests/IJavaScriptStringEncoder.cs
@@ -4,7 +4,7 @@
 
 using System.IO;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     /// <summary>
     /// Provides services for JavaScript-escaping strings.

--- a/src/System.Text.Encodings.Web/tests/IUrlEncoder.cs
+++ b/src/System.Text.Encodings.Web/tests/IUrlEncoder.cs
@@ -4,7 +4,7 @@
 
 using System.IO;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     /// <summary>
     /// Provides services for URL-escaping strings.

--- a/src/System.Text.Encodings.Web/tests/PerformanceTests.cs
+++ b/src/System.Text.Encodings.Web/tests/PerformanceTests.cs
@@ -2,16 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Text.Encodings.Web;
 using Xunit;
 using Xunit.Abstractions;
 
 #if RELEASE
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public class PerformanceTests
     {

--- a/src/System.Text.Encodings.Web/tests/TemporaryEncoderAdapters.cs
+++ b/src/System.Text.Encodings.Web/tests/TemporaryEncoderAdapters.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
-using System.Text.Encodings.Web;
 using System.Text.Unicode;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     // These implement ASP.NET interfaces. They will be removed once we transition ASP.NET
     internal sealed class HtmlEncoder : IHtmlEncoder

--- a/src/System.Text.Encodings.Web/tests/TemporaryEncoderExtensions.cs
+++ b/src/System.Text.Encodings.Web/tests/TemporaryEncoderExtensions.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     /// <summary>
     /// Helpful extension methods for the encoder classes.

--- a/src/System.Text.Encodings.Web/tests/TemporaryInternalTypes.cs
+++ b/src/System.Text.Encodings.Web/tests/TemporaryInternalTypes.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using System.Threading;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     /// <summary>
     /// A class which can perform HTML encoding given an allow list of characters which

--- a/src/System.Text.Encodings.Web/tests/TextEncoderSettingsTests.cs
+++ b/src/System.Text.Encodings.Web/tests/TextEncoderSettingsTests.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public static class TextEncoderSettingsExtensions
     {
@@ -32,13 +30,9 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void Ctor_OtherTextEncoderSettingsAsInterface()
         {
-            // Arrange
             var originalFilter = new OddTextEncoderSettings();
-
-            // Act
             var newFilter = new TextEncoderSettings(originalFilter);
 
-            // Assert
             for (int i = 0; i <= Char.MaxValue; i++)
             {
                 Assert.Equal((i % 2) == 1, newFilter.IsCharacterAllowed((char)i));
@@ -48,15 +42,12 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void Ctor_OtherTextEncoderSettingsAsConcreteType_Clones()
         {
-            // Arrange
             var originalFilter = new TextEncoderSettings();
             originalFilter.AllowCharacter('x');
-
-            // Act
+            
             var newFilter = new TextEncoderSettings(originalFilter);
             newFilter.AllowCharacter('y');
-
-            // Assert
+            
             Assert.True(originalFilter.IsCharacterAllowed('x'));
             Assert.False(originalFilter.IsCharacterAllowed('y'));
             Assert.True(newFilter.IsCharacterAllowed('x'));
@@ -66,10 +57,8 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void Ctor_UnicodeRanges()
         {
-            // Act
             var filter = new TextEncoderSettings(UnicodeRanges.LatinExtendedA, UnicodeRanges.LatinExtendedC);
 
-            // Assert
             for (int i = 0; i < 0x0100; i++)
             {
                 Assert.False(filter.IsCharacterAllowed((char)i));
@@ -95,11 +84,9 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void AllowChar()
         {
-            // Arrange
             var filter = new TextEncoderSettings();
             filter.AllowCharacter('\u0100');
-
-            // Assert
+            
             Assert.True(filter.IsCharacterAllowed('\u0100'));
             Assert.False(filter.IsCharacterAllowed('\u0101'));
         }
@@ -107,11 +94,9 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void AllowChars_Array()
         {
-            // Arrange
             var filter = new TextEncoderSettings();
             filter.AllowCharacters('\u0100', '\u0102');
-
-            // Assert
+            
             Assert.True(filter.IsCharacterAllowed('\u0100'));
             Assert.False(filter.IsCharacterAllowed('\u0101'));
             Assert.True(filter.IsCharacterAllowed('\u0102'));
@@ -121,11 +106,9 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void AllowChars_String()
         {
-            // Arrange
             var filter = new TextEncoderSettings();
             filter.AllowCharacters('\u0100', '\u0102');
-
-            // Assert
+            
             Assert.True(filter.IsCharacterAllowed('\u0100'));
             Assert.False(filter.IsCharacterAllowed('\u0101'));
             Assert.True(filter.IsCharacterAllowed('\u0102'));
@@ -135,11 +118,9 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void AllowFilter()
         {
-            // Arrange
             var filter = new TextEncoderSettings(UnicodeRanges.BasicLatin);
             filter.AllowCodePoints(new OddTextEncoderSettings().GetAllowedCodePoints());
 
-            // Assert
             for (int i = 0; i <= 0x007F; i++)
             {
                 Assert.True(filter.IsCharacterAllowed((char)i));
@@ -153,11 +134,9 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void AllowRange()
         {
-            // Arrange
             var filter = new TextEncoderSettings();
             filter.AllowRange(UnicodeRanges.LatinExtendedA);
-
-            // Assert
+            
             for (int i = 0; i < 0x0100; i++)
             {
                 Assert.False(filter.IsCharacterAllowed((char)i));
@@ -175,11 +154,9 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void AllowRanges()
         {
-            // Arrange
             var filter = new TextEncoderSettings();
             filter.AllowRanges(UnicodeRanges.LatinExtendedA, UnicodeRanges.LatinExtendedC);
 
-            // Assert
             for (int i = 0; i < 0x0100; i++)
             {
                 Assert.False(filter.IsCharacterAllowed((char)i));
@@ -205,7 +182,6 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void Clear()
         {
-            // Arrange
             var filter = new TextEncoderSettings();
             for (int i = 1; i <= Char.MaxValue; i++)
             {
@@ -214,8 +190,6 @@ namespace Microsoft.Framework.WebEncoders
 
             // Act
             filter.Clear();
-
-            // Assert
             for (int i = 0; i <= Char.MaxValue; i++)
             {
                 Assert.False(filter.IsCharacterAllowed((char)i));
@@ -225,11 +199,9 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void ForbidChar()
         {
-            // Arrange
             var filter = new TextEncoderSettings(UnicodeRanges.BasicLatin);
             filter.ForbidCharacter('x');
-
-            // Assert
+            
             Assert.True(filter.IsCharacterAllowed('w'));
             Assert.False(filter.IsCharacterAllowed('x'));
             Assert.True(filter.IsCharacterAllowed('y'));
@@ -239,11 +211,9 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void ForbidChars_Array()
         {
-            // Arrange
             var filter = new TextEncoderSettings(UnicodeRanges.BasicLatin);
             filter.ForbidCharacters('x', 'z');
-
-            // Assert
+            
             Assert.True(filter.IsCharacterAllowed('w'));
             Assert.False(filter.IsCharacterAllowed('x'));
             Assert.True(filter.IsCharacterAllowed('y'));
@@ -253,11 +223,9 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void ForbidChars_String()
         {
-            // Arrange
             var filter = new TextEncoderSettings(UnicodeRanges.BasicLatin);
             filter.ForbidCharacters('x', 'z');
-
-            // Assert
+            
             Assert.True(filter.IsCharacterAllowed('w'));
             Assert.False(filter.IsCharacterAllowed('x'));
             Assert.True(filter.IsCharacterAllowed('y'));
@@ -267,11 +235,9 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void ForbidRange()
         {
-            // Arrange
             var filter = new TextEncoderSettings(new OddTextEncoderSettings());
             filter.ForbidRange(UnicodeRanges.Specials);
-
-            // Assert
+            
             for (int i = 0; i <= 0xFFEF; i++)
             {
                 Assert.Equal((i % 2) == 1, filter.IsCharacterAllowed((char)i));
@@ -285,11 +251,9 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void ForbidRanges()
         {
-            // Arrange
             var filter = new TextEncoderSettings(new OddTextEncoderSettings());
             filter.ForbidRanges(UnicodeRanges.BasicLatin, UnicodeRanges.Specials);
-
-            // Assert
+            
             for (int i = 0; i <= 0x007F; i++)
             {
                 Assert.False(filter.IsCharacterAllowed((char)i));
@@ -307,7 +271,6 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void GetAllowedCodePoints()
         {
-            // Arrange
             var expected = Enumerable.Range(UnicodeRanges.BasicLatin.FirstCodePoint, UnicodeRanges.BasicLatin.Length)
                 .Concat(Enumerable.Range(UnicodeRanges.Specials.FirstCodePoint, UnicodeRanges.Specials.Length))
                 .Except(new int[] { 'x' })
@@ -316,12 +279,8 @@ namespace Microsoft.Framework.WebEncoders
 
             var filter = new TextEncoderSettings(UnicodeRanges.BasicLatin, UnicodeRanges.Specials);
             filter.ForbidCharacter('x');
-
-            // Act
-            var retVal = filter.GetAllowedCodePoints().OrderBy(i => i).ToArray();
-
-            // Assert
-            Assert.Equal<int>(expected, retVal);
+            
+            Assert.Equal(expected, filter.GetAllowedCodePoints().OrderBy(i => i).ToArray());
         }
 
         // a code point filter which allows only odd code points through

--- a/src/System.Text.Encodings.Web/tests/UnicodeEncoderBase.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeEncoderBase.cs
@@ -2,16 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Text.Encodings.Web;
 using System.Text.Internal;
 using System.Text.Unicode;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     internal unsafe abstract class UnicodeEncoderBase
     {

--- a/src/System.Text.Encodings.Web/tests/UnicodeHelpersTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeHelpersTests.cs
@@ -2,18 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public unsafe class UnicodeHelpersTests
     {
@@ -92,11 +89,9 @@ namespace Microsoft.Framework.WebEncoders
                 {
                     continue; // no surrogates
                 }
-
-                // Arrange
+                
                 byte[] expectedUtf8Bytes = _utf8EncodingThrowOnInvalidBytes.GetBytes(Char.ConvertFromUtf32(i));
 
-                // Act
                 List<byte> actualUtf8Bytes = new List<byte>(4);
                 uint asUtf8 = (uint)UnicodeHelpers.GetUtf8RepresentationForScalarValue((uint)i);
                 do
@@ -104,7 +99,6 @@ namespace Microsoft.Framework.WebEncoders
                     actualUtf8Bytes.Add((byte)asUtf8);
                 } while ((asUtf8 >>= 8) != 0);
 
-                // Assert
                 Assert.Equal(expectedUtf8Bytes, actualUtf8Bytes);
             }
         }

--- a/src/System.Text.Encodings.Web/tests/UnicodeRangeTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeRangeTests.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public class UnicodeRangeTests
     {
@@ -32,10 +30,8 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void Ctor_SuccessCase()
         {
-            // Act
             var range = new UnicodeRange(0x0100, 128); // Latin Extended-A
 
-            // Assert
             Assert.Equal(0x0100, range.FirstCodePoint);
             Assert.Equal(128, range.Length);
         }
@@ -50,10 +46,8 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void FromSpan_SuccessCase()
         {
-            // Act
             var range = UnicodeRange.Create('\u0180', '\u024F'); // Latin Extended-B
-
-            // Assert
+            
             Assert.Equal(0x0180, range.FirstCodePoint);
             Assert.Equal(208, range.Length);
         }
@@ -61,10 +55,8 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void FromSpan_SuccessCase_All()
         {
-            // Act
             var range = UnicodeRange.Create('\u0000', '\uFFFF');
-
-            // Assert
+            
             Assert.Equal(0, range.FirstCodePoint);
             Assert.Equal(0x10000, range.Length);
         }

--- a/src/System.Text.Encodings.Web/tests/UnicodeRangesTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeRangesTests.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
-using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public class UnicodeRangesTests
     {
@@ -18,7 +16,7 @@ namespace Microsoft.Framework.WebEncoders
             UnicodeRange range = UnicodeRanges.None;
             Assert.NotNull(range);
 
-            // Test 1: the range should be empty
+            // The range should be empty
             Assert.Equal(0, range.FirstCodePoint);
             Assert.Equal(0, range.Length);
         }
@@ -198,7 +196,7 @@ namespace Microsoft.Framework.WebEncoders
             UnicodeRange range = (UnicodeRange)propInfo.GetValue(null);
             Assert.NotNull(range);
 
-            // Test 1: the range should span the range first..last
+            // The range should span the range first..last
             Assert.Equal(first, range.FirstCodePoint);
             Assert.Equal(last, range.FirstCodePoint + range.Length - 1);
         }

--- a/src/System.Text.Encodings.Web/tests/UrlEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UrlEncoderTests.cs
@@ -2,16 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public class UrlEncoderTests
     {
@@ -23,7 +20,7 @@ namespace Microsoft.Framework.WebEncoders
             Assert.Equal("%F0%9F%92%A9", System.Text.Encodings.Web.UrlEncoder.Default.Encode("\U0001f4a9"));
             using (var writer = new StringWriter())
             {
-                System.Text.Encodings.Web.UrlEncoder.Default.Encode(writer, "\U0001f4a9");
+                UrlEncoder.Default.Encode(writer, "\U0001f4a9");
                 Assert.Equal("%F0%9F%92%A9", writer.GetStringBuilder().ToString());
             }
         }
@@ -31,13 +28,11 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void Ctor_WithTextEncoderSettings()
         {
-            // Arrange
             var filter = new TextEncoderSettings();
             filter.AllowCharacters('a', 'b');
             filter.AllowCharacters('\0', '&', '\uFFFF', 'd');
             UrlEncoder encoder = new UrlEncoder(filter);
-
-            // Act & assert
+            
             Assert.Equal("a", encoder.UrlEncode("a"));
             Assert.Equal("b", encoder.UrlEncode("b"));
             Assert.Equal("%63", encoder.UrlEncode("c"));
@@ -50,10 +45,8 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void Ctor_WithUnicodeRanges()
         {
-            // Arrange
             UrlEncoder encoder = new UrlEncoder(UnicodeRanges.Latin1Supplement, UnicodeRanges.MiscellaneousSymbols);
 
-            // Act & assert
             Assert.Equal("%61", encoder.UrlEncode("a"));
             Assert.Equal("\u00E9", encoder.UrlEncode("\u00E9" /* LATIN SMALL LETTER E WITH ACUTE */));
             Assert.Equal("\u2601", encoder.UrlEncode("\u2601" /* CLOUD */));
@@ -62,10 +55,8 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void Ctor_WithNoParameters_DefaultsToBasicLatin()
         {
-            // Arrange
             UrlEncoder encoder = new UrlEncoder();
-
-            // Act & assert
+            
             Assert.Equal("a", encoder.UrlEncode("a"));
             Assert.Equal("%C3%A9", encoder.UrlEncode("\u00E9" /* LATIN SMALL LETTER E WITH ACUTE */));
             Assert.Equal("%E2%98%81", encoder.UrlEncode("\u2601" /* CLOUD */));
@@ -74,11 +65,9 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void Default_EquivalentToBasicLatin()
         {
-            // Arrange
             UrlEncoder controlEncoder = new UrlEncoder(UnicodeRanges.BasicLatin);
             UrlEncoder testEncoder = UrlEncoder.Default;
-
-            // Act & assert
+            
             for (int i = 0; i <= Char.MaxValue; i++)
             {
                 if (!IsSurrogateCodePoint(i))
@@ -92,10 +81,9 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void UrlEncode_AllRangesAllowed_StillEncodesForbiddenChars()
         {
-            // Arrange
             UrlEncoder encoder = new UrlEncoder(UnicodeRanges.All);
 
-            // Act & assert - BMP chars
+            // BMP chars
             for (int i = 0; i <= 0xFFFF; i++)
             {
                 string input = new String((char)i, 1);
@@ -158,7 +146,7 @@ namespace Microsoft.Framework.WebEncoders
                 Assert.Equal(expected, retVal);
             }
 
-            // Act & assert - astral chars
+            // Astral chars
             for (int i = 0x10000; i <= 0x10FFFF; i++)
             {
                 string input = Char.ConvertFromUtf32(i);
@@ -171,48 +159,36 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void UrlEncode_BadSurrogates_ReturnsUnicodeReplacementChar()
         {
-            // Arrange
             UrlEncoder encoder = new UrlEncoder(UnicodeRanges.All); // allow all codepoints
 
             // "a<unpaired leading>b<unpaired trailing>c<trailing before leading>d<unpaired trailing><valid>e<high at end of string>"
             const string input = "a\uD800b\uDFFFc\uDFFF\uD800d\uDFFF\uD800\uDFFFe\uD800";
             const string expected = "a%EF%BF%BDb%EF%BF%BDc%EF%BF%BD%EF%BF%BDd%EF%BF%BD%F0%90%8F%BFe%EF%BF%BD"; // 'D800' 'DFFF' was preserved since it's valid
 
-            // Act
-            string retVal = encoder.UrlEncode(input);
-
-            // Assert
-            Assert.Equal(expected, retVal);
+            Assert.Equal(expected, encoder.UrlEncode(input));
         }
 
         [Fact]
         public void UrlEncode_EmptyStringInput_ReturnsEmptyString()
         {
-            // Arrange
             UrlEncoder encoder = new UrlEncoder();
-
-            // Act & assert
             Assert.Equal("", encoder.UrlEncode(""));
         }
 
         [Fact]
         public void UrlEncode_InputDoesNotRequireEncoding_ReturnsOriginalStringInstance()
         {
-            // Arrange
             UrlEncoder encoder = new UrlEncoder();
             string input = "Hello,there!";
 
-            // Act & assert
             Assert.Same(input, encoder.UrlEncode(input));
         }
 
         [Fact]
         public void UrlEncode_NullInput_ReturnsNull()
         {
-            // Arrange
             UrlEncoder encoder = new UrlEncoder();
-
-            Assert.Throws<ArgumentNullException>(() => { encoder.UrlEncode(null); });
+            Assert.Throws<ArgumentNullException>(() => encoder.UrlEncode(null));
         }
 
         [Fact]
@@ -242,28 +218,20 @@ namespace Microsoft.Framework.WebEncoders
         [Fact]
         public void UrlEncode_CharArray()
         {
-            // Arrange
             UrlEncoder encoder = new UrlEncoder();
             var output = new StringWriter();
 
-            // Act
             encoder.UrlEncode("Hello+world!".ToCharArray(), 3, 5, output);
-
-            // Assert
             Assert.Equal("lo%2Bwo", output.ToString());
         }
 
         [Fact]
         public void UrlEncode_StringSubstring()
         {
-            // Arrange
             UrlEncoder encoder = new UrlEncoder();
             var output = new StringWriter();
-
-            // Act
+            
             encoder.UrlEncode("Hello+world!", 3, 5, output);
-
-            // Assert
             Assert.Equal("lo%2Bwo", output.ToString());
         }
 
@@ -272,12 +240,10 @@ namespace Microsoft.Framework.WebEncoders
         {
             // Per the design document, we provide additional defense-in-depth
             // by never emitting HTML-sensitive characters unescaped.
-
-            // Arrange
+            
             UrlEncoder urlEncoder = new UrlEncoder(UnicodeRanges.All);
             HtmlEncoder htmlEncoder = new HtmlEncoder(UnicodeRanges.All);
-
-            // Act & assert
+            
             for (int i = 0; i <= 0x10FFFF; i++)
             {
                 if (IsSurrogateCodePoint(i))


### PR DESCRIPTION
- Fix namespaces
- Remove unecessary legacy arrange, act, asssert comments
- Shorten a few tests

(I'm not sure if removing the arrange, act and assert comments counts as an acceptable change according to the contribution guidelines)