### PR TITLE
Use batchFile to run powershell script.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -154,7 +154,7 @@ branchList.each { branchName ->
 	                }
 
 	                // Unpack the build data
-	                batchFile("PowerShell -command \"\"C:\\Packer\\unpacker.ps1 .\\bin\\build.pack .\\bin\"\"")
+	                batchFile("PowerShell -command \"\"C:\\Packer\\unpacker.ps1 .\\bin\\build.pack .\\bin > .\\bin\\unpacker.log\"\"")
 	                // Run the tests
 	                batchFile("run-test.cmd .\\bin\\tests\\Windows_NT.AnyCPU.${configurationGroup}")
             	}

--- a/netci.groovy
+++ b/netci.groovy
@@ -154,7 +154,7 @@ branchList.each { branchName ->
 	                }
 
 	                // Unpack the build data
-	                powerShell("C:\\Packer\\unpacker.ps1 .\\bin\\build.pack .\\bin | Out-File .\\bin\\unpacker.log")
+	                batchFile("PowerShell -command \"\"C:\\Packer\\unpacker.ps1 .\\bin\\build.pack .\\bin\"\"")
 	                // Run the tests
 	                batchFile("run-test.cmd .\\bin\\tests\\Windows_NT.AnyCPU.${configurationGroup}")
             	}

--- a/run-test.cmd
+++ b/run-test.cmd
@@ -7,8 +7,8 @@ pushd %1
 
 FOR /D %%F IN (*.Tests) DO (
 pushd %%F\dnxcore50
-@echo "corerun.exe xunit.console.netcore.exe %%F.dll -xml testResults.xml -notrait category=failing -notrait category=nonwindowstests"
-corerun.exe xunit.console.netcore.exe %%F.dll -notrait category=failing -notrait category=nonwindowstests
+@echo "corerun.exe xunit.console.netcore.exe %%F.dll -xml testResults.xml -notrait category=failing -notrait category=nonwindowstests -notrait Benchmark=true"
+corerun.exe xunit.console.netcore.exe %%F.dll -notrait category=failing -notrait category=nonwindowstests -notrait Benchmark=true
 popd )
 
 popd


### PR DESCRIPTION
Using powerShell plugin, i get error 
```
Copied 2 artifacts from "dotnet_corefx » outerloop_winnano_debug_bld" build number 1
11:05:05 [outerloop_win---75965e55] $ powershell.exe -NonInteractive -ExecutionPolicy ByPass "& 'C:\Users\DOTNET~1\AppData\Local\Temp\hudson3828990339729019528.ps1'"
11:05:05 
11:05:05 ******************** START Argument Information ********************
11:05:05 Args' Count: 1
11:05:05      #0: -NonInteractive -ExecutionPolicy ByPass & 'C:\Users\DOTNET~1\AppData\Local\Temp\hudson3828990339729019528.ps1'
11:05:05 ******************** END   Argument Information ********************
11:05:05 
11:05:08 System.Management.Automation.ParseException (Check .\log.txt for more information):
11:05:08 
11:05:08 At line:1 char:41
11:05:08 + -NonInteractive -ExecutionPolicy ByPass & 'C:\Users\DOTNET~1\AppData\ ...
11:05:08 +                                         ~
11:05:08 The ampersand (&) character is not allowed. The & operator is reserved for future use; wrap an ampersand in double quotation marks ("&") to pass it as part of a string.
```

This issue is reported for 1.3 powershell plugin update [here ](https://issues.jenkins-ci.org/browse/JENKINS-31069?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20component%20%3D%20%27powershell-plugin%27)

Using this to unblock for now, till the powershell plugin can be downgraded to 1.2.

@mmitche @ellismg 