### PR TITLE
Fix Console.KeyAvailable to wait only for a single character

### DIFF
--- a/src/Native/System.Native/pal_console.cpp
+++ b/src/Native/System.Native/pal_console.cpp
@@ -224,8 +224,11 @@ extern "C" void SystemNative_GetControlCharacters(
 
 extern "C" int32_t SystemNative_StdinReady()
 {
+    SystemNative_InitializeConsoleBeforeRead(1, 0);
     struct pollfd fd = { .fd = STDIN_FILENO, .events = POLLIN };
-    return poll(&fd, 1, 0) > 0 ? 1 : 0;
+    int rv = poll(&fd, 1, 0) > 0 ? 1 : 0;
+    SystemNative_UninitializeConsoleAfterRead();
+    return rv;
 }
 
 extern "C" int32_t SystemNative_ReadStdin(void* buffer, int32_t bufferSize)


### PR DESCRIPTION
After my previous round of console fixes, KeyAvailable is now not putting the terminal in non-blocking mode, and as a result is waiting for an enter or EOL to be pressed before it'll return true.

cc: @pallavit, @andschwa 