### PR TITLE
CredentialCache.Remove compat: Don't throw when key not found

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
+++ b/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
@@ -133,11 +133,15 @@ namespace System.Net
                 GlobalLog.Print("CredentialCache::Remove() Removing key:[" + key.ToString() + "]");
             }
 
-            if (_cache[key] is SystemNetworkCredential)
+            NetworkCredential value;
+            if (_cache.TryGetValue(key, out value))
             {
-                --_numbDefaultCredInCache;
+                if (value is SystemNetworkCredential)
+                {
+                    --_numbDefaultCredInCache;
+                }
+                _cache.Remove(key);
             }
-            _cache.Remove(key);
         }
 
 
@@ -164,11 +168,15 @@ namespace System.Net
                 GlobalLog.Print("CredentialCache::Remove() Removing key:[" + key.ToString() + "]");
             }
 
-            if (_cacheForHosts[key] is SystemNetworkCredential)
+            NetworkCredential value;
+            if (_cacheForHosts.TryGetValue(key, out value))
             {
-                --_numbDefaultCredInCache;
+                if (value is SystemNetworkCredential)
+                {
+                    --_numbDefaultCredInCache;
+                }
+                _cacheForHosts.Remove(key);
             }
-            _cacheForHosts.Remove(key);
         }
 
         /// <devdoc>

--- a/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
@@ -142,8 +142,7 @@ namespace System.Net.Primitives.Functional.Tests
             //Doesn't throw, just returns
             cc.Remove(null, "authenticationType");
             cc.Remove(new Uri("http://some.com"), null);
-
-            Assert.Throws<KeyNotFoundException>(() => cc.Remove(new Uri("http://non.existant"), "invalid-authentication-type")); //No such credential
+            cc.Remove(new Uri("http://some.com"), "authenticationType");
         }
 
         [Fact]
@@ -164,8 +163,7 @@ namespace System.Net.Primitives.Functional.Tests
             cc.Remove(null, 500, "authenticationType");
             cc.Remove("host", 500, null);
             cc.Remove("host", -1, "authenticationType");
-
-            Assert.Throws<KeyNotFoundException>(() => cc.Remove("invalid-host", 500, "invalid-authentication-type")); //No such credential
+            cc.Remove("host", 500, "authenticationType");
         }
 
         [Fact]


### PR DESCRIPTION
This PR changes `CredentialCache.Remove` to not throw in .NET Core to match the behavior of the full framework.

In the full framework, `CredentialCache.Remove` does not throw when the key isn't found, which is consistent with the behavior described in the MSDN [documentation](https://msdn.microsoft.com/en-us/library/4zaz5c95(v=vs.110).aspx):

> If authType is null or uriPrefix is null, or no matching credential is found in the cache, this method does nothing.

cc: @stephentoub @davidsh