### PR TITLE
Add a redist package for InteropServices

### DIFF
--- a/pkg/redist/System.Runtime.InteropServices/lib/System.Runtime.InteropServices.builds
+++ b/pkg/redist/System.Runtime.InteropServices/lib/System.Runtime.InteropServices.builds
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Runtime.InteropServices.depproj" />
+    <Project Include="System.Runtime.InteropServices.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
+    <Project Include="System.Runtime.InteropServices.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/pkg/redist/System.Runtime.InteropServices/lib/System.Runtime.InteropServices.depproj
+++ b/pkg/redist/System.Runtime.InteropServices/lib/System.Runtime.InteropServices.depproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.20.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Runtime.InteropServices/lib/netcore50/project.json
+++ b/pkg/redist/System.Runtime.InteropServices/lib/netcore50/project.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Targets": "1.0.0",
+    "System.Runtime.InteropServices": "4.0.20"
+  },
+  "frameworks": {
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win8": {},
+    "win8-aot": {}
+  }
+}

--- a/pkg/redist/System.Runtime.InteropServices/lib/project.json
+++ b/pkg/redist/System.Runtime.InteropServices/lib/project.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Targets": "1.0.0",
+    "System.Runtime.InteropServices": "4.0.20"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/pkg/redist/System.Runtime.InteropServices/pkg/System.Runtime.InteropServices.builds
+++ b/pkg/redist/System.Runtime.InteropServices/pkg/System.Runtime.InteropServices.builds
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Runtime.InteropServices.pkgproj" />
+    <Project Include="any\System.Runtime.InteropServices.pkgproj" />
+    <Project Include="aot\System.Runtime.InteropServices.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/System.Runtime.InteropServices/pkg/System.Runtime.InteropServices.pkgproj
+++ b/pkg/redist/System.Runtime.InteropServices/pkg/System.Runtime.InteropServices.pkgproj
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <!-- bump up the version since we are redisting the 4.0.20 bits in a new package -->
+    <Version>4.0.21</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)System.Runtime.InteropServices\ref\4.0.0\System.Runtime.InteropServices.depproj">
+      <SupportedFramework>net45;netcore45</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="$(SourceDir)System.Runtime.InteropServices\ref\4.0.10\System.Runtime.InteropServices.depproj">
+      <SupportedFramework>net451;netcore451;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="$(SourceDir)System.Runtime.InteropServices\ref\4.0.20\System.Runtime.InteropServices.depproj">
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="any\System.Runtime.InteropServices.pkgproj" />
+    <ProjectReference Include="aot\System.Runtime.InteropServices.pkgproj" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Runtime.InteropServices/pkg/any/System.Runtime.InteropServices.pkgproj
+++ b/pkg/redist/System.Runtime.InteropServices/pkg/any/System.Runtime.InteropServices.pkgproj
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Runtime.InteropServices.depproj" />
+    <ProjectReference Include="..\..\lib\System.Runtime.InteropServices.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Runtime.InteropServices/pkg/aot/System.Runtime.InteropServices.pkgproj
+++ b/pkg/redist/System.Runtime.InteropServices/pkg/aot/System.Runtime.InteropServices.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Runtime.InteropServices.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.InteropServices/ref/4.0.20/System.Runtime.InteropServices.depproj
+++ b/src/System.Runtime.InteropServices/ref/4.0.20/System.Runtime.InteropServices.depproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.20.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.InteropServices/ref/4.0.20/project.json
+++ b/src/System.Runtime.InteropServices/ref/4.0.20/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Runtime.InteropServices": "4.0.20"
+  },
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Currently anything depending on Interop get's baselined to the latest
which takes a dependency on System.Runtime 4.1 which breaks the
baseline.  Additionally this was creating downgrades when folks
referenced both S.R 4.0.20 or lower and S.R.IS.

Once I have this package I'll need to update the baseline in buildtools.

I've analyzed all the other assemblies where we needed to baseline to
an older API version and there are no other instances of this problem.

/cc @weshaggard