### PR TITLE
Change StringBuffer to work with uint.

### DIFF
--- a/src/Common/src/System/IO/PathInternal.Windows.StringBuffer.cs
+++ b/src/Common/src/System/IO/PathInternal.Windows.StringBuffer.cs
@@ -31,7 +31,7 @@ namespace System.IO
         /// <summary>
         /// Gets the length of the root of the path (drive, share, etc.).
         /// </summary>
-        internal unsafe static ulong GetRootLength(StringBuffer path)
+        internal unsafe static uint GetRootLength(StringBuffer path)
         {
             Debug.Assert(path != null);
             if (path.Length == 0) return 0;

--- a/src/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/Common/src/System/IO/PathInternal.Windows.cs
@@ -239,15 +239,15 @@ namespace System.IO
         {
             fixed(char* value = path)
             {
-                return (int)GetRootLength(value, (ulong)path.Length);
+                return (int)GetRootLength(value, (uint)path.Length);
             }
         }
 
-        private unsafe static ulong GetRootLength(char* path, ulong pathLength)
+        private unsafe static uint GetRootLength(char* path, uint pathLength)
         {
-            ulong i = 0;
-            ulong volumeSeparatorLength = 2;  // Length to the colon "C:"
-            ulong uncRootLength = 2;          // Length to the start of the server name "\\"
+            uint i = 0;
+            uint volumeSeparatorLength = 2;  // Length to the colon "C:"
+            uint uncRootLength = 2;          // Length to the start of the server name "\\"
 
             bool extendedSyntax = StartsWithOrdinal(path, pathLength, ExtendedPathPrefix);
             bool extendedUncSyntax = StartsWithOrdinal(path, pathLength, UncExtendedPathPrefix);
@@ -257,12 +257,12 @@ namespace System.IO
                 if (extendedUncSyntax)
                 {
                     // "\\" -> "\\?\UNC\"
-                    uncRootLength = (ulong)UncExtendedPathPrefix.Length;
+                    uncRootLength = (uint)UncExtendedPathPrefix.Length;
                 }
                 else
                 {
                     // "C:" -> "\\?\C:"
-                    volumeSeparatorLength += (ulong)ExtendedPathPrefix.Length;
+                    volumeSeparatorLength += (uint)ExtendedPathPrefix.Length;
                 }
             }
 
@@ -290,9 +290,9 @@ namespace System.IO
             return i;
         }
 
-        private unsafe static bool StartsWithOrdinal(char* source, ulong sourceLength, string value)
+        private unsafe static bool StartsWithOrdinal(char* source, uint sourceLength, string value)
         {
-            if (sourceLength < (ulong)value.Length) return false;
+            if (sourceLength < (uint)value.Length) return false;
             for (int i = 0; i < value.Length; i++)
             {
                 if (value[i] != source[i]) return false;

--- a/src/Common/tests/Tests/System/Runtime/InteropServices/StringBufferTests.cs
+++ b/src/Common/tests/Tests/System/Runtime/InteropServices/StringBufferTests.cs
@@ -29,12 +29,12 @@ namespace Tests.System.Runtime.InteropServices
             string testString = "Test";
             using (var buffer = new StringBuffer(testString))
             {
-                Assert.Equal((ulong)testString.Length, buffer.Length);
-                Assert.Equal((ulong)testString.Length + 1, buffer.CharCapacity);
+                Assert.Equal((uint)testString.Length, buffer.Length);
+                Assert.Equal((uint)testString.Length + 1, buffer.CharCapacity);
 
                 for (int i = 0; i < testString.Length; i++)
                 {
-                    Assert.Equal(testString[i], buffer[(ulong)i]);
+                    Assert.Equal(testString[i], buffer[(uint)i]);
                 }
 
                 // Check the null termination
@@ -49,11 +49,11 @@ namespace Tests.System.Runtime.InteropServices
         {
             using (var buffer = new StringBuffer("Food"))
             {
-                Assert.Equal((ulong)5, buffer.CharCapacity);
+                Assert.Equal((uint)5, buffer.CharCapacity);
                 buffer.Length = 3;
                 Assert.Equal("Foo", buffer.ToString());
                 // Shouldn't reduce capacity when dropping length
-                Assert.Equal((ulong)5, buffer.CharCapacity);
+                Assert.Equal((uint)5, buffer.CharCapacity);
             }
         }
 
@@ -151,7 +151,7 @@ namespace Tests.System.Runtime.InteropServices
         {
             using (var buffer = new StringBuffer(source))
             {
-                Assert.Equal(expected, buffer.SubstringEquals(value, startIndex: (ulong)startIndex, count: count));
+                Assert.Equal(expected, buffer.SubstringEquals(value, startIndex: (uint)startIndex, count: count));
             }
         }
 
@@ -210,9 +210,9 @@ namespace Tests.System.Runtime.InteropServices
             using (var valueBuffer = new StringBuffer(value))
             {
                 if (count == -1)
-                    buffer.Append(valueBuffer, (ulong)startIndex, valueBuffer.Length - (ulong)startIndex);
+                    buffer.Append(valueBuffer, (uint)startIndex, valueBuffer.Length - (uint)startIndex);
                 else
-                    buffer.Append(valueBuffer, (ulong)startIndex, (ulong)count);
+                    buffer.Append(valueBuffer, (uint)startIndex, (uint)count);
                 Assert.Equal(expected, buffer.ToString());
             }
         }
@@ -231,7 +231,7 @@ namespace Tests.System.Runtime.InteropServices
         {
             using (var buffer = new StringBuffer())
             {
-                Assert.Throws<ArgumentNullException>(() => buffer.Append((StringBuffer)null));
+                Assert.Throws<ArgumentNullException>(() => buffer.Append((StringBuffer)null, 0, 0));
             }
         }
 
@@ -312,7 +312,7 @@ namespace Tests.System.Runtime.InteropServices
         {
             using (var buffer = new StringBuffer(source))
             {
-                Assert.Equal(expected, buffer.Substring(startIndex: (ulong)startIndex, count: count));
+                Assert.Equal(expected, buffer.Substring(startIndex: (uint)startIndex, count: count));
             }
         }
 
@@ -360,7 +360,7 @@ namespace Tests.System.Runtime.InteropServices
                     Buffer.MemoryCopy(contentPointer, buffer.CharPointer, (long)buffer.CharCapacity * 2, content.Length * sizeof(char));
                 }
 
-                Assert.Equal((ulong)0, buffer.Length);
+                Assert.Equal((uint)0, buffer.Length);
                 buffer.SetLengthToFirstNull();
                 Assert.Equal(endLength, buffer.Length);
             }
@@ -397,7 +397,7 @@ namespace Tests.System.Runtime.InteropServices
             InlineData(@"Foo", @"Bar", 1, 0, 3, "FBar"),
             InlineData(@"Foo", @"Bar", 1, 1, 2, "Far"),
             ]
-        public void CopyFromString(string content, string source, ulong bufferIndex, int sourceIndex, int count, string expected)
+        public void CopyFromString(string content, string source, uint bufferIndex, int sourceIndex, int count, string expected)
         {
             using (var buffer = new StringBuffer(content))
             {
@@ -447,7 +447,7 @@ namespace Tests.System.Runtime.InteropServices
             InlineData(@"Foo", @"Bar", 1, 0, 3, "FBar"),
             InlineData(@"Foo", @"Bar", 1, 1, 2, "Far"),
             ]
-        public void CopyToBufferString(string destination, string content, ulong destinationIndex, ulong bufferIndex, ulong count, string expected)
+        public void CopyToBufferString(string destination, string content, uint destinationIndex, uint bufferIndex, uint count, string expected)
         {
             using (var buffer = new StringBuffer(content))
             using (var destinationBuffer = new StringBuffer(destination))
@@ -473,7 +473,7 @@ namespace Tests.System.Runtime.InteropServices
             InlineData("Foo", 3, 1),
             InlineData("Foo", 4, 0),
             ]
-        public void CopyToBufferThrowsIndexingBeyondSourceBufferLength(string source, ulong index, ulong count)
+        public void CopyToBufferThrowsIndexingBeyondSourceBufferLength(string source, uint index, uint count)
         {
             using (var buffer = new StringBuffer(source))
             using (var targetBuffer = new StringBuffer())


### PR DESCRIPTION
Uint fits the intended usage (interop, DWORD) better than ulong. It is still far larger than
what can be expected from a simple buffer- Windows strings can't even go over short.MaxValue.