### PR TITLE
remove assert on gss_buffer members

### DIFF
--- a/src/Native/System.Net.Security.Native/pal_gssapi.cpp
+++ b/src/Native/System.Net.Security.Native/pal_gssapi.cpp
@@ -43,7 +43,6 @@ static uint32_t NetSecurityNative_HandleError(uint32_t majorStatus,
 {
     assert(targetBuffer != nullptr);
     assert(gssBuffer != nullptr);
-    assert(gssBuffer->value == nullptr || gssBuffer->length > 0);
 
     targetBuffer->length = gssBuffer->length;
     targetBuffer->data = static_cast<uint8_t*>(gssBuffer->value);


### PR DESCRIPTION
Fix for #6199 

Testing in downstream components revealed that the earlier fix  #6201, is not sufficient.

There are cases where the instance of ```gss_buffer_t``` returned from the api is not null and has a zero length, but its data field may point to a non-null pointer.

This PR attempts removes assertions about relation between the length and the data pointer.

cc: @stephentoub  @vijaykota 