### PR TITLE
Implement Process.Modules on OS X

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetLine.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetLine.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetLine", SetLastError = true)]
+        internal static extern string GetLine(IntPtr stream);
+    }
+}

--- a/src/Common/src/Interop/Unix/System.Native/Interop.POpen.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.POpen.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_POpen", SetLastError = true)]
+        internal static extern IntPtr POpen(string command, string type);
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_PClose", SetLastError = true)]
+        internal static extern int PClose(IntPtr stream);
+    }
+}

--- a/src/Native/System.Native/pal_io.cpp
+++ b/src/Native/System.Native/pal_io.cpp
@@ -833,6 +833,17 @@ extern "C" int32_t SystemNative_PosixFAdvise(intptr_t fd, int64_t offset, int64_
 #endif
 }
 
+extern "C" char* SystemNative_GetLine(FILE* stream)
+{
+    assert(stream != nullptr);
+
+    char* lineptr = nullptr;
+    size_t n = 0;
+    ssize_t length = getline(&lineptr, &n, stream);
+    
+    return length >= 0 ? lineptr : nullptr;
+}
+
 extern "C" int32_t SystemNative_Read(intptr_t fd, void* buffer, int32_t bufferSize)
 {
     assert(buffer != nullptr || bufferSize == 0);

--- a/src/Native/System.Native/pal_io.h
+++ b/src/Native/System.Native/pal_io.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "pal_types.h"
+#include <stdio.h>
 #include <dirent.h>
 
 /**
@@ -587,6 +588,13 @@ extern "C" Error SystemNative_Poll(PollEvent* pollEvents, uint32_t eventCount, i
  * Returns 0 on success; otherwise, the error code is returned and errno is NOT set.
  */
 extern "C" int32_t SystemNative_PosixFAdvise(intptr_t fd, int64_t offset, int64_t length, FileAdvice advice);
+
+/**
+* Reads a line from the provided stream.
+*
+* Returns the read line, or null if no line could be read.  The caller is responsible for freeing the malloc'd line.
+*/
+extern "C" char* SystemNative_GetLine(FILE* stream);
 
 /**
  * Reads the number of bytes specified into the provided buffer from the specified, opened file descriptor.

--- a/src/Native/System.Native/pal_process.cpp
+++ b/src/Native/System.Native/pal_process.cpp
@@ -236,6 +236,19 @@ done:
     return success ? 0 : -1;
 }
 
+extern "C" FILE* SystemNative_POpen(const char* command, const char* type)
+{
+    assert(command != nullptr);
+    assert(type != nullptr);
+    return popen(command, type);
+}
+
+extern "C" int32_t SystemNative_PClose(FILE* stream)
+{
+    assert(stream != nullptr);
+    return pclose(stream);
+}
+
 // Each platform type has it's own RLIMIT values but the same name, so we need
 // to convert our standard types into the platform specific ones.
 static int32_t ConvertRLimitResourcesPalToPlatform(RLimitResources value)

--- a/src/Native/System.Native/pal_process.h
+++ b/src/Native/System.Native/pal_process.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "pal_types.h"
+#include <stdio.h>
 #include <string.h>
 
 /**
@@ -29,6 +30,16 @@ SystemNative_ForkAndExecProcess(const char* filename,   // filename argument to 
                    int32_t* stdinFd,       // [out] if redirectStdin, the parent's fd for the child's stdin
                    int32_t* stdoutFd,      // [out] if redirectStdout, the parent's fd for the child's stdout
                    int32_t* stderrFd);     // [out] if redirectStderr, the parent's fd for the child's stderr
+
+/**
+ * Shim for the popen function.
+ */
+extern "C" FILE* SystemNative_POpen(const char* command, const char* type);
+
+/**
+ * Shim for the pclose function.
+ */
+extern "C" int32_t SystemNative_PClose(FILE* stream);
 
 /************
  * The values below in the header are fixed and correct for managed callers to use forever.

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -257,11 +257,14 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.ForkAndExecProcess.cs">
       <Link>Common\Interop\Unix\Interop.ForkAndExecProcess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetSetPriority.cs">
-      <Link>Common\Interop\Unix\Interop.GetSetPriority.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetLine.cs">
+      <Link>Common\Interop\Unix\Interop.GetLine.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetPid.cs">
       <Link>Common\Interop\Unix\Interop.GetPid.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetSetPriority.cs">
+      <Link>Common\Interop\Unix\Interop.GetSetPriority.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetSid.cs">
       <Link>Common\Interop\Unix\Interop.GetSid.cs</Link>
@@ -270,13 +273,16 @@
       <Link>Common\Interop\Unix\Interop.Kill.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.ReadLink.cs">
-      <Link>Common\Interop\Unix\Interop.readlink.cs</Link>
+      <Link>Common\Interop\Unix\Interop.ReadLink.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.ResourceLimits.cs">
       <Link>Common\Interop\Unix\Interop.ResourceLimits.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.PathConf.cs">
       <Link>Common\Interop\Unix\Interop.PathConf.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.POpen.cs">
+      <Link>Common\Interop\Unix\Interop.POpen.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.WaitPid.cs">
       <Link>Common\Interop\Unix\Interop.WaitPid.cs</Link>

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -315,6 +315,9 @@
     <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
       <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+      <Link>Common\System\StringExtensions.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" ('$(TargetsFreeBSD)' == 'true' OR '$(TargetsUnknownUnix)' == 'true') AND '$(IsPartialFacadeAssembly)'!='true'">
     <Compile Include="System\Diagnostics\Process.UnknownUnix.cs" />

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.OSX.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.OSX.cs
@@ -153,7 +153,7 @@ namespace System.Diagnostics
                         {
                             continue;
                         }
-                        string filePath = line.Substring(filePathPos).Trim();
+                        string filePath = line.SubstringTrim(filePathPos);
 
                         // Add the module
                         modules.Add(new ModuleInfo()

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.OSX.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.OSX.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace System.Diagnostics
@@ -103,8 +105,76 @@ namespace System.Diagnostics
         /// <returns>The array of modules.</returns>
         internal static ModuleInfo[] GetModuleInfos(int processId)
         {
-            // We currently don't provide support for modules on OS X.
-            return Array.Empty<ModuleInfo>();
+            var modules = new List<ModuleInfo>();
+
+            // On Linux we can read from procfs.  On OS X we can get similar data by getting the output from vmmap.
+            // This is the same basic approach taken by the PAL in libcoreclr.
+            IntPtr popenStdout = Interop.Sys.POpen($"/usr/bin/vmmap -interleaved {processId} -wide", "r");
+            Debug.Assert(popenStdout != IntPtr.Zero, $"popen failed: {Interop.Sys.GetLastErrorInfo()}");
+            if (popenStdout != IntPtr.Zero) // if this failed, we'll just return an empty set of modules
+            {
+                try
+                {
+                    string line;
+                    while ((line = Interop.Sys.GetLine(popenStdout)) != null)
+                    {
+                        // Example line (amongst other lines that don't look like this)
+                        // __TEXT   0000000104c85000-000000010513b000 [ 4824K] r-x/rwx SM=COW  /Users/mikem/coreclr/bin/Product/OSx.x64.Debug/libcoreclr.dylib
+                        const string __TEXT = "__TEXT";
+                        const int AddressLength = 16;
+                        const string PathStart = " /";
+
+                        // Only care about __TEXT entries
+                        if (!line.StartsWith(__TEXT))
+                        {
+                            continue;
+                        }
+
+                        // Move to the address
+                        int pos = __TEXT.Length;
+                        for (; pos < line.Length && char.IsWhiteSpace(line[pos]); pos++) ;
+                        int addressEndPos = checked(pos + AddressLength + 1 + AddressLength);
+                        if (addressEndPos >= line.Length)
+                        {
+                            continue;
+                        }
+
+                        // Parse the address range
+                        ulong startAddress, endAddress;
+                        if (!ulong.TryParse(line.Substring(pos, AddressLength), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out startAddress) ||
+                            !ulong.TryParse(line.Substring(pos + AddressLength + 1, AddressLength), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out endAddress))
+                        {
+                            continue;
+                        }
+
+                        // Find the first space-slash.  If it exists, that's the start of the path.
+                        int filePathPos = line.IndexOf(PathStart, addressEndPos);
+                        if (filePathPos < 0)
+                        {
+                            continue;
+                        }
+                        string filePath = line.Substring(filePathPos).Trim();
+
+                        // Add the module
+                        modules.Add(new ModuleInfo()
+                        {
+                            _fileName = filePath,
+                            _baseName = Path.GetFileName(filePath),
+                            _baseOfDll = new IntPtr((long)startAddress),
+                            _sizeOfImage = (int)(endAddress - startAddress),
+                            _entryPoint = IntPtr.Zero // unknown
+                        });
+                    }
+                }
+                finally
+                {
+                    int rv = Interop.Sys.PClose(popenStdout);
+                    Debug.Assert(rv == 0, $"pclose failed: {Interop.Sys.GetLastErrorInfo()}"); // ignore any release failures from closing
+                }
+            }
+
+            // Return the set of modules found.
+            return modules.ToArray();
         }
 
         // ----------------------------------

--- a/src/System.Diagnostics.Process/tests/ProcessModuleTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessModuleTests.cs
@@ -2,35 +2,39 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using Xunit;
 
 namespace System.Diagnostics.Tests
 {
     public class ProcessModuleTests : ProcessTestBase
     {
-        [Fact, PlatformSpecific(~PlatformID.OSX)]
-        public void TestModulePropertiesExceptOnOSX()
+        [Fact]
+        public void TestModuleProperties()
         {
-            ProcessModuleCollection moduleCollection = Process.GetCurrentProcess().Modules;
-            Assert.True(moduleCollection.Count > 0);
+            ProcessModuleCollection modules = Process.GetCurrentProcess().Modules;
+            Assert.True(modules.Count > 0);
 
-            for (int i = 0; i < moduleCollection.Count; i++)
+            foreach (ProcessModule module in modules)
             {
-                Assert.True(moduleCollection[i].BaseAddress.ToInt64() > 0);
-                // From MSDN: Due to changes in the way that Windows loads assemblies, 
-                // EntryPointAddress will always return 0 on Windows 8 or Windows 8.1 and should not be relied on for those platforms.
-                Assert.True(moduleCollection[i].EntryPointAddress.ToInt64() >= 0);
-                Assert.True(moduleCollection[i].ModuleMemorySize > 0);
+                Assert.NotNull(module);
+
+                Assert.NotNull(module.FileName);
+                Assert.NotEmpty(module.FileName);
+
+                Assert.InRange(module.BaseAddress.ToInt64(), 1, long.MaxValue);
+                Assert.InRange(module.EntryPointAddress.ToInt64(), 0, long.MaxValue);
+                Assert.InRange(module.ModuleMemorySize, 1, long.MaxValue);
             }
         }
 
-        [Fact, PlatformSpecific(PlatformID.OSX)]
-        public void TestModulePropertiesOnOSX()
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void TestModulesContainsUnixNativeLibs()
         {
-            // Getting modules for a process given a pid is not supported on OSX.
-            ProcessModuleCollection moduleCollection = _process.Modules;
-            Assert.Equal(0, moduleCollection.Count);
-            Assert.Null(_process.MainModule);
+            ProcessModuleCollection modules = Process.GetCurrentProcess().Modules;
+            Assert.Contains(modules.Cast<ProcessModule>(), m => m.FileName.Contains("libcoreclr"));
+            Assert.Contains(modules.Cast<ProcessModule>(), m => m.FileName.Contains("System.Native"));
         }
     }
 }


### PR DESCRIPTION
Today Process.Modules just returns an empty collection on OS X, whereas on Linux we use data from procfs to populate it.  This commit adds similar support on OS X by popen'ing vmmap.

cc: @Priya91, @pallavit, @sokket 
Fixes #1727 