### PR TITLE
Build redist packages

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -6,6 +6,7 @@
       <AdditionalProperties>SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
     </Project>
     <Project Include="*\pkg\*.builds" />
+    <Project Include="..\pkg\redist\pkg.builds"/>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/src.builds
+++ b/src/src.builds
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="*\src\*.builds" />
+    <Project Include="..\pkg\redist\lib.builds"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>


### PR DESCRIPTION
Make the open build also build redist packages to ensure that
changes to projects in src don't break them.

/cc @chcosta @weshaggard 