### PR TITLE
Fix WriteEscapedJsonString for Special Control Characters.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
@@ -24,6 +24,9 @@ namespace System.Runtime.Serialization.Json
         private const char WHITESPACE = ' ';
         private const char CARRIAGE_RETURN = '\r';
         private const char NEWLINE = '\n';
+        private const char BACKSPACE = '\b';
+        private const char FORM_FEED = '\f';
+        private const char HORIZONTAL_TABULATION = '\t';
         private const string xmlNamespace = "http://www.w3.org/XML/1998/namespace";
         private const string xmlnsNamespace = "http://www.w3.org/2000/xmlns/";
 
@@ -1384,29 +1387,27 @@ namespace System.Runtime.Serialization.Json
                 for (j = 0; j < str.Length; j++)
                 {
                     char ch = chars[j];
-                    if (ch <= FORWARD_SLASH)
-                    {
-                        if (ch == FORWARD_SLASH || ch == JsonGlobals.QuoteChar)
-                        {
-                            _nodeWriter.WriteChars(chars + i, j - i);
-                            _nodeWriter.WriteText(BACK_SLASH);
-                            _nodeWriter.WriteText(ch);
-                            i = j + 1;
-                        }
-                        else if (ch < WHITESPACE)
-                        {
-                            _nodeWriter.WriteChars(chars + i, j - i);
-                            _nodeWriter.WriteText(BACK_SLASH);
-                            _nodeWriter.WriteText('u');
-                            _nodeWriter.WriteText(string.Format(CultureInfo.InvariantCulture, "{0:x4}", (int)ch));
-                            i = j + 1;
-                        }
-                    }
-                    else if (ch == BACK_SLASH)
+                    char abbrev;
+                    if (ch == BACK_SLASH || ch == JsonGlobals.QuoteChar || ch == FORWARD_SLASH)
                     {
                         _nodeWriter.WriteChars(chars + i, j - i);
                         _nodeWriter.WriteText(BACK_SLASH);
                         _nodeWriter.WriteText(ch);
+                        i = j + 1;
+                    }
+                    else if (TryEscapeControlCharacter(ch, out abbrev))
+                    {
+                        _nodeWriter.WriteChars(chars + i, j - i);
+                        _nodeWriter.WriteText(BACK_SLASH);
+                        _nodeWriter.WriteText(abbrev);
+                        i = j + 1;
+                    }
+                    else if (ch < WHITESPACE)
+                    {
+                        _nodeWriter.WriteChars(chars + i, j - i);
+                        _nodeWriter.WriteText(BACK_SLASH);
+                        _nodeWriter.WriteText('u');
+                        _nodeWriter.WriteText(string.Format(CultureInfo.InvariantCulture, "{0:x4}", (int)ch));
                         i = j + 1;
                     }
                     else if ((ch >= HIGH_SURROGATE_START && (ch <= LOW_SURROGATE_END || ch >= MAX_CHAR)) || IsUnicodeNewlineCharacter(ch))
@@ -1423,6 +1424,33 @@ namespace System.Runtime.Serialization.Json
                     _nodeWriter.WriteChars(chars + i, j - i);
                 }
             }
+        }
+
+        private bool TryEscapeControlCharacter(char ch, out char abbrev)
+        {
+            switch (ch)
+            {
+                case BACKSPACE:
+                    abbrev = 'b';
+                    break;
+                case FORM_FEED:
+                    abbrev = 'f';
+                    break;
+                case NEWLINE:
+                    abbrev = 'n';
+                    break;
+                case CARRIAGE_RETURN:
+                    abbrev = 'r';
+                    break;
+                case HORIZONTAL_TABULATION:
+                    abbrev = 't';
+                    break;
+                default:
+                    abbrev = ' ';
+                    return false;
+            }
+
+            return true;
         }
 
         private void WriteIndent()


### PR DESCRIPTION
For some special control characters, the escaped strings generated by DataContractJsonSerializer are not compatible with ECMAScript V6. The PR is to fix this issue. The changes are based on http://www.ecma-international.org/ecma-262/6.0/#sec-quotejsonstring. 

Ref #5647.