### PR TITLE
Implement and expose Console.TreatControlCAsInput

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetSignalForBreak.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetSignalForBreak.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSignalForBreak")]
+        internal static extern bool GetSignalForBreak();
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSignalForBreak")]
+        internal static extern bool SetSignalForBreak(bool signalForBreak);
+    }
+}

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetConsoleMode.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetConsoleMode.cs
@@ -10,12 +10,17 @@ internal partial class Interop
     internal partial class mincore
     {
         [DllImport(Libraries.Console_L1, SetLastError = true)]
-        private extern static bool GetConsoleMode(IntPtr handle, out int mode);
+        internal extern static bool GetConsoleMode(IntPtr handle, out int mode);
 
         internal static bool IsGetConsoleModeCallSuccessful(IntPtr handle)
         {
             int mode;
             return GetConsoleMode(handle, out mode);
         }
+
+        [DllImport(Libraries.Console_L1, SetLastError = true)]
+        internal static extern bool SetConsoleMode(IntPtr handle, int mode);
+
+        internal const int ENABLE_PROCESSED_INPUT = 0x0001;
     }
 }

--- a/src/Native/System.Native/pal_console.h
+++ b/src/Native/System.Native/pal_console.h
@@ -104,6 +104,20 @@ extern "C" void SystemNative_UninitializeConsoleAfterRead();
  */
 extern "C" int32_t SystemNative_ReadStdin(void* buffer, int32_t bufferSize);
 
+/**
+ * Gets the terminal's break mode.
+ */
+extern "C" int32_t SystemNative_GetSignalForBreak();
+
+/**
+ * Configures the terminal's break mode.
+ *
+ * signalForBreak should be 1 to treat break as signals, or 0 to treat break as input.
+ *
+ * Returns 1 on success, 0 on failure, in which case errno is set.
+ */
+extern "C" int32_t SystemNative_SetSignalForBreak(int32_t signalForBreak);
+
 enum CtrlCode : int32_t
 {
     Interrupt = 0,

--- a/src/System.Console/ref/System.Console.cs
+++ b/src/System.Console/ref/System.Console.cs
@@ -51,6 +51,7 @@ namespace System
         public static void SetWindowPosition(int left, int top) { }
         public static void SetWindowSize(int width, int height) { }
         public static string Title { get { return default(string); } set { } }
+        public static bool TreatControlCAsInput { get { return default(bool); } set { } }
         public static int WindowHeight { get { return default(int); } set { } }
         public static int WindowWidth { get { return default(int); } set { } }
         public static int WindowLeft { get { return default(int); } set { } }

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -221,6 +221,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.RegisterForCtrlC.cs">
       <Link>Common\Interop\Unix\Interop.RegisterForCtrlC.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SetSignalForBreak.cs">
+      <Link>Common\Interop\Unix\Interop.SetSignalForBreak.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SNPrintF.cs">
       <Link>Common\Interop\Unix\Interop.SNPrintF.cs</Link>
     </Compile>

--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -392,6 +392,12 @@ namespace System
             }
         }
 
+        public static bool TreatControlCAsInput
+        {
+            get { return ConsolePal.TreatControlCAsInput; }
+            set { ConsolePal.TreatControlCAsInput = value; }
+        }
+
         public static Stream OpenStandardInput()
         {
             return ConsolePal.OpenStandardInput();

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -104,6 +104,27 @@ namespace System
             return keyInfo;
         }
 
+        public static bool TreatControlCAsInput
+        {
+            get
+            {
+                if (Console.IsInputRedirected)
+                    return false;
+
+                EnsureInitialized();
+                return !Interop.Sys.GetSignalForBreak();
+            }
+            set
+            {
+                if (!Console.IsInputRedirected)
+                {
+                    EnsureInitialized();
+                    if (!Interop.Sys.SetSignalForBreak(signalForBreak: !value))
+                        throw Interop.GetExceptionForIoErrno(Interop.Sys.GetLastErrorInfo());
+                }
+            }
+        }
+
         private const ConsoleColor UnknownColor = (ConsoleColor)(-1);
         private static ConsoleColor s_trackedForegroundColor = UnknownColor;
         private static ConsoleColor s_trackedBackgroundColor = UnknownColor;

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -374,6 +374,43 @@ namespace System
             return info;
         }
 
+        public static bool TreatControlCAsInput
+        {
+            get
+            {
+                IntPtr handle = InputHandle;
+                if (handle == s_InvalidHandleValue)
+                    throw new IOException(SR.IO_NoConsole);
+
+                int mode = 0;
+                if (!Interop.mincore.GetConsoleMode(handle, out mode))
+                    Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());
+
+                return (mode & Interop.mincore.ENABLE_PROCESSED_INPUT) == 0;
+            }
+            set
+            {
+                IntPtr handle = InputHandle;
+                if (handle == s_InvalidHandleValue)
+                    throw new IOException(SR.IO_NoConsole);
+
+                int mode = 0;
+                Interop.mincore.GetConsoleMode(handle, out mode); // failure ignored in full framework
+
+                if (value)
+                {
+                    mode &= ~Interop.mincore.ENABLE_PROCESSED_INPUT;
+                }
+                else
+                {
+                    mode |= Interop.mincore.ENABLE_PROCESSED_INPUT;
+                }
+
+                if (!Interop.mincore.SetConsoleMode(handle, mode))
+                    Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());
+            }
+        }
+
         // For ResetColor
         private static volatile bool _haveReadDefaultColors;
         private static volatile byte _defaultColors;


### PR DESCRIPTION
This provides Windows and Unix implementations of TreatControlCAsInput, and exposes it in the contract.  The Windows implementation is ported from the full framework. The Unix implementation relies on setting the terminal's ISIG flag, which controls whether it generates signals.  This mostly results in the same behaviors as on Windows.  However, one notable difference is it doesn't just affect ctrl-C, but all of the ctrl-*s that result in signals, e.g. ctrl-\, ctrl-Z, etc.

cc: @pallavit, @andschwa
Closes https://github.com/dotnet/corefx/issues/4636