### PR TITLE
Explicitly disable SqlClient ManualTests with a build flag

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/README.md
+++ b/src/System.Data.SqlClient/tests/ManualTests/README.md
@@ -2,7 +2,7 @@
 
 These tests require dedicated test servers, so they're designed to be run manually using a custom set of connection strings. These connection strings should be added in [ConnectionString.xml](https://github.com/dotnet/corefx/blob/master/src/System.Data.SqlClient/tests/ManualTests/DataCommon/ConnectionString.xml). Each connection string references which version of SQL Server it targets, as well as the sample database it expects. Info for these sample databases can be found [here](https://msdn.microsoft.com/en-us/library/8b6y4c7s.aspx). Connection strings that end in "NamedPipes" are also meant to be used with named pipes, rather than the default TCP.
 
-Note: These tests are marked as unsupported on all platforms so that they aren't run automatically. To make these tests runnable, comment out the UnsupportedPlatforms line in the ManualTests csproj.
+Note: These tests are disabled by default so that they aren't run automatically. To make these tests runnable, run the tests with the flag "EnableManualTests=true". (e.g. on Windows use "msbuild /t:BuildAndTest /p:EnableManualTests=true")
 
 Instructions for running tests: [Unix](https://github.com/dotnet/corefx/blob/master/Documentation/building/cross-platform-testing.md) and [Windows](https://github.com/dotnet/corefx/blob/master/Documentation/building/windows-instructions.md).
 Documentation for connection string parameters: [SqlConnection.ConnectionString](https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlconnection.connectionstring.aspx).

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -7,22 +7,20 @@
   <PropertyGroup>
     <ProjectGuid>{45DB5F86-7AE3-45C6-870D-F9357B66BDB5}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <UnsupportedPlatforms>Linux;NetBSD;OSX;Windows_NT</UnsupportedPlatforms>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetsWindows)' != 'true' ">
-    <DefineConstants>$(DefineConstants);MANAGED_SNI</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+  <PropertyGroup Condition=" '$(TargetsWindows)' != 'true' ">
+    <DefineConstants>$(DefineConstants);MANAGED_SNI</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Data.SqlClient.csproj">
       <Name>System.Data.SqlClient</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <!-- SQL Common Files -->
+  <ItemGroup Condition=" '$(EnableManualTests)' == 'true' ">
     <Compile Include="SQL\Common\AsyncDebugScope.cs" />
     <Compile Include="SQL\Common\ConnectionPoolWrapper.cs" />
     <Compile Include="SQL\Common\InternalConnectionWrapper.cs" />
@@ -33,27 +31,27 @@
     <Compile Include="SQL\Common\SystemDataInternals\DataReaderHelper.cs" />
     <Compile Include="SQL\Common\SystemDataInternals\TdsParserHelper.cs" />
     <Compile Include="SQL\Common\SystemDataInternals\TdsParserStateObjectHelper.cs" />
-    <!-- Data Common Files -->
+
     <Compile Include="DataCommon\AssemblyResourceManager.cs" />
     <Compile Include="DataCommon\CarriageReturnLineFeedReplacer.cs" />
     <Compile Include="DataCommon\DataSourceBuilder.cs" />
     <Compile Include="DataCommon\DataTestClass.cs" />
     <Compile Include="DataCommon\ProxyServer.cs" />
     <Compile Include="DataCommon\SystemDataResourceManager.cs" />
-    <!-- ADO Tests -->
+
     <Compile Include="ADO\BaseProviderAsyncTest\BaseProviderAsyncTest.cs" />
     <Compile Include="ADO\BaseProviderAsyncTest\MockCommand.cs" />
     <Compile Include="ADO\BaseProviderAsyncTest\MockConnection.cs" />
     <Compile Include="ADO\BaseProviderAsyncTest\MockDataReader.cs" />
     <Compile Include="ADO\ParametersTest\ParametersTest.cs" />
-    <!-- DDBasics Tests -->
+
     <Compile Include="DDBasics\AsyncTest\AsyncTest.cs" />
     <Compile Include="DDBasics\DataTypes\DataTypes.cs" />
     <Compile Include="DDBasics\MARSTest\DDMARSTest.cs" />
-    <!-- ProviderAgnostic Tests -->
+
     <Compile Include="ProviderAgnostic\MultipleResultsTest\MultipleResultsTest.cs" />
     <Compile Include="ProviderAgnostic\ReaderTest\ReaderTest.cs" />
-    <!-- SQL Tests -->
+
     <Compile Include="SQL\AsyncTest\AsyncTest.cs" />
     <Compile Include="SQL\CommandCancel\CommandCancel.cs" />
     <Compile Include="SQL\ConnectionPoolTest\ConnectionPoolTest.cs" />
@@ -78,8 +76,7 @@
     <Compile Include="SQL\TransactionTest\TransactionTest.cs" />
     <Compile Include="SQL\WeakRefTest\WeakRefTest.cs" />
     <Compile Include="SQL\WeakRefTestYukonSpecific\WeakRefTestYukonSpecific.cs" />
-  </ItemGroup>
-  <ItemGroup>
+
     <None Include="DDBasics\DataTypes\data.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -88,7 +85,6 @@
     </None>
     <None Include="DataCommon\ConnectionString.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <SubType>Designer</SubType>
     </None>
     <None Include="project.json" />
   </ItemGroup>


### PR DESCRIPTION
Some test runs haven't been honoring UnsupportedPlatform tags appropriately, so I've disabled the ManualTests by requiring an EnableManualTests=true build flag. 