### PR TITLE
Test coverage for GetHashCode on IntPtr/UIntPtr.

### DIFF
--- a/src/System.Runtime/tests/System/IntPtr.cs
+++ b/src/System.Runtime/tests/System/IntPtr.cs
@@ -139,6 +139,14 @@ public static class IntPtrTests
         Assert.Throws<OverflowException>(() => (int)ptr);
     }
 
+    [ConditionalFact(nameof(Is64Bit))]
+    public static void TestGetHashCodeRespectAllBits()
+    {
+        var ptr1 = new IntPtr(0x123456FFFFFFFF);
+        var ptr2 = new IntPtr(0x654321FFFFFFFF);
+        Assert.NotEqual(ptr1.GetHashCode(), ptr2.GetHashCode());
+    }
+
     private static void VerifyPointer(IntPtr ptr, long expected)
     {
         Assert.Equal(expected, ptr.ToInt64());

--- a/src/System.Runtime/tests/System/UIntPtr.cs
+++ b/src/System.Runtime/tests/System/UIntPtr.cs
@@ -136,6 +136,14 @@ public static class UIntPtrTests
         Assert.Throws<OverflowException>(() => (uint)ptr);
     }
 
+    [ConditionalFact(nameof(Is64Bit))]
+    public static void TestGetHashCodeRespectAllBits()
+    {
+        var ptr1 = new UIntPtr(0x123456FFFFFFFF);
+        var ptr2 = new UIntPtr(0x654321FFFFFFFF);
+        Assert.NotEqual(ptr1.GetHashCode(), ptr2.GetHashCode());
+    }
+
     private static void VerifyPointer(UIntPtr ptr, ulong expected)
     {
         Assert.Equal(expected, ptr.ToUInt64());


### PR DESCRIPTION
The behavior of GetHashCode on IntPtr and UIntPtr was changed in the CoreCLR. When the (U)IntPtr is on a 64-bit platform, all bits of the value are now considered. See dotnet/coreclr#3511 for details.

Fix #6715