### PR TITLE
X509Certificates support net46/netstandard1.3

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/pkg/System.Security.Cryptography.X509Certificates.pkgproj
+++ b/src/System.Security.Cryptography.X509Certificates/pkg/System.Security.Cryptography.X509Certificates.pkgproj
@@ -2,8 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <ProjectReference Include="..\ref\4.0\System.Security.Cryptography.X509Certificates.csproj">
+      <SupportedFramework>net46</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\ref\System.Security.Cryptography.X509Certificates.csproj">
       <SupportedFramework>net461;netcore50;netstandardapp1.5</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Security.Cryptography.X509Certificates.csproj">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.X509Certificates.csproj">
       <AdditionalProperties>TargetGroup=net461</AdditionalProperties>


### PR DESCRIPTION
The recent API refactoring dropped support for net46/netstandard1.3 from
the System.Security.Cryptography.X509Certificates package.  Add the
4.0 versions of this contract that support net46/netstandard1.3.

This fixes the issue we're seeing when trying to consume the latest packages 
in corefx: https://github.com/dotnet/corefx/pull/6713.

/cc @bartonjs 