### PR TITLE
Add a few PlatformNotSupported exception messages

### DIFF
--- a/src/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -276,4 +276,7 @@
   <data name="ProcessInformationUnavailable" xml:space="preserve">
     <value>Unable to retrieve the specified information about the process or thread.  It may have exited or may be privileged.</value>
   </data>
+  <data name="RemoteMachinesNotSupported" xml:space="preserve">
+    <value>Access to processes on remote machines is not supported on this platform.</value>
+  </data>
 </root>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Unix.cs
@@ -75,7 +75,7 @@ namespace System.Diagnostics
         {
             if (IsRemoteMachine(machineName))
             {
-                throw new PlatformNotSupportedException();
+                throw new PlatformNotSupportedException(SR.RemoteMachinesNotSupported);
             }
         }
 

--- a/src/System.IO.Pipes/src/Resources/Strings.resx
+++ b/src/System.IO.Pipes/src/Resources/Strings.resx
@@ -267,4 +267,13 @@
   <data name="ArgumentOutOfRange_FileLengthTooBig" xml:space="preserve">
     <value>Specified file length was too large for the file system.</value>
   </data>
+  <data name="PlatformNotSupported_MessageTransmissionMode" xml:space="preserve">
+    <value>Message transmission mode is not supported on this platform.</value>
+  </data>
+  <data name="PlatformNotSupported_RemotePipes" xml:space="preserve">
+    <value>Access to remote named pipes is not supported on this platform.</value>
+  </data>
+  <data name="PlatformNotSupproted_InvalidNameChars" xml:space="preserve">
+    <value>The name of a pipe on this platform must only include characters valid in file names.</value>
+  </data>
 </root>

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
@@ -37,7 +37,7 @@ namespace System.IO.Pipes
 
             if (transmissionMode == PipeTransmissionMode.Message)
             {
-                throw new PlatformNotSupportedException();
+                throw new PlatformNotSupportedException(SR.PlatformNotSupported_MessageTransmissionMode);
             }
 
             // NOTE: We don't have a good way to enforce maxNumberOfServerInstances, and don't currently try.

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -26,7 +26,7 @@ namespace System.IO.Pipes
             if (serverName != "." && serverName != Interop.Sys.GetHostName())
             {
                 // Cross-machine pipes are not supported.
-                throw new PlatformNotSupportedException();
+                throw new PlatformNotSupportedException(SR.PlatformNotSupported_RemotePipes);
             }
 
             if (pipeName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
@@ -34,7 +34,7 @@ namespace System.IO.Pipes
                 // Since pipes are stored as files in the file system, we don't support
                 // pipe names that are actually paths or that otherwise have invalid
                 // filename characters in them.
-                throw new PlatformNotSupportedException();
+                throw new PlatformNotSupportedException(SR.PlatformNotSupproted_InvalidNameChars);
             }
 
             // Return the pipe path
@@ -194,7 +194,7 @@ namespace System.IO.Pipes
 
                 if (value != PipeTransmissionMode.Byte) // Unix pipes are only byte-based, not message-based
                 {
-                    throw new PlatformNotSupportedException();
+                    throw new PlatformNotSupportedException(SR.PlatformNotSupported_MessageTransmissionMode);
                 }
 
                 // nop, since it's already the only valid value


### PR DESCRIPTION
Most of the PlatformNotSupportedExceptions we throw in our Unix code paths are unconditional, e.g. in System.Console:
```C#
public static string Title
{
    get { throw new PlatformNotSupportedException(); }
    set { ... }
}
```
making it easy to understand without a customized message that the method being called isn't supported.

However, when there's more nuance, e.g. when the operation isn't supported because of a particular parameter value being used, we do want to use a message to clarify exactly what's not supported.  Most such cases already have a custom message, but a few don't.

This commit fixes those that I could find that still need one (if we encounter more, we can add those on a case-by-case basis).

cc: @ianhays, @dsplaisted 
Fixes https://github.com/dotnet/corefx/issues/6720