### PR TITLE
HttpResponseMessage.ReasonPhrase should not be null

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -47,14 +47,9 @@ namespace System.Net.Http
                 Interop.WinHttp.WINHTTP_QUERY_STATUS_CODE);
 
             int reasonPhraseLength = GetResponseHeader(requestHandle, Interop.WinHttp.WINHTTP_QUERY_STATUS_TEXT, buffer);
-            if (reasonPhraseLength > 0)
-            {
-                response.ReasonPhrase = GetReasonPhrase(response.StatusCode, buffer, reasonPhraseLength);
-            }
-            else
-            {
-                response.ReasonPhrase = string.Empty;
-            }
+            response.ReasonPhrase = reasonPhraseLength > 0 ?
+                GetReasonPhrase(response.StatusCode, buffer, reasonPhraseLength) :
+                string.Empty;
 
             // Create response stream and wrap it in a StreamContent object.
             var responseStream = new WinHttpResponseStream(requestHandle, state);

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -51,6 +51,10 @@ namespace System.Net.Http
             {
                 response.ReasonPhrase = GetReasonPhrase(response.StatusCode, buffer, reasonPhraseLength);
             }
+            else
+            {
+                response.ReasonPhrase = string.Empty;
+            }
 
             // Create response stream and wrap it in a StreamContent object.
             var responseStream = new WinHttpResponseStream(requestHandle, state);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -696,20 +696,20 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [Fact]
-        public async Task GetAsync_CallMethod_ExpectedStatusLine()
+        [Theory]
+        [InlineData(HttpStatusCode.MethodNotAllowed, "Custom description")]
+        [InlineData(HttpStatusCode.MethodNotAllowed, "")]
+        public async Task GetAsync_CallMethod_ExpectedStatusLine(HttpStatusCode statusCode, string reasonPhrase)
         {
-            HttpStatusCode expectedStatusCode = HttpStatusCode.MethodNotAllowed;
-            string expectedReasonPhrase = "Custom descrption";
             using (var client = new HttpClient())
             {
                 using (HttpResponseMessage response = await client.GetAsync(HttpTestServers.StatusCodeUri(
                     false,
-                    (int)expectedStatusCode,
-                    expectedReasonPhrase)))
+                    (int)statusCode,
+                    reasonPhrase)))
                 {
-                    Assert.Equal(expectedStatusCode, response.StatusCode);
-                    Assert.Equal(expectedReasonPhrase, response.ReasonPhrase);
+                    Assert.Equal(statusCode, response.StatusCode);
+                    Assert.Equal(reasonPhrase, response.ReasonPhrase);
                 }
             }
         }


### PR DESCRIPTION
Recent changes due to PR #3199 caused the `HttpResponseMessage.ReasonPhrase` property to be a null string if the HTTP server response only contained a statuscode but no description on the status line. The existing .NET Framwork behavior is to have empty string as the property value in that case.

Added a new test to validate this change.

Fixes #6721.