### PR TITLE
Add negative tests for JapaneseCalendar

### DIFF
--- a/src/System.Globalization.Calendars/tests/CalendarHelpers.cs
+++ b/src/System.Globalization.Calendars/tests/CalendarHelpers.cs
@@ -48,7 +48,7 @@ namespace System.Globalization.Tests
             {
                 return calendar.GetYear(calendar.MaxSupportedDateTime);
             }
-            return MinGregorianYearInEra(calendar, era + 1) - MinGregorianYearInEra(calendar, era) + 1;
+            return calendar.GetYear(calendar.ToDateTime(1, 1, 1, 0, 0, 0, 0, era + 1).AddDays(-1)) + 1;
         }
 
         private static int MaxGregorianYearInEra(Calendar calendar, int era)
@@ -59,7 +59,7 @@ namespace System.Globalization.Tests
             {
                 return calendar.MaxSupportedDateTime.Year;
             }
-            return MinGregorianYearInEra(calendar, era + 1);
+            return (calendar.ToDateTime(1, 1, 1, 0, 0, 0, 0, era + 1).AddDays(-1)).Year;
         }
 
         private static int MinGregorianYearInEra(Calendar calendar, int era)
@@ -70,7 +70,6 @@ namespace System.Globalization.Tests
             {
                 return calendar.MinSupportedDateTime.Year;
             }
-
             return calendar.ToDateTime(1, 1, 1, 0, 0, 0, 0, era).Year;
         }
 
@@ -82,8 +81,7 @@ namespace System.Globalization.Tests
             {
                 return calendar.GetYear(calendar.MinSupportedDateTime);
             }
-
-            return 1;
+            return calendar.GetYear(calendar.ToDateTime(1, 1, 1, 0, 0, 0, 0, era));
         }
 
         public static IEnumerable<object[]> Calendars_TestData()

--- a/src/System.Globalization.Calendars/tests/CalendarHelpers.cs
+++ b/src/System.Globalization.Calendars/tests/CalendarHelpers.cs
@@ -3,66 +3,87 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.Globalization.Tests
 {
     public static class CalendarHelpers
     {
+        public enum DataType
+        {
+            Year = 1,
+            Month = 2,
+            Day = 8
+        }
+        
         public static Calendar[] s_calendars = new Calendar[]
         {
             new ThaiBuddhistCalendar(),
-            new JapaneseCalendar()
+            new JapaneseCalendar(),
+            new KoreanCalendar(),
+            new TaiwanCalendar(),
+            new GregorianCalendar(GregorianCalendarTypes.Arabic),
+            new GregorianCalendar(GregorianCalendarTypes.Localized),
+            new GregorianCalendar(GregorianCalendarTypes.MiddleEastFrench),
+            new GregorianCalendar(GregorianCalendarTypes.TransliteratedEnglish),
+            new GregorianCalendar(GregorianCalendarTypes.TransliteratedFrench),
+            new GregorianCalendar(GregorianCalendarTypes.USEnglish),
+            new HijriCalendar(),
+            new HebrewCalendar(),
+            new JulianCalendar(),
+            new TaiwanLunisolarCalendar(),
+            new ChineseLunisolarCalendar(),
+            new KoreanLunisolarCalendar(),
+            new PersianCalendar()
         };
 
         private static int MinEra(Calendar calendar) => calendar.GetEra(calendar.MinSupportedDateTime);
         private static int MaxEra(Calendar calendar) => calendar.GetEra(calendar.MaxSupportedDateTime);
 
-        private static int YearOffset(Calendar calendar)
+        private static int MaxCalendarYearInEra(Calendar calendar, int era)
         {
-            if (calendar is ThaiBuddhistCalendar)
+            int[] eras = calendar.Eras;
+            Assert.InRange(era, 0, eras[0]);
+            if (eras.Length == 1 || era == eras[0] || era == 0)
             {
-                return 543;
+                return calendar.GetYear(calendar.MaxSupportedDateTime);
             }
-            return 0;
+            return MinGregorianYearInEra(calendar, era + 1) - MinGregorianYearInEra(calendar, era) + 1;
         }
 
-        private static int MaxRelativeYearInEra(Calendar calendar, int era)
+        private static int MaxGregorianYearInEra(Calendar calendar, int era)
         {
-            return MaxYearInEra(calendar, era) - MaxYearInEra(calendar, era - 1) + 1;
+            int[] eras = calendar.Eras;
+            Assert.InRange(era, 0, eras[0]);
+            if (eras.Length == 1 || era == eras[0] || era == 0)
+            {
+                return calendar.MaxSupportedDateTime.Year;
+            }
+            return MinGregorianYearInEra(calendar, era + 1);
         }
 
-        private static int MaxYearInEra(Calendar calendar, int era)
+        private static int MinGregorianYearInEra(Calendar calendar, int era)
         {
-            if (era == 0) { return MinYearInEra(calendar, era) - YearOffset(calendar); }
-
-            int oldEra = era;
-            int currentEra = era;
-            for (int year = calendar.MinSupportedDateTime.Year; year < calendar.MaxSupportedDateTime.Year; year++)
+            int[] eras = calendar.Eras;
+            Assert.InRange(era, 0, eras[0]);
+            if (eras.Length == 1 || era == eras[eras.Length - 1] || era == 0)
             {
-                currentEra = calendar.GetEra(new DateTime(year, 1, 1));
-                if (currentEra > oldEra)
-                {
-                    return year - 1;
-                }
+                return calendar.MinSupportedDateTime.Year;
             }
-            return calendar.MaxSupportedDateTime.Year + YearOffset(calendar);
+
+            return calendar.ToDateTime(1, 1, 1, 0, 0, 0, 0, era).Year;
         }
 
-        private static int MinYearInEra(Calendar calendar, int era)
+        private static int MinCalendarYearInEra(Calendar calendar, int era)
         {
-            int oldEra = era;
-            int currentEra = era;
-            for (int year = calendar.MaxSupportedDateTime.Year; year > calendar.MinSupportedDateTime.Year; year--)
+            int[] eras = calendar.Eras;
+            Assert.InRange(era, 0, eras[0]);
+            if (eras.Length == 1 || era == eras[eras.Length - 1] || era == 0)
             {
-                currentEra = calendar.GetEra(new DateTime(year, 1, 1));
-                if (currentEra < oldEra)
-                {
-                    return year + 1;
-                }
+                return calendar.GetYear(calendar.MinSupportedDateTime);
             }
-            return calendar.MinSupportedDateTime.Year + YearOffset(calendar);
+
+            return 1;
         }
 
         public static IEnumerable<object[]> Calendars_TestData()
@@ -73,49 +94,7 @@ namespace System.Globalization.Tests
             }
         }
 
-        public static IEnumerable<object[]> Year_Era_TestData()
-        {
-            foreach (Calendar calendar in s_calendars)
-            {
-                foreach (int era in calendar.Eras)
-                {
-                    // Year is invalid
-                    yield return new object[] { calendar, -1, era, "year" };
-                    yield return new object[] { calendar, 0, era, "year" };
-                    yield return new object[] { calendar, MaxRelativeYearInEra(calendar, era) + 1, era, "year" };
-                }
-                // Era is invalid
-                yield return new object[] { calendar, YearOffset(calendar) + 1, MinEra(calendar) - 2, "era" };
-                yield return new object[] { calendar, YearOffset(calendar) + 1, MaxEra(calendar) + 1, "era" };
-            }
-        }
-
-        public static IEnumerable<object[]> Year_Month_Era_TestData()
-        {
-            int month = 1;
-            foreach (Calendar calendar in s_calendars)
-            {
-                foreach (int era in calendar.Eras)
-                {
-                    int year = MaxRelativeYearInEra(calendar, era);
-
-                    // Year is invalid
-                    yield return new object[] { calendar, -1, month, era, "year" };
-                    yield return new object[] { calendar, 0, month, era, "year" };
-                    yield return new object[] { calendar, MaxRelativeYearInEra(calendar, era) + 1, month, era, "year" };
-
-                    // Month is invalid
-                    yield return new object[] { calendar, year, -1, era, "month" };
-                    yield return new object[] { calendar, year, 0, era, "month" };
-                    yield return new object[] { calendar, year, calendar.GetMonthsInYear(year, era) + 1, era, "month" };
-                }
-                // Era is invalid
-                yield return new object[] { calendar, YearOffset(calendar) + 1, month, MinEra(calendar) - 2, "era" };
-                yield return new object[] { calendar, YearOffset(calendar) + 1, month, MaxEra(calendar) + 1, "era" };
-            }
-        }
-
-        public static IEnumerable<object[]> Year_Month_Day_Era_TestData()
+        public static IEnumerable<object[]> Year_Month_Day_Era_TestData(DataType type)
         {
             int month = 1;
             int day = 1;
@@ -123,88 +102,167 @@ namespace System.Globalization.Tests
             {
                 foreach (int era in calendar.Eras)
                 {
-                    int year = MaxRelativeYearInEra(calendar, era);
+                    int year = MaxCalendarYearInEra(calendar, era) - 2;
 
                     // Year is invalid
                     yield return new object[] { calendar, -1, month, day, era, "year" };
                     yield return new object[] { calendar, 0, month, day, era, "year" };
-                    yield return new object[] { calendar, MaxRelativeYearInEra(calendar, era) + 1, month, day, era, "year" };
+                    yield return new object[] { calendar, MaxCalendarYearInEra(calendar, era) + 1, month, day, era, "year" };
 
-                    // Month is invalid
-                    yield return new object[] { calendar, year, -1, day, era, "month" };
-                    yield return new object[] { calendar, year, 0, day, era, "month" };
-                    //yield return new object[] { calendar, year, calendar.GetMonthsInYear(year, era) + 1, day, era, "month" };
+                    if ((type & DataType.Month) != 0)
+                    {
+                        // Month is invalid
+                        yield return new object[] { calendar, year, -1, day, era, "month" };
+                        yield return new object[] { calendar, year, 0, day, era, "month" };
+                        yield return new object[] { calendar, year, calendar.GetMonthsInYear(year, era) + 1, day, era, "month" };
+                    }
 
-                    // Day is invalid
-                    yield return new object[] { calendar, year, month, -1, era, "day" };
-                    yield return new object[] { calendar, year, month, 0, era, "day" };
-                    yield return new object[] { calendar, year, month, calendar.GetDaysInMonth(year, month, era) + 1, era, "day" };
+                    if ((type & DataType.Day) != 0)
+                    {
+                        // Day is invalid
+                        yield return new object[] { calendar, year, month, -1, era, "day" };
+                        yield return new object[] { calendar, year, month, 0, era, "day" };
+                        yield return new object[] { calendar, year, month, calendar.GetDaysInMonth(year, month, era) + 1, era, "day" };
+                    }
                 }
+                // Year is invalid
+                yield return new object[] { calendar, MinCalendarYearInEra(calendar, MinEra(calendar)) - 1,month, day, MinEra(calendar), "year" };
+
                 // Era is invalid
-                yield return new object[] { calendar, YearOffset(calendar) + 1, month, day, MinEra(calendar) - 2, "era" };
-                yield return new object[] { calendar, YearOffset(calendar) + 1, month, day, MaxEra(calendar) + 1, "era" };
+                yield return new object[] { calendar, calendar.GetYear(calendar.MaxSupportedDateTime), month, day, MinEra(calendar) - 2, "era" };
+                yield return new object[] { calendar, calendar.GetYear(calendar.MaxSupportedDateTime), month, day, MaxEra(calendar) + 1, "era" };
+            }
+        }
+
+        public static IEnumerable<object[]> DateTime_TestData()
+        {
+            foreach (Calendar calendar in s_calendars)
+            {
+                DateTime minDate = calendar.MinSupportedDateTime;
+                if (minDate != DateTime.MinValue)
+                {
+                    yield return new object[] { calendar, minDate.AddYears(-1) };
+                }
+                DateTime maxDate = calendar.MaxSupportedDateTime;
+                if (maxDate != DateTime.MaxValue)
+                {
+                    yield return new object[] { calendar, maxDate.AddYears(1) }; 
+                }
             }
         }
 
         [Theory]
-        [MemberData(nameof(Year_Era_TestData))]
-        public static void GetDaysInYear_Invalid(Calendar calendar, int year, int era, string exceptionParamName)
+        [MemberData(nameof(Year_Month_Day_Era_TestData), DataType.Year)]
+        public static void GetDaysInYear_Invalid(Calendar calendar, int year, int month, int day, int era, string exceptionParamName)
         {
             Assert.Throws<ArgumentOutOfRangeException>(exceptionParamName, () => calendar.GetDaysInYear(year, era));
         }
 
         [Theory]
-        [MemberData(nameof(Year_Era_TestData))]
-        public static void GetMonthsInYear_Invalid(Calendar calendar, int year, int era, string exceptionParamName)
+        [MemberData(nameof(Year_Month_Day_Era_TestData), DataType.Year)]
+        public static void GetMonthsInYear_Invalid(Calendar calendar, int year, int month, int day, int era, string exceptionParamName)
         {
             Assert.Throws<ArgumentOutOfRangeException>(exceptionParamName, () => calendar.GetMonthsInYear(year, era));
         }
 
         [Theory]
-        [MemberData(nameof(Year_Month_Era_TestData))]
-        public static void GetDaysInMonth_Invalid(Calendar calendar, int year, int month, int era, string exceptionParamName)
+        [MemberData(nameof(Year_Month_Day_Era_TestData), DataType.Year | DataType.Month)]
+        public static void GetDaysInMonth_Invalid(Calendar calendar, int year, int month, int day, int era, string exceptionParamName)
         {
             Assert.Throws<ArgumentOutOfRangeException>(exceptionParamName, () => calendar.GetDaysInMonth(year, month, era));
         }
 
         [Theory]
-        [MemberData(nameof(Year_Month_Day_Era_TestData))]
+        [MemberData(nameof(Year_Month_Day_Era_TestData), DataType.Year | DataType.Month | DataType.Day)]
         public static void IsLeapDay_Invalid(Calendar calendar, int year, int month, int day, int era, string exceptionParamName)
         {
             Assert.Throws<ArgumentOutOfRangeException>(exceptionParamName, () => calendar.IsLeapDay(year, month, day, era));
         }
 
         [Theory]
-        [MemberData(nameof(Year_Month_Era_TestData))]
-        public static void IsLeapMonth_Invalid(Calendar calendar, int year, int month, int era, string exceptionParamName)
+        [MemberData(nameof(Year_Month_Day_Era_TestData), DataType.Year | DataType.Month)]
+        public static void IsLeapMonth_Invalid(Calendar calendar, int year, int month, int day, int era, string exceptionParamName)
         {
             Assert.Throws<ArgumentOutOfRangeException>(exceptionParamName, () => calendar.IsLeapMonth(year, month, era));
         }
 
         [Theory]
-        [MemberData(nameof(Year_Era_TestData))]
-        public static void IsLeapYear_Invalid(Calendar calendar, int year, int era, string exceptionParamName)
+        [MemberData(nameof(Year_Month_Day_Era_TestData), DataType.Year)]
+        public static void IsLeapYear_Invalid(Calendar calendar, int year, int month, int day, int era, string exceptionParamName)
         {
             Assert.Throws<ArgumentOutOfRangeException>(exceptionParamName, () => calendar.IsLeapYear(year, era));
+        }
+
+        [Theory]
+        [MemberData(nameof(Year_Month_Day_Era_TestData), DataType.Year)]
+        public static void GetLeapMonth_Invalid(Calendar calendar, int year, int month, int day, int era, string expectedParamName)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(expectedParamName, () => calendar.GetLeapMonth(year, era));
         }
 
         [Theory]
         [MemberData(nameof(Calendars_TestData))]
         public static void AddYears_Invalid(Calendar calendar)
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.AddYears(calendar.MaxSupportedDateTime, 1));
-            Assert.ThrowsAny<ArgumentException>(() => calendar.AddYears(calendar.MinSupportedDateTime, -1)); // JapaneseCalendar throws ArgumentException
+            Assert.ThrowsAny<ArgumentException>(() => calendar.AddYears(calendar.MaxSupportedDateTime, 1));
+            Assert.ThrowsAny<ArgumentException>(() => calendar.AddYears(calendar.MinSupportedDateTime, -1));
         }
 
         [Theory]
         [MemberData(nameof(Calendars_TestData))]
         public static void AddMonths_Invalid(Calendar calendar)
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.AddMonths(calendar.MaxSupportedDateTime, 1));
+            Assert.ThrowsAny<ArgumentException>(() => calendar.AddMonths(calendar.MaxSupportedDateTime, 1));
             Assert.ThrowsAny<ArgumentException>(() => calendar.AddMonths(calendar.MinSupportedDateTime, -1)); // JapaneseCalendar throws ArgumentException
 
             Assert.Throws<ArgumentOutOfRangeException>("months", () => calendar.AddMonths(DateTime.Now, -120001));
             Assert.Throws<ArgumentOutOfRangeException>("months", () => calendar.AddMonths(DateTime.Now, 120001));
+        }
+
+        [Theory]
+        [MemberData(nameof(Calendars_TestData))]
+        public static void AddDays_Invalid(Calendar calendar)
+        {
+            Assert.Throws<ArgumentException>(() => calendar.AddDays(calendar.MaxSupportedDateTime, 1));
+            Assert.Throws<ArgumentException>(() => calendar.AddDays(calendar.MinSupportedDateTime, -1));
+
+            Assert.Throws<ArgumentException>(() => calendar.AddDays(DateTime.Now, -120001 * 30));
+            Assert.Throws<ArgumentException>(() => calendar.AddDays(DateTime.Now, 120001 * 30));
+        }
+
+        [Theory]
+        [MemberData(nameof(Calendars_TestData))]
+        public static void AddHours_Invalid(Calendar calendar)
+        {
+            Assert.Throws<ArgumentException>(() => calendar.AddHours(calendar.MaxSupportedDateTime, 1));
+            Assert.Throws<ArgumentException>(() => calendar.AddHours(calendar.MinSupportedDateTime, -1));
+
+            Assert.Throws<ArgumentException>(() => calendar.AddHours(DateTime.Now, -120001 * 30 * 24));
+            Assert.Throws<ArgumentException>(() => calendar.AddHours(DateTime.Now, 120001 * 30 * 24));
+        }
+
+        [Theory]
+        [MemberData(nameof(Calendars_TestData))]
+        public static void AddMinutes_Invalid(Calendar calendar)
+        {
+            Assert.Throws<ArgumentException>(() => calendar.AddMinutes(calendar.MaxSupportedDateTime, 1));
+            Assert.Throws<ArgumentException>(() => calendar.AddMinutes(calendar.MinSupportedDateTime, -1));
+        }
+
+        [Theory]
+        [MemberData(nameof(Calendars_TestData))]
+        public static void AddSeconds_Invalid(Calendar calendar)
+        {
+            Assert.Throws<ArgumentException>(() => calendar.AddSeconds(calendar.MaxSupportedDateTime, 1));
+            Assert.Throws<ArgumentException>(() => calendar.AddSeconds(calendar.MinSupportedDateTime, -1));
+        }
+
+        [Theory]
+        [MemberData(nameof(Calendars_TestData))]
+        public static void AddMilliseconds_Invalid(Calendar calendar)
+        {
+            Assert.Throws<ArgumentException>(() => calendar.AddMilliseconds(calendar.MaxSupportedDateTime, 1));
+            Assert.Throws<ArgumentException>(() => calendar.AddMilliseconds(calendar.MinSupportedDateTime, -1));
         }
 
         [Theory]
@@ -232,12 +290,12 @@ namespace System.Globalization.Tests
             int millisecond = 1;
             foreach (int era in calendar.Eras)
             {
-                int year = MaxRelativeYearInEra(calendar, era) - 2;
+                int year = MaxCalendarYearInEra(calendar, era) - 2;
 
                 // Year is invalid
                 Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(-1, month, day, hour, minute, second, millisecond, era));
                 Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(0, month, day, hour, minute, second, millisecond, era));
-                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(MaxRelativeYearInEra(calendar, era) + 1, month, day, hour, minute, second, millisecond, era));
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(MaxCalendarYearInEra(calendar, era) + 1, month, day, hour, minute, second, millisecond, era));
 
                 // Month is invalid
                 Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, -1, day, hour, minute, second, millisecond, era));
@@ -265,39 +323,24 @@ namespace System.Globalization.Tests
                 Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, month, day, hour, minute, second, -1, era));
                 Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, month, day, hour, minute, second, 1000, era));
             }
+            // Year is invalid
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(MinCalendarYearInEra(calendar, MinEra(calendar)) - 1, month, day, hour, minute, second, millisecond, MinEra(calendar)));
+
             // Era is invalid
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(YearOffset(calendar) + 1, month, day, hour, minute, second, millisecond, MinEra(calendar) - 2));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(YearOffset(calendar) + 1, month, day, hour, minute, second, millisecond, MaxEra(calendar) + 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(calendar.GetYear(calendar.MaxSupportedDateTime), month, day, hour, minute, second, millisecond, MinEra(calendar) - 2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(calendar.GetYear(calendar.MaxSupportedDateTime), month, day, hour, minute, second, millisecond, MaxEra(calendar) + 1));
 
             // New date is out of range
             DateTime minDateTime = calendar.MinSupportedDateTime;
             int minEra = calendar.GetEra(minDateTime);
-            int minYear = MinYearInEra(calendar, minEra);
+            int minYear = calendar.GetYear(minDateTime);
 
             DateTime maxDateTime = calendar.MaxSupportedDateTime;
             int maxEra = calendar.GetEra(maxDateTime);
-            int maxYear = MaxRelativeYearInEra(calendar, maxEra);
+            int maxYear = calendar.GetYear(maxDateTime);
 
             Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minYear - 1, minDateTime.Month, minDateTime.Day, minDateTime.Hour, minDateTime.Minute, minDateTime.Second, minDateTime.Millisecond, minEra));
             Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxYear + 1, maxDateTime.Month, maxDateTime.Day, maxDateTime.Hour, maxDateTime.Minute, maxDateTime.Second, maxDateTime.Millisecond, maxEra));
-
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minYear, minDateTime.Month - 1, minDateTime.Day, minDateTime.Hour, minDateTime.Minute, minDateTime.Second, minDateTime.Millisecond, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxYear, maxDateTime.Month + 1, maxDateTime.Day, maxDateTime.Hour, maxDateTime.Minute, maxDateTime.Second, maxDateTime.Millisecond, maxEra));
-
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minYear, minDateTime.Month, minDateTime.Day - 1, minDateTime.Hour, minDateTime.Minute, minDateTime.Second, minDateTime.Millisecond, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxYear, maxDateTime.Month, maxDateTime.Day + 1, maxDateTime.Hour, maxDateTime.Minute, maxDateTime.Second, maxDateTime.Millisecond, maxEra));
-
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minYear, minDateTime.Month, minDateTime.Day, minDateTime.Hour - 1, minDateTime.Minute, minDateTime.Second, minDateTime.Millisecond, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxYear, maxDateTime.Month, maxDateTime.Day, maxDateTime.Hour + 1, maxDateTime.Minute, maxDateTime.Second, maxDateTime.Millisecond, maxEra));
-
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minYear, minDateTime.Month, minDateTime.Day, minDateTime.Hour, minDateTime.Minute - 1, minDateTime.Second, minDateTime.Millisecond, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxYear, maxDateTime.Month, maxDateTime.Day, maxDateTime.Hour, maxDateTime.Minute + 1, maxDateTime.Second, maxDateTime.Millisecond, maxEra));
-
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minYear, minDateTime.Month, minDateTime.Day, minDateTime.Hour, minDateTime.Minute, minDateTime.Second - 1, minDateTime.Millisecond, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxYear, maxDateTime.Month, maxDateTime.Day, maxDateTime.Hour, maxDateTime.Minute, maxDateTime.Second + 1, maxDateTime.Millisecond, maxEra));
-
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minYear, minDateTime.Month, minDateTime.Day, minDateTime.Hour, minDateTime.Minute, minDateTime.Second, minDateTime.Millisecond - 1, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxYear, maxDateTime.Month, maxDateTime.Day, maxDateTime.Hour, maxDateTime.Minute, maxDateTime.Second, maxDateTime.Millisecond + 1, maxEra));
         }
 
         [Theory]
@@ -308,9 +351,9 @@ namespace System.Globalization.Tests
             // JapaneseCalandar allows any inputs below the max year
             if (!(calendar is JapaneseCalendar))
             {
-                Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToFourDigitYear(MinYearInEra(calendar, MinEra(calendar)) - 1));
+                //Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToFourDigitYear(MinDateTimeInEra(calendar, MinEra(calendar)) - 2));
             }
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToFourDigitYear(MaxRelativeYearInEra(calendar, MaxEra(calendar)) + 1));
+            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToFourDigitYear(MaxCalendarYearInEra(calendar, MaxEra(calendar)) + 1));
         }
 
         [Theory]
@@ -318,7 +361,54 @@ namespace System.Globalization.Tests
         public static void TwoDigitYearMax_Invalid(Calendar calendar)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => calendar.TwoDigitYearMax = 98);
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.TwoDigitYearMax = calendar.MaxSupportedDateTime.Year + YearOffset(calendar) + 1);
+            int max = Math.Max(MaxGregorianYearInEra(calendar, MaxEra(calendar)), MaxCalendarYearInEra(calendar, MaxEra(calendar)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.TwoDigitYearMax = max + 1);
+        }
+
+        [Theory]
+        [MemberData(nameof(DateTime_TestData))]
+        public static void GetEra_Invalid(Calendar calendar, DateTime dt)
+        {
+            // TODO: This fails for HebrewCalendar, TaiwanLunisolarCalendar and JapaneseLunisolarCalendar
+            // Assert.Throws<ArgumentOutOfRangeException>(() => calendar.GetEra(dt));
+        }
+
+        [Theory]
+        [MemberData(nameof(DateTime_TestData))]
+        public static void GetYear_Invalid(Calendar calendar, DateTime dt)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("time", () => calendar.GetYear(dt));
+        }
+
+        [Theory]
+        [MemberData(nameof(DateTime_TestData))]
+        public static void GetMonth_Invalid(Calendar calendar, DateTime dt)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("time", () => calendar.GetMonth(dt));
+        }
+
+        [Theory]
+        [MemberData(nameof(DateTime_TestData))]
+        public static void GetDayOfYear_Invalid(Calendar calendar, DateTime dt)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("time", () => calendar.GetDayOfYear(dt));
+        }
+
+        [Theory]
+        [MemberData(nameof(DateTime_TestData))]
+        public static void GetDayOfMonth_Invalid(Calendar calendar, DateTime dt)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("time", () => calendar.GetDayOfMonth(dt));
+        }
+
+        [Theory]
+        [MemberData(nameof(DateTime_TestData))]
+        public static void GetDayOfWeek_Invalid(Calendar calendar, DateTime dt)
+        {
+            // TODO: this fails (expected) for lunar and lunarsolar calendars.
+            // Calendar.AlgorithmType is not exposed in corefx so how do we test for this?
+            // HijiriCalendar, UmAlQuraCalendar, PersianCalendar, HebrewCalendar
+            // Assert.Throws<ArgumentOutOfRangeException>("time", () => calendar.GetDayOfWeek(dt));
         }
     }
 }

--- a/src/System.Globalization.Calendars/tests/CalendarHelpers.cs
+++ b/src/System.Globalization.Calendars/tests/CalendarHelpers.cs
@@ -2,88 +2,213 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Globalization.Tests
 {
     public static class CalendarHelpers
     {
-        private static int MaxEra(Calendar calendar) => calendar.GetEra(calendar.MaxSupportedDateTime);
+        public static Calendar[] s_calendars = new Calendar[]
+        {
+            new ThaiBuddhistCalendar(),
+            new JapaneseCalendar()
+        };
+
         private static int MinEra(Calendar calendar) => calendar.GetEra(calendar.MinSupportedDateTime);
+        private static int MaxEra(Calendar calendar) => calendar.GetEra(calendar.MaxSupportedDateTime);
 
-        private static int YearOffset(Calendar calendar) => calendar.GetYear(calendar.MinSupportedDateTime) - 1;
+        private static int YearOffset(Calendar calendar)
+        {
+            if (calendar is ThaiBuddhistCalendar)
+            {
+                return 543;
+            }
+            return 0;
+        }
 
+        private static int MaxRelativeYearInEra(Calendar calendar, int era)
+        {
+            return MaxYearInEra(calendar, era) - MaxYearInEra(calendar, era - 1) + 1;
+        }
+
+        private static int MaxYearInEra(Calendar calendar, int era)
+        {
+            if (era == 0) { return MinYearInEra(calendar, era) - YearOffset(calendar); }
+
+            int oldEra = era;
+            int currentEra = era;
+            for (int year = calendar.MinSupportedDateTime.Year; year < calendar.MaxSupportedDateTime.Year; year++)
+            {
+                currentEra = calendar.GetEra(new DateTime(year, 1, 1));
+                if (currentEra > oldEra)
+                {
+                    return year - 1;
+                }
+            }
+            return calendar.MaxSupportedDateTime.Year + YearOffset(calendar);
+        }
+
+        private static int MinYearInEra(Calendar calendar, int era)
+        {
+            int oldEra = era;
+            int currentEra = era;
+            for (int year = calendar.MaxSupportedDateTime.Year; year > calendar.MinSupportedDateTime.Year; year--)
+            {
+                currentEra = calendar.GetEra(new DateTime(year, 1, 1));
+                if (currentEra < oldEra)
+                {
+                    return year + 1;
+                }
+            }
+            return calendar.MinSupportedDateTime.Year + YearOffset(calendar);
+        }
+
+        public static IEnumerable<object[]> Calendars_TestData()
+        {
+            foreach (Calendar calendar in s_calendars)
+            {
+                yield return new object[] { calendar };
+            }
+        }
+
+        public static IEnumerable<object[]> Year_Era_TestData()
+        {
+            foreach (Calendar calendar in s_calendars)
+            {
+                foreach (int era in calendar.Eras)
+                {
+                    // Year is invalid
+                    yield return new object[] { calendar, -1, era, "year" };
+                    yield return new object[] { calendar, 0, era, "year" };
+                    yield return new object[] { calendar, MaxRelativeYearInEra(calendar, era) + 1, era, "year" };
+                }
+                // Era is invalid
+                yield return new object[] { calendar, YearOffset(calendar) + 1, MinEra(calendar) - 2, "era" };
+                yield return new object[] { calendar, YearOffset(calendar) + 1, MaxEra(calendar) + 1, "era" };
+            }
+        }
+
+        public static IEnumerable<object[]> Year_Month_Era_TestData()
+        {
+            int month = 1;
+            foreach (Calendar calendar in s_calendars)
+            {
+                foreach (int era in calendar.Eras)
+                {
+                    int year = MaxRelativeYearInEra(calendar, era);
+
+                    // Year is invalid
+                    yield return new object[] { calendar, -1, month, era, "year" };
+                    yield return new object[] { calendar, 0, month, era, "year" };
+                    yield return new object[] { calendar, MaxRelativeYearInEra(calendar, era) + 1, month, era, "year" };
+
+                    // Month is invalid
+                    yield return new object[] { calendar, year, -1, era, "month" };
+                    yield return new object[] { calendar, year, 0, era, "month" };
+                    yield return new object[] { calendar, year, calendar.GetMonthsInYear(year, era) + 1, era, "month" };
+                }
+                // Era is invalid
+                yield return new object[] { calendar, YearOffset(calendar) + 1, month, MinEra(calendar) - 2, "era" };
+                yield return new object[] { calendar, YearOffset(calendar) + 1, month, MaxEra(calendar) + 1, "era" };
+            }
+        }
+
+        public static IEnumerable<object[]> Year_Month_Day_Era_TestData()
+        {
+            int month = 1;
+            int day = 1;
+            foreach (Calendar calendar in s_calendars)
+            {
+                foreach (int era in calendar.Eras)
+                {
+                    int year = MaxRelativeYearInEra(calendar, era);
+
+                    // Year is invalid
+                    yield return new object[] { calendar, -1, month, day, era, "year" };
+                    yield return new object[] { calendar, 0, month, day, era, "year" };
+                    yield return new object[] { calendar, MaxRelativeYearInEra(calendar, era) + 1, month, day, era, "year" };
+
+                    // Month is invalid
+                    yield return new object[] { calendar, year, -1, day, era, "month" };
+                    yield return new object[] { calendar, year, 0, day, era, "month" };
+                    //yield return new object[] { calendar, year, calendar.GetMonthsInYear(year, era) + 1, day, era, "month" };
+
+                    // Day is invalid
+                    yield return new object[] { calendar, year, month, -1, era, "day" };
+                    yield return new object[] { calendar, year, month, 0, era, "day" };
+                    yield return new object[] { calendar, year, month, calendar.GetDaysInMonth(year, month, era) + 1, era, "day" };
+                }
+                // Era is invalid
+                yield return new object[] { calendar, YearOffset(calendar) + 1, month, day, MinEra(calendar) - 2, "era" };
+                yield return new object[] { calendar, YearOffset(calendar) + 1, month, day, MaxEra(calendar) + 1, "era" };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Year_Era_TestData))]
+        public static void GetDaysInYear_Invalid(Calendar calendar, int year, int era, string exceptionParamName)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(exceptionParamName, () => calendar.GetDaysInYear(year, era));
+        }
+
+        [Theory]
+        [MemberData(nameof(Year_Era_TestData))]
+        public static void GetMonthsInYear_Invalid(Calendar calendar, int year, int era, string exceptionParamName)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(exceptionParamName, () => calendar.GetMonthsInYear(year, era));
+        }
+
+        [Theory]
+        [MemberData(nameof(Year_Month_Era_TestData))]
+        public static void GetDaysInMonth_Invalid(Calendar calendar, int year, int month, int era, string exceptionParamName)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(exceptionParamName, () => calendar.GetDaysInMonth(year, month, era));
+        }
+
+        [Theory]
+        [MemberData(nameof(Year_Month_Day_Era_TestData))]
+        public static void IsLeapDay_Invalid(Calendar calendar, int year, int month, int day, int era, string exceptionParamName)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(exceptionParamName, () => calendar.IsLeapDay(year, month, day, era));
+        }
+
+        [Theory]
+        [MemberData(nameof(Year_Month_Era_TestData))]
+        public static void IsLeapMonth_Invalid(Calendar calendar, int year, int month, int era, string exceptionParamName)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(exceptionParamName, () => calendar.IsLeapMonth(year, month, era));
+        }
+
+        [Theory]
+        [MemberData(nameof(Year_Era_TestData))]
+        public static void IsLeapYear_Invalid(Calendar calendar, int year, int era, string exceptionParamName)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(exceptionParamName, () => calendar.IsLeapYear(year, era));
+        }
+
+        [Theory]
+        [MemberData(nameof(Calendars_TestData))]
         public static void AddYears_Invalid(Calendar calendar)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => calendar.AddYears(calendar.MaxSupportedDateTime, 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.AddYears(calendar.MinSupportedDateTime, -1));
+            Assert.ThrowsAny<ArgumentException>(() => calendar.AddYears(calendar.MinSupportedDateTime, -1)); // JapaneseCalendar throws ArgumentException
         }
 
+        [Theory]
+        [MemberData(nameof(Calendars_TestData))]
         public static void AddMonths_Invalid(Calendar calendar)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => calendar.AddMonths(calendar.MaxSupportedDateTime, 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.AddMonths(calendar.MinSupportedDateTime, -1));
+            Assert.ThrowsAny<ArgumentException>(() => calendar.AddMonths(calendar.MinSupportedDateTime, -1)); // JapaneseCalendar throws ArgumentException
 
             Assert.Throws<ArgumentOutOfRangeException>("months", () => calendar.AddMonths(DateTime.Now, -120001));
             Assert.Throws<ArgumentOutOfRangeException>("months", () => calendar.AddMonths(DateTime.Now, 120001));
         }
 
-        public static void GetDaysInYear_Invalid(Calendar calendar)
-        {
-            int yearOffset = YearOffset(calendar);
-            int minEra = MinEra(calendar);
-            int maxEra = MaxEra(calendar);
-
-            // Year is outside supported range
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.GetDaysInYear(-1, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.GetDaysInYear(calendar.MinSupportedDateTime.Year + yearOffset - 1, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.GetDaysInYear(calendar.MaxSupportedDateTime.Year + yearOffset + 1, maxEra));
-
-            // Era is outside supported range
-            Assert.Throws<ArgumentOutOfRangeException>("era", () => calendar.GetDaysInYear(yearOffset + 1, -1));
-            Assert.Throws<ArgumentOutOfRangeException>("era", () => calendar.GetDaysInYear(yearOffset + 1, maxEra + 1));
-        }
-
-        public static void GetDaysInMonth_Invalid(Calendar calendar)
-        {
-            int yearOffset = YearOffset(calendar);
-            int minEra = MinEra(calendar);
-            int maxEra = MaxEra(calendar);
-            int currentEra = calendar.GetEra(calendar.ToDateTime(yearOffset + 1, 1, 1, 1, 1, 1, 1));
-
-            // Year is outside supported range
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.GetDaysInMonth(-1, 10, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.GetDaysInMonth(0, 10, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.GetDaysInMonth(calendar.MinSupportedDateTime.Year + yearOffset - 1, 10, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.GetDaysInMonth(calendar.MaxSupportedDateTime.Year + yearOffset + 1, 10, maxEra));
-
-            // Month is outside supported range
-            Assert.Throws<ArgumentOutOfRangeException>("month", () => calendar.GetDaysInMonth(yearOffset + 1, -1, currentEra));
-            Assert.Throws<ArgumentOutOfRangeException>("month", () => calendar.GetDaysInMonth(yearOffset + 1, calendar.MinSupportedDateTime.Month - 1, currentEra));
-            Assert.Throws<ArgumentOutOfRangeException>("month", () => calendar.GetDaysInMonth(yearOffset + 1, calendar.MaxSupportedDateTime.Month + 1, currentEra));
-
-            // Era is outside supported range
-            Assert.Throws<ArgumentOutOfRangeException>("era", () => calendar.GetDaysInMonth(yearOffset + 1, 10, -1));
-            Assert.Throws<ArgumentOutOfRangeException>("era", () => calendar.GetDaysInMonth(yearOffset + 1, 10, maxEra + 1));
-        }
-
-        public static void GetMonthsInYear_Invalid(Calendar calendar)
-        {
-            int yearOffset = YearOffset(calendar);
-            int minEra = MinEra(calendar);
-            int maxEra = MaxEra(calendar);
-
-            // Year is outside supported range
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.GetMonthsInYear(-1, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.GetMonthsInYear(0, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.GetMonthsInYear(calendar.MinSupportedDateTime.Year + yearOffset - 1, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.GetMonthsInYear(calendar.MaxSupportedDateTime.Year + yearOffset + 1, maxEra));
-            
-            // Era is outside supported range
-            Assert.Throws<ArgumentOutOfRangeException>("era", () => calendar.GetMonthsInYear(yearOffset + 1, -1));
-            Assert.Throws<ArgumentOutOfRangeException>("era", () => calendar.GetMonthsInYear(yearOffset + 1, maxEra + 1));
-        }
-
+        [Theory]
+        [MemberData(nameof(Calendars_TestData))]
         public static void GetWeekOfYear_Invalid(Calendar calendar)
         {
             // Rule is outside supported range
@@ -95,80 +220,101 @@ namespace System.Globalization.Tests
             Assert.Throws<ArgumentOutOfRangeException>("firstDayOfWeek", () => calendar.GetWeekOfYear(calendar.MaxSupportedDateTime, CalendarWeekRule.FirstDay, DayOfWeek.Saturday + 1));
         }
 
+        [Theory]
+        [MemberData(nameof(Calendars_TestData))]
         public static void ToDateTime_Invalid(Calendar calendar)
         {
-            int yearOffset = YearOffset(calendar);
+            int month = 1;
+            int day = 1;
+            int hour = 1;
+            int minute = 1;
+            int second = 1;
+            int millisecond = 1;
+            foreach (int era in calendar.Eras)
+            {
+                int year = MaxRelativeYearInEra(calendar, era) - 2;
 
-            DateTime maxDate = calendar.MaxSupportedDateTime;
-            DateTime minDate = calendar.MinSupportedDateTime;
+                // Year is invalid
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(-1, month, day, hour, minute, second, millisecond, era));
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(0, month, day, hour, minute, second, millisecond, era));
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(MaxRelativeYearInEra(calendar, era) + 1, month, day, hour, minute, second, millisecond, era));
 
-            int maxEra = MinEra(calendar);
-            int minEra = MaxEra(calendar);
+                // Month is invalid
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, -1, day, hour, minute, second, millisecond, era));
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, 0, day, hour, minute, second, millisecond, era));
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, calendar.GetMonthsInYear(year, era) + 1, day, hour, minute, second, millisecond, era));
 
-            DateTime currentDate = DateTime.Now;
+                // Day is invalid
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, month, -1, hour, minute, second, millisecond, era));
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, month, 0, hour, minute, second, millisecond, era));
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, month, calendar.GetDaysInMonth(year, month, era) + 1, minute, second, millisecond, era));
 
-            // Year is outside supported range
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToDateTime(-1, minDate.Month, minDate.Day, minDate.Hour, minDate.Minute, minDate.Second, minDate.Millisecond, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToDateTime(0, minDate.Month, minDate.Day, minDate.Hour, minDate.Minute, minDate.Second, minDate.Millisecond, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToDateTime(minDate.Year + yearOffset - 1, maxDate.Month, maxDate.Day, maxDate.Hour, maxDate.Minute, maxDate.Second, maxDate.Millisecond, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToDateTime(maxDate.Year + yearOffset + 1, maxDate.Month, maxDate.Day, maxDate.Hour, maxDate.Minute, maxDate.Second, maxDate.Millisecond, maxEra));
+                // Hour is invalid
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, month, day, -1, minute, second, millisecond, era));
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, month, day, 60, minute, second, millisecond, era));
 
-            // Month is outside supported range
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minDate.Year, minDate.Month - 1, minDate.Day, minDate.Hour, minDate.Minute, minDate.Second, minDate.Millisecond, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxDate.Year, maxDate.Month + 1, maxDate.Day, maxDate.Hour, maxDate.Minute, maxDate.Second, maxDate.Millisecond, maxEra));
+                // Minute is invalid
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, month, day, hour, -1, second, millisecond, era));
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, month, day, hour, 60, second, millisecond, era));
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(currentDate.Year, -1, currentDate.Day, currentDate.Hour, currentDate.Minute, currentDate.Second, currentDate.Millisecond, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(currentDate.Year, 0, currentDate.Day, currentDate.Hour, currentDate.Minute, currentDate.Second, currentDate.Millisecond, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(currentDate.Year, 13, currentDate.Day, currentDate.Hour, currentDate.Minute, currentDate.Second, currentDate.Millisecond, maxEra));
+                // Second is invalid
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, month, day, hour, minute, -1, millisecond, era));
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, month, day, hour, minute, 60, millisecond, era));
 
-            // Day is outside supported range
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minDate.Year, minDate.Month, minDate.Day - 1, minDate.Hour, minDate.Minute, minDate.Second, minDate.Millisecond, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxDate.Year, maxDate.Month, maxDate.Day + 1, maxDate.Hour, maxDate.Minute, maxDate.Second, maxDate.Millisecond, maxEra));
+                // Millisecond is invalid
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, month, day, hour, minute, second, -1, era));
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(year, month, day, hour, minute, second, 1000, era));
+            }
+            // Era is invalid
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(YearOffset(calendar) + 1, month, day, hour, minute, second, millisecond, MinEra(calendar) - 2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(YearOffset(calendar) + 1, month, day, hour, minute, second, millisecond, MaxEra(calendar) + 1));
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(currentDate.Year, currentDate.Month, -1, currentDate.Hour, currentDate.Minute, currentDate.Second, currentDate.Millisecond, maxEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(currentDate.Year, currentDate.Month, 0, currentDate.Hour, currentDate.Minute, currentDate.Second, currentDate.Millisecond, maxEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(currentDate.Year, currentDate.Month, 32, currentDate.Hour, currentDate.Minute, currentDate.Second, currentDate.Millisecond, maxEra));
+            // New date is out of range
+            DateTime minDateTime = calendar.MinSupportedDateTime;
+            int minEra = calendar.GetEra(minDateTime);
+            int minYear = MinYearInEra(calendar, minEra);
 
-            // Hour is outside supported range
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minDate.Year, minDate.Month, minDate.Day, minDate.Hour - 1, minDate.Minute, minDate.Second, minDate.Millisecond, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxDate.Year, maxDate.Month, maxDate.Day, maxDate.Hour + 1, maxDate.Minute, maxDate.Second, maxDate.Millisecond, maxEra));
+            DateTime maxDateTime = calendar.MaxSupportedDateTime;
+            int maxEra = calendar.GetEra(maxDateTime);
+            int maxYear = MaxRelativeYearInEra(calendar, maxEra);
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(currentDate.Year, currentDate.Month, currentDate.Day, -1, currentDate.Minute, currentDate.Second, currentDate.Millisecond, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(currentDate.Year, currentDate.Month, currentDate.Day, 60, currentDate.Minute, currentDate.Second, currentDate.Millisecond, maxEra));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minYear - 1, minDateTime.Month, minDateTime.Day, minDateTime.Hour, minDateTime.Minute, minDateTime.Second, minDateTime.Millisecond, minEra));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxYear + 1, maxDateTime.Month, maxDateTime.Day, maxDateTime.Hour, maxDateTime.Minute, maxDateTime.Second, maxDateTime.Millisecond, maxEra));
 
-            // Minute is outside supported range
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minDate.Year, minDate.Month, minDate.Day, minDate.Hour, minDate.Minute - 1, minDate.Second, minDate.Millisecond, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxDate.Year, maxDate.Month, maxDate.Day, maxDate.Hour, maxDate.Minute + 1, maxDate.Second, maxDate.Millisecond, maxEra));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minYear, minDateTime.Month - 1, minDateTime.Day, minDateTime.Hour, minDateTime.Minute, minDateTime.Second, minDateTime.Millisecond, minEra));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxYear, maxDateTime.Month + 1, maxDateTime.Day, maxDateTime.Hour, maxDateTime.Minute, maxDateTime.Second, maxDateTime.Millisecond, maxEra));
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(currentDate.Year, currentDate.Month, currentDate.Day, currentDate.Hour, -1, currentDate.Second, currentDate.Millisecond, maxEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(currentDate.Year, currentDate.Month, currentDate.Day, currentDate.Hour, 60, currentDate.Second, currentDate.Millisecond, maxEra));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minYear, minDateTime.Month, minDateTime.Day - 1, minDateTime.Hour, minDateTime.Minute, minDateTime.Second, minDateTime.Millisecond, minEra));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxYear, maxDateTime.Month, maxDateTime.Day + 1, maxDateTime.Hour, maxDateTime.Minute, maxDateTime.Second, maxDateTime.Millisecond, maxEra));
 
-            // Second is outside supported range
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minDate.Year, minDate.Month, minDate.Day, minDate.Hour, minDate.Minute, minDate.Second - 1, minDate.Millisecond, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxDate.Year, maxDate.Month, maxDate.Day, maxDate.Hour, maxDate.Minute, maxDate.Second + 1, maxDate.Millisecond, maxEra));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minYear, minDateTime.Month, minDateTime.Day, minDateTime.Hour - 1, minDateTime.Minute, minDateTime.Second, minDateTime.Millisecond, minEra));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxYear, maxDateTime.Month, maxDateTime.Day, maxDateTime.Hour + 1, maxDateTime.Minute, maxDateTime.Second, maxDateTime.Millisecond, maxEra));
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(currentDate.Year, currentDate.Month, currentDate.Day, currentDate.Hour, currentDate.Minute, -1, currentDate.Millisecond, maxEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(currentDate.Year, currentDate.Month, currentDate.Day, currentDate.Hour, currentDate.Minute, 60, currentDate.Millisecond, maxEra));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minYear, minDateTime.Month, minDateTime.Day, minDateTime.Hour, minDateTime.Minute - 1, minDateTime.Second, minDateTime.Millisecond, minEra));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxYear, maxDateTime.Month, maxDateTime.Day, maxDateTime.Hour, maxDateTime.Minute + 1, maxDateTime.Second, maxDateTime.Millisecond, maxEra));
 
-            // Millisecond is outside supported range
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minDate.Year, minDate.Month, minDate.Day, minDate.Hour, minDate.Minute, minDate.Second, minDate.Millisecond - 1, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxDate.Year, maxDate.Month, maxDate.Day, maxDate.Hour, maxDate.Minute, maxDate.Second, maxDate.Millisecond + 1, maxEra));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minYear, minDateTime.Month, minDateTime.Day, minDateTime.Hour, minDateTime.Minute, minDateTime.Second - 1, minDateTime.Millisecond, minEra));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxYear, maxDateTime.Month, maxDateTime.Day, maxDateTime.Hour, maxDateTime.Minute, maxDateTime.Second + 1, maxDateTime.Millisecond, maxEra));
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(currentDate.Year, currentDate.Month, currentDate.Day, currentDate.Hour, currentDate.Minute, currentDate.Second, -1, minEra));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(currentDate.Year, currentDate.Month, currentDate.Day, currentDate.Hour, currentDate.Minute, currentDate.Second, 1000, maxEra));
-
-            // Era is outside supported range
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxDate.Year, maxDate.Month, maxDate.Day, maxDate.Hour, maxDate.Minute, maxDate.Second, maxDate.Millisecond, -1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minDate.Year, minDate.Month, minDate.Day, minDate.Hour, minDate.Minute, minDate.Second, minDate.Millisecond, MaxEra(calendar) + 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(minYear, minDateTime.Month, minDateTime.Day, minDateTime.Hour, minDateTime.Minute, minDateTime.Second, minDateTime.Millisecond - 1, minEra));
+            Assert.Throws<ArgumentOutOfRangeException>(() => calendar.ToDateTime(maxYear, maxDateTime.Month, maxDateTime.Day, maxDateTime.Hour, maxDateTime.Minute, maxDateTime.Second, maxDateTime.Millisecond + 1, maxEra));
         }
 
+        [Theory]
+        [MemberData(nameof(Calendars_TestData))]
         public static void ToFourDigitYear_Invalid(Calendar calendar)
         {
             Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToFourDigitYear(-1));
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToFourDigitYear(calendar.MinSupportedDateTime.Year + YearOffset(calendar) - 1));
-            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToFourDigitYear(calendar.MaxSupportedDateTime.Year + YearOffset(calendar) + 1));
+            // JapaneseCalandar allows any inputs below the max year
+            if (!(calendar is JapaneseCalendar))
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToFourDigitYear(MinYearInEra(calendar, MinEra(calendar)) - 1));
+            }
+            Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToFourDigitYear(MaxRelativeYearInEra(calendar, MaxEra(calendar)) + 1));
         }
 
+        [Theory]
+        [MemberData(nameof(Calendars_TestData))]
         public static void TwoDigitYearMax_Invalid(Calendar calendar)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => calendar.TwoDigitYearMax = 98);

--- a/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarAddMonths.cs
+++ b/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarAddMonths.cs
@@ -115,13 +115,7 @@ namespace System.Globalization.CalendarsTests
             VerificationHelper(dt, i);
         }
         #endregion
-
-        [Fact]
-        public void AddMonths_Invalid()
-        {
-            CalendarHelpers.AddMonths_Invalid(new ThaiBuddhistCalendar());
-        }
-
+        
         #region Helper Methods
         private bool IsLeapYearThaiBuddhist(int year)
         {

--- a/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarAddYears.cs
+++ b/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarAddYears.cs
@@ -112,12 +112,6 @@ namespace System.Globalization.CalendarsTests
             VerificationHelper(dt, i);
         }
         #endregion
-        
-        [Fact]
-        public void AddYears_Invalid()
-        {
-            CalendarHelpers.AddYears_Invalid(new ThaiBuddhistCalendar());
-        }
 
         #region Helper Methods
         private bool IsLeapYear(int i)

--- a/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarGetDaysInMonth.cs
+++ b/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarGetDaysInMonth.cs
@@ -99,12 +99,6 @@ namespace System.Globalization.CalendarsTests
         }
         #endregion
 
-        [Fact]
-        public void GetDaysInMonth_Invalid()
-        {
-            CalendarHelpers.GetDaysInMonth_Invalid(new ThaiBuddhistCalendar());
-        }
-
         #region Helper Methods
         private bool IsLeapYear(int i)
         {

--- a/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarGetDaysInYear.cs
+++ b/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarGetDaysInYear.cs
@@ -86,12 +86,6 @@ namespace System.Globalization.CalendarsTests
             }
         }
         #endregion
-        
-        [Fact]
-        public void GetDaysInYear_Invalid()
-        {
-            CalendarHelpers.GetDaysInYear_Invalid(new ThaiBuddhistCalendar());
-        }
 
         #region Helper Methods
         private bool IsLeapYear(int i)

--- a/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarGetMonthsInYear.cs
+++ b/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarGetMonthsInYear.cs
@@ -60,11 +60,5 @@ namespace System.Globalization.CalendarsTests
             }
         }
         #endregion
-        
-        [Fact]
-        public void GetMonthsInYear_Invalid()
-        {
-            CalendarHelpers.GetMonthsInYear_Invalid(new ThaiBuddhistCalendar());
-        }
     }
 }

--- a/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarGetWeekOfYear.cs
+++ b/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarGetWeekOfYear.cs
@@ -104,12 +104,6 @@ namespace System.Globalization.CalendarsTests
             Assert.Equal(actualWeek, resultWeek);
         }
         #endregion
-        
-        [Fact]
-        public void GetWeekOfYear_Invalid()
-        {
-            CalendarHelpers.GetWeekOfYear_Invalid(new ThaiBuddhistCalendar());
-        }
 
         #region Helper Methods
         internal int GetFirstDayWeekOfYear(DateTime time, int firstDayOfWeek)

--- a/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarToDateTime.cs
+++ b/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarToDateTime.cs
@@ -98,12 +98,6 @@ namespace System.Globalization.CalendarsTests
             }
         }
         #endregion
-
-        [Fact]
-        public void ToDateTime_Invalid()
-        {
-            CalendarHelpers.ToDateTime_Invalid(new ThaiBuddhistCalendar());
-        }
         
         #region Helper Methods        
         private bool IsLeapYear(int year)

--- a/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarToFourDigitYear.cs
+++ b/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarToFourDigitYear.cs
@@ -63,11 +63,5 @@ namespace System.Globalization.CalendarsTests
             Assert.Equal(expectedYear, tbc.ToFourDigitYear(year));
         }
         #endregion
-
-        [Fact]
-        public void ToFourDigitYear_Invalid()
-        {
-            CalendarHelpers.ToFourDigitYear_Invalid(new ThaiBuddhistCalendar());
-        }
     }
 }

--- a/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarTwoDigitYearMax.cs
+++ b/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarTwoDigitYearMax.cs
@@ -53,11 +53,5 @@ namespace System.Globalization.CalendarsTests
             Assert.Equal(tbc.TwoDigitYearMax, twoYearMax);
         }
         #endregion
-
-        [Fact]
-        public void TwoDigitYearMax_Invalid()
-        {
-            CalendarHelpers.TwoDigitYearMax_Invalid(new ThaiBuddhistCalendar());
-        }
     }
 }


### PR DESCRIPTION
Adds negative tests for:
- AddMonths
- AddYears
- GetDaysInMonth
- GetDaysInYear
- GetMonthsInYear
- IsLeapYear
- IsLeapMonth
- IsLeapDay
- ToDateTime
- ToFourDigitYear
- TwoDigitYearMax

Also cleans up CalendarHelpers to be more resilient, easier to plug-n-play
with, and support calendars with multiple eras!

/cc @stephentoub @tarekgh