### PR TITLE
Adding the indexer to the SqlBulkCopyColumnMappingCollection class

### DIFF
--- a/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
+++ b/src/System.Data.SqlClient/ref/System.Data.SqlClient.cs
@@ -250,6 +250,7 @@ namespace System.Data.SqlClient
     public sealed partial class SqlBulkCopyColumnMappingCollection
     {
         internal SqlBulkCopyColumnMappingCollection() { }
+        public System.Data.SqlClient.SqlBulkCopyColumnMapping this[int index] { get { return default(System.Data.SqlClient.SqlBulkCopyColumnMapping); } }
         public System.Data.SqlClient.SqlBulkCopyColumnMapping Add(System.Data.SqlClient.SqlBulkCopyColumnMapping bulkCopyColumnMapping) { return default(System.Data.SqlClient.SqlBulkCopyColumnMapping); }
         public System.Data.SqlClient.SqlBulkCopyColumnMapping Add(int sourceColumnIndex, int destinationColumnIndex) { return default(System.Data.SqlClient.SqlBulkCopyColumnMapping); }
         public System.Data.SqlClient.SqlBulkCopyColumnMapping Add(int sourceColumnIndex, string destinationColumn) { return default(System.Data.SqlClient.SqlBulkCopyColumnMapping); }


### PR DESCRIPTION
Fix for #6734 