### PR TITLE
Two error handling changes to SslStream

### DIFF
--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Runtime.ExceptionServices;
 using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography.X509Certificates;
@@ -38,7 +39,7 @@ namespace System.Net.Security
         private bool _handshakeCompleted;
         private bool _certValidationFailed;
         private SecurityStatusPal _securityStatus;
-        private Exception _exception;
+        private ExceptionDispatchInfo _exception;
 
         private enum CachedSessionStatus : byte
         {
@@ -100,7 +101,7 @@ namespace System.Net.Security
             //
             if (_exception != null)
             {
-                throw _exception;
+                _exception.Throw();
             }
 
             if (Context != null && Context.IsValidContext)
@@ -425,11 +426,13 @@ namespace System.Net.Security
             }
         }
 
-        private Exception SetException(Exception e)
+        private ExceptionDispatchInfo SetException(Exception e)
         {
+            Debug.Assert(e != null, $"Expected non-null Exception to be passed to {nameof(SetException)}");
+
             if (_exception == null)
             {
-                _exception = e;
+                _exception = ExceptionDispatchInfo.Capture(e);
             }
 
             if (_exception != null && Context != null)
@@ -460,7 +463,7 @@ namespace System.Net.Security
         {
             if (_exception != null)
             {
-                throw _exception;
+                _exception.Throw();
             }
 
             if (authSucessCheck && !IsAuthenticated)
@@ -479,7 +482,7 @@ namespace System.Net.Security
         //
         internal void Close()
         {
-            _exception = new ObjectDisposedException("SslStream");
+            _exception = ExceptionDispatchInfo.Capture(new ObjectDisposedException("SslStream"));
             if (Context != null)
             {
                 Context.Close();
@@ -679,13 +682,13 @@ namespace System.Net.Security
                 _Framing = Framing.Unknown;
                 _handshakeCompleted = false;
 
-                if (SetException(e) == e)
+                if (SetException(e).SourceException == e)
                 {
                     throw;
                 }
                 else
                 {
-                    throw _exception;
+                    _exception.Throw();
                 }
             }
             finally
@@ -746,7 +749,7 @@ namespace System.Net.Security
                 _Framing = Framing.Unknown;
                 _handshakeCompleted = false;
 
-                throw SetException(e);
+                SetException(e).Throw();
             }
         }
 
@@ -804,14 +807,14 @@ namespace System.Net.Security
         {
             if (message.Failed)
             {
-                StartSendAuthResetSignal(null, asyncRequest, new AuthenticationException(SR.net_auth_SSPI, message.GetException()));
+                StartSendAuthResetSignal(null, asyncRequest, ExceptionDispatchInfo.Capture(new AuthenticationException(SR.net_auth_SSPI, message.GetException())));
                 return;
             }
             else if (message.Done && !_pendingReHandshake)
             {
                 if (!CompleteHandshake())
                 {
-                    StartSendAuthResetSignal(null, asyncRequest, new AuthenticationException(SR.net_ssl_io_cert_validation, null));
+                    StartSendAuthResetSignal(null, asyncRequest, ExceptionDispatchInfo.Capture(new AuthenticationException(SR.net_ssl_io_cert_validation, null)));
                     return;
                 }
 
@@ -937,7 +940,7 @@ namespace System.Net.Security
                     Exception e = EnqueueOldKeyDecryptedData(buffer, offset, count);
                     if (e != null)
                     {
-                        StartSendAuthResetSignal(null, asyncRequest, e);
+                        StartSendAuthResetSignal(null, asyncRequest, ExceptionDispatchInfo.Capture(e));
                         return;
                     }
 
@@ -949,7 +952,7 @@ namespace System.Net.Security
                 {
                     // Fail re-handshake.
                     ProtocolToken message = new ProtocolToken(null, status);
-                    StartSendAuthResetSignal(null, asyncRequest, new AuthenticationException(SR.net_auth_SSPI, message.GetException()));
+                    StartSendAuthResetSignal(null, asyncRequest, ExceptionDispatchInfo.Capture(new AuthenticationException(SR.net_auth_SSPI, message.GetException())));
                     return;
                 }
 
@@ -967,14 +970,14 @@ namespace System.Net.Security
         //  This is to reset auth state on remote side.
         //  If this write succeeds we will allow auth retrying.
         //
-        private void StartSendAuthResetSignal(ProtocolToken message, AsyncProtocolRequest asyncRequest, Exception exception)
+        private void StartSendAuthResetSignal(ProtocolToken message, AsyncProtocolRequest asyncRequest, ExceptionDispatchInfo exception)
         {
             if (message == null || message.Size == 0)
             {
                 //
                 // We don't have an alert to send so cannot retry and fail prematurely.
                 //
-                throw exception;
+                exception.Throw();
             }
 
             if (asyncRequest == null)
@@ -992,7 +995,7 @@ namespace System.Net.Security
                 InnerStreamAPM.EndWrite(ar);
             }
 
-            throw exception;
+            exception.Throw();
         }
 
         // - Loads the channel parameters
@@ -1076,7 +1079,7 @@ namespace System.Net.Security
                 Exception exception = asyncState as Exception;
                 if (exception != null)
                 {
-                    throw exception;
+                    ExceptionDispatchInfo.Capture(exception).Throw();
                 }
 
                 sslState.CheckCompletionBeforeNextReceive((ProtocolToken)asyncState, asyncRequest);

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
@@ -932,7 +932,7 @@ namespace System.Net.Security
                 int offset = 0;
                 SecurityStatusPal status = PrivateDecryptData(buffer, ref offset, ref count);
 
-                if (status == SecurityStatusPal.OK)
+                if (status.ErrorCode == SecurityStatusPalErrorCode.OK)
                 {
                     Exception e = EnqueueOldKeyDecryptedData(buffer, offset, count);
                     if (e != null)
@@ -945,7 +945,7 @@ namespace System.Net.Security
                     StartReceiveBlob(buffer, asyncRequest);
                     return;
                 }
-                else if (status != SecurityStatusPal.Renegotiate)
+                else if (status.ErrorCode != SecurityStatusPalErrorCode.Renegotiate)
                 {
                     // Fail re-handshake.
                     ProtocolToken message = new ProtocolToken(null, status);

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslStreamInternal.cs
@@ -403,11 +403,11 @@ namespace System.Net.Security
 
                     int chunkBytes = Math.Min(count, _sslState.MaxDataSize);
                     int encryptedBytes;
-                    SecurityStatusPal errorCode = _sslState.EncryptData(buffer, offset, chunkBytes, ref outBuffer, out encryptedBytes);
-                    if (errorCode != SecurityStatusPal.OK)
+                    SecurityStatusPal status = _sslState.EncryptData(buffer, offset, chunkBytes, ref outBuffer, out encryptedBytes);
+                    if (status.ErrorCode != SecurityStatusPalErrorCode.OK)
                     {
                         // Re-handshake status is not supported.
-                        ProtocolToken message = new ProtocolToken(null, errorCode);
+                        ProtocolToken message = new ProtocolToken(null, status);
                         throw new IOException(SR.net_io_encrypt, message.GetException());
                     }
 
@@ -657,9 +657,9 @@ namespace System.Net.Security
             // Decrypt into internal buffer, change "readBytes" to count now _Decrypted Bytes_.
             int data_offset = 0;
 
-            SecurityStatusPal errorCode = _sslState.DecryptData(InternalBuffer, ref data_offset, ref readBytes);
+            SecurityStatusPal status = _sslState.DecryptData(InternalBuffer, ref data_offset, ref readBytes);
 
-            if (errorCode != SecurityStatusPal.OK)
+            if (status.ErrorCode != SecurityStatusPalErrorCode.OK)
             {
                 byte[] extraBuffer = null;
                 if (readBytes != 0)
@@ -670,7 +670,7 @@ namespace System.Net.Security
 
                 // Reset internal buffer count.
                 SkipBytes(InternalBufferCount);
-                return ProcessReadErrorCode(errorCode, buffer, offset, count, asyncRequest, extraBuffer);
+                return ProcessReadErrorCode(status, buffer, offset, count, asyncRequest, extraBuffer);
             }
 
 
@@ -707,9 +707,9 @@ namespace System.Net.Security
         //
         // Only processing SEC_I_RENEGOTIATE.
         //
-        private int ProcessReadErrorCode(SecurityStatusPal errorCode, byte[] buffer, int offset, int count, AsyncProtocolRequest asyncRequest, byte[] extraBuffer)
+        private int ProcessReadErrorCode(SecurityStatusPal status, byte[] buffer, int offset, int count, AsyncProtocolRequest asyncRequest, byte[] extraBuffer)
         {
-            ProtocolToken message = new ProtocolToken(null, errorCode);
+            ProtocolToken message = new ProtocolToken(null, status);
 
             if (GlobalLog.IsEnabled)
             {

--- a/src/System.Net.Security/src/System/Net/SecurityStatusPal.cs
+++ b/src/System.Net.Security/src/System/Net/SecurityStatusPal.cs
@@ -4,7 +4,26 @@
 
 namespace System.Net
 {
-    internal enum SecurityStatusPal
+    internal struct SecurityStatusPal
+    {
+        public readonly SecurityStatusPalErrorCode ErrorCode;
+        public readonly Exception Exception;
+
+        public SecurityStatusPal(SecurityStatusPalErrorCode errorCode, Exception exception = null)
+        {
+            ErrorCode = errorCode;
+            Exception = exception;
+        }
+
+        public override string ToString()
+        {
+            return Exception == null ?
+                $"{nameof(ErrorCode)}={ErrorCode}" :
+                $"{nameof(ErrorCode)}={ErrorCode}, {nameof(Exception)}={Exception}";
+        }
+    }
+
+    internal enum SecurityStatusPalErrorCode
     {
         NotSet = 0,
         OK,

--- a/src/System.Net.Security/src/System/Net/SslStreamPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/SslStreamPal.Windows.cs
@@ -28,7 +28,7 @@ namespace System.Net
 
         public static Exception GetException(SecurityStatusPal status)
         {
-            int win32Code = (int)GetInteropFromSecurityStatusPal(status);
+            int win32Code = (int)GetInteropFromSecurityStatusPal(status.ErrorCode);
             return new Win32Exception(win32Code);
         }
 
@@ -184,7 +184,7 @@ namespace System.Net
                 }
             }
 
-            return GetSecurityStatusPalFromInterop(errorCode);
+            return new SecurityStatusPal(SecurityStatusPalErrorCodeFromInterop(errorCode));
         }
 
         public unsafe static SafeFreeContextBufferChannelBinding QueryContextChannelBinding(SafeDeleteContext securityContext, ChannelBindingKind attribute)
@@ -303,181 +303,181 @@ namespace System.Net
 
         private static SecurityStatusPal GetSecurityStatusPalFromWin32Int(int win32SecurityStatus)
         {
-            return GetSecurityStatusPalFromInterop((Interop.SecurityStatus)win32SecurityStatus);
+            return new SecurityStatusPal(SecurityStatusPalErrorCodeFromInterop((Interop.SecurityStatus)win32SecurityStatus));
         }
 
-        private static SecurityStatusPal GetSecurityStatusPalFromInterop(Interop.SecurityStatus win32SecurityStatus)
+        private static SecurityStatusPalErrorCode SecurityStatusPalErrorCodeFromInterop(Interop.SecurityStatus win32SecurityStatus)
         {
             switch (win32SecurityStatus)
             {
                 case Interop.SecurityStatus.OK:
-                    return SecurityStatusPal.OK;
+                    return SecurityStatusPalErrorCode.OK;
                 case Interop.SecurityStatus.ContinueNeeded:
-                    return SecurityStatusPal.ContinueNeeded;
+                    return SecurityStatusPalErrorCode.ContinueNeeded;
                 case Interop.SecurityStatus.CompleteNeeded:
-                    return SecurityStatusPal.CompleteNeeded;
+                    return SecurityStatusPalErrorCode.CompleteNeeded;
                 case Interop.SecurityStatus.CompAndContinue:
-                    return SecurityStatusPal.CompAndContinue;
+                    return SecurityStatusPalErrorCode.CompAndContinue;
                 case Interop.SecurityStatus.ContextExpired:
-                    return SecurityStatusPal.ContextExpired;
+                    return SecurityStatusPalErrorCode.ContextExpired;
                 case Interop.SecurityStatus.CredentialsNeeded:
-                    return SecurityStatusPal.CredentialsNeeded;
+                    return SecurityStatusPalErrorCode.CredentialsNeeded;
                 case Interop.SecurityStatus.Renegotiate:
-                    return SecurityStatusPal.Renegotiate;
+                    return SecurityStatusPalErrorCode.Renegotiate;
                 case Interop.SecurityStatus.OutOfMemory:
-                    return SecurityStatusPal.OutOfMemory;
+                    return SecurityStatusPalErrorCode.OutOfMemory;
                 case Interop.SecurityStatus.InvalidHandle:
-                    return SecurityStatusPal.InvalidHandle;
+                    return SecurityStatusPalErrorCode.InvalidHandle;
                 case Interop.SecurityStatus.Unsupported:
-                    return SecurityStatusPal.Unsupported;
+                    return SecurityStatusPalErrorCode.Unsupported;
                 case Interop.SecurityStatus.TargetUnknown:
-                    return SecurityStatusPal.TargetUnknown;
+                    return SecurityStatusPalErrorCode.TargetUnknown;
                 case Interop.SecurityStatus.InternalError:
-                    return SecurityStatusPal.InternalError;
+                    return SecurityStatusPalErrorCode.InternalError;
                 case Interop.SecurityStatus.PackageNotFound:
-                    return SecurityStatusPal.PackageNotFound;
+                    return SecurityStatusPalErrorCode.PackageNotFound;
                 case Interop.SecurityStatus.NotOwner:
-                    return SecurityStatusPal.NotOwner;
+                    return SecurityStatusPalErrorCode.NotOwner;
                 case Interop.SecurityStatus.CannotInstall:
-                    return SecurityStatusPal.CannotInstall;
+                    return SecurityStatusPalErrorCode.CannotInstall;
                 case Interop.SecurityStatus.InvalidToken:
-                    return SecurityStatusPal.InvalidToken;
+                    return SecurityStatusPalErrorCode.InvalidToken;
                 case Interop.SecurityStatus.CannotPack:
-                    return SecurityStatusPal.CannotPack;
+                    return SecurityStatusPalErrorCode.CannotPack;
                 case Interop.SecurityStatus.QopNotSupported:
-                    return SecurityStatusPal.QopNotSupported;
+                    return SecurityStatusPalErrorCode.QopNotSupported;
                 case Interop.SecurityStatus.NoImpersonation:
-                    return SecurityStatusPal.NoImpersonation;
+                    return SecurityStatusPalErrorCode.NoImpersonation;
                 case Interop.SecurityStatus.LogonDenied:
-                    return SecurityStatusPal.LogonDenied;
+                    return SecurityStatusPalErrorCode.LogonDenied;
                 case Interop.SecurityStatus.UnknownCredentials:
-                    return SecurityStatusPal.UnknownCredentials;
+                    return SecurityStatusPalErrorCode.UnknownCredentials;
                 case Interop.SecurityStatus.NoCredentials:
-                    return SecurityStatusPal.NoCredentials;
+                    return SecurityStatusPalErrorCode.NoCredentials;
                 case Interop.SecurityStatus.MessageAltered:
-                    return SecurityStatusPal.MessageAltered;
+                    return SecurityStatusPalErrorCode.MessageAltered;
                 case Interop.SecurityStatus.OutOfSequence:
-                    return SecurityStatusPal.OutOfSequence;
+                    return SecurityStatusPalErrorCode.OutOfSequence;
                 case Interop.SecurityStatus.NoAuthenticatingAuthority:
-                    return SecurityStatusPal.NoAuthenticatingAuthority;
+                    return SecurityStatusPalErrorCode.NoAuthenticatingAuthority;
                 case Interop.SecurityStatus.IncompleteMessage:
-                    return SecurityStatusPal.IncompleteMessage;
+                    return SecurityStatusPalErrorCode.IncompleteMessage;
                 case Interop.SecurityStatus.IncompleteCredentials:
-                    return SecurityStatusPal.IncompleteCredentials;
+                    return SecurityStatusPalErrorCode.IncompleteCredentials;
                 case Interop.SecurityStatus.BufferNotEnough:
-                    return SecurityStatusPal.BufferNotEnough;
+                    return SecurityStatusPalErrorCode.BufferNotEnough;
                 case Interop.SecurityStatus.WrongPrincipal:
-                    return SecurityStatusPal.WrongPrincipal;
+                    return SecurityStatusPalErrorCode.WrongPrincipal;
                 case Interop.SecurityStatus.TimeSkew:
-                    return SecurityStatusPal.TimeSkew;
+                    return SecurityStatusPalErrorCode.TimeSkew;
                 case Interop.SecurityStatus.UntrustedRoot:
-                    return SecurityStatusPal.UntrustedRoot;
+                    return SecurityStatusPalErrorCode.UntrustedRoot;
                 case Interop.SecurityStatus.IllegalMessage:
-                    return SecurityStatusPal.IllegalMessage;
+                    return SecurityStatusPalErrorCode.IllegalMessage;
                 case Interop.SecurityStatus.CertUnknown:
-                    return SecurityStatusPal.CertUnknown;
+                    return SecurityStatusPalErrorCode.CertUnknown;
                 case Interop.SecurityStatus.CertExpired:
-                    return SecurityStatusPal.CertExpired;
+                    return SecurityStatusPalErrorCode.CertExpired;
                 case Interop.SecurityStatus.AlgorithmMismatch:
-                    return SecurityStatusPal.AlgorithmMismatch;
+                    return SecurityStatusPalErrorCode.AlgorithmMismatch;
                 case Interop.SecurityStatus.SecurityQosFailed:
-                    return SecurityStatusPal.SecurityQosFailed;
+                    return SecurityStatusPalErrorCode.SecurityQosFailed;
                 case Interop.SecurityStatus.SmartcardLogonRequired:
-                    return SecurityStatusPal.SmartcardLogonRequired;
+                    return SecurityStatusPalErrorCode.SmartcardLogonRequired;
                 case Interop.SecurityStatus.UnsupportedPreauth:
-                    return SecurityStatusPal.UnsupportedPreauth;
+                    return SecurityStatusPalErrorCode.UnsupportedPreauth;
                 case Interop.SecurityStatus.BadBinding:
-                    return SecurityStatusPal.BadBinding;
+                    return SecurityStatusPalErrorCode.BadBinding;
                 default:
                     Debug.Fail("Unknown Interop.SecurityStatus value: " + win32SecurityStatus);
                     throw new InternalException();
             }
         }
 
-        private static Interop.SecurityStatus GetInteropFromSecurityStatusPal(SecurityStatusPal status)
+        private static Interop.SecurityStatus GetInteropFromSecurityStatusPal(SecurityStatusPalErrorCode status)
         {
             switch (status)
             {
-                case SecurityStatusPal.NotSet:
+                case SecurityStatusPalErrorCode.NotSet:
                     Debug.Fail("SecurityStatus NotSet");
                     throw new InternalException();
-                case SecurityStatusPal.OK:
+                case SecurityStatusPalErrorCode.OK:
                     return Interop.SecurityStatus.OK;
-                case SecurityStatusPal.ContinueNeeded:
+                case SecurityStatusPalErrorCode.ContinueNeeded:
                     return Interop.SecurityStatus.ContinueNeeded;
-                case SecurityStatusPal.CompleteNeeded:
+                case SecurityStatusPalErrorCode.CompleteNeeded:
                     return Interop.SecurityStatus.CompleteNeeded;
-                case SecurityStatusPal.CompAndContinue:
+                case SecurityStatusPalErrorCode.CompAndContinue:
                     return Interop.SecurityStatus.CompAndContinue;
-                case SecurityStatusPal.ContextExpired:
+                case SecurityStatusPalErrorCode.ContextExpired:
                     return Interop.SecurityStatus.ContextExpired;
-                case SecurityStatusPal.CredentialsNeeded:
+                case SecurityStatusPalErrorCode.CredentialsNeeded:
                     return Interop.SecurityStatus.CredentialsNeeded;
-                case SecurityStatusPal.Renegotiate:
+                case SecurityStatusPalErrorCode.Renegotiate:
                     return Interop.SecurityStatus.Renegotiate;
-                case SecurityStatusPal.OutOfMemory:
+                case SecurityStatusPalErrorCode.OutOfMemory:
                     return Interop.SecurityStatus.OutOfMemory;
-                case SecurityStatusPal.InvalidHandle:
+                case SecurityStatusPalErrorCode.InvalidHandle:
                     return Interop.SecurityStatus.InvalidHandle;
-                case SecurityStatusPal.Unsupported:
+                case SecurityStatusPalErrorCode.Unsupported:
                     return Interop.SecurityStatus.Unsupported;
-                case SecurityStatusPal.TargetUnknown:
+                case SecurityStatusPalErrorCode.TargetUnknown:
                     return Interop.SecurityStatus.TargetUnknown;
-                case SecurityStatusPal.InternalError:
+                case SecurityStatusPalErrorCode.InternalError:
                     return Interop.SecurityStatus.InternalError;
-                case SecurityStatusPal.PackageNotFound:
+                case SecurityStatusPalErrorCode.PackageNotFound:
                     return Interop.SecurityStatus.PackageNotFound;
-                case SecurityStatusPal.NotOwner:
+                case SecurityStatusPalErrorCode.NotOwner:
                     return Interop.SecurityStatus.NotOwner;
-                case SecurityStatusPal.CannotInstall:
+                case SecurityStatusPalErrorCode.CannotInstall:
                     return Interop.SecurityStatus.CannotInstall;
-                case SecurityStatusPal.InvalidToken:
+                case SecurityStatusPalErrorCode.InvalidToken:
                     return Interop.SecurityStatus.InvalidToken;
-                case SecurityStatusPal.CannotPack:
+                case SecurityStatusPalErrorCode.CannotPack:
                     return Interop.SecurityStatus.CannotPack;
-                case SecurityStatusPal.QopNotSupported:
+                case SecurityStatusPalErrorCode.QopNotSupported:
                     return Interop.SecurityStatus.QopNotSupported;
-                case SecurityStatusPal.NoImpersonation:
+                case SecurityStatusPalErrorCode.NoImpersonation:
                     return Interop.SecurityStatus.NoImpersonation;
-                case SecurityStatusPal.LogonDenied:
+                case SecurityStatusPalErrorCode.LogonDenied:
                     return Interop.SecurityStatus.LogonDenied;
-                case SecurityStatusPal.UnknownCredentials:
+                case SecurityStatusPalErrorCode.UnknownCredentials:
                     return Interop.SecurityStatus.UnknownCredentials;
-                case SecurityStatusPal.NoCredentials:
+                case SecurityStatusPalErrorCode.NoCredentials:
                     return Interop.SecurityStatus.NoCredentials;
-                case SecurityStatusPal.MessageAltered:
+                case SecurityStatusPalErrorCode.MessageAltered:
                     return Interop.SecurityStatus.MessageAltered;
-                case SecurityStatusPal.OutOfSequence:
+                case SecurityStatusPalErrorCode.OutOfSequence:
                     return Interop.SecurityStatus.OutOfSequence;
-                case SecurityStatusPal.NoAuthenticatingAuthority:
+                case SecurityStatusPalErrorCode.NoAuthenticatingAuthority:
                     return Interop.SecurityStatus.NoAuthenticatingAuthority;
-                case SecurityStatusPal.IncompleteMessage:
+                case SecurityStatusPalErrorCode.IncompleteMessage:
                     return Interop.SecurityStatus.IncompleteMessage;
-                case SecurityStatusPal.IncompleteCredentials:
+                case SecurityStatusPalErrorCode.IncompleteCredentials:
                     return Interop.SecurityStatus.IncompleteCredentials;
-                case SecurityStatusPal.BufferNotEnough:
+                case SecurityStatusPalErrorCode.BufferNotEnough:
                     return Interop.SecurityStatus.BufferNotEnough;
-                case SecurityStatusPal.WrongPrincipal:
+                case SecurityStatusPalErrorCode.WrongPrincipal:
                     return Interop.SecurityStatus.WrongPrincipal;
-                case SecurityStatusPal.TimeSkew:
+                case SecurityStatusPalErrorCode.TimeSkew:
                     return Interop.SecurityStatus.TimeSkew;
-                case SecurityStatusPal.UntrustedRoot:
+                case SecurityStatusPalErrorCode.UntrustedRoot:
                     return Interop.SecurityStatus.UntrustedRoot;
-                case SecurityStatusPal.IllegalMessage:
+                case SecurityStatusPalErrorCode.IllegalMessage:
                     return Interop.SecurityStatus.IllegalMessage;
-                case SecurityStatusPal.CertUnknown:
+                case SecurityStatusPalErrorCode.CertUnknown:
                     return Interop.SecurityStatus.CertUnknown;
-                case SecurityStatusPal.CertExpired:
+                case SecurityStatusPalErrorCode.CertExpired:
                     return Interop.SecurityStatus.CertExpired;
-                case SecurityStatusPal.AlgorithmMismatch:
+                case SecurityStatusPalErrorCode.AlgorithmMismatch:
                     return Interop.SecurityStatus.AlgorithmMismatch;
-                case SecurityStatusPal.SecurityQosFailed:
+                case SecurityStatusPalErrorCode.SecurityQosFailed:
                     return Interop.SecurityStatus.SecurityQosFailed;
-                case SecurityStatusPal.SmartcardLogonRequired:
+                case SecurityStatusPalErrorCode.SmartcardLogonRequired:
                     return Interop.SecurityStatus.SmartcardLogonRequired;
-                case SecurityStatusPal.UnsupportedPreauth:
+                case SecurityStatusPalErrorCode.UnsupportedPreauth:
                     return Interop.SecurityStatus.UnsupportedPreauth;
-                case SecurityStatusPal.BadBinding:
+                case SecurityStatusPalErrorCode.BadBinding:
                     return Interop.SecurityStatus.BadBinding;
                 default:
                     Debug.Fail("Unknown Interop.SecurityStatus value: " + status);

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Net.Test.Common;
+using System.Runtime.ExceptionServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
@@ -162,7 +163,7 @@ namespace System.Net.Security.Tests
                     }
                     catch (AggregateException ex)
                     {
-                        throw ex.InnerException;
+                        ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
                     }
 
                     if (!serverAuthenticationCompleted)

--- a/src/System.Net.Security/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/unix/project.json
@@ -1,9 +1,12 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23908",
+    "Microsoft.Win32.Primitives": "4.0.1-rc3-23908",
     "System.Net.Primitives": "4.0.10",
+    "System.Collections": "4.0.11-rc3-23908",
     "System.Net.Sockets": "4.1.0-rc3-23908",
     "System.Net.TestData": "1.0.0-prerelease",
+    "System.Security.Cryptography.Algorithms": "4.1.0-rc3-23908",
     "System.Security.Cryptography.X509Certificates": "4.0.0-rc3-23908",
     "System.Security.Principal": "4.0.0",
     "xunit": "2.1.0",


### PR DESCRIPTION
Commit (1). Pass Exception through SecurityStatusPal in SslStream. There isn't a good mapping between OpenSSL errors and most of the errors in SecurityStatusPal.  As a result, with the current set up, important information about errors that occurred is getting lost and translated into meaningless information by the time it makes it out to the developer, making it difficult to diagnose the cause of a failure. This commit allows the original exception behind a failure to be passed through the PAL layer, such that when an exception is eventually thrown, the Unix implementation can choose to use the original exception rather than translating the error code.  For example, instead of:
```
System.Security.Authentication.AuthenticationException : A call to SSPI failed, see inner exception.
---- Interop+OpenSsl+SslException : Operation failed with error - 12.
```
(where "12" is the number that ends up getting used for all failures, as the numerical value of SecurityStatusPal.InternalError), we now get:
```
System.Security.Authentication.AuthenticationException : A call to SSPI failed, see inner exception.
---- Interop+OpenSsl+SslException : SSL Handshake failed with OpenSSL error - SSL_ERROR_SSL.
-------- Interop+Crypto+OpenSslCryptographicException : error:140740B5:SSL routines:SSL23_CLIENT_HELLO:no ciphers available
```

Commit (2). Use ExceptionDispatchInfo in SslStream. Currently in SslStream, exceptions get captured and then later thrown with "throw exception;".  This causes their stack traces to get overwritten, losing information about where the exception actually came from.  This commit changes these locations to use ExceptionDispatchInfo instead, enabling the stacks and Watson bucket information to be preserved. For example, instead of:
```
System.IO.IOException: Authentication failed because the remote party has closed the transport stream.
     at System.Net.Security.SslState.InternalEndProcessAuthentication(LazyAsyncResult lazyResult) in corefx\src\System.Net.Security\src\System\Net\SecureProtocols\SslState.cs:line 752
     at System.Net.Security.SslState.EndProcessAuthentication(IAsyncResult result) in corefx\src\System.Net.Security\src\System\Net\SecureProtocols\SslState.cs:line 722
     at System.Net.Security.SslStream.EndAuthenticateAsClient(IAsyncResult asyncResult) in corefx\src\System.Net.Security\src\System\Net\SecureProtocols\SslStream.cs:line 125
     at System.Threading.Tasks.TaskFactory`1.FromAsyncCoreLogic(IAsyncResult iar, Func`2 endFunction, Action`1 endAction, Task`1 promise, Boolean requiresSynchronization)
  --- End of stack trace from previous location where exception was thrown ---
     at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
     at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
     at Xunit.Assert.<RecordExceptionAsync>d__61.MoveNext()
```
we now get:
```
System.IO.IOException: Authentication failed because the remote party has closed the transport stream.
     at System.Net.Security.SslState.StartReadFrame(Byte[] buffer, Int32 readBytes, AsyncProtocolRequest asyncRequest) in corefx\src\System.Net.Security\src\System\Net\SecureProtocols\SslState.cs:line 882
     at System.Net.Security.SslState.PartialFrameCallback(AsyncProtocolRequest asyncRequest) in corefx\src\System.Net.Security\src\System\Net\SecureProtocols\SslState.cs:line 1110
  --- End of stack trace from previous location where exception was thrown ---
     at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
     at System.Net.Security.SslState.InternalEndProcessAuthentication(LazyAsyncResult lazyResult) in corefx\src\System.Net.Security\src\System\Net\SecureProtocols\SslState.cs:line 752
     at System.Net.Security.SslState.EndProcessAuthentication(IAsyncResult result) in corefx\src\System.Net.Security\src\System\Net\SecureProtocols\SslState.cs:line 722
     at System.Net.Security.SslStream.EndAuthenticateAsClient(IAsyncResult asyncResult) in corefx\src\System.Net.Security\src\System\Net\SecureProtocols\SslStream.cs:line 125
     at System.Threading.Tasks.TaskFactory`1.FromAsyncCoreLogic(IAsyncResult iar, Func`2 endFunction, Action`1 endAction, Task`1 promise, Boolean requiresSynchronization)
  --- End of stack trace from previous location where exception was thrown ---
     at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
     at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
     at Xunit.Assert.<RecordExceptionAsync>d__61.MoveNext()
```
Contributes to https://github.com/dotnet/corefx/issues/5606 and https://github.com/dotnet/corefx/issues/5890. For both this doesn't completely fix the issue: I've stayed away from touching NegotiateStream to avoid conflicts with the incoming PR from the NegotiateStream work on Unix.

Commit (3).  Fixes some warnings during the build for the System.Net.Security.Tests project when building for Unix.

cc: @davidsh, @cipop, @ericeil, @bartonjs, @vijaykota, @kapilash 