### PR TITLE
Re-enable System.Net.Security "no encryption" tests on Linux

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtxOptions.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtxOptions.cs
@@ -34,7 +34,7 @@ internal static partial class Interop
         internal static extern void SslCtxSetVerify(SafeSslContextHandle ctx, SslCtxSetVerifyCallback callback);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SetEncryptionPolicy")]
-        internal static extern void SetEncryptionPolicy(SafeSslContextHandle ctx, EncryptionPolicy policy);
+        internal static extern bool SetEncryptionPolicy(SafeSslContextHandle ctx, EncryptionPolicy policy);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetClientCAList")]
         internal static extern void SslCtxSetClientCAList(SafeSslContextHandle ctx, SafeX509NameStackHandle x509NameStackPtr);

--- a/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
@@ -70,7 +70,10 @@ internal static partial class Interop
                 // https://www.openssl.org/docs/manmaster/ssl/SSL_shutdown.html
                 Ssl.SslCtxSetQuietShutdown(innerContext);
 
-                Ssl.SetEncryptionPolicy(innerContext, policy);
+                if (!Ssl.SetEncryptionPolicy(innerContext, policy))
+                {
+                    throw new PlatformNotSupportedException(SR.Format(SR.net_ssl_encryptionpolicy_notsupported, policy));
+                }
 
                 if (certHandle != null && certKeyHandle != null)
                 {

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -499,7 +499,7 @@ CryptoNative_SslCtxSetCertVerifyCallback(SSL_CTX* ctx, SslCtxSetCertVerifyCallba
 #define SSL_TXT_Separator ":"
 #define SSL_TXT_AllIncludingNull SSL_TXT_ALL SSL_TXT_Separator SSL_TXT_eNULL
 
-extern "C" void CryptoNative_SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy policy)
+extern "C" int32_t CryptoNative_SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy policy)
 {
     const char* cipherString = nullptr;
     switch (policy)
@@ -519,7 +519,7 @@ extern "C" void CryptoNative_SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy 
 
     assert(cipherString != nullptr);
 
-    SSL_CTX_set_cipher_list(ctx, cipherString);
+    return SSL_CTX_set_cipher_list(ctx, cipherString);
 }
 
 extern "C" void CryptoNative_SslCtxSetClientCAList(SSL_CTX* ctx, X509NameStack* list)

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.h
@@ -354,8 +354,9 @@ CryptoNative_SslCtxSetCertVerifyCallback(SSL_CTX* ctx, SslCtxSetCertVerifyCallba
 
 /*
 Sets the specified encryption policy on the SSL_CTX.
+Returns 1 if any cipher could be selected, and 0 if none were available.
 */
-extern "C" void CryptoNative_SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy policy);
+extern "C" int32_t CryptoNative_SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy policy);
 
 /*
 Shims the SSL_CTX_set_client_CA_list method.

--- a/src/System.Net.Security/src/Resources/Strings.resx
+++ b/src/System.Net.Security/src/Resources/Strings.resx
@@ -414,4 +414,7 @@
   <data name="net_ssl_invalid_certificate" xml:space="preserve">
     <value>SSL certificate returned is invalid, OpenSSL error - {0}.</value>
   </data>
+  <data name="net_ssl_encryptionpolicy_notsupported" xml:space="preserve">
+    <value>The '{0}' encryption policy is not supported by this installation of OpenSSL.</value>
+  </data>
 </root>

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAllowNoEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAllowNoEncryptionTest.cs
@@ -72,8 +72,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [ActiveIssue(5557, PlatformID.Linux)]
-        [Fact]
+        [ConditionalFact(nameof(SupportsNullEncryption))]
         public async Task ServerAllowNoEncryption_ClientNoEncryption_ConnectWithNoEncryption()
         {
             using (var serverAllowNoEncryption = new DummyTcpServer(
@@ -94,5 +93,7 @@ namespace System.Net.Security.Tests
                 }
             }
         }
+
+        private static bool SupportsNullEncryption => TestConfiguration.SupportsNullEncryption;
     }
 }

--- a/src/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
@@ -49,8 +49,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [ActiveIssue(5557, PlatformID.Linux)]
-        [Fact]
+        [ConditionalFact(nameof(SupportsNullEncryption))]
         public async Task ServerNoEncryption_ClientAllowNoEncryption_ConnectWithNoEncryption()
         {
             using (var serverNoEncryption = new DummyTcpServer(
@@ -73,8 +72,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [ActiveIssue(5557, PlatformID.Linux)]
-        [Fact]
+        [ConditionalFact(nameof(SupportsNullEncryption))]
         public async Task ServerNoEncryption_ClientNoEncryption_ConnectWithNoEncryption()
         {
             using (var serverNoEncryption = new DummyTcpServer(
@@ -95,5 +93,7 @@ namespace System.Net.Security.Tests
                 }
             }
         }
+
+        private static bool SupportsNullEncryption => TestConfiguration.SupportsNullEncryption;
     }
 }

--- a/src/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
@@ -72,8 +72,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [ActiveIssue(5557, PlatformID.Linux)]
-        [Fact]
+        [ConditionalFact(nameof(SupportsNullEncryption))]
         public async Task ServerRequireEncryption_ClientNoEncryption_NoConnect()
         {
             using (var serverRequireEncryption = new DummyTcpServer(
@@ -88,5 +87,7 @@ namespace System.Net.Security.Tests
                 }
             }
         }
+
+        private static bool SupportsNullEncryption => TestConfiguration.SupportsNullEncryption;
     }
 }

--- a/src/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 
@@ -67,5 +69,26 @@ namespace System.Net.Security.Tests
             Assert.NotNull(certificate);
             return certificate;
         }
+
+        public static bool SupportsNullEncryption { get { return s_supportsNullEncryption.Value; } }
+
+        private static Lazy<bool> s_supportsNullEncryption = new Lazy<bool>(() =>
+        {
+            // On Windows, null ciphers (no encryption) are supported.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return true;
+            }
+
+            // On Unix, it depends on how openssl was built.  So we ask openssl if it has any.
+            try
+            {
+                using (Process p = Process.Start(new ProcessStartInfo("openssl", "ciphers NULL") { RedirectStandardOutput = true }))
+                {
+                    return p.StandardOutput.ReadToEnd().Trim().Length > 0;
+                }
+            }
+            catch { return false; }
+        });
     }
 }

--- a/src/System.Net.Security/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/unix/project.json
@@ -2,8 +2,9 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23908",
     "Microsoft.Win32.Primitives": "4.0.1-rc3-23908",
-    "System.Net.Primitives": "4.0.10",
     "System.Collections": "4.0.11-rc3-23908",
+    "System.Diagnostics.Process": "4.1.0-rc3-23908",
+    "System.Net.Primitives": "4.0.10",
     "System.Net.Sockets": "4.1.0-rc3-23908",
     "System.Net.TestData": "1.0.0-prerelease",
     "System.Security.Cryptography.Algorithms": "4.1.0-rc3-23908",

--- a/src/System.Net.Security/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/win/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23908",
+    "System.Diagnostics.Process": "4.1.0-rc3-23908",
     "System.Net.Primitives": "4.0.10",
     "System.Net.Sockets": "4.1.0-rc3-23908",
     "System.Net.TestData": "1.0.0-prerelease",


### PR DESCRIPTION
We'd disabled these tests on Linux because they were failing on OpenSUSE.  The reason turned out to be that the OpenSSL installed on OpenSUSE was built explicitly without null cipher support.  This commit re-enables the tests, but as ConditionalFacts that check whether we're either on Windows or on a Unix with an OpenSSL that sports null ciphers.

cc: @ericeil, @bartonjs, @davidsh, @CIPop, @vijaykota 
Fixes #5557 