### PR TITLE
Fix XmlSerializer Serializing DateTime when DataType = "time"

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -1285,6 +1285,18 @@ namespace SerializationTypes
         }
     }
 
+    public class DateTimeDataTypeTimeType
+    {
+        DateTime _value;
+
+        [XmlText(DataType = "time")]
+        public DateTime Value
+        {
+            get { return _value; }
+            set { _value = value; }
+        }
+    }
+
     [DataContract(IsReference = false)]
     public class SimpleDC
     {

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -1285,7 +1285,7 @@ namespace SerializationTypes
         }
     }
 
-    public class DateTimeDataTypeTimeType
+    public class TypeWithDateTimePropertyAsXmlTime
     {
         DateTime _value;
 

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlCustomFormatter.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlCustomFormatter.cs
@@ -28,7 +28,8 @@ namespace System.Xml.Serialization
 
         internal static string FromTime(DateTime value)
         {
-            return XmlConvert.ToString(DateTime.MinValue + value.TimeOfDay, "HH:mm:ss.fffffffzzzzzz");
+            string dateFormat = value.Kind == DateTimeKind.Utc ? "HH:mm:ss.fffffffZ" : "HH:mm:ss.fffffffzzzzzz";
+            return XmlConvert.ToString(DateTime.MinValue + value.TimeOfDay, dateFormat);
         }
 
         internal static string FromDateTime(DateTime value)
@@ -207,7 +208,7 @@ namespace System.Xml.Serialization
 
         internal static DateTime ToTime(string value)
         {
-            return DateTime.ParseExact(value, s_allTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AllowLeadingWhite | DateTimeStyles.AllowTrailingWhite | DateTimeStyles.NoCurrentDateDefault);
+            return DateTime.ParseExact(value, s_allTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AllowLeadingWhite | DateTimeStyles.AllowTrailingWhite | DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.RoundtripKind);
         }
 
         internal static char ToChar(string value)

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlCustomFormatter.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlCustomFormatter.cs
@@ -29,7 +29,14 @@ namespace System.Xml.Serialization
         internal static string FromTime(DateTime value)
         {
             string dateFormat = value.Kind == DateTimeKind.Utc ? "HH:mm:ss.fffffffZ" : "HH:mm:ss.fffffffzzzzzz";
-            return XmlConvert.ToString(DateTime.MinValue + value.TimeOfDay, dateFormat);
+
+            // On Desktop we do the following convertion by calling XmlConvert.ToString(DateTime value, string format).
+            // This overload, however,  is not available on CoreFx. Calling XmlConvert.ToString(value, format) would
+            // end up using XmlConvert.ToString(DateTimeOffset value, string format), which would generated differnt result.
+            // Therefore here we directly use DateTime.ToString which is used by XmlConvert.ToString(DateTime, string)
+            // on Desktop.
+            DateTime dateTimeValue = DateTime.MinValue + value.TimeOfDay;
+            return dateTimeValue.ToString(dateFormat, DateTimeFormatInfo.InvariantInfo);
         }
 
         internal static string FromDateTime(DateTime value)

--- a/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
+++ b/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
@@ -101,6 +101,34 @@ public static partial class XmlSerializerTests
     }
 
     [Fact]
+    public static void Xml_DateTime_DataType_Time()
+    {
+        DateTime localTime = new DateTime(549269870000L, DateTimeKind.Local);
+        DateTimeDataTypeTimeType localTimeOjbect = new DateTimeDataTypeTimeType()
+        {
+            Value = localTime
+        };
+
+        string localTimeString = localTime.ToString("HH:mm:ss.fffffffzzzzzz");
+        DateTimeDataTypeTimeType localTimeOjbectRoundTrip = SerializeAndDeserialize(localTimeOjbect,
+string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
+<DateTimeDataTypeTimeType xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">{0}</DateTimeDataTypeTimeType>", localTimeString));
+
+        Assert.StrictEqual(localTimeOjbect.Value, localTimeOjbectRoundTrip.Value);
+
+        DateTimeDataTypeTimeType utcTimeOjbect = new DateTimeDataTypeTimeType()
+        {
+            Value = new DateTime(549269870000L, DateTimeKind.Utc)
+        };
+
+        DateTimeDataTypeTimeType utcTimeRoundTrip = SerializeAndDeserialize(utcTimeOjbect,
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<DateTimeDataTypeTimeType xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">15:15:26.9870000Z</DateTimeDataTypeTimeType>");
+
+        Assert.StrictEqual(utcTimeOjbect.Value, utcTimeRoundTrip.Value);
+    }
+
+    [Fact]
     public static void Xml_DecimalAsRoot()
     {
         foreach (decimal value in new decimal[] { (decimal)-1.2, (decimal)0, (decimal)2.3, decimal.MinValue, decimal.MaxValue })

--- a/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
+++ b/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
@@ -101,29 +101,31 @@ public static partial class XmlSerializerTests
     }
 
     [Fact]
-    public static void Xml_DateTime_DataType_Time()
+    public static void Xml_TypeWithDateTimePropertyAsXmlTime()
     {
         DateTime localTime = new DateTime(549269870000L, DateTimeKind.Local);
-        DateTimeDataTypeTimeType localTimeOjbect = new DateTimeDataTypeTimeType()
+        TypeWithDateTimePropertyAsXmlTime localTimeOjbect = new TypeWithDateTimePropertyAsXmlTime()
         {
             Value = localTime
         };
 
-        string localTimeString = localTime.ToString("HH:mm:ss.fffffffzzzzzz");
-        DateTimeDataTypeTimeType localTimeOjbectRoundTrip = SerializeAndDeserialize(localTimeOjbect,
+        // This is how we convert DateTime from time to string.
+        var localTimeDateTime = DateTime.MinValue + localTime.TimeOfDay;
+        string localTimeString = localTimeDateTime.ToString("HH:mm:ss.fffffffzzzzzz", DateTimeFormatInfo.InvariantInfo);
+        TypeWithDateTimePropertyAsXmlTime localTimeOjbectRoundTrip = SerializeAndDeserialize(localTimeOjbect,
 string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
-<DateTimeDataTypeTimeType xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">{0}</DateTimeDataTypeTimeType>", localTimeString));
+<TypeWithDateTimePropertyAsXmlTime xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">{0}</TypeWithDateTimePropertyAsXmlTime>", localTimeString));
 
         Assert.StrictEqual(localTimeOjbect.Value, localTimeOjbectRoundTrip.Value);
 
-        DateTimeDataTypeTimeType utcTimeOjbect = new DateTimeDataTypeTimeType()
+        TypeWithDateTimePropertyAsXmlTime utcTimeOjbect = new TypeWithDateTimePropertyAsXmlTime()
         {
             Value = new DateTime(549269870000L, DateTimeKind.Utc)
         };
 
-        DateTimeDataTypeTimeType utcTimeRoundTrip = SerializeAndDeserialize(utcTimeOjbect,
+        TypeWithDateTimePropertyAsXmlTime utcTimeRoundTrip = SerializeAndDeserialize(utcTimeOjbect,
 @"<?xml version=""1.0"" encoding=""utf-8""?>
-<DateTimeDataTypeTimeType xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">15:15:26.9870000Z</DateTimeDataTypeTimeType>");
+<TypeWithDateTimePropertyAsXmlTime xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">15:15:26.9870000Z</TypeWithDateTimePropertyAsXmlTime>");
 
         Assert.StrictEqual(utcTimeOjbect.Value, utcTimeRoundTrip.Value);
     }


### PR DESCRIPTION
XmlSerializer incorrectly serializes DateTime fields/properties marked with [XmlText(DataType = "time")] if the DateTime value is of UTC kind. The UTC DateTime was serialized as a local DateTime and wouldn't make a round trip.

Fix #6761