### PR TITLE
Add DEBUG ifdefs to SqlClient tests that are only supposed to run in debug mode.

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/RunTests.cmd
+++ b/src/System.Data.SqlClient/tests/ManualTests/RunTests.cmd
@@ -3,8 +3,8 @@ IF "%1"=="/?" (
 ECHO Usage: "%0" [TestClass]
 ) ELSE IF "%1"=="" (
 echo Running all tests.
-msbuild /t:BuildAndTest
+msbuild /t:BuildAndTest /p:EnableManualTests=true
 ) ELSE (
 echo Running SqlClient test suite "%1".
-msbuild /t:BuildAndTest "/p:XunitOptions=-class System.Data.SqlClient.ManualTesting.Tests.%1"
+msbuild /t:BuildAndTest /p:EnableManualTests=true "/p:XunitOptions=-class System.Data.SqlClient.ManualTesting.Tests.%1"
 )

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
@@ -54,7 +54,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         {
             BasicConnectionPoolingTest(tcpConnectionString);
             ClearAllPoolsTest(tcpConnectionString);
-#if MANAGED_SNI
+#if MANAGED_SNI && DEBUG
             KillConnectionTest(tcpConnectionString);
 #endif
             ReclaimEmancipatedOnOpenTest(tcpConnectionString);

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
@@ -93,6 +93,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             connection4.Close();
         }
 
+#if MANAGED_SNI && DEBUG
         /// <summary>
         /// Tests if killing the connection using the InternalConnectionWrapper is working
         /// </summary>
@@ -124,6 +125,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 }
             }
         }
+#endif
 
         /// <summary>
         /// Tests if clearing all of the pools does actually remove the pools

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/MARSTest/SQLMARSTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/MARSTest/SQLMARSTest.cs
@@ -13,6 +13,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
     {
         private static readonly string s_yukonConnectionString = (new SqlConnectionStringBuilder(DataTestClass.SQL2005_Northwind) { MultipleActiveResultSets = true }).ConnectionString;
 
+#if DEBUG
         [Fact]
         public static void MARSAsyncTimeoutTest()
         {
@@ -105,7 +106,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 }
             }
         }
-
+#endif
 
         [Fact]
         public static void MARSSyncBusyReaderTest()


### PR DESCRIPTION
Some tests require test hooks that are only included in Debug builds.