### PR TITLE
Fix path syntax handling

### DIFF
--- a/src/Common/src/System/Runtime/InteropServices/StringBuffer.cs
+++ b/src/Common/src/System/Runtime/InteropServices/StringBuffer.cs
@@ -28,20 +28,6 @@ namespace System.Runtime.InteropServices
         }
 
         /// <summary>
-        /// Instantiate the buffer with a copy of the specified string.
-        /// </summary>
-        public unsafe StringBuffer(string initialContents)
-            : base(0)
-        {
-            // We don't pass the count of bytes to the base constructor, appending will
-            // initialize to the correct size for the specified initial contents.
-            if (initialContents != null)
-            {
-                Append(initialContents);
-            }
-        }
-
-        /// <summary>
         /// Get/set the character at the given index.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if attempting to index outside of the buffer length.</exception>
@@ -92,7 +78,7 @@ namespace System.Runtime.InteropServices
             get { return _length; }
             set
             {
-                if (value == uint.MaxValue) throw new ArgumentOutOfRangeException("Length");
+                if (value == uint.MaxValue) throw new ArgumentOutOfRangeException(nameof(Length));
 
                 // Null terminate
                 EnsureCharCapacity(value + 1);

--- a/src/Common/tests/Tests/System/IO/PathInternal.Windows.Tests.cs
+++ b/src/Common/tests/Tests/System/IO/PathInternal.Windows.Tests.cs
@@ -4,53 +4,98 @@
 
 using System;
 using System.IO;
-using System.Text;
+using System.Runtime.InteropServices;
 using Xunit;
 
 public class PathInternal_Windows_Tests
 {
-    [Theory]
-    [InlineData(PathInternal.ExtendedPathPrefix, PathInternal.ExtendedPathPrefix)]
-    [InlineData(@"Foo", @"Foo")]
-    [InlineData(@"C:\Foo", @"\\?\C:\Foo")]
-    [InlineData(@"\\.\Foo", @"\\.\Foo")]
-    [InlineData(@"\\Server\Share", PathInternal.UncExtendedPathPrefix + @"Server\Share")]
+    [Theory
+        InlineData(PathInternal.ExtendedPathPrefix, PathInternal.ExtendedPathPrefix)
+        InlineData(@"Foo", @"Foo")
+        InlineData(@"C:\Foo", @"\\?\C:\Foo")
+        InlineData(@"\\.\Foo", @"\\.\Foo")
+        InlineData(@"\\?\Foo", @"\\?\Foo")
+        InlineData(@"\??\Foo", @"\??\Foo")
+        InlineData(@"//?/Foo", @"//?/Foo")
+        InlineData(@"\\Server\Share", PathInternal.UncExtendedPathPrefix + @"Server\Share")
+        ]
     [PlatformSpecific(PlatformID.Windows)]
     public void EnsureExtendedPrefixTest(string path, string expected)
     {
-        StringBuilder sb = new StringBuilder(path);
-        PathInternal.EnsureExtendedPrefix(sb);
-        Assert.Equal(expected, sb.ToString());
-
         Assert.Equal(expected, PathInternal.EnsureExtendedPrefix(path));
     }
 
-    [Theory,
-        InlineData("", true),
-        InlineData("C:", true),
-        InlineData("**", true),
-        InlineData(@"\\.\path", false),
-        InlineData(@"\\?\path", false),
-        InlineData(@"\\.", false),
-        InlineData(@"\\?", false),
-        InlineData(@"\\", false),
-        InlineData(@"//", false),
-        InlineData(@"\a", true),
-        InlineData(@"/a", true),
-        InlineData(@"\", true),
-        InlineData(@"/", true),
-        InlineData(@"C:Path", true),
-        InlineData(@"C:\Path", false),
-        InlineData(@"\\?\C:\Path", false),
-        InlineData(@"Path", true),
-        InlineData(@"X", true)]
+    [Theory
+        InlineData(@"", false)
+        InlineData(@"\\?\", true)
+        InlineData(@"\??\", true)
+        InlineData(@"\\.\", false)
+        InlineData(@"\\?", false)
+        InlineData(@"\??", false)
+        InlineData(@"//?/", false)
+        InlineData(@"/??/", false)
+        ]
     [PlatformSpecific(PlatformID.Windows)]
-    public void IsRelativeTest(string path, bool expected)
+    public void IsExtendedTest(string path, bool expected)
     {
-        StringBuilder sb = new StringBuilder(path);
-        Assert.Equal(expected, PathInternal.IsRelative(sb));
+        StringBuffer sb = new StringBuffer();
+        sb.Append(path);
+        Assert.Equal(expected, PathInternal.IsExtended(sb));
 
-        Assert.Equal(expected, PathInternal.IsRelative(path));
+        Assert.Equal(expected, PathInternal.IsExtended(path));
+    }
+
+    [Theory
+        InlineData(@"", false)
+        InlineData(@"\\?\", true)
+        InlineData(@"\??\", true)
+        InlineData(@"\\.\", true)
+        InlineData(@"\\?", false)
+        InlineData(@"\??", false)
+        InlineData(@"//?/", true)
+        InlineData(@"/??/", false)
+        ]
+    [PlatformSpecific(PlatformID.Windows)]
+    public void IsDeviceTest(string path, bool expected)
+    {
+        StringBuffer sb = new StringBuffer();
+        sb.Append(path);
+
+        Assert.Equal(expected, PathInternal.IsDevice(sb));
+
+        Assert.Equal(expected, PathInternal.IsDevice(path));
+    }
+
+    [Theory
+        InlineData("", true)
+        InlineData("C:", true)
+        InlineData("**", true)
+        InlineData(@"\\.\path", false)
+        InlineData(@"\\?\path", false)
+        InlineData(@"\\.", false)
+        InlineData(@"\\?", false)
+        InlineData(@"\?", false)
+        InlineData(@"/?", false)
+        InlineData(@"\\", false)
+        InlineData(@"//", false)
+        InlineData(@"\a", true)
+        InlineData(@"/a", true)
+        InlineData(@"\", true)
+        InlineData(@"/", true)
+        InlineData(@"C:Path", true)
+        InlineData(@"C:\Path", false)
+        InlineData(@"\\?\C:\Path", false)
+        InlineData(@"Path", true)
+        InlineData(@"X", true)
+        ]
+    [PlatformSpecific(PlatformID.Windows)]
+    public void IsPartiallyQualifiedTest(string path, bool expected)
+    {
+        StringBuffer sb = new StringBuffer();
+        sb.Append(path);
+        Assert.Equal(expected, PathInternal.IsPartiallyQualified(sb));
+
+        Assert.Equal(expected, PathInternal.IsPartiallyQualified(path));
     }
 
     [Theory,

--- a/src/Common/tests/Tests/System/Runtime/InteropServices/StringBufferTests.cs
+++ b/src/Common/tests/Tests/System/Runtime/InteropServices/StringBufferTests.cs
@@ -27,8 +27,9 @@ namespace Tests.System.Runtime.InteropServices
         public unsafe void CreateFromString()
         {
             string testString = "Test";
-            using (var buffer = new StringBuffer(testString))
+            using (var buffer = new StringBuffer())
             {
+                buffer.Append(testString);
                 Assert.Equal((uint)testString.Length, buffer.Length);
                 Assert.Equal((uint)testString.Length + 1, buffer.CharCapacity);
 
@@ -47,8 +48,9 @@ namespace Tests.System.Runtime.InteropServices
         [Fact]
         public void ReduceLength()
         {
-            using (var buffer = new StringBuffer("Food"))
+            using (var buffer = new StringBuffer())
             {
+                buffer.Append("Food");
                 Assert.Equal((uint)5, buffer.CharCapacity);
                 buffer.Length = 3;
                 Assert.Equal("Foo", buffer.ToString());
@@ -88,8 +90,9 @@ namespace Tests.System.Runtime.InteropServices
             ]
         public void StartsWith(string source, string value, bool expected)
         {
-            using (var buffer = new StringBuffer(source))
+            using (var buffer = new StringBuffer())
             {
+                buffer.Append(source);
                 Assert.Equal(expected, buffer.StartsWith(value));
             }
         }
@@ -124,8 +127,9 @@ namespace Tests.System.Runtime.InteropServices
         [Fact]
         public void SubstringEqualsOverSizeCountWithIndexThrows()
         {
-            using (var buffer = new StringBuffer("A"))
+            using (var buffer = new StringBuffer())
             {
+                buffer.Append("A");
                 Assert.Throws<ArgumentOutOfRangeException>(() => buffer.SubstringEquals("", startIndex: 1, count: 1));
             }
         }
@@ -149,8 +153,9 @@ namespace Tests.System.Runtime.InteropServices
             ]
         public void SubstringEquals(string source, string value, int startIndex, int count, bool expected)
         {
-            using (var buffer = new StringBuffer(source))
+            using (var buffer = new StringBuffer())
             {
+                buffer.Append(source);
                 Assert.Equal(expected, buffer.SubstringEquals(value, startIndex: (uint)startIndex, count: count));
             }
         }
@@ -199,16 +204,20 @@ namespace Tests.System.Runtime.InteropServices
         public void AppendTests(string source, string value, int startIndex, int count, string expected)
         {
             // From string
-            using (var buffer = new StringBuffer(source))
+            using (var buffer = new StringBuffer())
             {
+                if (source != null) buffer.Append(source);
                 buffer.Append(value, startIndex, count);
                 Assert.Equal(expected, buffer.ToString());
             }
 
             // From buffer
-            using (var buffer = new StringBuffer(source))
-            using (var valueBuffer = new StringBuffer(value))
+            using (var buffer = new StringBuffer())
+            using (var valueBuffer = new StringBuffer())
             {
+                if (source != null) buffer.Append(source);
+                valueBuffer.Append(value);
+
                 if (count == -1)
                     buffer.Append(valueBuffer, (uint)startIndex, valueBuffer.Length - (uint)startIndex);
                 else
@@ -310,8 +319,9 @@ namespace Tests.System.Runtime.InteropServices
             ]
         public void ToStringTest(string source, int startIndex, int count, string expected)
         {
-            using (var buffer = new StringBuffer(source))
+            using (var buffer = new StringBuffer())
             {
+                buffer.Append(source);
                 Assert.Equal(expected, buffer.Substring(startIndex: (uint)startIndex, count: count));
             }
         }
@@ -319,8 +329,10 @@ namespace Tests.System.Runtime.InteropServices
         [Fact]
         public unsafe void SetLengthToFirstNullNoNull()
         {
-            using (var buffer = new StringBuffer("A"))
+            using (var buffer = new StringBuffer())
             {
+                buffer.Append("A");
+
                 // Wipe out the last null
                 buffer.CharPointer[buffer.Length] = 'B';
                 buffer.SetLengthToFirstNull();
@@ -346,8 +358,10 @@ namespace Tests.System.Runtime.InteropServices
             ]
         public unsafe void SetLengthToFirstNullTests(string content, ulong startLength, ulong endLength)
         {
-            using (var buffer = new StringBuffer(content))
+            using (var buffer = new StringBuffer())
             {
+                buffer.Append(content);
+
                 // With existing content
                 Assert.Equal(startLength, buffer.Length);
                 buffer.SetLengthToFirstNull();
@@ -382,8 +396,10 @@ namespace Tests.System.Runtime.InteropServices
         public void TrimEnd(string content, char[] trimChars, string expected)
         {
             // We want equivalence with built-in string behavior
-            using (var buffer = new StringBuffer(content))
+            using (var buffer = new StringBuffer())
             {
+                buffer.Append(content);
+
                 buffer.TrimEnd(trimChars);
                 Assert.Equal(expected, buffer.ToString());
             }
@@ -399,8 +415,10 @@ namespace Tests.System.Runtime.InteropServices
             ]
         public void CopyFromString(string content, string source, uint bufferIndex, int sourceIndex, int count, string expected)
         {
-            using (var buffer = new StringBuffer(content))
+            using (var buffer = new StringBuffer())
             {
+                buffer.Append(content);
+
                 buffer.CopyFrom(bufferIndex, source, sourceIndex, count);
                 Assert.Equal(expected, buffer.ToString());
             }
@@ -449,9 +467,12 @@ namespace Tests.System.Runtime.InteropServices
             ]
         public void CopyToBufferString(string destination, string content, uint destinationIndex, uint bufferIndex, uint count, string expected)
         {
-            using (var buffer = new StringBuffer(content))
-            using (var destinationBuffer = new StringBuffer(destination))
+            using (var buffer = new StringBuffer())
+            using (var destinationBuffer = new StringBuffer())
             {
+                buffer.Append(content);
+                destinationBuffer.Append(destination);
+
                 buffer.CopyTo(bufferIndex, destinationBuffer, destinationIndex, count);
                 Assert.Equal(expected, destinationBuffer.ToString());
             }
@@ -475,9 +496,11 @@ namespace Tests.System.Runtime.InteropServices
             ]
         public void CopyToBufferThrowsIndexingBeyondSourceBufferLength(string source, uint index, uint count)
         {
-            using (var buffer = new StringBuffer(source))
+            using (var buffer = new StringBuffer())
             using (var targetBuffer = new StringBuffer())
             {
+                buffer.Append(source);
+
                 Assert.Throws<ArgumentOutOfRangeException>(() => { buffer.CopyTo(index, targetBuffer, 0, count); });
             }
         }


### PR DESCRIPTION
- Properly account for dos device paths
- Remove unused path helpers
- Remove all validation for extended paths
- Recognize `\??\` syntax
- Handle device paths that get normalized

@stephentoub, @ianhays, @ramarag, @Priya91, @terrajobst, @weshaggard 