### PR TITLE
Fix IAsyncResult.AsyncState cast to ExceptionDispatchInfo

### DIFF
--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
@@ -1076,10 +1076,10 @@ namespace System.Net.Security
 
                 // Special case for an error notification.
                 object asyncState = asyncRequest.AsyncState;
-                Exception exception = asyncState as Exception;
+                ExceptionDispatchInfo exception = asyncState as ExceptionDispatchInfo;
                 if (exception != null)
                 {
-                    ExceptionDispatchInfo.Capture(exception).Throw();
+                    exception.Throw();
                 }
 
                 sslState.CheckCompletionBeforeNextReceive((ProtocolToken)asyncState, asyncRequest);


### PR DESCRIPTION
I had this change locally but neglected to include it as part of my SslStream errors fix-up PR yesterday.  In one place we were storing an exception into an AsyncState typed as object, and then were pulling it out and checking whether it was an exception... when I changed the storing location to use ExceptionDispatchInfo (https://github.com/stephentoub/corefx/blob/fix_edi_asyncstate/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs#L989), the cast on the way out also needed to change.

cc: @ericeil, @bartonjs, @davidsh