### PR TITLE
Disable test parallelization for ManualTests, since it breaks ConnectionPoolTests

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/App.config
+++ b/src/System.Data.SqlClient/tests/ManualTests/App.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <appSettings>
-    <add key="xunit.parallelizeTestCollections" value="false"/>
-  </appSettings>
-</configuration>

--- a/src/System.Data.SqlClient/tests/ManualTests/App.config
+++ b/src/System.Data.SqlClient/tests/ManualTests/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <appSettings>
+    <add key="xunit.parallelizeTestCollections" value="false"/>
+  </appSettings>
+</configuration>

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="SQL\TransactionTest\TransactionTest.cs" />
     <Compile Include="SQL\WeakRefTest\WeakRefTest.cs" />
     <Compile Include="SQL\WeakRefTestYukonSpecific\WeakRefTestYukonSpecific.cs" />
+    <Compile Include="XUnitAssemblyAttributes.cs" />
 
     <None Include="DDBasics\DataTypes\data.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -86,7 +87,6 @@
     <None Include="DataCommon\ConnectionString.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="App.config" />
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -86,6 +86,7 @@
     <None Include="DataCommon\ConnectionString.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="App.config" />
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Data.SqlClient/tests/ManualTests/XUnitAssemblyAttributes.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/XUnitAssemblyAttributes.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+// Connection pools are created per process, per connection string. So having a bunch of tests
+// run in parallel with identical connection strings causes Clear Pool tests to report incorrect results.
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]


### PR DESCRIPTION
Since Connection Pools are created per process per connection string, a bunch of tests running in parallel with the same connection strings were causing problems with ClearAllPoolsTest in ConnectionPoolTests. 