### PR TITLE
Fixing bug #6675 which prevented the OSX FSW from watching aliased or linked folders.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.RealPath.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.RealPath.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        /// <summary>
+        /// Takes a path containing relative subpaths or links and returns the absolute path.
+        /// This function works on both files and folders and returns a null-terminated string.
+        /// </summary>
+        /// <param name="path">The path to the file system object</param>
+        /// <returns>Returns the result string on success and null on failure</returns>
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_RealPath", SetLastError = true)]
+        internal static extern string RealPath(string path);
+    }
+}

--- a/src/Native/System.Native/pal_io.cpp
+++ b/src/Native/System.Native/pal_io.cpp
@@ -1103,3 +1103,9 @@ extern "C" int32_t SystemNative_INotifyRemoveWatch(intptr_t fd, int32_t wd)
     return -1;
 #endif
 }
+
+extern "C" char* SystemNative_RealPath(const char* path)
+{
+    assert(path != nullptr);
+    return realpath(path, nullptr);
+}

--- a/src/Native/System.Native/pal_io.h
+++ b/src/Native/System.Native/pal_io.h
@@ -672,3 +672,10 @@ extern "C" int32_t SystemNative_INotifyAddWatch(intptr_t fd, const char* pathNam
 * Returns 0 on success, or -1 if an error occurred (in which case, errno is set appropriately).
 */
 extern "C" int32_t SystemNative_INotifyRemoveWatch(intptr_t fd, int32_t wd);
+
+/**
+* Expands all symbolic links and expands all paths to return an absolute path
+*
+* Returns the result absolute path on success or null on error with errno set appropriately.
+*/
+extern "C" char* SystemNative_RealPath(const char* path);

--- a/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
+++ b/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
@@ -114,6 +114,9 @@
     <Compile Include="$(CommonPath)\Interop\OSX\Interop.RunLoop.cs">
       <Link>Common\Interop\OSX\Interop.RunLoop.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.RealPath.cs">
+      <Link>Common\Interop\Unix\Interop.RealPath.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Sync.cs">
       <Link>Common\Interop\Unix\Interop.Sync.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -172,6 +172,14 @@ namespace System.IO
 
             internal void Start()
             {
+                // Make sure _fullPath doesn't contain a link or alias
+                // since the OS will give back the actual, non link'd or alias'd paths
+                _fullDirectory = Interop.Sys.RealPath(_fullDirectory);
+                if (_fullDirectory == null)
+                {
+                    throw Interop.GetExceptionForIoErrno(Interop.Sys.GetLastErrorInfo(), _fullDirectory, true);
+                }
+
                 // Get the path to watch and verify we created the CFStringRef
                 SafeCreateHandle path = Interop.CoreFoundation.CFStringCreateWithCString(_fullDirectory);
                 if (path.IsInvalid)

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -554,4 +554,21 @@ public class FileSystemWatcherTests
         }
     }
 
+    [Fact]
+    public static void FileSystemWatcher_WatchingAliasedFolderResolvesToRealPathWhenWatching()
+    {
+        using (var dir = Utility.CreateTestDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())))
+        using (var fsw = new FileSystemWatcher(dir.Path))
+        {
+            AutoResetEvent are = Utility.WatchForEvents(fsw, WatcherChangeTypes.Created);
+
+            fsw.Filter = "*";
+            fsw.EnableRaisingEvents = true;
+
+            using (var temp = Utility.CreateTestDirectory(Path.Combine(dir.Path, "foo")))
+            {
+                Utility.ExpectEvent(are, "created");
+            }
+        }
+    }
 }


### PR DESCRIPTION
This pack fixes bug #6675 which prevented the FSW on OS X from working on paths that were linked or aliased. The root cause was that the ```Path.GetFullPath``` function call would expand relative paths but would not resolve links and aliases; once the underlying OS notified us about changes, the change path would be the actual path and not the linked / aliased one, causing the FSW to drop the change.

The fix is to use the ```realpath``` function (readlink did not seem to work on directories during my testing) to expand any links or aliases in the path before passing to the FSW. This means that the path ```/tmp``` could be passed in, but we will resolve the path as ```/private/tmp```, for example, since the OS would prefix all changes with that path.

This pack also adds a unit test to validate this scenario on OS X by creating a folder to watch in the temp directory and watching for a folder create that we make happen.

@stephentoub @victorhurdugaci 