### PR TITLE
Fix default permissions in UnixFileStream

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.FChMod.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.FChMod.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FChMod", SetLastError = true)]
+        internal static extern int FChMod(SafeFileHandle fd, int mode);
+    }
+}

--- a/src/Native/System.Native/pal_io.cpp
+++ b/src/Native/System.Native/pal_io.cpp
@@ -494,6 +494,13 @@ extern "C" int32_t SystemNative_ChMod(const char* path, int32_t mode)
     return result;
 }
 
+extern "C" int32_t SystemNative_FChMod(intptr_t fd, int32_t mode)
+{
+    int32_t result;
+    while (CheckInterrupted(result = fchmod(ToFileDescriptor(fd), static_cast<mode_t>(mode))));
+    return result;
+}
+
 extern "C" int32_t SystemNative_MkFifo(const char* path, int32_t mode)
 {
     int32_t result;

--- a/src/Native/System.Native/pal_io.h
+++ b/src/Native/System.Native/pal_io.h
@@ -431,6 +431,13 @@ extern "C" int32_t SystemNative_MkDir(const char* path, int32_t mode);
 extern "C" int32_t SystemNative_ChMod(const char* path, int32_t mode);
 
 /**
+* Change permissions of a file. Implemented as a shim to fchmod(2).
+*
+* Returns 0 for success, -1 for failure. Sets errno for failure.
+*/
+extern "C" int32_t SystemNative_FChMod(intptr_t fd, int32_t mode);
+
+/**
  * Create a FIFO (named pipe). Implemented as a shim to mkfifo(3).
  *
  * Returns 0 for success, -1 for failure. Sets errno for failure.

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -110,9 +110,17 @@ namespace System.IO
                 _asyncState = new AsyncState();
             }
 
-            // Translate the arguments into arguments for an open call
+            // Translate the arguments into arguments for an open call.
             Interop.Sys.OpenFlags openFlags = PreOpenConfigurationFromOptions(mode, access, options); // FileShare currently ignored
-            Interop.Sys.Permissions openPermissions = Interop.Sys.Permissions.S_IRWXU; // creator has read/write/execute permissions; no permissions for anyone else
+
+            // If the file gets created a new, we'll select the permissions for it.  Most utilities by default use 666 (read and 
+            // write for all). However, on Windows it's possible to write out a file and then execute it.  To maintain that similarity, 
+            // we use 766, so that in additoin the user has execute privileges. No matter what we choose, it'll be subject to the umask 
+            // applied by the system, such that the actual permissions will typically be less than what we select here.
+            const Interop.Sys.Permissions openPermissions =
+                Interop.Sys.Permissions.S_IRWXU |
+                Interop.Sys.Permissions.S_IRGRP | Interop.Sys.Permissions.S_IWGRP |
+                Interop.Sys.Permissions.S_IROTH | Interop.Sys.Permissions.S_IWOTH;
 
             // Open the file and store the safe handle. Subsequent code in this method expects the safe handle to be initialized.
             _fileHandle = SafeFileHandle.Open(path, openFlags, (int)openPermissions);

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -246,17 +246,14 @@
   <data name="Cryptography_FileStatusError" xml:space="preserve">
     <value>Unable to get file status.</value>
   </data>
-  <data name="Cryptography_InsufficientFilePermissions" xml:space="preserve">
-    <value>Invalid file permissions. The file '{0}' must be readable and writable by the owner.</value>
-  </data>
   <data name="Cryptography_InvalidDirectoryPermissions" xml:space="preserve">
     <value>Invalid directory permissions. The directory '{0}' must be readable, writable and executable by the owner. It must not be readable, writable or executable by anyone other than the owner.</value>
   </data>
   <data name="Cryptography_OwnerNotCurrentUser" xml:space="preserve">
     <value>The owner of '{0}' is not the current user.</value>
   </data>
-  <data name="Cryptography_TooBroadFilePermissions" xml:space="preserve">
-    <value>Invalid file permissions. The file '{0}' must not be readable or writable by anyone other than the owner.</value>
+  <data name="Cryptography_InvalidFilePermissions" xml:space="preserve">
+    <value>Invalid file permissions. The file '{0}' must readable and writable by the current owner and by no one else, and the permissions could not be changed to meet that criteria.</value>
   </data>
   <data name="Cryptography_Invalid_X500Name" xml:space="preserve">
     <value>The string contains an invalid X500 name attribute key, oid, value or delimiter.</value>

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -234,6 +234,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Close.cs">
       <Link>Common\Interop\Unix\Interop.Close.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FChMod.cs">
+      <Link>Common\Interop\Unix\System.Native\Interop.FChMod.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetEUid.cs">
       <Link>Common\Interop\Unix\Interop.GetEUid.cs</Link>
     </Compile>


### PR DESCRIPTION
We currently have UnixFileStream create new files with the permissions 700.  This doesn't map to what's commonly expected on Unix, where most utilities default instead to at least 666.

This commit changes the default to be 766, which attempts to map to what's commonly expected on Unix, while also factoring in the default on Windows, where a new FileStream's output can be executed by default.  All of these permissions are of course subject to the system's umask, such that the actual permissions applied will likely be less than what's specified.

The commit also fixes up some code in X509Certificates, which was coded to rely on the more limited permissions being applied.

cc: @bartonjs, @ianhays 