### PR TITLE
Remove content headers in CurlHandler when automatically decompressed

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -96,6 +96,34 @@ namespace System.Net.Http
 
             public void EnsureResponseMessagePublished()
             {
+                // If this is the response hasn't been published yet, do any finaly processing of the response 
+                // message before it's published.
+                if (!Task.IsCompleted)
+                {
+                    // On Windows, if the response was automatically decompressed, Content-Encoding and Content-Length
+                    // headers are removed from the response. Do the same thing here.
+                    DecompressionMethods dm = _handler.AutomaticDecompression;
+                    if (dm != DecompressionMethods.None)
+                    {
+                        HttpContentHeaders contentHeaders = _responseMessage.Content.Headers;
+                        IEnumerable<string> encodings;
+                        if (contentHeaders.TryGetValues(HttpKnownHeaderNames.ContentEncoding, out encodings))
+                        {
+                            foreach (string encoding in encodings)
+                            {
+                                if (((dm & DecompressionMethods.GZip) != 0 && string.Equals(encoding, EncodingNameGzip, StringComparison.OrdinalIgnoreCase)) ||
+                                    ((dm & DecompressionMethods.Deflate) != 0 && string.Equals(encoding, EncodingNameDeflate, StringComparison.OrdinalIgnoreCase)))
+                                {
+                                    contentHeaders.Remove(HttpKnownHeaderNames.ContentEncoding);
+                                    contentHeaders.Remove(HttpKnownHeaderNames.ContentLength);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Now ensure it's published.
                 bool result = TrySetResult(_responseMessage);
                 Debug.Assert(result || Task.Status == TaskStatus.RanToCompletion,
                     "If the task was already completed, it should have been completed succesfully; " +

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -220,6 +220,19 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [Theory, MemberData(nameof(CompressedServers))]
+        public async Task GetAsync_DefaultAutomaticDecompression_HeadersRemoved(Uri server)
+        {
+            using (var client = new HttpClient())
+            using (HttpResponseMessage response = await client.GetAsync(server, HttpCompletionOption.ResponseHeadersRead))
+            {
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                Assert.False(response.Content.Headers.Contains("Content-Encoding"), "Content-Encoding unexpectedly found");
+                Assert.False(response.Content.Headers.Contains("Content-Length"), "Content-Length unexpectedly found");
+            }
+        }
+
         [Fact]
         public async Task GetAsync_ServerNeedsAuthAndSetCredential_StatusCodeOK()
         {


### PR DESCRIPTION
WinHttpHandler removes the Content-Length and Content-Encoding headers when the content was automatically decompressed.  Do the same in CurlHandler.

cc: @davidsh, @kapilash, @ericeil 
Fixes #6796