### PR TITLE
Let the system allocate ports for the IPv6 sockets in ConnectExTest

### DIFF
--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/ConnectExTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/ConnectExTest.cs
@@ -21,7 +21,9 @@ namespace System.Net.Sockets.Tests
         {
             int port;
             SocketTestServer server = SocketTestServer.SocketTestServerFactory(IPAddress.Loopback, out port);
-            SocketTestServer server6 = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.IPv6Loopback, port));
+
+            int port6;
+            SocketTestServer server6 = SocketTestServer.SocketTestServerFactory(IPAddress.IPv6Loopback, out port6);
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 
@@ -41,7 +43,7 @@ namespace System.Net.Sockets.Tests
             sock.Dispose();
 
             sock = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
-            args.RemoteEndPoint = new IPEndPoint(IPAddress.IPv6Loopback, port);
+            args.RemoteEndPoint = new IPEndPoint(IPAddress.IPv6Loopback, port6);
             complete.Reset();
 
             Assert.True(sock.ConnectAsync(args));

--- a/src/System.Net.Sockets/tests/FunctionalTests/ConnectExTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ConnectExTest.cs
@@ -35,7 +35,8 @@ namespace System.Net.Sockets.Tests
             int port;
             SocketTestServer server = SocketTestServer.SocketTestServerFactory(IPAddress.Loopback, out port);
 
-            SocketTestServer server6 = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.IPv6Loopback, port));
+            int port6;
+            SocketTestServer server6 = SocketTestServer.SocketTestServerFactory(IPAddress.IPv6Loopback, out port6);
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 
@@ -55,7 +56,7 @@ namespace System.Net.Sockets.Tests
                 sock.Dispose();
 
                 sock = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
-                args.RemoteEndPoint = new IPEndPoint(IPAddress.IPv6Loopback, port);
+                args.RemoteEndPoint = new IPEndPoint(IPAddress.IPv6Loopback, port6);
                 complete.Reset();
 
                 Assert.True(sock.ConnectAsync(args));


### PR DESCRIPTION
This avoids an "address in use" error when running concurrently with other tests.

Fixes #4628.

@CIPop @stephentoub 