### PR TITLE
Expose additional APIs in System.ComponentModel contracts

### DIFF
--- a/src/System.ComponentModel.Primitives/ref/System.ComponentModel.Primitives.cs
+++ b/src/System.ComponentModel.Primitives/ref/System.ComponentModel.Primitives.cs
@@ -8,9 +8,62 @@
 
 namespace System.ComponentModel
 {
+    public sealed partial class BrowsableAttribute : System.Attribute
+    {
+        public static readonly System.ComponentModel.BrowsableAttribute Default;
+        public static readonly System.ComponentModel.BrowsableAttribute No;
+        public static readonly System.ComponentModel.BrowsableAttribute Yes;
+        public BrowsableAttribute(bool browsable) { }
+        public bool Browsable { get; }
+        public override bool Equals(object obj) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+    }
+    public partial class CategoryAttribute : System.Attribute
+    {
+        public CategoryAttribute() { }
+        public CategoryAttribute(string category) { }
+        public static System.ComponentModel.CategoryAttribute Action { get; }
+        public static System.ComponentModel.CategoryAttribute Appearance { get; }
+        public static System.ComponentModel.CategoryAttribute Asynchronous { get; }
+        public static System.ComponentModel.CategoryAttribute Behavior { get; }
+        public string Category { get; }
+        public static System.ComponentModel.CategoryAttribute Data { get; }
+        public static System.ComponentModel.CategoryAttribute Default { get; }
+        public static System.ComponentModel.CategoryAttribute Design { get; }
+        public static System.ComponentModel.CategoryAttribute DragDrop { get; }
+        public static System.ComponentModel.CategoryAttribute Focus { get; }
+        public static System.ComponentModel.CategoryAttribute Format { get; }
+        public static System.ComponentModel.CategoryAttribute Key { get; }
+        public static System.ComponentModel.CategoryAttribute Layout { get; }
+        public static System.ComponentModel.CategoryAttribute Mouse { get; }
+        public static System.ComponentModel.CategoryAttribute WindowStyle { get; }
+        public override bool Equals(object obj) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        protected virtual string GetLocalizedString(string value) { return default(string); }
+    }
     public partial class ComponentCollection
     {
         internal ComponentCollection() { }
+    }
+    public partial class DescriptionAttribute : System.Attribute
+    {
+        public static readonly System.ComponentModel.DescriptionAttribute Default;
+        public DescriptionAttribute() { }
+        public DescriptionAttribute(string description) { }
+        public virtual string Description { get; }
+        protected string DescriptionValue { get; set; }
+        public override bool Equals(object obj) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+    }
+    public partial class DisplayNameAttribute : System.Attribute
+    {
+        public static readonly System.ComponentModel.DisplayNameAttribute Default;
+        public DisplayNameAttribute() { }
+        public DisplayNameAttribute(string displayName) { }
+        public virtual string DisplayName { get; }
+        protected string DisplayNameValue { get; set; }
+        public override bool Equals(object obj) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
     }
     public partial interface IComponent : System.IDisposable
     {
@@ -24,11 +77,91 @@ namespace System.ComponentModel
         void Add(System.ComponentModel.IComponent component, string name);
         void Remove(System.ComponentModel.IComponent component);
     }
+    public sealed partial class ImmutableObjectAttribute : System.Attribute
+    {
+        public static readonly System.ComponentModel.ImmutableObjectAttribute Default;
+        public static readonly System.ComponentModel.ImmutableObjectAttribute No;
+        public static readonly System.ComponentModel.ImmutableObjectAttribute Yes;
+        public ImmutableObjectAttribute(bool immutable) { }
+        public bool Immutable { get; }
+        public override bool Equals(object obj) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+    }
+    public sealed partial class InitializationEventAttribute : System.Attribute
+    {
+        public InitializationEventAttribute(string eventName) { }
+        public string EventName { get; }
+    }
     public partial interface ISite : System.IServiceProvider
     {
         System.ComponentModel.IComponent Component { get; }
         System.ComponentModel.IContainer Container { get; }
         bool DesignMode { get; }
         string Name { get; set; }
+    }
+    public sealed partial class LocalizableAttribute : System.Attribute
+    {
+        public static readonly System.ComponentModel.LocalizableAttribute Default;
+        public static readonly System.ComponentModel.LocalizableAttribute No;
+        public static readonly System.ComponentModel.LocalizableAttribute Yes;
+        public LocalizableAttribute(bool isLocalizable) { }
+        public bool IsLocalizable { get; }
+        public override bool Equals(object obj) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+    }
+    public sealed partial class MergablePropertyAttribute : System.Attribute
+    {
+        public static readonly System.ComponentModel.MergablePropertyAttribute Default;
+        public static readonly System.ComponentModel.MergablePropertyAttribute No;
+        public static readonly System.ComponentModel.MergablePropertyAttribute Yes;
+        public MergablePropertyAttribute(bool allowMerge) { }
+        public bool AllowMerge { get; }
+        public override bool Equals(object obj) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+    }
+    public sealed partial class NotifyParentPropertyAttribute : System.Attribute
+    {
+        public static readonly System.ComponentModel.NotifyParentPropertyAttribute Default;
+        public static readonly System.ComponentModel.NotifyParentPropertyAttribute No;
+        public static readonly System.ComponentModel.NotifyParentPropertyAttribute Yes;
+        public NotifyParentPropertyAttribute(bool notifyParent) { }
+        public bool NotifyParent { get; }
+        public override bool Equals(object obj) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+    }
+    public sealed partial class ParenthesizePropertyNameAttribute : System.Attribute
+    {
+        public static readonly System.ComponentModel.ParenthesizePropertyNameAttribute Default;
+        public ParenthesizePropertyNameAttribute() { }
+        public ParenthesizePropertyNameAttribute(bool needParenthesis) { }
+        public bool NeedParenthesis { get; }
+        public override bool Equals(object o) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+    }
+    public sealed partial class ReadOnlyAttribute : System.Attribute
+    {
+        public static readonly System.ComponentModel.ReadOnlyAttribute Default;
+        public static readonly System.ComponentModel.ReadOnlyAttribute No;
+        public static readonly System.ComponentModel.ReadOnlyAttribute Yes;
+        public ReadOnlyAttribute(bool isReadOnly) { }
+        public bool IsReadOnly { get; }
+        public override bool Equals(object value) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+    }
+    public enum RefreshProperties
+    {
+        All = 1,
+        None = 0,
+        Repaint = 2,
+    }
+    public sealed partial class RefreshPropertiesAttribute : System.Attribute
+    {
+        public static readonly System.ComponentModel.RefreshPropertiesAttribute All;
+        public static readonly System.ComponentModel.RefreshPropertiesAttribute Default;
+        public static readonly System.ComponentModel.RefreshPropertiesAttribute Repaint;
+        public RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties refresh) { }
+        public System.ComponentModel.RefreshProperties RefreshProperties { get; }
+        public override bool Equals(object value) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
     }
 }

--- a/src/System.ComponentModel.Primitives/src/System.ComponentModel.Primitives.csproj
+++ b/src/System.ComponentModel.Primitives/src/System.ComponentModel.Primitives.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{F620F382-30D1-451E-B125-2A612F92068B}</ProjectGuid>
     <RootNamespace>System.ComponentModel.Primitives</RootNamespace>
     <AssemblyName>System.ComponentModel.Primitives</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.0</PackageTargetFramework>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net45'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.0</NuGetTargetMoniker>

--- a/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -12,6 +12,36 @@ namespace System.ComponentModel
     {
         public ArrayConverter() { }
         public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) { return default(object); }
+        public override System.ComponentModel.PropertyDescriptorCollection GetProperties(System.ComponentModel.ITypeDescriptorContext context, object value, System.Attribute[] attributes) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public override bool GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+    }
+    public partial class AttributeCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public static readonly System.ComponentModel.AttributeCollection Empty;
+        protected AttributeCollection() { }
+        public AttributeCollection(params System.Attribute[] attributes) { }
+        protected virtual System.Attribute[] Attributes { get; }
+        public bool Contains(System.Attribute attribute) { return default(bool); }
+        public bool Contains(System.Attribute[] attributes) { return default(bool); }
+        public void CopyTo(System.Array array, int index) { }
+        public int Count { get; }
+        public static System.ComponentModel.AttributeCollection FromExisting(System.ComponentModel.AttributeCollection existing, params System.Attribute[] newAttributes) { return default(System.ComponentModel.AttributeCollection); }
+        protected System.Attribute GetDefaultAttribute(System.Type attributeType) { return default(System.Attribute); }
+        public System.Collections.IEnumerator GetEnumerator() { return default(System.Collections.IEnumerator); }
+        bool System.Collections.ICollection.IsSynchronized { get; }
+        public bool Matches(System.Attribute attribute) { return default(bool); }
+        public bool Matches(System.Attribute[] attributes) { return default(bool); }
+        object System.Collections.ICollection.SyncRoot { get; }
+        public virtual System.Attribute this[int index] { get { return default(System.Attribute); } }
+        public virtual System.Attribute this[System.Type attributeType] { get { return default(System.Attribute); } }
+    }
+    public partial class AttributeProviderAttribute : System.Attribute
+    {
+        public AttributeProviderAttribute(string typeName) { }
+        public AttributeProviderAttribute(string typeName, string propertyName) { }
+        public AttributeProviderAttribute(System.Type type) { }
+        public string PropertyName { get; }
+        public string TypeName { get; }
     }
     public abstract partial class BaseNumberConverter : System.ComponentModel.TypeConverter
     {
@@ -26,11 +56,15 @@ namespace System.ComponentModel
         public BooleanConverter() { }
         public override bool CanConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Type sourceType) { return default(bool); }
         public override object ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) { return default(object); }
+        public override System.ComponentModel.TypeConverter.StandardValuesCollection GetStandardValues(System.ComponentModel.ITypeDescriptorContext context) { return default(System.ComponentModel.TypeConverter.StandardValuesCollection); }
+        public override bool GetStandardValuesExclusive(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+        public override bool GetStandardValuesSupported(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
     }
     public partial class ByteConverter : System.ComponentModel.BaseNumberConverter
     {
         public ByteConverter() { }
     }
+    public delegate void CancelEventHandler(object sender, System.ComponentModel.CancelEventArgs e);
     public partial class CharConverter : System.ComponentModel.TypeConverter
     {
         public CharConverter() { }
@@ -38,10 +72,54 @@ namespace System.ComponentModel
         public override object ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) { return default(object); }
         public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) { return default(object); }
     }
+    public enum CollectionChangeAction
+    {
+        Add = 1,
+        Refresh = 3,
+        Remove = 2,
+    }
+    public partial class CollectionChangeEventArgs : System.EventArgs
+    {
+        public CollectionChangeEventArgs(System.ComponentModel.CollectionChangeAction action, object element) { }
+        public virtual System.ComponentModel.CollectionChangeAction Action { get; }
+        public virtual object Element { get; }
+    }
+    public delegate void CollectionChangeEventHandler(object sender, System.ComponentModel.CollectionChangeEventArgs e);
     public partial class CollectionConverter : System.ComponentModel.TypeConverter
     {
         public CollectionConverter() { }
         public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) { return default(object); }
+        public override System.ComponentModel.PropertyDescriptorCollection GetProperties(System.ComponentModel.ITypeDescriptorContext context, object value, System.Attribute[] attributes) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public override bool GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+    }
+    public partial class CultureInfoConverter : System.ComponentModel.TypeConverter
+    {
+        public CultureInfoConverter() { }
+        public override bool CanConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Type sourceType) { return default(bool); }
+        public override bool CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType) { return default(bool); }
+        public override object ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) { return default(object); }
+        public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) { return default(object); }
+        protected virtual string GetCultureName(System.Globalization.CultureInfo culture) { return default(string); }
+        public override System.ComponentModel.TypeConverter.StandardValuesCollection GetStandardValues(System.ComponentModel.ITypeDescriptorContext context) { return default(System.ComponentModel.TypeConverter.StandardValuesCollection); }
+        public override bool GetStandardValuesExclusive(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+        public override bool GetStandardValuesSupported(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+    }
+    public abstract partial class CustomTypeDescriptor : System.ComponentModel.ICustomTypeDescriptor
+    {
+        protected CustomTypeDescriptor() { }
+        protected CustomTypeDescriptor(System.ComponentModel.ICustomTypeDescriptor parent) { }
+        public virtual System.ComponentModel.AttributeCollection GetAttributes() { return default(System.ComponentModel.AttributeCollection); }
+        public virtual string GetClassName() { return default(string); }
+        public virtual string GetComponentName() { return default(string); }
+        public virtual System.ComponentModel.TypeConverter GetConverter() { return default(System.ComponentModel.TypeConverter); }
+        public virtual System.ComponentModel.EventDescriptor GetDefaultEvent() { return default(System.ComponentModel.EventDescriptor); }
+        public virtual System.ComponentModel.PropertyDescriptor GetDefaultProperty() { return default(System.ComponentModel.PropertyDescriptor); }
+        public virtual object GetEditor(System.Type editorBaseType) { return default(object); }
+        public virtual System.ComponentModel.EventDescriptorCollection GetEvents() { return default(System.ComponentModel.EventDescriptorCollection); }
+        public virtual System.ComponentModel.EventDescriptorCollection GetEvents(System.Attribute[] attributes) { return default(System.ComponentModel.EventDescriptorCollection); }
+        public virtual System.ComponentModel.PropertyDescriptorCollection GetProperties() { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public virtual System.ComponentModel.PropertyDescriptorCollection GetProperties(System.Attribute[] attributes) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public virtual object GetPropertyOwner(System.ComponentModel.PropertyDescriptor pd) { return default(object); }
     }
     public partial class DateTimeConverter : System.ComponentModel.TypeConverter
     {
@@ -65,6 +143,39 @@ namespace System.ComponentModel
         public override bool CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType) { return default(bool); }
         public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) { return default(object); }
     }
+    public sealed partial class DefaultEventAttribute : System.Attribute
+    {
+        public static readonly System.ComponentModel.DefaultEventAttribute Default;
+        public DefaultEventAttribute(string name) { }
+        public override bool Equals(object obj) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public string Name { get; }
+    }
+    public sealed partial class DefaultPropertyAttribute : System.Attribute
+    {
+        public static readonly System.ComponentModel.DefaultPropertyAttribute Default;
+        public DefaultPropertyAttribute(string name) { }
+        public override bool Equals(object obj) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public string Name { get; }
+    }
+    public enum DesignerSerializationVisibility
+    {
+        Content = 2,
+        Hidden = 0,
+        Visible = 1,
+    }
+    public sealed partial class DesignerSerializationVisibilityAttribute : System.Attribute
+    {
+        public static readonly System.ComponentModel.DesignerSerializationVisibilityAttribute Content;
+        public static readonly System.ComponentModel.DesignerSerializationVisibilityAttribute Default;
+        public static readonly System.ComponentModel.DesignerSerializationVisibilityAttribute Hidden;
+        public static readonly System.ComponentModel.DesignerSerializationVisibilityAttribute Visible;
+        public DesignerSerializationVisibilityAttribute(DesignerSerializationVisibility visibility) { }
+        public override bool Equals(object obj) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+        public System.ComponentModel.DesignerSerializationVisibility Visibility { get; }
+    }
     public partial class DoubleConverter : System.ComponentModel.BaseNumberConverter
     {
         public DoubleConverter() { }
@@ -73,10 +184,80 @@ namespace System.ComponentModel
     {
         public EnumConverter(System.Type type) { }
         protected System.Type EnumType { get { return default(System.Type); } }
+        protected virtual System.Collections.IComparer Comparer { get; }
         public override bool CanConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Type sourceType) { return default(bool); }
         public override bool CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType) { return default(bool); }
         public override object ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) { return default(object); }
         public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) { return default(object); }
+        public override System.ComponentModel.TypeConverter.StandardValuesCollection GetStandardValues(System.ComponentModel.ITypeDescriptorContext context) { return default(System.ComponentModel.TypeConverter.StandardValuesCollection); }
+        public override bool GetStandardValuesExclusive(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+        public override bool GetStandardValuesSupported(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+        public override bool IsValid(System.ComponentModel.ITypeDescriptorContext context, object value) { return default(bool); }
+        protected System.ComponentModel.TypeConverter.StandardValuesCollection Values { get; set; }
+    }
+    public abstract partial class EventDescriptor : System.ComponentModel.MemberDescriptor
+    {
+        protected EventDescriptor(System.ComponentModel.MemberDescriptor descr) : base(default(System.ComponentModel.MemberDescriptor)) { }
+        protected EventDescriptor(System.ComponentModel.MemberDescriptor descr, System.Attribute[] attrs) : base(default(System.ComponentModel.MemberDescriptor), default(System.Attribute[])) { }
+        protected EventDescriptor(string name, System.Attribute[] attrs) : base(default(string), default(System.Attribute[])) { }
+        public abstract void AddEventHandler(object component, System.Delegate value);
+        public abstract System.Type ComponentType { get; }
+        public abstract System.Type EventType { get; }
+        public abstract bool IsMulticast { get; }
+        public abstract void RemoveEventHandler(object component, System.Delegate value);
+    }
+    public partial class EventDescriptorCollection : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+    {
+        public static readonly System.ComponentModel.EventDescriptorCollection Empty;
+        public EventDescriptorCollection(System.ComponentModel.EventDescriptor[] events) { }
+        public EventDescriptorCollection(System.ComponentModel.EventDescriptor[] events, bool readOnly) { }
+        int System.Collections.IList.Add(object value) { return default(int); }
+        bool System.Collections.IList.Contains(object value) { return default(bool); }
+        public int Count { get; }
+        int System.Collections.IList.IndexOf(object value) { return default(int); }
+        void System.Collections.IList.Insert(int index, object value) { }
+        bool System.Collections.ICollection.IsSynchronized { get; }
+        object System.Collections.ICollection.SyncRoot { get; }
+        bool System.Collections.IList.IsFixedSize { get; }
+        bool System.Collections.IList.IsReadOnly { get; }
+        void System.Collections.IList.Remove(object value) { }
+        object System.Collections.IList.this[int index] { get { return default(object); } set { } }
+        public virtual System.ComponentModel.EventDescriptor this[int index] { get { return default(System.ComponentModel.EventDescriptor); } }
+        public virtual System.ComponentModel.EventDescriptor this[string name] { get { return default(System.ComponentModel.EventDescriptor); } }
+        public int Add(System.ComponentModel.EventDescriptor value) { return default(int); }
+        public void Clear() { }
+        public bool Contains(System.ComponentModel.EventDescriptor value) { return default(bool); }
+        public virtual System.ComponentModel.EventDescriptor Find(string name, bool ignoreCase) { return default(System.ComponentModel.EventDescriptor); }
+        public System.Collections.IEnumerator GetEnumerator() { return default(System.Collections.IEnumerator); }
+        public int IndexOf(System.ComponentModel.EventDescriptor value) { return default(int); }
+        public void Insert(int index, System.ComponentModel.EventDescriptor value) { }
+        protected void InternalSort(System.Collections.IComparer sorter) { }
+        protected void InternalSort(string[] names) { }
+        public void Remove(System.ComponentModel.EventDescriptor value) { }
+        public void RemoveAt(int index) { }
+        public virtual System.ComponentModel.EventDescriptorCollection Sort() { return default(System.ComponentModel.EventDescriptorCollection); }
+        public virtual System.ComponentModel.EventDescriptorCollection Sort(System.Collections.IComparer comparer) { return default(System.ComponentModel.EventDescriptorCollection); }
+        public virtual System.ComponentModel.EventDescriptorCollection Sort(string[] names) { return default(System.ComponentModel.EventDescriptorCollection); }
+        public virtual System.ComponentModel.EventDescriptorCollection Sort(string[] names, System.Collections.IComparer comparer) { return default(System.ComponentModel.EventDescriptorCollection); }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+    }
+    public sealed partial class EventHandlerList : System.IDisposable
+    {
+        public EventHandlerList() { }
+        public System.Delegate this[object key] { get { return default(System.Delegate); } set { } }
+        public void AddHandler(object key, System.Delegate value) { }
+        public void AddHandlers(System.ComponentModel.EventHandlerList listToAddFrom) { }
+        public void Dispose() { }
+        public void RemoveHandler(object key, System.Delegate value) { }
+    }
+    public sealed partial class ExtenderProvidedPropertyAttribute : System.Attribute
+    {
+        public ExtenderProvidedPropertyAttribute() { }
+        public System.ComponentModel.PropertyDescriptor ExtenderProperty { get; }
+        public System.ComponentModel.IExtenderProvider Provider { get; }
+        public System.Type ReceiverType { get; }
+        public override bool Equals(object obj) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
     }
     public partial class GuidConverter : System.ComponentModel.TypeConverter
     {
@@ -85,6 +266,37 @@ namespace System.ComponentModel
         public override bool CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType) { return default(bool); }
         public override object ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) { return default(object); }
         public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) { return default(object); }
+    }
+    public partial class HandledEventArgs : System.EventArgs
+    {
+        public HandledEventArgs() { }
+        public HandledEventArgs(bool defaultHandledValue) { }
+        public bool Handled { get; set; }
+    }
+    public delegate void HandledEventHandler(object sender, System.ComponentModel.HandledEventArgs e);
+    public partial interface ICustomTypeDescriptor
+    {
+        System.ComponentModel.AttributeCollection GetAttributes();
+        string GetClassName();
+        string GetComponentName();
+        System.ComponentModel.TypeConverter GetConverter();
+        System.ComponentModel.EventDescriptor GetDefaultEvent();
+        System.ComponentModel.PropertyDescriptor GetDefaultProperty();
+        object GetEditor(System.Type editorBaseType);
+        System.ComponentModel.EventDescriptorCollection GetEvents();
+        System.ComponentModel.EventDescriptorCollection GetEvents(System.Attribute[] attributes);
+        System.ComponentModel.PropertyDescriptorCollection GetProperties();
+        System.ComponentModel.PropertyDescriptorCollection GetProperties(System.Attribute[] attributes);
+        object GetPropertyOwner(System.ComponentModel.PropertyDescriptor pd);
+    }
+    public partial interface IExtenderProvider
+    {
+        bool CanExtend(object extendee);
+    }
+    public partial interface IListSource
+    {
+        bool ContainsListCollection { get; }
+        System.Collections.IList GetList();
     }
     public partial class Int16Converter : System.ComponentModel.BaseNumberConverter
     {
@@ -98,6 +310,12 @@ namespace System.ComponentModel
     {
         public Int64Converter() { }
     }
+    public partial class InvalidAsynchronousStateException : System.ArgumentException
+    {
+        public InvalidAsynchronousStateException() { }
+        public InvalidAsynchronousStateException(string message) { }
+        public InvalidAsynchronousStateException(string message, System.Exception innerException) { }
+    }
     public partial interface ITypeDescriptorContext : System.IServiceProvider
     {
         System.ComponentModel.IContainer Container { get; }
@@ -106,10 +324,42 @@ namespace System.ComponentModel
         void OnComponentChanged();
         bool OnComponentChanging();
     }
+    public partial interface ITypedList
+    {
+        System.ComponentModel.PropertyDescriptorCollection GetItemProperties(System.ComponentModel.PropertyDescriptor[] listAccessors);
+        string GetListName(System.ComponentModel.PropertyDescriptor[] listAccessors);
+    }
+    public abstract partial class MemberDescriptor
+    {
+        protected MemberDescriptor(System.ComponentModel.MemberDescriptor descr) { }
+        protected MemberDescriptor(System.ComponentModel.MemberDescriptor oldMemberDescriptor, System.Attribute[] newAttributes) { }
+        protected MemberDescriptor(string name) { }
+        protected MemberDescriptor(string name, System.Attribute[] attributes) { }
+        protected virtual System.Attribute[] AttributeArray { get; set; }
+        public virtual System.ComponentModel.AttributeCollection Attributes { get; }
+        public virtual string Category { get; }
+        public virtual string Description { get; }
+        public virtual bool DesignTimeOnly { get; }
+        public virtual string DisplayName { get; }
+        public virtual bool IsBrowsable { get; }
+        public virtual string Name { get; }
+        protected virtual int NameHashCode { get; }
+        protected virtual System.ComponentModel.AttributeCollection CreateAttributeCollection() { return default(System.ComponentModel.AttributeCollection); }
+        public override bool Equals(object obj) { return default(bool); }
+        protected virtual void FillAttributes(System.Collections.IList attributeList) { }
+        protected static System.Reflection.MethodInfo FindMethod(System.Type componentClass, string name, System.Type[] args, System.Type returnType) { return default(System.Reflection.MethodInfo); }
+        protected static System.Reflection.MethodInfo FindMethod(System.Type componentClass, string name, System.Type[] args, System.Type returnType, bool publicOnly) { return default(System.Reflection.MethodInfo); }
+        public override int GetHashCode() { return default(int); }
+        protected virtual object GetInvocationTarget(System.Type type, object instance) { return default(object); }
+        protected static object GetInvokee(System.Type componentClass, object component) { return default(object); }
+        protected static System.ComponentModel.ISite GetSite(object component) { return default(System.ComponentModel.ISite); }
+    }
     public partial class MultilineStringConverter : System.ComponentModel.TypeConverter
     {
         public MultilineStringConverter() { }
         public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) { return default(object); }
+        public override System.ComponentModel.PropertyDescriptorCollection GetProperties(System.ComponentModel.ITypeDescriptorContext context, object value, System.Attribute[] attributes) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public override bool GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
     }
     public partial class NullableConverter : System.ComponentModel.TypeConverter
     {
@@ -121,11 +371,119 @@ namespace System.ComponentModel
         public override bool CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType) { return default(bool); }
         public override object ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) { return default(object); }
         public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) { return default(object); }
+        public override object CreateInstance(System.ComponentModel.ITypeDescriptorContext context, System.Collections.IDictionary propertyValues) { return default(object); }
+        public override bool GetCreateInstanceSupported(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+        public override System.ComponentModel.PropertyDescriptorCollection GetProperties(System.ComponentModel.ITypeDescriptorContext context, object value, System.Attribute[] attributes) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public override bool GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+        public override System.ComponentModel.TypeConverter.StandardValuesCollection GetStandardValues(System.ComponentModel.ITypeDescriptorContext context) { return default(System.ComponentModel.TypeConverter.StandardValuesCollection); }
+        public override bool GetStandardValuesExclusive(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+        public override bool GetStandardValuesSupported(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+        public override bool IsValid(System.ComponentModel.ITypeDescriptorContext context, object value) { return default(bool); }
     }
-    public abstract partial class PropertyDescriptor
+    public abstract partial class PropertyDescriptor : System.ComponentModel.MemberDescriptor
     {
-        internal PropertyDescriptor() { }
+        protected PropertyDescriptor(System.ComponentModel.MemberDescriptor descr) : base(default(System.ComponentModel.MemberDescriptor)) { }
+        protected PropertyDescriptor(System.ComponentModel.MemberDescriptor descr, System.Attribute[] attrs) : base(default(System.ComponentModel.MemberDescriptor), default(System.Attribute[])) { }
+        protected PropertyDescriptor(string name, System.Attribute[] attrs) : base(default(string), default(System.Attribute[])) { }
+        public abstract System.Type ComponentType { get; }
+        public virtual System.ComponentModel.TypeConverter Converter { get; }
+        public virtual bool IsLocalizable { get; }
+        public abstract bool IsReadOnly { get; }
+        public abstract System.Type PropertyType { get; }
+        public virtual bool SupportsChangeEvents { get; }
+        public virtual void AddValueChanged(object component, System.EventHandler handler) { }
+        public abstract bool CanResetValue(object component);
+        protected object CreateInstance(System.Type type) { return default(object); }
+        public override bool Equals(object obj) { return default(bool); }
+        protected override void FillAttributes(System.Collections.IList attributeList) { }
+        public System.ComponentModel.PropertyDescriptorCollection GetChildProperties() { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public System.ComponentModel.PropertyDescriptorCollection GetChildProperties(System.Attribute[] filter) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public System.ComponentModel.PropertyDescriptorCollection GetChildProperties(object instance) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public virtual System.ComponentModel.PropertyDescriptorCollection GetChildProperties(object instance, System.Attribute[] filter) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public override int GetHashCode() { return default(int); }
+        protected override object GetInvocationTarget(System.Type type, object instance) { return default(object); }
+        protected System.Type GetTypeFromName(string typeName) { return default(System.Type); }
+        public abstract object GetValue(object component);
+        protected internal System.EventHandler GetValueChangedHandler(object component) { return default(System.EventHandler); }
+        protected virtual void OnValueChanged(object component, System.EventArgs e) { }
+        public virtual void RemoveValueChanged(object component, System.EventHandler handler) { }
+        public abstract void ResetValue(object component);
+        public System.ComponentModel.DesignerSerializationVisibility SerializationVisibility { get { return default(System.ComponentModel.DesignerSerializationVisibility); } }
+        public abstract void SetValue(object component, object value);
+        public abstract bool ShouldSerializeValue(object component);
     }
+    public partial class PropertyDescriptorCollection : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IDictionary, System.Collections.IList
+    {
+        public static readonly System.ComponentModel.PropertyDescriptorCollection Empty;
+        public PropertyDescriptorCollection(System.ComponentModel.PropertyDescriptor[] properties) { }
+        public PropertyDescriptorCollection(System.ComponentModel.PropertyDescriptor[] properties, bool readOnly) { }
+        public int Count { get; }
+        bool System.Collections.ICollection.IsSynchronized { get; }
+        object System.Collections.ICollection.SyncRoot { get; }
+        bool System.Collections.IDictionary.IsFixedSize { get; }
+        void System.Collections.IDictionary.Add(object key, object value) { }
+        bool System.Collections.IDictionary.Contains(object key) { return default(bool); }
+        object System.Collections.IDictionary.this[object key] { get { return default(object); } set { } }
+        void System.Collections.IDictionary.Remove(object key) { }
+        bool System.Collections.IDictionary.IsReadOnly { get; }
+        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { return default(System.Collections.IDictionaryEnumerator); }
+        System.Collections.ICollection System.Collections.IDictionary.Keys { get; }
+        System.Collections.ICollection System.Collections.IDictionary.Values { get; }
+        bool System.Collections.IList.IsFixedSize { get; }
+        bool System.Collections.IList.IsReadOnly { get; }
+        int System.Collections.IList.Add(object value) { return default(int); }
+        void System.Collections.IList.Remove(object value) { }
+        bool System.Collections.IList.Contains(object value) { return default(bool); }
+        int System.Collections.IList.IndexOf(object value) { return default(int); }
+        void System.Collections.IList.Insert(int index, object value) { }
+        object System.Collections.IList.this[int index] { get { return default(object); } set { } }
+        public virtual System.ComponentModel.PropertyDescriptor this[int index] { get { return default(System.ComponentModel.PropertyDescriptor); } }
+        public virtual System.ComponentModel.PropertyDescriptor this[string name] { get { return default(System.ComponentModel.PropertyDescriptor); } }
+        public int Add(System.ComponentModel.PropertyDescriptor value) { return default(int); }
+        public void Clear() { }
+        public bool Contains(System.ComponentModel.PropertyDescriptor value) { return default(bool); }
+        public void CopyTo(System.Array array, int index) { }
+        public virtual System.ComponentModel.PropertyDescriptor Find(string name, bool ignoreCase) { return default(System.ComponentModel.PropertyDescriptor); }
+        public virtual System.Collections.IEnumerator GetEnumerator() { return default(System.Collections.IEnumerator); }
+        public int IndexOf(System.ComponentModel.PropertyDescriptor value) { return default(int); }
+        public void Insert(int index, System.ComponentModel.PropertyDescriptor value) { }
+        protected void InternalSort(System.Collections.IComparer sorter) { }
+        protected void InternalSort(string[] names) { }
+        public void Remove(System.ComponentModel.PropertyDescriptor value) { }
+        public void RemoveAt(int index) { }
+        public virtual System.ComponentModel.PropertyDescriptorCollection Sort() { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public virtual System.ComponentModel.PropertyDescriptorCollection Sort(System.Collections.IComparer comparer) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public virtual System.ComponentModel.PropertyDescriptorCollection Sort(string[] names) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public virtual System.ComponentModel.PropertyDescriptorCollection Sort(string[] names, System.Collections.IComparer comparer) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+    }
+    public sealed partial class ProvidePropertyAttribute : System.Attribute
+    {
+        public ProvidePropertyAttribute(string propertyName, string receiverTypeName) { }
+        public ProvidePropertyAttribute(string propertyName, System.Type receiverType) { }
+        public string PropertyName { get; }
+        public string ReceiverTypeName { get; }
+        public override bool Equals(object obj) { return default(bool); }
+        public override int GetHashCode() { return default(int); }
+    }
+    public partial class ReferenceConverter : System.ComponentModel.TypeConverter
+    {
+        public ReferenceConverter(System.Type type) { }
+        public override bool CanConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Type sourceType) { return default(bool); }
+        public override object ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) { return default(object); }
+        public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) { return default(object); }
+        public override System.ComponentModel.TypeConverter.StandardValuesCollection GetStandardValues(System.ComponentModel.ITypeDescriptorContext context) { return default(System.ComponentModel.TypeConverter.StandardValuesCollection); }
+        public override bool GetStandardValuesExclusive(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+        public override bool GetStandardValuesSupported(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+        protected virtual bool IsValueAllowed(System.ComponentModel.ITypeDescriptorContext context, object value) { return default(bool); }
+    }
+    public partial class RefreshEventArgs : System.EventArgs
+    {
+        public RefreshEventArgs(object componentChanged) { }
+        public RefreshEventArgs(System.Type typeChanged) { }
+        public object ComponentChanged { get; }
+        public System.Type TypeChanged { get; }
+    }
+    public delegate void RefreshEventHandler(System.ComponentModel.RefreshEventArgs e);
     public partial class SByteConverter : System.ComponentModel.BaseNumberConverter
     {
         public SByteConverter() { }
@@ -157,30 +515,161 @@ namespace System.ComponentModel
         public bool CanConvertTo(System.Type destinationType) { return default(bool); }
         public virtual object ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) { return default(object); }
         public object ConvertFrom(object value) { return default(object); }
+        public object ConvertFromInvariantString(System.ComponentModel.ITypeDescriptorContext context, string text) { return default(object); }
         public object ConvertFromInvariantString(string text) { return default(object); }
         public object ConvertFromString(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, string text) { return default(object); }
+        public object ConvertFromString(System.ComponentModel.ITypeDescriptorContext context, string text) { return default(object); }
         public object ConvertFromString(string text) { return default(object); }
         public virtual object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) { return default(object); }
         public object ConvertTo(object value, System.Type destinationType) { return default(object); }
+        public string ConvertToInvariantString(System.ComponentModel.ITypeDescriptorContext context, object value) { return default(string); }
         public string ConvertToInvariantString(object value) { return default(string); }
         public string ConvertToString(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) { return default(string); }
+        public string ConvertToString(System.ComponentModel.ITypeDescriptorContext context, object value) { return default(string); }
         public string ConvertToString(object value) { return default(string); }
+        public object CreateInstance(System.Collections.IDictionary propertyValues) { return default(object); }
+        public virtual object CreateInstance(System.ComponentModel.ITypeDescriptorContext context, System.Collections.IDictionary propertyValues) { return default(object); }
         protected System.Exception GetConvertFromException(object value) { return default(System.Exception); }
         protected System.Exception GetConvertToException(object value, System.Type destinationType) { return default(System.Exception); }
+        public bool GetCreateInstanceSupported() { return default(bool); }
+        public virtual bool GetCreateInstanceSupported(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+        public System.ComponentModel.PropertyDescriptorCollection GetProperties(System.ComponentModel.ITypeDescriptorContext context, object value) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public virtual System.ComponentModel.PropertyDescriptorCollection GetProperties(System.ComponentModel.ITypeDescriptorContext context, object value, System.Attribute[] attributes) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public System.ComponentModel.PropertyDescriptorCollection GetProperties(object value) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public bool GetPropertiesSupported() { return default(bool); }
+        public virtual bool GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+        public System.Collections.ICollection GetStandardValues() { return default(System.Collections.ICollection); }
+        public virtual System.ComponentModel.TypeConverter.StandardValuesCollection GetStandardValues(System.ComponentModel.ITypeDescriptorContext context) { return default(System.ComponentModel.TypeConverter.StandardValuesCollection); }
+        public bool GetStandardValuesExclusive() { return default(bool); }
+        public virtual bool GetStandardValuesExclusive(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+        public bool GetStandardValuesSupported() { return default(bool); }
+        public virtual bool GetStandardValuesSupported(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+        public virtual bool IsValid(System.ComponentModel.ITypeDescriptorContext context, object value) { return default(bool); }
+        public bool IsValid(object value) { return default(bool); }
+        protected System.ComponentModel.PropertyDescriptorCollection SortProperties(System.ComponentModel.PropertyDescriptorCollection props, string[] names) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        protected abstract partial class SimplePropertyDescriptor : System.ComponentModel.PropertyDescriptor
+        {
+            protected SimplePropertyDescriptor(System.Type componentType, string name, System.Type propertyType) : base(default(System.ComponentModel.MemberDescriptor)) { }
+            protected SimplePropertyDescriptor(System.Type componentType, string name, System.Type propertyType, System.Attribute[] attributes) : base(default(System.ComponentModel.MemberDescriptor)) { }
+            public override System.Type ComponentType { get; }
+            public override bool IsReadOnly { get; }
+            public override System.Type PropertyType { get; }
+            public override bool CanResetValue(object component) { return default(bool); }
+            public override void ResetValue(object component) { }
+            public override bool ShouldSerializeValue(object component) { return default(bool); }
+        }
+        public partial class StandardValuesCollection : System.Collections.ICollection, System.Collections.IEnumerable
+        {
+            public StandardValuesCollection(System.Collections.ICollection values) { }
+            public int Count { get; }
+            bool System.Collections.ICollection.IsSynchronized { get; }
+            object System.Collections.ICollection.SyncRoot { get; }
+            public object this[int index] { get { return default(object); } }
+            public void CopyTo(System.Array array, int index) { }
+            public System.Collections.IEnumerator GetEnumerator() { return default(System.Collections.IEnumerator); }
+        }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(32767))]
     public sealed partial class TypeConverterAttribute : System.Attribute
     {
+        public static readonly System.ComponentModel.TypeConverterAttribute Default;
+        public TypeConverterAttribute() { }
         public TypeConverterAttribute(string typeName) { }
         public TypeConverterAttribute(System.Type type) { }
         public string ConverterTypeName { get { return default(string); } }
         public override bool Equals(object obj) { return default(bool); }
         public override int GetHashCode() { return default(int); }
     }
+    public abstract partial class TypeDescriptionProvider
+    {
+        protected TypeDescriptionProvider() { }
+        protected TypeDescriptionProvider(System.ComponentModel.TypeDescriptionProvider parent) { }
+        public virtual object CreateInstance(System.IServiceProvider provider, System.Type objectType, System.Type[] argTypes, object[] args) { return default(object); }
+        public virtual System.Collections.IDictionary GetCache(object instance) { return default(System.Collections.IDictionary); }
+        public virtual System.ComponentModel.ICustomTypeDescriptor GetExtendedTypeDescriptor(object instance) { return default(System.ComponentModel.ICustomTypeDescriptor); }
+        protected internal virtual System.ComponentModel.IExtenderProvider[] GetExtenderProviders(object instance) { return default(System.ComponentModel.IExtenderProvider[]); }
+        public virtual string GetFullComponentName(object component) { return default(string); }
+        public System.Type GetReflectionType(object instance) { return default(System.Type); }
+        public System.Type GetReflectionType(System.Type objectType) { return default(System.Type); }
+        public virtual System.Type GetReflectionType(System.Type objectType, object instance) { return default(System.Type); }
+        public virtual System.Type GetRuntimeType(System.Type reflectionType) { return default(System.Type); }
+        public System.ComponentModel.ICustomTypeDescriptor GetTypeDescriptor(object instance) { return default(System.ComponentModel.ICustomTypeDescriptor); }
+        public System.ComponentModel.ICustomTypeDescriptor GetTypeDescriptor(System.Type objectType) { return default(System.ComponentModel.ICustomTypeDescriptor); }
+        public virtual System.ComponentModel.ICustomTypeDescriptor GetTypeDescriptor(System.Type objectType, object instance) { return default(System.ComponentModel.ICustomTypeDescriptor); }
+        public virtual bool IsSupportedType(System.Type type) { return default(bool); }
+    }
+    public sealed partial class TypeDescriptionProviderAttribute : System.Attribute
+    {
+        public TypeDescriptionProviderAttribute(string typeName) { }
+        public TypeDescriptionProviderAttribute(System.Type type) { }
+        public string TypeName { get; }
+    }
     public sealed partial class TypeDescriptor
     {
-        internal TypeDescriptor() { }
+        public static System.Type InterfaceType { get; }
+        public static event System.ComponentModel.RefreshEventHandler Refreshed { add { } remove { } }
+        public static System.ComponentModel.TypeDescriptionProvider AddAttributes(object instance, params System.Attribute[] attributes) { return default(System.ComponentModel.TypeDescriptionProvider); }
+        public static System.ComponentModel.TypeDescriptionProvider AddAttributes(System.Type type, params System.Attribute[] attributes) { return default(System.ComponentModel.TypeDescriptionProvider); }
+        public static void AddEditorTable(System.Type editorBaseType, System.Collections.Hashtable table) { }
+        public static void AddProvider(System.ComponentModel.TypeDescriptionProvider provider, object instance) { }
+        public static void AddProvider(System.ComponentModel.TypeDescriptionProvider provider, System.Type type) { }
+        public static void AddProviderTransparent(System.ComponentModel.TypeDescriptionProvider provider, object instance) { }
+        public static void AddProviderTransparent(System.ComponentModel.TypeDescriptionProvider provider, System.Type type) { }
+        public static void CreateAssociation(object primary, object secondary) { }
+        public static System.ComponentModel.EventDescriptor CreateEvent(System.Type componentType, System.ComponentModel.EventDescriptor oldEventDescriptor, params System.Attribute[] attributes) { return default(System.ComponentModel.EventDescriptor); }
+        public static System.ComponentModel.EventDescriptor CreateEvent(System.Type componentType, string name, System.Type type, params System.Attribute[] attributes) { return default(System.ComponentModel.EventDescriptor); }
+        public static object CreateInstance(System.IServiceProvider provider, System.Type objectType, System.Type[] argTypes, object[] args) { return default(object); }
+        public static System.ComponentModel.PropertyDescriptor CreateProperty(System.Type componentType, System.ComponentModel.PropertyDescriptor oldPropertyDescriptor, params System.Attribute[] attributes) { return default(System.ComponentModel.PropertyDescriptor); }
+        public static System.ComponentModel.PropertyDescriptor CreateProperty(System.Type componentType, string name, System.Type type, params System.Attribute[] attributes) { return default(System.ComponentModel.PropertyDescriptor); }
+        public static object GetAssociation(System.Type type, object primary) { return default(object); }
+        public static System.ComponentModel.AttributeCollection GetAttributes(object component) { return default(System.ComponentModel.AttributeCollection); }
+        public static System.ComponentModel.AttributeCollection GetAttributes(object component, bool noCustomTypeDesc) { return default(System.ComponentModel.AttributeCollection); }
+        public static System.ComponentModel.AttributeCollection GetAttributes(System.Type componentType) { return default(System.ComponentModel.AttributeCollection); }
+        public static string GetClassName(object component) { return default(string); }
+        public static string GetClassName(object component, bool noCustomTypeDesc) { return default(string); }
+        public static string GetClassName(System.Type componentType) { return default(string); }
+        public static string GetComponentName(object component) { return default(string); }
+        public static string GetComponentName(object component, bool noCustomTypeDesc) { return default(string); }
+        public static System.ComponentModel.TypeConverter GetConverter(object component) { return default(System.ComponentModel.TypeConverter); }
+        public static System.ComponentModel.TypeConverter GetConverter(object component, bool noCustomTypeDesc) { return default(System.ComponentModel.TypeConverter); }
         public static System.ComponentModel.TypeConverter GetConverter(System.Type type) { return default(System.ComponentModel.TypeConverter); }
+        public static System.ComponentModel.EventDescriptor GetDefaultEvent(object component) { return default(System.ComponentModel.EventDescriptor); }
+        public static System.ComponentModel.EventDescriptor GetDefaultEvent(object component, bool noCustomTypeDesc) { return default(System.ComponentModel.EventDescriptor); }
+        public static System.ComponentModel.EventDescriptor GetDefaultEvent(System.Type componentType) { return default(System.ComponentModel.EventDescriptor); }
+        public static System.ComponentModel.PropertyDescriptor GetDefaultProperty(object component) { return default(System.ComponentModel.PropertyDescriptor); }
+        public static System.ComponentModel.PropertyDescriptor GetDefaultProperty(object component, bool noCustomTypeDesc) { return default(System.ComponentModel.PropertyDescriptor); }
+        public static System.ComponentModel.PropertyDescriptor GetDefaultProperty(System.Type componentType) { return default(System.ComponentModel.PropertyDescriptor); }
+        public static object GetEditor(object component, System.Type editorBaseType) { return default(object); }
+        public static object GetEditor(object component, System.Type editorBaseType, bool noCustomTypeDesc) { return default(object); }
+        public static object GetEditor(System.Type type, System.Type editorBaseType) { return default(object); }
+        public static System.ComponentModel.EventDescriptorCollection GetEvents(object component) { return default(System.ComponentModel.EventDescriptorCollection); }
+        public static System.ComponentModel.EventDescriptorCollection GetEvents(object component, System.Attribute[] attributes) { return default(System.ComponentModel.EventDescriptorCollection); }
+        public static System.ComponentModel.EventDescriptorCollection GetEvents(object component, System.Attribute[] attributes, bool noCustomTypeDesc) { return default(System.ComponentModel.EventDescriptorCollection); }
+        public static System.ComponentModel.EventDescriptorCollection GetEvents(object component, bool noCustomTypeDesc) { return default(System.ComponentModel.EventDescriptorCollection); }
+        public static System.ComponentModel.EventDescriptorCollection GetEvents(System.Type componentType) { return default(System.ComponentModel.EventDescriptorCollection); }
+        public static System.ComponentModel.EventDescriptorCollection GetEvents(System.Type componentType, System.Attribute[] attributes) { return default(System.ComponentModel.EventDescriptorCollection); }
+        public static string GetFullComponentName(object component) { return default(string); }
+        public static System.ComponentModel.PropertyDescriptorCollection GetProperties(object component) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public static System.ComponentModel.PropertyDescriptorCollection GetProperties(object component, System.Attribute[] attributes) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public static System.ComponentModel.PropertyDescriptorCollection GetProperties(object component, System.Attribute[] attributes, bool noCustomTypeDesc) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public static System.ComponentModel.PropertyDescriptorCollection GetProperties(object component, bool noCustomTypeDesc) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public static System.ComponentModel.PropertyDescriptorCollection GetProperties(System.Type componentType) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public static System.ComponentModel.PropertyDescriptorCollection GetProperties(System.Type componentType, System.Attribute[] attributes) { return default(System.ComponentModel.PropertyDescriptorCollection); }
+        public static System.ComponentModel.TypeDescriptionProvider GetProvider(object instance) { return default(System.ComponentModel.TypeDescriptionProvider); }
+        public static System.ComponentModel.TypeDescriptionProvider GetProvider(System.Type type) { return default(System.ComponentModel.TypeDescriptionProvider); }
+        public static System.Type GetReflectionType(object instance) { return default(System.Type); }
+        public static System.Type GetReflectionType(System.Type type) { return default(System.Type); }
+        public static void Refresh(object component) { }
+        public static void Refresh(System.Reflection.Assembly assembly) { }
+        public static void Refresh(System.Reflection.Module module) { }
+        public static void Refresh(System.Type type) { }
+        public static void RemoveAssociation(object primary, object secondary) { }
+        public static void RemoveAssociations(object primary) { }
+        public static void RemoveProvider(System.ComponentModel.TypeDescriptionProvider provider, object instance) { }
+        public static void RemoveProvider(System.ComponentModel.TypeDescriptionProvider provider, System.Type type) { }
+        public static void RemoveProviderTransparent(System.ComponentModel.TypeDescriptionProvider provider, object instance) { }
+        public static void RemoveProviderTransparent(System.ComponentModel.TypeDescriptionProvider provider, System.Type type) { }
+        public static void SortDescriptorArray(System.Collections.IList infos) { }
     }
     public abstract partial class TypeListConverter : System.ComponentModel.TypeConverter
     {
@@ -189,6 +678,9 @@ namespace System.ComponentModel
         public override bool CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType) { return default(bool); }
         public override object ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) { return default(object); }
         public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) { return default(object); }
+        public override System.ComponentModel.TypeConverter.StandardValuesCollection GetStandardValues(System.ComponentModel.ITypeDescriptorContext context) { return default(System.ComponentModel.TypeConverter.StandardValuesCollection); }
+        public override bool GetStandardValuesExclusive(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
+        public override bool GetStandardValuesSupported(System.ComponentModel.ITypeDescriptorContext context) { return default(bool); }
     }
     public partial class UInt16Converter : System.ComponentModel.BaseNumberConverter
     {

--- a/src/System.ComponentModel.TypeConverter/ref/project.json
+++ b/src/System.ComponentModel.TypeConverter/ref/project.json
@@ -1,9 +1,11 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.0",
+    "System.Collections.NonGeneric": "4.0.0",
     "System.ComponentModel": "4.0.0",
     "System.ComponentModel.Primitives": "4.0.0",
-    "System.Globalization": "4.0.0"
+    "System.Globalization": "4.0.0",
+    "System.Reflection": "4.0.0",
+    "System.Runtime": "4.0.0"
   },
   "frameworks": {
     "netstandard1.0": {

--- a/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
+++ b/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{AF3EBF3B-526A-4B51-9F3D-62B0113CD01F}</ProjectGuid>
     <RootNamespace>System.ComponentModel.TypeConverter</RootNamespace>
     <AssemblyName>System.ComponentModel.TypeConverter</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.3</PackageTargetFramework>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net45'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>


### PR DESCRIPTION
This exposes the APIs tracked by #6573 in the contracts. Tests to come alongside implementation.

cc: @terrajobst @twsouthwick @weshaggard 