### PR TITLE
Fix SocketAsyncContext's "requeue" operation

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -371,8 +371,16 @@ namespace System.Net.Sockets
                 Debug.Assert(!IsStopped, "Expected !IsStopped");
                 Debug.Assert(operation.Next == null, "Operation already in queue");
 
-                operation.Next = (_tail == null) ? operation : _tail.Next;
-                _tail = operation;
+                if (IsEmpty)
+                {
+                    operation.Next = operation;
+                    _tail = operation;
+                }
+                else
+                {
+                    operation.Next = _tail.Next;
+                    _tail.Next = operation;
+                }
             }
 
             public OperationQueue<TOperation> Stop()


### PR DESCRIPTION
`Requeue` is supposed to add an item back to the head of the queue.  It was not implemented correctly, resulting in a corrupt queue in cases where an operation needed to be retried after an attempt to complete it on the event handler thread.

This addresses part of #6806 (the assert).  The test code in that issue still fails with a different problem, which I'll look into next.

@stephentoub, @pgavlin 