### PR TITLE
Add value for SNI_PN9 string resource for backwards compatibility with native SNI

### DIFF
--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -1036,7 +1036,7 @@
     <value>VIA Provider</value>
   </data>
   <data name="SNI_PN9" xml:space="preserve">
-    <value></value>
+    <value>SQL Network Interfaces</value>
   </data>
   <data name="SNI_PN10" xml:space="preserve">
     <value>SQL Network Interfaces</value>


### PR DESCRIPTION
Native SNI uses SNI_PN9 when reporting Network Interface errors. SNI Provider 9 is just a max value placeholder in managed SNI, so it isn't actually used when creating error messages. So adding a duplicate string value for SNI_PN9 won't cause any problems. 