### PR TITLE
Remove unimplemented properties from the reference assembly.

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
@@ -8,7 +8,6 @@
 namespace System.Diagnostics {
   public partial class DiagnosticListener : System.Diagnostics.DiagnosticSource, System.IDisposable, System.IObservable<System.Collections.Generic.KeyValuePair<string, object>> {
     public DiagnosticListener(string name) { }
-    public static System.Diagnostics.DiagnosticListener DefaultListener { get { return default(System.Diagnostics.DiagnosticListener); } }
     public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { return default(string); } }
     public static IObservable<DiagnosticListener> AllListeners { get { return default(IObservable<DiagnosticListener>); } } 
     public virtual void Dispose() { }
@@ -19,7 +18,6 @@ namespace System.Diagnostics {
   }
   public abstract partial class DiagnosticSource {
     protected DiagnosticSource() { }
-    public static System.Diagnostics.DiagnosticSource DefaultSource { get { return default(System.Diagnostics.DiagnosticSource); } }
     public abstract bool IsEnabled(string name);
     public abstract void Write(string name, object value);
   }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -34,16 +34,6 @@ namespace System.Diagnostics
     /// </summary>
     public class DiagnosticListener : DiagnosticSource, IObservable<KeyValuePair<string, object>>, IDisposable
     {
-#if false
-        /// <summary>
-        /// This is the DiagnosticListener that is used by default by the class library.   
-        /// Generally you don't want to make your own but rather have everyone use this one, which
-        /// ensures that everyone who wished to subscribe gets the callbacks.  
-        /// The main reason not to us this one is that you WANT isolation from other 
-        /// events in the system (e.g. multi-tenancy).  
-        /// </summary>
-        public static DiagnosticListener DefaultListener { get { return s_default; } }
-#endif 
         /// <summary>
         /// When you subscribe to this you get callbacks for all NotificationListeners in the appdomain
         /// as well as those that occurred in the past, and all future Listeners created in the future. 

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
@@ -12,15 +12,6 @@ namespace System.Diagnostics
     /// </summary>
     public abstract class DiagnosticSource
     {
-#if false
-        /// <summary>
-        /// The NotificationSource that you should be writing to by default.  This is what
-        /// most of the class library does.   Data written here goes to DefaultListener
-        /// which dispatches to all its subscribers.  
-        /// </summary>
-        // public static DiagnosticSource DefaultSource { get { return DiagnosticListener.DefaultListener; } }
-#endif 
-
         /// <summary>
         /// Write is a generic way of logging complex payloads.  Each notification
         /// is given a name, which identifies it as well as a object (typically an anonymous type)


### PR DESCRIPTION
We had two properties, DefaultSource and DefaultListener that were removed as part of API review feedback, but they were not removed from the reference assembly.   This update removes them form the reference assembly.  