### PR TITLE
Fix WinHttpHandler when no proxy creds after 407 response

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
@@ -122,6 +122,15 @@ namespace System.Net.Http
                     
                     state.LastStatusCode = statusCode;
 
+                    // If we don't have any proxy credentials to try, then we end up with 407.
+                    ICredentials proxyCreds = state.Proxy == null ?
+                        state.DefaultProxyCredentials :
+                        state.Proxy.Credentials;
+                     if (proxyCreds == null)
+                     {
+                         break;
+                     }
+
                     // Determine authorization scheme to use. We ignore the firstScheme
                     // parameter which is included in the supportedSchemes flags already.
                     // We pass the schemes to ChooseAuthScheme which will pick the scheme

--- a/src/System.Net.Http/tests/FunctionalTests/LoopbackGetRequestHttpProxy.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/LoopbackGetRequestHttpProxy.cs
@@ -63,11 +63,6 @@ namespace System.Net.Http.Functional.Tests
                 // a 407 response. Optionally, process a new request that would expect credentials.
                 if (requireAuth && !headers.ContainsKey("Proxy-Authorization"))
                 {
-                    if (expectCreds)
-                    {
-                        Task<Socket> secondListen = listener.AcceptSocketAsync();
-                    }
-
                     // Send back a 407
                     await clientSocket.SendAsync(
                         new ArraySegment<byte>(Encoding.ASCII.GetBytes("HTTP/1.1 407 Proxy Auth Required\r\nProxy-Authenticate: Basic\r\n\r\n")),

--- a/src/System.Net.Http/tests/FunctionalTests/LoopbackGetRequestHttpProxy.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/LoopbackGetRequestHttpProxy.cs
@@ -24,15 +24,15 @@ namespace System.Net.Http.Functional.Tests
             public string AuthenticationHeaderValue;
         }
 
-        public static Task<ProxyResult> StartAsync(out int port, bool requireAuth)
+        public static Task<ProxyResult> StartAsync(out int port, bool requireAuth, bool expectCreds)
         {
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
             port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            return StartAsync(listener, requireAuth);
+            return StartAsync(listener, requireAuth, expectCreds);
         }
 
-        private static async Task<ProxyResult> StartAsync(TcpListener listener, bool requireAuth)
+        private static async Task<ProxyResult> StartAsync(TcpListener listener, bool requireAuth, bool expectCreds)
         {
             ProxyResult result = new ProxyResult();
             var headers = new Dictionary<string, string>();
@@ -60,10 +60,13 @@ namespace System.Net.Http.Functional.Tests
                 await getAndReadRequest().ConfigureAwait(false);
 
                 // If we're expecting credentials, look for them, and if we didn't get them, send back 
-                // a response and process a new request.
+                // a 407 response. Optionally, process a new request that would expect credentials.
                 if (requireAuth && !headers.ContainsKey("Proxy-Authorization"))
                 {
-                    Task<Socket> secondListen = listener.AcceptSocketAsync();
+                    if (expectCreds)
+                    {
+                        Task<Socket> secondListen = listener.AcceptSocketAsync();
+                    }
 
                     // Send back a 407
                     await clientSocket.SendAsync(
@@ -72,8 +75,16 @@ namespace System.Net.Http.Functional.Tests
                     clientSocket.Shutdown(SocketShutdown.Send);
                     clientSocket.Dispose();
 
-                    // Wait for a new connection that should have an auth header this time and parse it.
-                    await getAndReadRequest().ConfigureAwait(false);
+                    if (expectCreds)
+                    {
+                        // Wait for a new connection that should have an auth header this time and parse it.
+                        await getAndReadRequest().ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        // No credentials will be coming in a subsequent request.
+                        return default(ProxyResult);
+                    }
                 }
 
                 // Store any auth header we may have for later comparison.


### PR DESCRIPTION
We were getting an assert if we had an authenticating proxy but didn't have any credentials to send. After the initial 407 was received from the proxy, we then tried to set credentials for a retry. But since we didn't have any, we triggered an assert in SetWinHttpCredential.

The fix is to check for null credentials after getting the 407 response. If there are no credentials, then we end the retry loop with the final 407 status code.