### PR TITLE
Don't invoke virtual property setters inside the base constructor.

### DIFF
--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/SymmetricAlgorithm.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/SymmetricAlgorithm.cs
@@ -11,8 +11,8 @@ namespace System.Security.Cryptography
     {
         protected SymmetricAlgorithm()
         {
-            Mode = CipherMode.CBC;
-            Padding = PaddingMode.PKCS7;
+            _cipherMode = CipherMode.CBC;
+            _paddingMode = PaddingMode.PKCS7;
         }
 
         public virtual int BlockSize


### PR DESCRIPTION
Classes that override these may not like having their virtual property setters called before the class is fully initialized.