### PR TITLE
Fix capitalization for NETFramework dependency

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/src/project.json
+++ b/src/System.Security.Cryptography.Algorithms/src/project.json
@@ -24,7 +24,7 @@
     },
     "net461": {
       "dependencies": {
-        "Microsoft.TargetingPack.NetFramework.v4.6.1": "1.0.1"
+        "Microsoft.TargetingPack.NETFramework.v4.6.1": "1.0.1"
       }
     }
   }


### PR DESCRIPTION
This avoids https://github.com/NuGet/Home/issues/2102 that corefx hasn't taken the fix for yet. dotnet CLI version is just barely too old.

This appears to be what was causing the zip to seem corrupted in https://github.com/dotnet/corefx/issues/6820.

/cc @Priya91 