### PR TITLE
Add check for pending async reads in SqlCommand ExecuteReaderAsync

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -1551,6 +1551,11 @@ namespace System.Data.SqlClient
         new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
         {
             TaskCompletionSource<SqlDataReader> source = new TaskCompletionSource<SqlDataReader>();
+            if(_stateObj != null)
+            {
+                source.SetException(ADP.ExceptionWithStackTrace(ADP.AsyncOperationPending()));
+                return source.Task;
+            }
 
             CancellationTokenRegistration registration = new CancellationTokenRegistration();
             if (cancellationToken.CanBeCanceled)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/6383 https://github.com/dotnet/corefx/issues/6571

Due to internal differences in handling async connections between native and managed SNI, managed SNI incorrectly handled multiple ExecuteReaderAsyncs on the same SqlCommand. Instead of throwing an AsyncOperationPending exception, it would fail due to state race conditions with the previous pending async operation.