### PR TITLE
Fix off-by-one similar to #6819 in other cases.

### DIFF
--- a/src/System.Linq/src/System/Linq/Partition.cs
+++ b/src/System.Linq/src/System/Linq/Partition.cs
@@ -260,7 +260,7 @@ namespace System.Linq
             public IPartition<TSource> Skip(int count)
             {
                 int minIndex = _minIndex + count;
-                return minIndex >= _maxIndex ? EmptyPartition<TSource>.Instance : new ListPartition<TSource>(_source, minIndex, _maxIndex);
+                return (uint)minIndex > (uint)_maxIndex ? EmptyPartition<TSource>.Instance : new ListPartition<TSource>(_source, minIndex, _maxIndex);
             }
 
             public IPartition<TSource> Take(int count)

--- a/src/System.Linq/src/System/Linq/Select.cs
+++ b/src/System.Linq/src/System/Linq/Select.cs
@@ -730,7 +730,7 @@ namespace System.Linq
             {
                 Debug.Assert(count > 0);
                 int minIndex = _minIndex + count;
-                return minIndex >= _maxIndex ? EmptyPartition<TResult>.Instance : new SelectListPartitionIterator<TSource, TResult>(_source, _selector, minIndex, _maxIndex);
+                return (uint)minIndex > (uint)_maxIndex ? EmptyPartition<TResult>.Instance : new SelectListPartitionIterator<TSource, TResult>(_source, _selector, minIndex, _maxIndex);
             }
 
             public IPartition<TResult> Take(int count)

--- a/src/System.Linq/tests/OrderedSubsetting.cs
+++ b/src/System.Linq/tests/OrderedSubsetting.cs
@@ -330,6 +330,15 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void SkipTakesOnlyOne()
+        {
+            Assert.Equal(new[] { 1 }, Enumerable.Range(1, 10).Shuffle().OrderBy(i => i).Take(1));
+            Assert.Equal(new[] { 2 }, Enumerable.Range(1, 10).Shuffle().OrderBy(i => i).Skip(1).Take(1));
+            Assert.Equal(new[] { 3 }, Enumerable.Range(1, 10).Shuffle().OrderBy(i => i).Take(3).Skip(2));
+            Assert.Equal(new[] { 1 }, Enumerable.Range(1, 10).Shuffle().OrderBy(i => i).Take(3).Take(1));
+        }
+
+        [Fact]
         public void EmptyToArray()
         {
             Assert.Empty(Enumerable.Range(0, 100).Shuffle().OrderBy(i => i).Skip(100).ToArray());

--- a/src/System.Linq/tests/RangeTests.cs
+++ b/src/System.Linq/tests/RangeTests.cs
@@ -168,6 +168,15 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void SkipTakeCanOnlyBeOne()
+        {
+            Assert.Equal(new[] { 1 }, Enumerable.Range(1, 10).Take(1));
+            Assert.Equal(new[] { 2 }, Enumerable.Range(1, 10).Skip(1).Take(1));
+            Assert.Equal(new[] { 3 }, Enumerable.Range(1, 10).Take(3).Skip(2));
+            Assert.Equal(new[] { 1 }, Enumerable.Range(1, 10).Take(3).Take(1));
+        }
+
+        [Fact]
         public void ElementAt()
         {
             Assert.Equal(4, Enumerable.Range(0, 10).ElementAt(4));

--- a/src/System.Linq/tests/RepeatTests.cs
+++ b/src/System.Linq/tests/RepeatTests.cs
@@ -173,6 +173,15 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void TakeCanOnlyBeOne()
+        {
+            Assert.Equal(new[] { 1 }, Enumerable.Repeat(1, 10).Take(1));
+            Assert.Equal(new[] { 1 }, Enumerable.Repeat(1, 10).Skip(1).Take(1));
+            Assert.Equal(new[] { 1 }, Enumerable.Repeat(1, 10).Take(3).Skip(2));
+            Assert.Equal(new[] { 1 }, Enumerable.Repeat(1, 10).Take(3).Take(1));
+        }
+
+        [Fact]
         public void SkipNone()
         {
             Assert.Equal(Enumerable.Repeat(12, 8), Enumerable.Repeat(12, 8).Skip(0));

--- a/src/System.Linq/tests/SelectTests.cs
+++ b/src/System.Linq/tests/SelectTests.cs
@@ -842,6 +842,10 @@ namespace System.Linq.Tests
             Assert.Empty(source.Take(-1));
             Assert.Equal(new[] { 2, 4, 6, 8 }, source.Take(4));
             Assert.Equal(new[] { 2, 4, 6, 8 }, source.Take(40));
+            Assert.Equal(new[] { 2 }, source.Take(1));
+            Assert.Equal(new[] { 4 }, source.Skip(1).Take(1));
+            Assert.Equal(new[] { 6 }, source.Take(3).Skip(2));
+            Assert.Equal(new[] { 2 }, source.Take(3).Take(1));
         }
 
         [Fact]
@@ -853,6 +857,10 @@ namespace System.Linq.Tests
             Assert.Empty(source.Take(-1));
             Assert.Equal(new[] { 2, 4, 6, 8 }, source.Take(4));
             Assert.Equal(new[] { 2, 4, 6, 8 }, source.Take(40));
+            Assert.Equal(new[] { 2 }, source.Take(1));
+            Assert.Equal(new[] { 4 }, source.Skip(1).Take(1));
+            Assert.Equal(new[] { 6 }, source.Take(3).Skip(2));
+            Assert.Equal(new[] { 2 }, source.Take(3).Take(1));
         }
 
         [Fact]
@@ -864,6 +872,10 @@ namespace System.Linq.Tests
             Assert.Empty(source.Take(-1));
             Assert.Equal(new[] { 2, 4, 6, 8 }, source.Take(4));
             Assert.Equal(new[] { 2, 4, 6, 8 }, source.Take(40));
+            Assert.Equal(new[] { 2 }, source.Take(1));
+            Assert.Equal(new[] { 4 }, source.Skip(1).Take(1));
+            Assert.Equal(new[] { 6 }, source.Take(3).Skip(2));
+            Assert.Equal(new[] { 2 }, source.Take(3).Take(1));
         }
 
         [Fact]

--- a/src/System.Linq/tests/TakeTests.cs
+++ b/src/System.Linq/tests/TakeTests.cs
@@ -416,6 +416,26 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void TakeCanOnlyBeOneList()
+        {
+            var source = new[] { 2, 4, 6, 8, 10 };
+            Assert.Equal(new[] { 2 }, source.Take(1));
+            Assert.Equal(new[] { 4 }, source.Skip(1).Take(1));
+            Assert.Equal(new[] { 6 }, source.Take(3).Skip(2));
+            Assert.Equal(new[] { 2 }, source.Take(3).Take(1));
+        }
+
+        [Fact]
+        public void TakeCanOnlyBeOneNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 2, 4, 6, 8, 10 });
+            Assert.Equal(new[] { 2 }, source.Take(1));
+            Assert.Equal(new[] { 4 }, source.Skip(1).Take(1));
+            Assert.Equal(new[] { 6 }, source.Take(3).Skip(2));
+            Assert.Equal(new[] { 2 }, source.Take(3).Take(1));
+        }
+
+        [Fact]
         public void RepeatEnumerating()
         {
             var source = new[] { 1, 2, 3, 4, 5 };


### PR DESCRIPTION
Fixes #6842

Also extend tests to cover both those and other places it could occur even if it currently doesn't.

Further,  name min/max index fields as inclusive as @stephentoub suggested, making the inclusive nature of the boundaries more explicit in the code.

Likely easier to review a commit at a time, as otherwise the fixes get lost in the name changes.

cc: @stephentoub @VSadov 