### PR TITLE
Typo fix its → it's

### DIFF
--- a/src/System.Linq/tests/CastTests.cs
+++ b/src/System.Linq/tests/CastTests.cs
@@ -214,7 +214,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = new object[0].Where(i => i != null).Cast<string>();
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<string>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/ConcatTests.cs
+++ b/src/System.Linq/tests/ConcatTests.cs
@@ -72,7 +72,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Concat(Enumerable.Range(0, 3));
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/DefaultIfEmptyTests.cs
+++ b/src/System.Linq/tests/DefaultIfEmptyTests.cs
@@ -113,7 +113,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).DefaultIfEmpty();
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/DistinctTests.cs
+++ b/src/System.Linq/tests/DistinctTests.cs
@@ -195,7 +195,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Distinct();
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/ExceptTests.cs
+++ b/src/System.Linq/tests/ExceptTests.cs
@@ -182,7 +182,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Except(Enumerable.Range(0, 3));
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/GroupJoinTests.cs
+++ b/src/System.Linq/tests/GroupJoinTests.cs
@@ -463,7 +463,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).GroupJoin(Enumerable.Empty<int>(), i => i, i => i, (o, i) => i);
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<IEnumerable<int>>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/IntersectTests.cs
+++ b/src/System.Linq/tests/IntersectTests.cs
@@ -182,7 +182,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Intersect(Enumerable.Range(0, 3));
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/JoinTests.cs
+++ b/src/System.Linq/tests/JoinTests.cs
@@ -414,7 +414,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Join(Enumerable.Empty<int>(), i => i, i => i, (o, i) => i);
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/OfTypeTests.cs
+++ b/src/System.Linq/tests/OfTypeTests.cs
@@ -121,7 +121,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).OfType<int>();
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/OrderedSubsetting.cs
+++ b/src/System.Linq/tests/OrderedSubsetting.cs
@@ -402,7 +402,7 @@ namespace System.Linq.Tests
         public void SelectForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = Enumerable.Range(-1, 8).Shuffle().OrderBy(i => i).Skip(1).Take(5).Select(i => i * 2);
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/ReverseTests.cs
+++ b/src/System.Linq/tests/ReverseTests.cs
@@ -100,7 +100,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Reverse();
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/SelectManyTests.cs
+++ b/src/System.Linq/tests/SelectManyTests.cs
@@ -332,7 +332,7 @@ namespace System.Linq.Tests.LegacyTests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).SelectMany(i => new int[0]);
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/SelectTests.cs
+++ b/src/System.Linq/tests/SelectTests.cs
@@ -730,7 +730,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Select(i => i);
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }
@@ -739,7 +739,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerateIndexed()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Select((e, i) => i);
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/SkipTests.cs
+++ b/src/System.Linq/tests/SkipTests.cs
@@ -201,7 +201,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Skip(2);
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }
@@ -210,7 +210,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerateIList()
         {
             var iterator = (new[] { 0, 1, 2 }).Skip(2);
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/SkipWhileTests.cs
+++ b/src/System.Linq/tests/SkipWhileTests.cs
@@ -154,7 +154,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).SkipWhile(e => true);
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }
@@ -163,7 +163,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerateIndexed()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).SkipWhile((e, i) => true);
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/TakeTests.cs
+++ b/src/System.Linq/tests/TakeTests.cs
@@ -177,7 +177,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Take(2);
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }
@@ -194,7 +194,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerateIList()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).ToList().Take(2);
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/TakeWhileTests.cs
+++ b/src/System.Linq/tests/TakeWhileTests.cs
@@ -157,7 +157,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).TakeWhile(e => true);
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }
@@ -166,7 +166,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerateIndexed()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).TakeWhile((e, i) => true);
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/UnionTests.cs
+++ b/src/System.Linq/tests/UnionTests.cs
@@ -289,7 +289,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Union(Enumerable.Range(0, 3));
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }
@@ -298,7 +298,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerateMultipleUnions()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Union(Enumerable.Range(0, 3)).Union(Enumerable.Range(2, 4)).Union(new[] { 9, 2, 4 });
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/WhereTests.cs
+++ b/src/System.Linq/tests/WhereTests.cs
@@ -1007,7 +1007,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Where(i => true);
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }

--- a/src/System.Linq/tests/ZipTests.cs
+++ b/src/System.Linq/tests/ZipTests.cs
@@ -375,7 +375,7 @@ namespace System.Linq.Tests
         public void ForcedToEnumeratorDoesntEnumerate()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Zip(Enumerable.Range(0, 3), (x, y) => x + y);
-            // Don't insist on this behaviour, but check its correct if it happens
+            // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }


### PR DESCRIPTION
It's bad enough I typed the wrong form of it's/its, but then I copy-pasted it another 25 times.