### PR TITLE
Implement SocketPal.Poll on Unix with poll instead of select

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.Poll.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Poll.cs
@@ -10,10 +10,12 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
+        [Flags]
         internal enum PollEvents : short
         {
             POLLNONE = 0x0000,  // No events occurred.
-            POLLIN   = 0x0001,  // any readable data available
+            POLLIN   = 0x0001,  // non-urgent readable data available
+            POLLPRI  = 0x0002,  // urgent readable data available
             POLLOUT  = 0x0004,  // data can be written without blocked
             POLLERR  = 0x0008,  // an error occurred
             POLLHUP  = 0x0010,  // the file descriptor hung up
@@ -46,7 +48,7 @@ internal static partial class Interop
         /// <param name="timeout">The amount of time to wait; -1 for infinite, 0 for immediate return, and a positive number is the number of milliseconds</param>
         /// <param name="triggered">The events that were returned by the poll call. May be PollEvents.POLLNONE in the case of a timeout.</param>
         /// <returns>An error or Error.SUCCESS.</returns>
-        internal static unsafe Error Poll(SafeFileHandle fd, PollEvents events, int timeout, out PollEvents triggered)
+        internal static unsafe Error Poll(SafeHandle fd, PollEvents events, int timeout, out PollEvents triggered)
         {
             bool gotRef = false;
             try

--- a/src/Native/System.Native/pal_io.cpp
+++ b/src/Native/System.Native/pal_io.cpp
@@ -102,6 +102,7 @@ static_assert(PAL_SEEK_END == SEEK_END, "");
 
 // Validate our PollFlags enum values are correct for the platform
 static_assert(PAL_POLLIN == POLLIN, "");
+static_assert(PAL_POLLPRI == POLLPRI, "");
 static_assert(PAL_POLLOUT == POLLOUT, "");
 static_assert(PAL_POLLERR == POLLERR, "");
 static_assert(PAL_POLLHUP == POLLHUP, "");

--- a/src/Native/System.Native/pal_io.h
+++ b/src/Native/System.Native/pal_io.h
@@ -218,7 +218,8 @@ enum SysConfName : int32_t
  */
 enum PollEvents : int16_t
 {
-    PAL_POLLIN = 0x0001,   /* any readable data available */
+    PAL_POLLIN = 0x0001,   /* non-urgent readable data available */
+    PAL_POLLPRI = 0x0002,  /* urgent readable data available */
     PAL_POLLOUT = 0x0004,  /* data can be written without blocked */
     PAL_POLLERR = 0x0008,  /* an error occurred */
     PAL_POLLHUP = 0x0010,  /* the file descriptor hung up */

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -442,6 +442,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MulticastOption.cs">
       <Link>Interop\Unix\System.Native\Interop.MulticastOption.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Poll.cs">
+      <Link>Interop\Unix\System.Native\Interop.Poll.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.PlatformSocketSupport.cs">
       <Link>Interop\Unix\System.Native\Interop.PlatformSocketSupport.cs</Link>
     </Compile>


### PR DESCRIPTION
SocketPal.Poll on Unix is currently implemented with select.  This is causing problems due to limitations of select, which fails with file descriptors >= FD_SETSIZE.  I've changed the implementation to use poll instead, which both fixes the problem and results in simpler code.  I've also added a few tests, and in the process of doing so cleaned up some related tests to use theories.

This is blocking #6833, which in CI is frequently getting file descriptors for sockets larger than FD_SETSIZE.

cc: @ericeil, @pgavlin, @davidsh, @CIPop
Contributes to #4728.