### PR TITLE
Cleanup some code in System.Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
@@ -274,8 +274,6 @@ namespace System.Linq.Expressions
         {
             var members = type.GetProperties(flags)
                 .Where(x => x.Name.Equals(propertyName, StringComparison.CurrentCultureIgnoreCase));
-            if (!members.Any())
-                return null;
 
             PropertyInfo pi;
             int count = FindBestProperty(members, arguments, out pi);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
@@ -456,51 +456,45 @@ namespace System.Linq.Expressions
 
         private static void ValidateAccessorArgumentTypes(MethodInfo method, ParameterInfo[] indexes, ref ReadOnlyCollection<Expression> arguments)
         {
-            if (indexes.Length > 0)
+            if (indexes.Length != arguments.Count)
             {
-                if (indexes.Length != arguments.Count)
+                throw Error.IncorrectNumberOfMethodCallArguments(method);
+            }
+
+            Expression[] newArgs = null;
+            for (int i = 0; i < indexes.Length; i++)
+            {
+                Expression arg = arguments[i];
+                ParameterInfo pi = indexes[i];
+                RequiresCanRead(arg, nameof(arguments));
+
+                Type parameterType = pi.ParameterType;
+                if (parameterType.IsByRef) throw Error.AccessorsCannotHaveByRefArgs();
+                TypeUtils.ValidateType(parameterType);
+
+                if (!TypeUtils.AreReferenceAssignable(parameterType, arg.Type))
                 {
-                    throw Error.IncorrectNumberOfMethodCallArguments(method);
+                    if (!TryQuote(parameterType, ref arg))
+                    {
+                        throw Error.ExpressionTypeDoesNotMatchMethodParameter(arg.Type, parameterType, method);
+                    }
                 }
-                Expression[] newArgs = null;
-                for (int i = 0, n = indexes.Length; i < n; i++)
+                if (newArgs == null && arg != arguments[i])
                 {
-                    Expression arg = arguments[i];
-                    ParameterInfo pi = indexes[i];
-                    RequiresCanRead(arg, nameof(arguments));
-
-                    Type pType = pi.ParameterType;
-                    if (pType.IsByRef) throw Error.AccessorsCannotHaveByRefArgs();
-                    TypeUtils.ValidateType(pType);
-
-                    if (!TypeUtils.AreReferenceAssignable(pType, arg.Type))
+                    newArgs = new Expression[arguments.Count];
+                    for (int j = 0; j < i; j++)
                     {
-                        if (!TryQuote(pType, ref arg))
-                        {
-                            throw Error.ExpressionTypeDoesNotMatchMethodParameter(arg.Type, pType, method);
-                        }
-                    }
-                    if (newArgs == null && arg != arguments[i])
-                    {
-                        newArgs = new Expression[arguments.Count];
-                        for (int j = 0; j < i; j++)
-                        {
-                            newArgs[j] = arguments[j];
-                        }
-                    }
-                    if (newArgs != null)
-                    {
-                        newArgs[i] = arg;
+                        newArgs[j] = arguments[j];
                     }
                 }
                 if (newArgs != null)
                 {
-                    arguments = new TrueReadOnlyCollection<Expression>(newArgs);
+                    newArgs[i] = arg;
                 }
             }
-            else if (arguments.Count > 0)
+            if (newArgs != null)
             {
-                throw Error.IncorrectNumberOfMethodCallArguments(method);
+                arguments = new TrueReadOnlyCollection<Expression>(newArgs);
             }
         }
         #endregion

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
@@ -273,7 +273,7 @@ namespace System.Linq.Expressions
         private static PropertyInfo FindProperty(Type type, string propertyName, Expression[] arguments, BindingFlags flags)
         {
             var props = type.GetProperties(flags).Where(x => x.Name.Equals(propertyName, StringComparison.CurrentCultureIgnoreCase)); ;
-            PropertyInfo[] members = new List<PropertyInfo>(props).ToArray();
+            PropertyInfo[] members = props.ToArray();
             if (members == null || members.Length == 0)
                 return null;
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
@@ -472,12 +472,9 @@ namespace System.Linq.Expressions
                 if (parameterType.IsByRef) throw Error.AccessorsCannotHaveByRefArgs();
                 TypeUtils.ValidateType(parameterType);
 
-                if (!TypeUtils.AreReferenceAssignable(parameterType, arg.Type))
+                if (!TypeUtils.AreReferenceAssignable(parameterType, arg.Type) && !TryQuote(parameterType, ref arg))
                 {
-                    if (!TryQuote(parameterType, ref arg))
-                    {
-                        throw Error.ExpressionTypeDoesNotMatchMethodParameter(arg.Type, parameterType, method);
-                    }
+                    throw Error.ExpressionTypeDoesNotMatchMethodParameter(arg.Type, parameterType, method);
                 }
                 if (newArgs == null && arg != arguments[i])
                 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
@@ -272,14 +272,13 @@ namespace System.Linq.Expressions
 
         private static PropertyInfo FindProperty(Type type, string propertyName, Expression[] arguments, BindingFlags flags)
         {
-            var props = type.GetProperties(flags).Where(x => x.Name.Equals(propertyName, StringComparison.CurrentCultureIgnoreCase)); ;
+            var props = type.GetProperties(flags).Where(x => x.Name.Equals(propertyName, StringComparison.CurrentCultureIgnoreCase));
             PropertyInfo[] members = props.ToArray();
-            if (members == null || members.Length == 0)
+            if (members.Length == 0)
                 return null;
 
             PropertyInfo pi;
-            var propertyInfos = members.Map(t => (PropertyInfo)t);
-            int count = FindBestProperty(propertyInfos, arguments, out pi);
+            int count = FindBestProperty(members, arguments, out pi);
 
             if (count == 0)
                 return null;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
@@ -159,7 +159,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             if (exception.Data[typeof(InterpretedFrameInfo)] == null)
             {
-                exception.Data[typeof(InterpretedFrameInfo)] = new List<InterpretedFrameInfo>(GetStackTraceDebugInfo()).ToArray();
+                exception.Data[typeof(InterpretedFrameInfo)] = GetStackTraceDebugInfo().ToArray();
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
@@ -157,7 +157,7 @@ namespace System.Linq.Expressions.Interpreter
 
         internal void SaveTraceToException(Exception exception)
         {
-            if (!exception.Data.Contains(typeof(InterpretedFrameInfo)))
+            if (exception.Data[typeof(InterpretedFrameInfo)] == null)
             {
                 exception.Data[typeof(InterpretedFrameInfo)] = GetStackTraceDebugInfo().ToArray();
             }


### PR DESCRIPTION
Removed some redundant allocations caused by creating a `List` and immediately calling `ToArray` on it. Also some code cleanup: removed some unnecessary semicolons/null checks, simplified if statements, reduced indentation.

cc @stephentoub