### PR TITLE
Avoid IComparer<T> allocations in System.Reflection.Metadata

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/EnumerableExtensions.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/EnumerableExtensions.cs
@@ -9,21 +9,6 @@ namespace System.Reflection.Internal
 {
     internal static class EnumerableExtensions
     {
-        private class ComparisonComparer<T> : Comparer<T>
-        {
-            private readonly Comparison<T> _compare;
-
-            public ComparisonComparer(Comparison<T> compare)
-            {
-                _compare = compare;
-            }
-
-            public override int Compare(T x, T y)
-            {
-                return _compare(x, y);
-            }
-        }
-
         private static class Functions<T>
         {
             public static readonly Func<T, T> Identity = t => t;
@@ -32,11 +17,6 @@ namespace System.Reflection.Internal
         public static IOrderedEnumerable<T> OrderBy<T>(this IEnumerable<T> source, IComparer<T> comparer)
         {
             return source.OrderBy(Functions<T>.Identity, comparer);
-        }
-
-        public static IOrderedEnumerable<T> OrderBy<T>(this IEnumerable<T> source, Comparison<T> compare)
-        {
-            return source.OrderBy(new ComparisonComparer<T>(compare));
         }
     }
 }


### PR DESCRIPTION
This pull request avoids allocating a new `IComparer<T>` every time `OrderBy` is called in specific methods in System.Reflection.Metadata. The previous implementation used `Funcs<>` and a `ComparisonComparer<T>` class to allow calling `OrderBy` via a lambda. While this was more convenient, it caused 2 unnecessary allocations: one for the delegate, and one for the comparer.

I've replaced all of these lambdas with dedicated classes to remove these allocations. In addition, I've removed the associated extension method and `ComparisonComparer<T>` class.

cc @stephentoub @JonHanna 