### PR TITLE
System.Reflection.Metadata: Supplant use of ImmutableArray.CreateRange with MoveToImmutable

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Heaps.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Heaps.cs
@@ -290,14 +290,15 @@ namespace Roslyn.Reflection.Metadata.Ecma335
 
         public ImmutableArray<int> GetHeapSizes()
         {
-            var heapSizes = new int[MetadataTokens.HeapCount];
+            var builder = ImmutableArray.CreateBuilder<int>(MetadataTokens.HeapCount);
+            builder.Count = builder.Capacity;
 
-            heapSizes[(int)HeapIndex.UserString] = _userStringWriter.Count;
-            heapSizes[(int)HeapIndex.String] = _stringWriter.Count;
-            heapSizes[(int)HeapIndex.Blob] = _blobHeapSize;
-            heapSizes[(int)HeapIndex.Guid] = _guidWriter.Count;
+            builder[(int)HeapIndex.UserString] = _userStringWriter.Count;
+            builder[(int)HeapIndex.String] = _stringWriter.Count;
+            builder[(int)HeapIndex.Blob] = _blobHeapSize;
+            builder[(int)HeapIndex.Guid] = _guidWriter.Count;
 
-            return ImmutableArray.CreateRange(heapSizes);
+            return builder.MoveToImmutable();
         }
 
         /// <summary>

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Tables.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Tables.cs
@@ -841,55 +841,56 @@ namespace Roslyn.Reflection.Metadata.Ecma335
 
         public ImmutableArray<int> GetRowCounts()
         {
-            var rowCounts = new int[MetadataTokens.TableCount];
+            var builder = ImmutableArray.CreateBuilder<int>(MetadataTokens.TableCount);
+            builder.Count = builder.Capacity;
 
-            rowCounts[(int)TableIndex.Assembly] = _assemblyTable.Count;
-            rowCounts[(int)TableIndex.AssemblyRef] = _assemblyRefTable.Count;
-            rowCounts[(int)TableIndex.ClassLayout] = _classLayoutTable.Count;
-            rowCounts[(int)TableIndex.Constant] = _constantTable.Count;
-            rowCounts[(int)TableIndex.CustomAttribute] = _customAttributeTable.Count;
-            rowCounts[(int)TableIndex.DeclSecurity] = _declSecurityTable.Count;
-            rowCounts[(int)TableIndex.EncLog] = _encLogTable.Count;
-            rowCounts[(int)TableIndex.EncMap] = _encMapTable.Count;
-            rowCounts[(int)TableIndex.EventMap] = _eventMapTable.Count;
-            rowCounts[(int)TableIndex.Event] = _eventTable.Count;
-            rowCounts[(int)TableIndex.ExportedType] = _exportedTypeTable.Count;
-            rowCounts[(int)TableIndex.FieldLayout] = _fieldLayoutTable.Count;
-            rowCounts[(int)TableIndex.FieldMarshal] = _fieldMarshalTable.Count;
-            rowCounts[(int)TableIndex.FieldRva] = _fieldRvaTable.Count;
-            rowCounts[(int)TableIndex.Field] = _fieldTable.Count;
-            rowCounts[(int)TableIndex.File] = _fileTable.Count;
-            rowCounts[(int)TableIndex.GenericParamConstraint] = _genericParamConstraintTable.Count;
-            rowCounts[(int)TableIndex.GenericParam] = _genericParamTable.Count;
-            rowCounts[(int)TableIndex.ImplMap] = _implMapTable.Count;
-            rowCounts[(int)TableIndex.InterfaceImpl] = _interfaceImplTable.Count;
-            rowCounts[(int)TableIndex.ManifestResource] = _manifestResourceTable.Count;
-            rowCounts[(int)TableIndex.MemberRef] = _memberRefTable.Count;
-            rowCounts[(int)TableIndex.MethodImpl] = _methodImplTable.Count;
-            rowCounts[(int)TableIndex.MethodSemantics] = _methodSemanticsTable.Count;
-            rowCounts[(int)TableIndex.MethodSpec] = _methodSpecTable.Count;
-            rowCounts[(int)TableIndex.MethodDef] = _methodDefTable.Count;
-            rowCounts[(int)TableIndex.ModuleRef] = _moduleRefTable.Count;
-            rowCounts[(int)TableIndex.Module] = _moduleTable.Count;
-            rowCounts[(int)TableIndex.NestedClass] = _nestedClassTable.Count;
-            rowCounts[(int)TableIndex.Param] = _paramTable.Count;
-            rowCounts[(int)TableIndex.PropertyMap] = _propertyMapTable.Count;
-            rowCounts[(int)TableIndex.Property] = _propertyTable.Count;
-            rowCounts[(int)TableIndex.StandAloneSig] = _standAloneSigTable.Count;
-            rowCounts[(int)TableIndex.TypeDef] = _typeDefTable.Count;
-            rowCounts[(int)TableIndex.TypeRef] = _typeRefTable.Count;
-            rowCounts[(int)TableIndex.TypeSpec] = _typeSpecTable.Count;
+            builder[(int)TableIndex.Assembly] = _assemblyTable.Count;
+            builder[(int)TableIndex.AssemblyRef] = _assemblyRefTable.Count;
+            builder[(int)TableIndex.ClassLayout] = _classLayoutTable.Count;
+            builder[(int)TableIndex.Constant] = _constantTable.Count;
+            builder[(int)TableIndex.CustomAttribute] = _customAttributeTable.Count;
+            builder[(int)TableIndex.DeclSecurity] = _declSecurityTable.Count;
+            builder[(int)TableIndex.EncLog] = _encLogTable.Count;
+            builder[(int)TableIndex.EncMap] = _encMapTable.Count;
+            builder[(int)TableIndex.EventMap] = _eventMapTable.Count;
+            builder[(int)TableIndex.Event] = _eventTable.Count;
+            builder[(int)TableIndex.ExportedType] = _exportedTypeTable.Count;
+            builder[(int)TableIndex.FieldLayout] = _fieldLayoutTable.Count;
+            builder[(int)TableIndex.FieldMarshal] = _fieldMarshalTable.Count;
+            builder[(int)TableIndex.FieldRva] = _fieldRvaTable.Count;
+            builder[(int)TableIndex.Field] = _fieldTable.Count;
+            builder[(int)TableIndex.File] = _fileTable.Count;
+            builder[(int)TableIndex.GenericParamConstraint] = _genericParamConstraintTable.Count;
+            builder[(int)TableIndex.GenericParam] = _genericParamTable.Count;
+            builder[(int)TableIndex.ImplMap] = _implMapTable.Count;
+            builder[(int)TableIndex.InterfaceImpl] = _interfaceImplTable.Count;
+            builder[(int)TableIndex.ManifestResource] = _manifestResourceTable.Count;
+            builder[(int)TableIndex.MemberRef] = _memberRefTable.Count;
+            builder[(int)TableIndex.MethodImpl] = _methodImplTable.Count;
+            builder[(int)TableIndex.MethodSemantics] = _methodSemanticsTable.Count;
+            builder[(int)TableIndex.MethodSpec] = _methodSpecTable.Count;
+            builder[(int)TableIndex.MethodDef] = _methodDefTable.Count;
+            builder[(int)TableIndex.ModuleRef] = _moduleRefTable.Count;
+            builder[(int)TableIndex.Module] = _moduleTable.Count;
+            builder[(int)TableIndex.NestedClass] = _nestedClassTable.Count;
+            builder[(int)TableIndex.Param] = _paramTable.Count;
+            builder[(int)TableIndex.PropertyMap] = _propertyMapTable.Count;
+            builder[(int)TableIndex.Property] = _propertyTable.Count;
+            builder[(int)TableIndex.StandAloneSig] = _standAloneSigTable.Count;
+            builder[(int)TableIndex.TypeDef] = _typeDefTable.Count;
+            builder[(int)TableIndex.TypeRef] = _typeRefTable.Count;
+            builder[(int)TableIndex.TypeSpec] = _typeSpecTable.Count;
 
-            rowCounts[(int)TableIndex.Document] = _documentTable.Count;
-            rowCounts[(int)TableIndex.MethodDebugInformation] = _methodDebugInformationTable.Count;
-            rowCounts[(int)TableIndex.LocalScope] = _localScopeTable.Count;
-            rowCounts[(int)TableIndex.LocalVariable] = _localVariableTable.Count;
-            rowCounts[(int)TableIndex.LocalConstant] = _localConstantTable.Count;
-            rowCounts[(int)TableIndex.StateMachineMethod] = _stateMachineMethodTable.Count;
-            rowCounts[(int)TableIndex.ImportScope] = _importScopeTable.Count;
-            rowCounts[(int)TableIndex.CustomDebugInformation] = _customDebugInformationTable.Count;
+            builder[(int)TableIndex.Document] = _documentTable.Count;
+            builder[(int)TableIndex.MethodDebugInformation] = _methodDebugInformationTable.Count;
+            builder[(int)TableIndex.LocalScope] = _localScopeTable.Count;
+            builder[(int)TableIndex.LocalVariable] = _localVariableTable.Count;
+            builder[(int)TableIndex.LocalConstant] = _localConstantTable.Count;
+            builder[(int)TableIndex.StateMachineMethod] = _stateMachineMethodTable.Count;
+            builder[(int)TableIndex.ImportScope] = _importScopeTable.Count;
+            builder[(int)TableIndex.CustomDebugInformation] = _customDebugInformationTable.Count;
 
-            return ImmutableArray.CreateRange(rowCounts);
+            return builder.MoveToImmutable();
         }
 
         #region Serialization

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataSerializer.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataSerializer.cs
@@ -79,7 +79,15 @@ namespace Roslyn.Reflection.Metadata.Ecma335
 #endif
     sealed class TypeSystemMetadataSerializer : MetadataSerializer
     {
-        private static readonly ImmutableArray<int> EmptyRowCounts = ImmutableArray.CreateRange(Enumerable.Repeat(0, MetadataTokens.TableCount));
+        private static readonly ImmutableArray<int> EmptyRowCounts = CreateEmptyRowCounts();
+
+        private static ImmutableArray<int> CreateEmptyRowCounts()
+        {
+            var builder = ImmutableArray.CreateBuilder<int>(MetadataTokens.TableCount);
+            builder.Count = builder.Capacity;
+            // Memory is already zeroed-out, no need to fill it here
+            return builder.MoveToImmutable();
+        }
 
         public TypeSystemMetadataSerializer(
             MetadataBuilder tables, 

--- a/src/System.Reflection.Metadata/tests/Metadata/Ecma335/MetadataBuilderTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/Ecma335/MetadataBuilderTests.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Reflection.Metadata.Ecma335.Tests
+{
+    public class MetadataBuilderTests
+    {
+        [Fact]
+        public void GetHeapSizes()
+        {
+            var builder = new MetadataBuilder();
+            builder.CompleteHeaps(); // do this so _stringWriter is initialized and we don't nullref
+            var heapSizes = builder.GetHeapSizes();
+            Assert.Equal(MetadataTokens.HeapCount, heapSizes.Length);
+        }
+
+        [Fact]
+        public void GetRowCounts()
+        {
+            var builder = new MetadataBuilder();
+            var rowCounts = builder.GetRowCounts();
+            Assert.Equal(MetadataTokens.TableCount, rowCounts.Length);
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/tests/Metadata/Ecma335/MetadataSerializerTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/Ecma335/MetadataSerializerTests.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace System.Reflection.Metadata.Ecma335.Tests
+{
+    public class MetadataSerializerTests
+    {
+        [Fact]
+        public void TypeSystemSerializer_EmptyRowCounts()
+        {
+            var serializer = CreateTSSerializer();
+            var externalRowCounts = serializer.MetadataSizes.ExternalRowCounts;
+            Assert.Equal(MetadataTokens.TableCount, externalRowCounts.Length);
+            Assert.DoesNotContain(externalRowCounts, count => count != 0); // array should be zeroed out
+        }
+
+        private TypeSystemMetadataSerializer CreateTSSerializer() =>
+            new TypeSystemMetadataSerializer(new MetadataBuilder(), "PDB v1.0", false);
+    }
+}

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -40,6 +40,8 @@
     <Compile Include="Metadata\Decoding\OpaqueHandleTypeProvider.cs" />
     <Compile Include="Metadata\Decoding\SignatureDecoderTests.cs" />
     <Compile Include="Metadata\Ecma335\MetadataAggregatorTests.cs" />
+    <Compile Include="Metadata\Ecma335\MetadataBuilderTests.cs" />
+    <Compile Include="Metadata\Ecma335\MetadataSerializerTests.cs" />
     <Compile Include="Metadata\Ecma335\MetadataTokensTests.cs" />
     <Compile Include="Metadata\HandleComparerTests.cs" />
     <Compile Include="Metadata\HandleTests.cs" />


### PR DESCRIPTION
Currently there are a few places in System.Reflection.Metadata where we use `ImmutableArray.CreateRange`. This is wasteful, since it makes 2 allocations: one for the source array and one for the newly created `ImmutableArray`. I've refactored these places to use `ImmutableArrayBuilder` and `MoveToImmutable`, so only one copy of the array is ever created.

cc @stephentoub @nguerrera @tmat