### PR TITLE
Fix WinHttpHandler proxy discovery behavior

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -995,8 +995,10 @@ nameof(value),
                     }
                     else if (_proxyHelper != null && _proxyHelper.AutoSettingsUsed)
                     {
-                        updateProxySettings = true;
-                        _proxyHelper.GetProxyForUrl(_sessionHandle, uri, out proxyInfo);
+                        if (_proxyHelper.GetProxyForUrl(_sessionHandle, uri, out proxyInfo))
+                        {
+                            updateProxySettings = true;
+                        }
                     }
 
                     if (updateProxySettings)

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
@@ -54,6 +54,16 @@ namespace System.Net.Http
             Debug.WriteLine(format, arg0);
         }
 
+        public static void Trace(string format, object arg0, object arg1)
+        {
+            if (!IsTraceEnabled())
+            {
+                return;
+            }
+            
+            Debug.WriteLine(format, arg0, arg1);
+        }
+
         public static void Trace(string format, object arg0, object arg1, object arg2)
         {
             if (!IsTraceEnabled())
@@ -62,6 +72,16 @@ namespace System.Net.Http
             }
             
             Debug.WriteLine(format, arg0, arg1, arg2);
+        }
+
+        public static void Trace(string format, object arg0, object arg1, object arg2, object arg3)
+        {
+            if (!IsTraceEnabled())
+            {
+                return;
+            }
+            
+            Debug.WriteLine(format, arg0, arg1, arg2, arg3);
         }
 
         public static void TraceCallbackStatus(string message, IntPtr handle, IntPtr context, uint status)

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
@@ -44,7 +44,7 @@ namespace System.Net.Http
             Debug.WriteLine(message);
         }
 
-        public static void Trace(string format, object arg0)
+        public static void Trace(string format, bool arg0)
         {
             if (!IsTraceEnabled())
             {
@@ -54,7 +54,27 @@ namespace System.Net.Http
             Debug.WriteLine(format, arg0);
         }
 
-        public static void Trace(string format, object arg0, object arg1)
+        public static void Trace(string format, int arg0)
+        {
+            if (!IsTraceEnabled())
+            {
+                return;
+            }
+            
+            Debug.WriteLine(format, arg0);
+        }
+
+        public static void Trace(string format, string arg0)
+        {
+            if (!IsTraceEnabled())
+            {
+                return;
+            }
+            
+            Debug.WriteLine(format, arg0);
+        }
+
+        public static void Trace(string format, string arg0, string arg1)
         {
             if (!IsTraceEnabled())
             {
@@ -64,7 +84,7 @@ namespace System.Net.Http
             Debug.WriteLine(format, arg0, arg1);
         }
 
-        public static void Trace(string format, object arg0, object arg1, object arg2)
+        public static void Trace(string format, IntPtr arg0, bool arg1, bool arg2)
         {
             if (!IsTraceEnabled())
             {
@@ -74,7 +94,7 @@ namespace System.Net.Http
             Debug.WriteLine(format, arg0, arg1, arg2);
         }
 
-        public static void Trace(string format, object arg0, object arg1, object arg2, object arg3)
+        public static void Trace(string format, string arg0, bool arg1, string arg2, string arg3)
         {
             if (!IsTraceEnabled())
             {

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinInetProxyHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinInetProxyHelper.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http
     // is not supported (i.e. before Win8.1/Win2K12R2) in the WinHttpOpen() function.
     internal class WinInetProxyHelper
     {
-        bool _useProxy = false;
+        private bool _useProxy = false;
 
         public WinInetProxyHelper()
         {

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinInetProxyHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinInetProxyHelper.cs
@@ -13,6 +13,8 @@ namespace System.Net.Http
     // is not supported (i.e. before Win8.1/Win2K12R2) in the WinHttpOpen() function.
     internal class WinInetProxyHelper
     {
+        bool _useProxy = false;
+
         public WinInetProxyHelper()
         {
             var proxyConfig = new Interop.WinHttp.WINHTTP_CURRENT_USER_IE_PROXY_CONFIG();
@@ -25,16 +27,25 @@ namespace System.Net.Http
                     AutoDetect = proxyConfig.AutoDetect;
                     Proxy = Marshal.PtrToStringUni(proxyConfig.Proxy);
                     ProxyBypass = Marshal.PtrToStringUni(proxyConfig.ProxyBypass);
+
+                    WinHttpTraceHelper.Trace(
+                        "WinInetProxyHelper.ctor: AutoConfigUrl={0}, AutoDetect={1}, Proxy={2}, ProxyBypass={3}",
+                        AutoConfigUrl,
+                        AutoDetect,
+                        Proxy,
+                        ProxyBypass);
+                    _useProxy = true;
                 }
                 else
                 {
-                    var lastError = Marshal.GetLastWin32Error();
-                    if (lastError != Interop.WinHttp.ERROR_FILE_NOT_FOUND)
-                    {
-                        throw WinHttpException.CreateExceptionUsingError(lastError);
-                    }
+                    // We match behavior of WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY and ignore errors.
+                    int lastError = Marshal.GetLastWin32Error();
+                    WinHttpTraceHelper.Trace("WinInetProxyHelper.ctor: error={0}", lastError);
                 }
+
+                WinHttpTraceHelper.Trace("WinInetProxyHelper.ctor: _useProxy={0}", _useProxy);
             }
+
             finally
             {
                 // FreeHGlobal already checks for null pointer before freeing the memory.
@@ -68,11 +79,26 @@ namespace System.Net.Http
 
         public string ProxyBypass { get; set; }
 
-        public void GetProxyForUrl(SafeWinHttpHandle sessionHandle, Uri uri, out Interop.WinHttp.WINHTTP_PROXY_INFO proxyInfo)
+        public bool GetProxyForUrl(
+            SafeWinHttpHandle sessionHandle,
+            Uri uri,
+            out Interop.WinHttp.WINHTTP_PROXY_INFO proxyInfo)
         {
+            proxyInfo.AccessType = Interop.WinHttp.WINHTTP_ACCESS_TYPE_NO_PROXY;
+            proxyInfo.Proxy = IntPtr.Zero;
+            proxyInfo.ProxyBypass = IntPtr.Zero;
+
+            if (!_useProxy)
+            {
+                return false;
+            }
+
+            bool useProxy = false;
+
             Interop.WinHttp.WINHTTP_AUTOPROXY_OPTIONS autoProxyOptions;
             autoProxyOptions.AutoConfigUrl = AutoConfigUrl;
-            autoProxyOptions.AutoDetectFlags = AutoDetect ? (Interop.WinHttp.WINHTTP_AUTO_DETECT_TYPE_DHCP | Interop.WinHttp.WINHTTP_AUTO_DETECT_TYPE_DNS_A) : 0;
+            autoProxyOptions.AutoDetectFlags = AutoDetect ?
+                (Interop.WinHttp.WINHTTP_AUTO_DETECT_TYPE_DHCP | Interop.WinHttp.WINHTTP_AUTO_DETECT_TYPE_DNS_A) : 0;
             autoProxyOptions.AutoLoginIfChallenged = false;
             autoProxyOptions.Flags =
                 (AutoDetect ? Interop.WinHttp.WINHTTP_AUTOPROXY_AUTO_DETECT : 0) |
@@ -92,50 +118,65 @@ namespace System.Net.Http
             //    URL and script are cached for future calls to WinHttpGetProxyForUrl.
             // 2. If Step 1 fails, with ERROR_WINHTTP_LOGIN_FAILURE, then call WinHttpGetProxyForUrl with the
             //    fAutoLogonIfChallenged member set to TRUE.
+            //
+            // We match behavior of WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY and ignore errors.
             var repeat = false;
             do
             {
-                if (Interop.WinHttp.WinHttpGetProxyForUrl(sessionHandle, uri.AbsoluteUri, ref autoProxyOptions, out proxyInfo))
+                if (Interop.WinHttp.WinHttpGetProxyForUrl(
+                    sessionHandle,
+                    uri.AbsoluteUri,
+                    ref autoProxyOptions,
+                    out proxyInfo))
                 {
-                    repeat = false;
+                    WinHttpTraceHelper.Trace("WinInetProxyHelper.GetProxyForUrl: Using autoconfig proxy settings");
+                    useProxy = true;
+                    
+                    break;
                 }
                 else
                 {
                     var lastError = Marshal.GetLastWin32Error();
-                    if (lastError == Interop.WinHttp.ERROR_WINHTTP_AUTODETECTION_FAILED)
-                    {
-                        // Fall back to manual settings if available.
-                        if (!string.IsNullOrEmpty(Proxy))
-                        {
-                            proxyInfo.AccessType = Interop.WinHttp.WINHTTP_ACCESS_TYPE_NAMED_PROXY;
-                            proxyInfo.Proxy = Marshal.StringToHGlobalUni(Proxy);
-                            proxyInfo.ProxyBypass = string.IsNullOrEmpty(ProxyBypass) ? IntPtr.Zero : Marshal.StringToHGlobalUni(ProxyBypass);
-                        }
-                        else
-                        {
-                            proxyInfo.AccessType = Interop.WinHttp.WINHTTP_ACCESS_TYPE_NO_PROXY;
-                            proxyInfo.Proxy = IntPtr.Zero;
-                            proxyInfo.ProxyBypass = IntPtr.Zero;
-                        }
+                    WinHttpTraceHelper.Trace("WinInetProxyHelper.GetProxyForUrl: error={0}", lastError);
 
-                        repeat = false;
-                    }
-                    else if (lastError == Interop.WinHttp.ERROR_WINHTTP_LOGIN_FAILURE)
+                    if (lastError == Interop.WinHttp.ERROR_WINHTTP_LOGIN_FAILURE)
                     {
                         if (repeat)
                         {
-                            throw WinHttpException.CreateExceptionUsingError(lastError);
+                            // We don't retry more than once.
+                            break;
                         }
-
-                        repeat = true;
-                        autoProxyOptions.AutoLoginIfChallenged = true;
+                        else
+                        {
+                            repeat = true;
+                            autoProxyOptions.AutoLoginIfChallenged = true;
+                        }
                     }
                     else
                     {
-                        WinHttpException.ThrowExceptionUsingLastError();
+                        break;
                     }
                 }
             } while (repeat);
+
+            // Fall back to manual settings if available.
+            if (!useProxy && !string.IsNullOrEmpty(Proxy))
+            {
+                proxyInfo.AccessType = Interop.WinHttp.WINHTTP_ACCESS_TYPE_NAMED_PROXY;
+                proxyInfo.Proxy = Marshal.StringToHGlobalUni(Proxy);
+                proxyInfo.ProxyBypass = string.IsNullOrEmpty(ProxyBypass) ?
+                    IntPtr.Zero : Marshal.StringToHGlobalUni(ProxyBypass);
+
+                WinHttpTraceHelper.Trace(
+                    "WinInetProxyHelper.GetProxyForUrl: Fallback to Proxy={0}, ProxyBypass={1}",
+                    Proxy,
+                    ProxyBypass);
+                useProxy = true;
+            }
+
+            WinHttpTraceHelper.Trace("WinInetProxyHelper.GetProxyForUrl: useProxy={0}", useProxy);
+
+            return useProxy;
         }
     }
 }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
@@ -751,7 +751,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
                 });
 
             Assert.Equal(Interop.WinHttp.WINHTTP_ACCESS_TYPE_NO_PROXY, APICallHistory.SessionProxySettings.AccessType);
-            Assert.Equal(null, APICallHistory.RequestProxySettings.AccessType);
+            Assert.Null(APICallHistory.RequestProxySettings.AccessType);
         }
 
         [Fact]

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
@@ -751,7 +751,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
                 });
 
             Assert.Equal(Interop.WinHttp.WINHTTP_ACCESS_TYPE_NO_PROXY, APICallHistory.SessionProxySettings.AccessType);
-            Assert.Equal(Interop.WinHttp.WINHTTP_ACCESS_TYPE_NO_PROXY, APICallHistory.RequestProxySettings.AccessType);
+            Assert.Equal(null, APICallHistory.RequestProxySettings.AccessType);
         }
 
         [Fact]


### PR DESCRIPTION
In order to support WindowsProxyUsePolicy.UseWinInetProxy, WinHTTP provides the WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY option. This allows for reading the per-user registry settings to determine how to find a proxy for a given url. This includes using WPAD protocol to find and execute a Javascript PAC file. The WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY only works on Windows 8.1 and above. For Windows 7 and Windows 8, we have to manually do the work and the WinInetProxyHelper class provides for that by calling various WinHTTP APIs.

This fix is about having the AUTOMATIC_PROXY behaviors work the same whether done automatically by WinHTTP or manually using the WinInetProxyHelper class. In general, errors processing the auto discovery logic should be ignored and the proxy settings should fallback to manual settings if present in the registry.

This is difficult to test in an Xunit test since registry settings need to be changed as well as recycling the "WinHTTP Web Proxy Autodiscover Discovery Service" since it caches PAC file processing. So, this was tested manually for now and additional traces were added to the WinInetProxyHelper class.

Fixes #6011