### PR TITLE
Fix MMF tests to not reuse names

### DIFF
--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -413,7 +413,6 @@ namespace System.IO.MemoryMappedFiles.Tests
                     {
                         continue;
                     }
-                    string mapName = tmpMapName == "CreateUniqueMapName()" ? CreateUniqueMapName() : tmpMapName;
 
                     foreach (long tmpCapacity in capacities)
                     {
@@ -427,6 +426,7 @@ namespace System.IO.MemoryMappedFiles.Tests
                                 continue;
                             }
 
+                            string mapName = tmpMapName == "CreateUniqueMapName()" ? CreateUniqueMapName() : tmpMapName;
                             yield return new object[] { mode, mapName, capacity, access };
                         }
                     }
@@ -492,9 +492,6 @@ namespace System.IO.MemoryMappedFiles.Tests
                 {
                     continue;
                 }
-                string mapName = tmpMapName == "CreateUniqueMapName()" ? 
-                    CreateUniqueMapName() : 
-                    tmpMapName;
 
                 foreach (long tmpCapacity in capacities)
                 {
@@ -508,6 +505,7 @@ namespace System.IO.MemoryMappedFiles.Tests
                         {
                             foreach (bool leaveOpen in leaveOpens)
                             {
+                                string mapName = tmpMapName == "CreateUniqueMapName()" ? CreateUniqueMapName() : tmpMapName;
                                 yield return new object[] { mapName, capacity, access, inheritability, leaveOpen };
                             }
                         }

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateNew.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateNew.Tests.cs
@@ -229,9 +229,6 @@ namespace System.IO.MemoryMappedFiles.Tests
                 {
                     continue;
                 }
-                string mapName = tmpMapName == "CreateUniqueMapName()" ? 
-                    CreateUniqueMapName() : 
-                    tmpMapName;
 
                 foreach (long tmpCapacity in capacities)
                 {
@@ -245,6 +242,7 @@ namespace System.IO.MemoryMappedFiles.Tests
                         {
                             foreach (HandleInheritability inheritability in inheritabilities)
                             {
+                                string mapName = tmpMapName == "CreateUniqueMapName()" ? CreateUniqueMapName() : tmpMapName;
                                 yield return new object[] { mapName, capacity, access, option, inheritability };
                             }
                         }

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateOrOpen.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateOrOpen.Tests.cs
@@ -226,7 +226,6 @@ namespace System.IO.MemoryMappedFiles.Tests
                 {
                     continue;
                 }
-                string mapName = tmpMapName == "CreateUniqueMapName()" ? CreateUniqueMapName() : tmpMapName;
 
                 foreach (long tmpCapacity in capacities)
                 {
@@ -240,6 +239,7 @@ namespace System.IO.MemoryMappedFiles.Tests
                         {
                             foreach (HandleInheritability inheritability in inheritabilities)
                             {
+                                string mapName = tmpMapName == "CreateUniqueMapName()" ? CreateUniqueMapName() : tmpMapName;
                                 yield return new object[] { mapName, capacity, access, option, inheritability };
                             }
                         }


### PR DESCRIPTION
Some of the MemoryMappedFiles tests are inadvertently reusing map names when the intention was that every test would use a unique name.  This caused a spurious failure in a recent CI run.