### PR TITLE
Cache UTF8Encoding instantiations in a few places

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -15,6 +15,9 @@ namespace System.Diagnostics
 {
     public partial class Process : IDisposable
     {
+        private static readonly UTF8Encoding s_utf8NoBom =
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
         /// <summary>
         /// Puts a Process component in state to interact with operating system processes that run in a 
         /// special mode by enabling the native property SeDebugPrivilege on the current thread.
@@ -251,19 +254,19 @@ namespace System.Diagnostics
             {
                 Debug.Assert(stdinFd >= 0);
                 _standardInput = new StreamWriter(OpenStream(stdinFd, FileAccess.Write),
-                    new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), StreamBufferSize) { AutoFlush = true };
+                    s_utf8NoBom, StreamBufferSize) { AutoFlush = true };
             }
             if (startInfo.RedirectStandardOutput)
             {
                 Debug.Assert(stdoutFd >= 0);
                 _standardOutput = new StreamReader(OpenStream(stdoutFd, FileAccess.Read),
-                    startInfo.StandardOutputEncoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), true, StreamBufferSize);
+                    startInfo.StandardOutputEncoding ?? s_utf8NoBom, true, StreamBufferSize);
             }
             if (startInfo.RedirectStandardError)
             {
                 Debug.Assert(stderrFd >= 0);
                 _standardError = new StreamReader(OpenStream(stderrFd, FileAccess.Read),
-                    startInfo.StandardErrorEncoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), true, StreamBufferSize);
+                    startInfo.StandardErrorEncoding ?? s_utf8NoBom, true, StreamBufferSize);
             }
 
             return true;

--- a/src/System.Private.DataContractSerialization/src/System/Xml/ValueHandle.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/ValueHandle.cs
@@ -667,6 +667,7 @@ namespace System.Xml
             int byteCount = _length;
             bool insufficientSpaceInCharsArray = false;
 
+            var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
             while (true)
             {
                 while (charCount > 0 && byteCount > 0)
@@ -688,7 +689,6 @@ namespace System.Xml
                 int actualByteCount;
                 int actualCharCount;
 
-                UTF8Encoding encoding = new UTF8Encoding(false, true);
                 try
                 {
                     // If we're asking for more than are possibly available, or more than are truly available then we can return the entire thing

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
@@ -36,7 +36,7 @@ namespace System.Security.Cryptography
         }
 
         public Rfc2898DeriveBytes(string password, byte[] salt, int iterations)
-            : this(new UTF8Encoding(false).GetBytes(password), salt, iterations)
+            : this(Encoding.UTF8.GetBytes(password), salt, iterations)
         {
         }
 
@@ -56,7 +56,7 @@ namespace System.Security.Cryptography
 
             _salt = Helpers.GenerateRandom(saltSize);
             _iterations = (uint)iterations;
-            _password = new UTF8Encoding(false).GetBytes(password);
+            _password = Encoding.UTF8.GetBytes(password);
             _hmacSha1 = new HMACSHA1(_password);
 
             Initialize();

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlTextReaderImpl.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlTextReaderImpl.cs
@@ -23,6 +23,11 @@ namespace System.Xml
 {
     internal partial class XmlTextReaderImpl : XmlReader, IXmlLineInfo, IXmlNamespaceResolver
     {
+        private static UTF8Encoding s_utf8BomThrowing;
+        
+        private static UTF8Encoding UTF8BomThrowing =>
+            s_utf8BomThrowing ?? (s_utf8BomThrowing = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true, throwOnInvalidBytes: true));
+        
         //
         // Private helper types
         //
@@ -2240,7 +2245,7 @@ namespace System.Xml
                 case 0xEFBB:
                     if ((next2Bytes & 0xFF00) == 0xBF00)
                     {
-                        return new UTF8Encoding(true, true);
+                        return UTF8BomThrowing;
                     }
                     break;
             }
@@ -2318,7 +2323,7 @@ namespace System.Xml
             Encoding newEncoding = null;
             if (String.Equals(newEncodingName, "utf-8", StringComparison.OrdinalIgnoreCase))
             {
-                newEncoding = new UTF8Encoding(true, true);
+                newEncoding = UTF8BomThrowing;
             }
             else
             {
@@ -2378,7 +2383,7 @@ namespace System.Xml
 
         private void SwitchEncodingToUTF8()
         {
-            SwitchEncoding(new UTF8Encoding(true, true));
+            SwitchEncoding(UTF8BomThrowing);
         }
 
         // Reads more data to the character buffer, discarding already parsed chars / decoded bytes.

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlTextReaderImplAsync.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlTextReaderImplAsync.cs
@@ -972,7 +972,7 @@ namespace System.Xml
 
         private Task SwitchEncodingToUTF8Async()
         {
-            return SwitchEncodingAsync(new UTF8Encoding(true, true));
+            return SwitchEncodingAsync(UTF8BomThrowing);
         }
 
         // Reads more data to the character buffer, discarding already parsed chars / decoded bytes.


### PR DESCRIPTION
There are a bunch of places throughout CoreFX where a new `UTF8Encoding` is instantiated and not cached. This is wasteful, since aside from reference equality there is virtually no difference between the Encoding instances. This pull request takes many such places and caches the encoding variable into a static field.

cc @stephentoub 