### PR TITLE
Enable tests blocked by #6258

### DIFF
--- a/src/System.Dynamic.Runtime/tests/Dynamic.Simple/DelegateTest.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Simple/DelegateTest.cs
@@ -35,7 +35,6 @@ namespace SampleDynamicTests
         }
 
         [Fact]
-        [ActiveIssue(6258)]
         public static void VariantFuncTest()
         {
             Func<string, dynamic, object, int> del = Foo;
@@ -47,7 +46,6 @@ namespace SampleDynamicTests
         }
 
         [Fact]
-        [ActiveIssue(6258)]
         public static void VariantActTest()
         {
             Action<string, dynamic, object> del = Bar;


### PR DESCRIPTION
These tests had to wait for the fix in #6273 to be available in the feeds before the `[ActiveIssue]` attribute could be removed.

Do this now.