### PR TITLE
Remove unused System.Console references

### DIFF
--- a/src/System.Collections.NonGeneric/tests/project.json
+++ b/src/System.Collections.NonGeneric/tests/project.json
@@ -3,7 +3,6 @@
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Collections": "4.0.10",
-    "System.Console": "4.0.0-rc3-23910",
     "System.Diagnostics.Debug": "4.0.10",
     "System.Globalization": "4.0.10",
     "System.IO": "4.0.10",

--- a/src/System.Collections.Specialized/tests/project.json
+++ b/src/System.Collections.Specialized/tests/project.json
@@ -3,7 +3,6 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Collections": "4.0.10",
     "System.Collections.NonGeneric": "4.0.0",
-    "System.Console": "4.0.0-rc3-23910",
     "System.Globalization": "4.0.10",
     "System.IO": "4.0.10",
     "System.Runtime": "4.0.20",

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -3,7 +3,6 @@
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Collections": "4.0.10",
-    "System.Console": "4.0.0-rc3-23910",
     "System.Globalization": "4.0.10",
     "System.IO": "4.0.10",
     "System.Linq": "4.0.0",

--- a/src/System.Diagnostics.Tracing/tests/project.json
+++ b/src/System.Diagnostics.Tracing/tests/project.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
-    "System.Console": "4.0.0-rc3-23910",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.Process": "4.1.0-rc3-23910",
     "System.Diagnostics.Tracing": "4.1.0-rc3-23910",

--- a/src/System.Linq/tests/project.json
+++ b/src/System.Linq/tests/project.json
@@ -3,7 +3,6 @@
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Collections": "4.0.10",
-    "System.Console": "4.0.0-rc3-23910",
     "System.Diagnostics.Debug": "4.0.10",
     "System.Runtime": "4.0.20",
     "System.Runtime.Extensions": "4.0.10",

--- a/src/System.Xml.XDocument/tests/SDMSample/project.json
+++ b/src/System.Xml.XDocument/tests/SDMSample/project.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Collections": "4.0.10",
-    "System.Console": "4.0.0-rc3-23910",
     "System.Globalization": "4.0.10",
     "System.IO": "4.0.10",
     "System.Runtime": "4.0.20",


### PR DESCRIPTION
From test projects, that had presumably been using `Console` and changed not to.