### PR TITLE
Adding DiagnosticSource to EventSource Bridge.

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/System.Diagnostics.DiagnosticSource.sln
+++ b/src/System.Diagnostics.DiagnosticSource/System.Diagnostics.DiagnosticSource.sln
@@ -15,8 +15,8 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F24D3391-2928-4E83-AADE-B34423498750}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F24D3391-2928-4E83-AADE-B34423498750}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F24D3391-2928-4E83-AADE-B34423498750}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{F24D3391-2928-4E83-AADE-B34423498750}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{F24D3391-2928-4E83-AADE-B34423498750}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F24D3391-2928-4E83-AADE-B34423498750}.Release|Any CPU.Build.0 = Release|Any CPU
 		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/System.Diagnostics.DiagnosticSource/System.Diagnostics.DiagnosticSource.sln
+++ b/src/System.Diagnostics.DiagnosticSource/System.Diagnostics.DiagnosticSource.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23103.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.DiagnosticSource", "src\System.Diagnostics.DiagnosticSource.csproj", "{F24D3391-2928-4E83-AADE-B34423498750}"
 EndProject
@@ -15,8 +15,8 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F24D3391-2928-4E83-AADE-B34423498750}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F24D3391-2928-4E83-AADE-B34423498750}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F24D3391-2928-4E83-AADE-B34423498750}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F24D3391-2928-4E83-AADE-B34423498750}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F24D3391-2928-4E83-AADE-B34423498750}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{F24D3391-2928-4E83-AADE-B34423498750}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/System.Diagnostics.DiagnosticSource/pkg/System.Diagnostics.DiagnosticSource.pkgproj
+++ b/src/System.Diagnostics.DiagnosticSource/pkg/System.Diagnostics.DiagnosticSource.pkgproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\src\System.Diagnostics.DiagnosticSource.builds">
-      <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
+      <SupportedFramework>net46;net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
     </ProjectReference>
   </ItemGroup>
 

--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.builds
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.builds
@@ -2,8 +2,10 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Diagnostics.DiagnosticSource.csproj" />
+    <Project Include="System.Diagnostics.DiagnosticSource.csproj"/>
+    <Project Include="System.Diagnostics.DiagnosticSource.csproj">
+      <TargetGroup>netstandard1.1</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -7,23 +7,50 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <UseOpenKey Condition="'$(UseOpenKey)'==''">true</UseOpenKey>
+    <!-- unset PackageTargetFramework we'll use PackageDestination instead -->
+    <PackageTargetFramework />
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
-  <ItemGroup Condition="'$(PackageTargetFramework)' == ''">
+
+  <!-- By default we build the 'latest'  which is netstandard1.3 -->
+  <ItemGroup Condition="'$(TargetGroup)' == ''">
+    <PackageDestination Include="lib/netstandard1.3">
+      <TargetFramework>netstandard1.3</TargetFramework>
+    </PackageDestination>
+
+    <!-- duplicate in net46 folder so older nuget clients can consume -->
+    <PackageDestination Include="lib/net46">
+      <TargetFramework>net46</TargetFramework>
+    </PackageDestination>
+  </ItemGroup>
+
+  <!-- However to allow it to work on V4.5 runtimes and other old platforms
+       we also have a separate complilation of this DLL that works for V4.5
+       (which is netstandard1.1 -->
+
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.1'">
     <PackageDestination Include="lib/netstandard1.1">
       <TargetFramework>netstandard1.1</TargetFramework>
     </PackageDestination>
-    <!-- Support downlevel targets -->
+
+    <!-- duplicate in portable folder so older nuget clients can consume -->
     <PackageDestination Include="lib/portable-net45+win8+wpa81">
       <TargetFramework>portable-net45+win8+wpa81</TargetFramework>
     </PackageDestination>
   </ItemGroup>
-  <!-- Default configurations to help VS understand the configurations -->
+
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard1.1'">
+      <DefineConstants>;NO_EVENTSOURCE_COMPLEX_TYPE_SUPPORT</DefineConstants>
+  </PropertyGroup> 
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <NoWarn>0420</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <NoWarn>0420</NoWarn>
   </PropertyGroup>
+
+  <!-- Default configurations to help VS understand the configurations -->
   <ItemGroup>
     <Compile Include="System\Diagnostics\DiagnosticSource.cs" />
     <Compile Include="System\Diagnostics\DiagnosticListener.cs" />

--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -43,6 +43,7 @@
       <DefineConstants>;NO_EVENTSOURCE_COMPLEX_TYPE_SUPPORT</DefineConstants>
   </PropertyGroup> 
 
+  <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <NoWarn>0420</NoWarn>
   </PropertyGroup>
@@ -50,7 +51,6 @@
     <NoWarn>0420</NoWarn>
   </PropertyGroup>
 
-  <!-- Default configurations to help VS understand the configurations -->
   <ItemGroup>
     <Compile Include="System\Diagnostics\DiagnosticSource.cs" />
     <Compile Include="System\Diagnostics\DiagnosticListener.cs" />

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
@@ -11,7 +11,7 @@ namespace System.Diagnostics
     /// (which can also write object), but is intended to log complex objects that can't be serialized.
     /// </summary>
     public abstract class DiagnosticSource
-    {
+    { 
         /// <summary>
         /// Write is a generic way of logging complex payloads.  Each notification
         /// is given a name, which identifies it as well as a object (typically an anonymous type)

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -2,32 +2,213 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics.Tracing;
+using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace System.Diagnostics
 {
     /// <summary>
-    /// Current this EventSource is only here so that the Debugger can inject code using Function evaluation
-    /// We may add actual logging requests as well at some point.   This can be removed if the debugger  no 
-    /// longer needs it.   
+    /// DiagnosticSourceEventSource serves two purposes 
+    /// 
+    ///   1) It allows debuggers to inject code via Function evaluation.  This is the purpose of the
+    ///   BreakPointWithDebuggerFuncEval function in the 'OnEventCommand' method.   Basically even in
+    ///   release code, debuggers can place a breakpoint in this method and and then trigger the
+    ///   DiagnosticSourceEventSource via ETW.  Thus from outside the process you can get a hook that
+    ///   is guarenteed to happen BEFORE any DiangosticSource events (if the process is just starting)
+    ///   or as soon as possible afterward if it is on attach.
+    ///   
+    ///   2) It provides a 'bridge' that allows DiagnosticSource messages to be forwarded to EventListers
+    ///   or ETW.    You can do this by enabling the Microsoft-Diagnostics-DiagnosticSource with the
+    ///   'Events' keyword (for diagnostics purposes, you should also turn on the 'Messages' keyword.  
+    ///   
+    ///   This EventSource defines a EventSource argument called 'FilterAndPayloadSpecs' that defines
+    ///   what DiagnsoticSources to enable and what parts of the payload to serialize into the key-value
+    ///   list that will be forwarded to the EventSource.    If it is empty, all serializable parts of
+    ///   every DiagnosticSource event will be forwarded (this is NOT recommended for monitoring but 
+    ///   can be useful for discovery).
+    ///   
+    ///   The FilterAndPayloadSpecs is one long string with the following structures
+    ///   
+    ///   * It is a newline separated list of FILTER_AND_PAYLOAD_SPEC
+    ///   * a FILTER_AND_PAYLOAD_SPEC can be 
+    ///       * EVENT_NAME : TRANSFORM_SPEC
+    ///       * EMPTY - turns on all sources with implicit payload elements. 
+    ///   * an EVENTNAME can be  
+    ///       * DIAGNOSTIC_SOURCE_NAME / DIAGNOSTC_EVENT_NAME   
+    ///       * DIAGNOSTIC_SOURCE_NAME    - which wildcards every event in the Diagnostic source or 
+    ///       * EMPTY                     - which turns on all sources
+    ///   * a TRANSFORM_SPEC can be 
+    ///       * - TRANSFORM_SPEC - the '-' indicates that implict payload elements should be supressed 
+    ///       * VARIABLE_NAME = PROPERTY_SPEC  - indicates that an payload element 'VARIABLE_NAME' is creatd from PROPERTY_SPEC
+    ///       * PROPERTY_SPEC                  - This is a shortcut where VARIABLE_NAME is the LAST property name
+    ///   * a PROPERTY_SPEC ca be
+    ///       * PROPERTY_NAME                  - fetches a property from the DiagnosticSource payload object
+    ///       * PROPERTY_NAME . PROPERTY NAME  - fetches a sub-property of the object. 
+    ///
+    /// Example1:
+    /// 
+    ///    "BridgeTestSource1/TestEvent1:cls_Point_X=cls.Point.X;cls_Point_Y=cls.Point.Y\r\n" + 
+    ///    "BridgeTestSource2/TestEvent2:-cls.Url"
+    ///   
+    /// This indicates that two events should be turned on, The 'TestEvent1' event in BridgeTestSource1 and the
+    /// 'TestEvent2' in BridgeTestSource2.   In the first case, because the transform did not begin with a - 
+    /// any primitive type/string of 'TestEvent1's payload will be serialized into the output.  In addition if
+    /// there a property of the payload object called 'cls' which in turn has a property 'Point' which in turn
+    /// has a property 'X' then that data is also put in the output with the name cls_Point_X.   Simmilarly 
+    /// if cls.Point.Y exists, then that value will also be put in the output with the name cls_Point_Y.
+    /// 
+    /// For the 'BridgeTestSource2/TestEvent2' event, becasue the - was specified NO implicit fields will be 
+    /// generated, but if there is a property call 'cls' which has a property 'Url' then that will be placed in
+    /// the output with the name 'Url' (since that was the last property name used and no Variable= clause was 
+    /// specified. 
+    /// 
+    /// Example:
+    /// 
+    ///     "BridgeTestSource1\r\n" + 
+    ///     "BridgeTestSource2"
+    ///     
+    /// This will enable all events for the BridgeTestSource1 and BridgeTestSource2 sources.   Any string/primtive 
+    /// properties of any of the events will be serialized into the output.  
+    /// 
+    /// Example:
+    /// 
+    ///     ""
+    ///     
+    /// This turns on all DiagnosticSources Any string/primtive properties of any of the events will be serialized 
+    /// into the output.   This is not likely to be a good idea as it will be very verbose, but is useful to quickly
+    /// discover what is available.
+    /// 
+    /// See the DiagnosticSourceEventSourceBridgeTest.cs for more explicit examples of using this bridge.  
     /// </summary>
     [EventSource(Name = "Microsoft-Diagnostics-DiagnosticSource")]
     internal class DiagnosticSourceEventSource : EventSource
     {
         public static DiagnosticSourceEventSource Logger = new DiagnosticSourceEventSource();
 
-        /// <summary>
-        /// On every command (which the debugger can force by turning on this EventSource with ETW)
-        /// call a function that the debugger can hook to do an arbitrary func evaluation.  
-        /// </summary>
-        /// <param name="args"></param>
-        protected override void OnEventCommand(EventCommandEventArgs args)
+        private class Keywords
         {
-            BreakPointWithDebuggerFuncEval();
+            /// <summary>
+            /// Indicates diagnostics messages from DiagnosticSourceEventSource should be included. 
+            /// </summary>
+            public const EventKeywords Messages = (EventKeywords)1;
+            /// <summary>
+            /// Indicates that all events from all diagnostic sources should be forwarded to the EventSource using the 'Event' event.  
+            /// </summary>
+            public const EventKeywords Events = (EventKeywords)2;
+        };
+
+        /// <summary>
+        /// Used to send ad-hoc diagnostics to humans.   
+        /// </summary>
+        [Event(1, Keywords = Keywords.Messages)]
+        public void Message(string Message)
+        {
+            WriteEvent(1, Message);
         }
 
-        #region private 
+#if !NO_EVENTSOURCE_COMPLEX_TYPE_SUPPORT
+        /// <summary>
+        /// Events from DiagnosticSource can be forwarded to EventSource using this event.  
+        /// </summary>
+        [Event(2, Keywords = Keywords.Events)]
+        private void Event(string SourceName, string EventName, IEnumerable<KeyValuePair<string, string>> Arguments)
+        {
+            WriteEvent(2, SourceName, EventName, Arguments);
+        }
+#endif 
+        /// <summary>
+        /// This is only used on V4.5 systems that dont have the ability to log KeyValuePairs directly.
+        /// It will eventually go away, but we should alwasy reserve the ID for this.    
+        /// </summary>
+        [Event(3, Keywords = Keywords.Events)]
+        private void EventJson(string SourceName, string EventName, string ArgmentsJson)
+        {
+            WriteEvent(3, SourceName, EventName, ArgmentsJson);
+        }
+
+        #region private
+
+#if NO_EVENTSOURCE_COMPLEX_TYPE_SUPPORT
+        /// <summary>
+        /// Converts a keyvalue bag to JSON.  Only used on V4.5 EventSources.  
+        /// </summary>
+        private static string ToJson(List<KeyValuePair<string, string>> keyValues)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine("{");
+            bool first = true;
+            foreach (var keyValue in keyValues)
+            {
+                if (!first)
+                    sb.Append(',').AppendLine();
+                first = false;
+
+                sb.Append('"').Append(keyValue.Key).Append("\":\"");
+
+                // Write out the value characters, escaping things as needed.  
+                foreach(var c in keyValue.Value)
+                {
+                    if (Char.IsControl(c))
+                    {
+                        if (c == '\n')
+                            sb.Append("\\n");
+                        else if (c == '\r')
+                            sb.Append("\\r");
+                        else
+                            sb.Append("\\u").Append(((int)c).ToString("x").PadLeft(4, '0'));
+                    }
+                    else 
+                    {
+                        if (c == '"' || c == '\\')
+                            sb.Append('\\');
+                        sb.Append(c);
+                    }
+                }
+                sb.Append('"');     // Close the string.  
+            }
+            sb.AppendLine().AppendLine("}");
+            return sb.ToString();
+        }
+#endif
+
+#if !NO_EVENTSOURCE_COMPLEX_TYPE_SUPPORT
+        /// <summary>
+        /// This constructor uses EventSourceSettings which is only available on V4.6 and above
+        /// systems.   We use the EventSourceSettings to turn on support for complex types. 
+        /// </summary>
+        private DiagnosticSourceEventSource() : base(EventSourceSettings.EtwSelfDescribingEventFormat) { }
+#endif
+
+        /// <summary>
+        /// Called when the EventSource gets a command from a EventListener or ETW. 
+        /// </summary>
+        [NonEvent]
+        protected override void OnEventCommand(EventCommandEventArgs command)
+        {
+            // On every command (which the debugger can force by turning on this EventSource with ETW)
+            // call a function that the debugger can hook to do an arbitrary func evaluation.  
+            BreakPointWithDebuggerFuncEval();
+
+            lock (this)
+            {
+                if ((command.Command == EventCommand.Update || command.Command == EventCommand.Enable) &&
+                    IsEnabled(EventLevel.Informational, Keywords.Events))
+                {
+                    string filterAndPayloadSpecs;
+                    command.Arguments.TryGetValue("FilterAndPayloadSpecs", out filterAndPayloadSpecs);
+                    FilterAndTransform.CreateFilterAndTransformList(ref _specs, filterAndPayloadSpecs, this);
+                }
+                else if (command.Command == EventCommand.Update || command.Command == EventCommand.Disable)
+                {
+                    FilterAndTransform.DestroyFilterAndTransformList(ref _specs);
+                }
+            }
+        }
+
+        #region debugger hooks 
         private volatile bool _false;       // A value that is always false but the compiler does not know this. 
 
         /// <summary>
@@ -35,7 +216,7 @@ namespace System.Diagnostics
         /// do function evaluation in the debugger.   Thus this is just a place that is useful
         /// for the debugger to place a breakpoint where it can inject code with function evaluation
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+        [NonEvent, MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
         private void BreakPointWithDebuggerFuncEval()
         {
             new object();   // This is only here because it helps old desktop runtimes emit a GC safe point at the start of the method
@@ -44,6 +225,475 @@ namespace System.Diagnostics
                 _false = false;
             }
         }
-        #endregion 
+        #endregion
+
+        #region EventSource hooks 
+
+        /// <summary>
+        /// FilterAndTransform represents on transformation specification from a DiagnosticsSource
+        /// to EventSource's 'Event' method.    (e.g.  MySource/MyEvent:out=prop1.prop2.prop3).
+        /// Its main method is 'Morph' which takes a DiagnosticSource object and morphss it into
+        /// a list of string,string key value pairs.   
+        /// 
+        /// This method also contains that static 'Create/Destroy FilterAndTransformList, which
+        /// simply parse a seriese of transformation specifications.  
+        /// </summary>
+        internal class FilterAndTransform
+        {
+            /// <summary>
+            /// Parses filterAndPayloadSpecs which is a list of lines each of which has the from
+            /// 
+            ///    DiagnosticSourceName/EventName:PAYLOAD_SPEC
+            ///    
+            /// where PAYLOADSPEC is a semicolon separated list of specifications of the form
+            /// 
+            ///    OutputName=Prop1.Prop2.PropN
+            ///    
+            /// Into linked list of FilterAndTransform that together forward events from the given
+            /// DiagnosticSource's to 'eventSource'.   Sets the 'specList' variable to this value
+            /// (destroying anything that was there previously).  
+            /// 
+            /// By default any serializable properties of the payload object are also included
+            /// in the output payload, however this feature and be tuned off by prefixing the
+            /// PAYLOADSPEC with a '-'.   
+            /// </summary>
+            public static void CreateFilterAndTransformList(ref FilterAndTransform specList, string filterAndPayloadSpecs, DiagnosticSourceEventSource eventSource)
+            {
+                DestroyFilterAndTransformList(ref specList);        // Stop anything that was on before. 
+                if (filterAndPayloadSpecs == null)
+                    filterAndPayloadSpecs = "";
+
+                // Points just beyond the last point in the string that has yet to be parsed.   Thus we start with the whole string.  
+                int endIdx = filterAndPayloadSpecs.Length;
+                for (;;)
+                {
+                    // Skip trailing whitespace.
+                    while (0 < endIdx && Char.IsWhiteSpace(filterAndPayloadSpecs[endIdx - 1]))
+                        --endIdx;
+
+                    int newlineIdx = filterAndPayloadSpecs.LastIndexOf('\n', endIdx - 1, endIdx);
+                    int startIdx = 0;
+                    if (0 <= newlineIdx)
+                        startIdx = newlineIdx + 1;  // starts after the newline, or zero if we don't find one.   
+
+                    // Skip leading whitespace
+                    while (startIdx < endIdx && Char.IsWhiteSpace(filterAndPayloadSpecs[startIdx]))
+                        startIdx++;
+
+                    specList = new FilterAndTransform(filterAndPayloadSpecs, startIdx, endIdx, eventSource, specList);
+                    endIdx = newlineIdx;
+                    if (endIdx < 0)
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// This destroys (turns off) the FilterAndTransform stopping the forwarding started with CreateFilterAndTransformList
+            /// </summary>
+            /// <param name="specList"></param>
+            public static void DestroyFilterAndTransformList(ref FilterAndTransform specList)
+            {
+                var curSpec = specList;
+                specList = null;            // Null out the list
+                while (curSpec != null)     // Dispose everything in the list.  
+                {
+                    curSpec.Dispose();
+                    curSpec = curSpec.Next;
+                }
+            }
+
+            /// <summary>
+            /// Creates one FilterAndTransform specification from filterAndPayloadSpec starting at 'startIdx' and ending just before 'endIdx'. 
+            /// This FilterAndTransform will subscribe to DiagnosticSources specified by the specification and forward them to 'eventSource.
+            /// For convience, the 'Next' field is set to the 'next' parameter, so you can easily form linked lists.  
+            /// </summary>
+            public FilterAndTransform(string filterAndPayloadSpec, int startIdx, int endIdx, DiagnosticSourceEventSource eventSource, FilterAndTransform next)
+            {
+#if DEBUG
+                string spec = filterAndPayloadSpec.Substring(startIdx, endIdx - startIdx);
+#endif 
+                Next = next;
+                _eventSource = eventSource;
+
+                string listenerNameFilter = null;       // Means WildCard. 
+                string eventNameFilter = null;          // Means WildCard.
+
+                var startTransformIdx = startIdx;
+                var endEventNameIdx = endIdx;
+                var colonIdx = filterAndPayloadSpec.IndexOf(':', startIdx, endIdx - startIdx);
+                if (0 <= colonIdx)
+                {
+                    endEventNameIdx = colonIdx;
+                    startTransformIdx = colonIdx + 1;
+                }
+
+                // Parse the Source/Event name into listenerNameFilter and eventNameFilter
+                var slashIdx = filterAndPayloadSpec.IndexOf('/', startIdx, endEventNameIdx - startIdx);
+                if (0 <= slashIdx)
+                {
+                    listenerNameFilter = filterAndPayloadSpec.Substring(startIdx, slashIdx - startIdx);
+                    eventNameFilter = filterAndPayloadSpec.Substring(slashIdx + 1, endEventNameIdx - slashIdx - 1);
+                }
+                else if (startIdx < endEventNameIdx)
+                {
+                    listenerNameFilter = filterAndPayloadSpec.Substring(startIdx, endEventNameIdx - startIdx);
+                }
+
+
+                _eventSource.Message("DiagnosticSource: Enabling '" + (listenerNameFilter ?? "*") + "/" + (eventNameFilter ?? "*") + "'");
+
+                // If the transform spec begins with a - it means you don't want implicit transforms. 
+                if (startTransformIdx < endIdx && filterAndPayloadSpec[startTransformIdx] == '-')
+                {
+                    _eventSource.Message("DiagnosticSource: supressing implicit transforms.");
+                    _noImplicitTransforms = true;
+                    startTransformIdx++;
+                }
+
+                // Parse all the explicit transforms, if present
+                if (startTransformIdx < endIdx)
+                {
+                    for (;;)
+                    {
+                        int specStartIdx = startTransformIdx;
+                        int semiColonIdx = filterAndPayloadSpec.LastIndexOf(';', endIdx - 1, endIdx - startTransformIdx);
+                        if (0 <= semiColonIdx)
+                            specStartIdx = semiColonIdx + 1;
+
+                        // Ignore empty specifications.  
+                        if (specStartIdx < endIdx)
+                        {
+                            if (_eventSource.IsEnabled(EventLevel.Informational, Keywords.Messages))
+                                _eventSource.Message("DiagnosticSource: Parsing Explicit Transform '" + filterAndPayloadSpec.Substring(specStartIdx, endIdx - specStartIdx) + "'");
+
+                            _explicitTransforms = new TransformSpec(filterAndPayloadSpec, specStartIdx, endIdx, _explicitTransforms);
+                        }
+                        if (startTransformIdx == specStartIdx)
+                            break;
+                        endIdx = semiColonIdx;
+                    }
+                }
+
+                // Set up a subscription that watches for the given Diagnostic Sources and events which will call back
+                // to the EventSource.   
+                _diagnosticsListenersSubscription = DiagnosticListener.AllListeners.Subscribe(new CallbackObserver<DiagnosticListener>(delegate (DiagnosticListener newListener)
+                {
+                    if (listenerNameFilter == null || listenerNameFilter == newListener.Name)
+                    {
+                        Predicate<string> eventNameFilterPredicate = null;
+                        if (eventNameFilter != null)
+                            eventNameFilterPredicate = (string eventName) => eventNameFilter == eventName;
+
+                        var subscription = newListener.Subscribe(new CallbackObserver<KeyValuePair<string, object>>(delegate (KeyValuePair<string, object> evnt)
+                        {
+                            // The filter given to the DiagnosticSource may not work if users don't is 'IsEnabled' as expected.
+                            // Thus we look for any events that may have snuck through and filter them out before forwarding.  
+                            if (eventNameFilter != null && eventNameFilter != evnt.Key)
+                                return;
+
+                            var outputArgs = this.Morph(evnt.Value);
+#if !NO_EVENTSOURCE_COMPLEX_TYPE_SUPPORT
+                            _eventSource.Event(newListener.Name, evnt.Key, outputArgs);
+#else
+                            _eventSource.EventJson(newListener.Name, evnt.Key, ToJson(outputArgs));
+#endif
+                        }), eventNameFilterPredicate);
+                        _liveSubscriptions = new Subscriptions(subscription, _liveSubscriptions);
+                    }
+                }));
+            }
+
+            private void Dispose()
+            {
+                if (_diagnosticsListenersSubscription != null)
+                {
+                    _diagnosticsListenersSubscription.Dispose();
+                    _diagnosticsListenersSubscription = null;
+                }
+
+                if (_liveSubscriptions != null)
+                {
+                    var subscr = _liveSubscriptions;
+                    _liveSubscriptions = null;
+                    while (subscr != null)
+                    {
+                        subscr.Subscription.Dispose();
+                        subscr = subscr.Next;
+                    }
+                }
+            }
+
+            public List<KeyValuePair<string, string>> Morph(object args)
+            {
+                // Transform the args into a bag of key-value strings.  
+                var outputArgs = new List<KeyValuePair<string, string>>();
+                if (args != null)
+                {
+                    if (!_noImplicitTransforms)
+                    {
+                        Type argType = args.GetType();
+                        if (_expectedArgType != argType)
+                        {
+                            // Figure out the default properties to send on to EventSource.  These are all string or primitive properties.  
+                            _implicitTransforms = null;
+                            TransformSpec newSerializableArgs = null;
+                            TypeInfo curTypeInfo = argType.GetTypeInfo();
+                            foreach (var property in curTypeInfo.DeclaredProperties)
+                            {
+                                var propertyType = property.PropertyType;
+                                if (propertyType == typeof(string) || propertyType.GetTypeInfo().IsPrimitive)
+                                    newSerializableArgs = new TransformSpec(property.Name, 0, property.Name.Length, newSerializableArgs);
+                            }
+                            _expectedArgType = argType;
+                            _implicitTransforms = Reverse(newSerializableArgs);
+                        }
+
+                        // Fetch all the fields that are alread serializable
+                        if (_implicitTransforms != null)
+                        {
+                            for (var serializableArg = _implicitTransforms; serializableArg != null; serializableArg = serializableArg.Next)
+                                outputArgs.Add(serializableArg.Morph(args));
+                        }
+                    }
+
+                    if (_explicitTransforms != null)
+                    {
+                        for (var explicitTransform = _explicitTransforms; explicitTransform != null; explicitTransform = explicitTransform.Next)
+                        {
+                            var keyValue = explicitTransform.Morph(args);
+                            if (keyValue.Value != null)
+                                outputArgs.Add(keyValue);
+                        }
+                    }
+                }
+                return outputArgs;
+            }
+
+            public FilterAndTransform Next;
+
+            #region private
+            // Reverses a linked list (of TransformSpecs) in place.    
+            private static TransformSpec Reverse(TransformSpec list)
+            {
+                TransformSpec ret = null;
+                while (list != null)
+                {
+                    var next = list.Next;
+                    list.Next = ret;
+                    ret = list;
+                    list = next;
+                }
+                return ret;
+            }
+
+            private IDisposable _diagnosticsListenersSubscription; // This is our subscription that listens for new Diagnostic source to appear. 
+            private Subscriptions _liveSubscriptions;              // These are the subscriptions that we are currently forwarding to the EventSource.
+            private bool _noImplicitTransforms;                    // Listner can say they don't want implicit transforms.  
+            private Type _expectedArgType;                         // This is the type where 'implicitTransforms is built for'
+            private TransformSpec _implicitTransforms;             // payload to include because the DiagnosticSource's object fields are already serializable 
+            private TransformSpec _explicitTransforms;             // payload to include because the user explicitly indicated how to fetch the field.  
+            private DiagnosticSourceEventSource _eventSource;      // Where the data is written to.  
+            #endregion
+        }
+
+        /// <summary>
+        /// Transform spec represents a string that decribes how to extact a piece of data from
+        /// the DiagnosticSource payload.   An example string is OUTSTR=EVENT_VALUE.PROP1.PROP2.PROP3
+        /// It has a Next field so they can be chained togehter in a linked list.  
+        /// </summary>
+        internal class TransformSpec
+        {
+            /// <summary>
+            /// parse the strings 'spec' from startIdx to endIdx (points just beyond the last considered char)
+            /// The syntax is ID1=ID2.ID3.ID4 ....   Where ID1= is optional.    
+            /// </summary>
+            public TransformSpec(string transformSpec, int startIdx, int endIdx, TransformSpec next = null)
+            {
+#if DEBUG
+                string spec = transformSpec.Substring(startIdx, endIdx - startIdx);
+#endif
+                Debug.Assert(transformSpec != null && startIdx < endIdx);
+                Next = next;
+
+                // Pick off the Var=
+                int equalsIdx = transformSpec.IndexOf('=', startIdx, endIdx - startIdx);
+                if (0 <= equalsIdx)
+                {
+                    _outputName = transformSpec.Substring(startIdx, equalsIdx - startIdx);
+                    startIdx = equalsIdx + 1;
+                }
+
+                // Working from back to front, create a PropertySpec for each .ID in the string.  
+                while (startIdx < endIdx)
+                {
+                    int dotIdx = transformSpec.LastIndexOf('.', endIdx - 1, endIdx - startIdx);
+                    int idIdx = startIdx;
+                    if (0 <= dotIdx)
+                        idIdx = dotIdx + 1;
+
+                    string propertName = transformSpec.Substring(idIdx, endIdx - idIdx);
+                    _fetches = new PropertySpec(propertName, _fetches);
+
+                    // If the user did not explicitly set a name, it is the last one (first to be processed from the end).  
+                    if (_outputName == null)
+                        _outputName = propertName;
+
+                    endIdx = dotIdx;    // This works even when LastIndexOf return -1.  
+                }
+            }
+
+            /// <summary>
+            /// Given the DiagnosticSourcePayload 'obj', compute a key-value pair from it.  For example 
+            /// if the spec is OUTSTR=EVENT_VALUE.PROP1.PROP2.PROP3 and the ultimate value of PROP3 is
+            /// 10 then the return key value pair is  KeyValuePair("OUTSTR","10") 
+            /// </summary>
+            public KeyValuePair<string, string> Morph(object obj)
+            {
+                for (PropertySpec cur = _fetches; cur != null; cur = cur.Next)
+                {
+                    if (obj != null)
+                        obj = cur.Fetch(obj);
+                }
+
+                return new KeyValuePair<string, string>(_outputName, obj?.ToString());
+            }
+
+            /// <summary>
+            /// A public field that can be used to form a linked list.   
+            /// </summary>
+            public TransformSpec Next;
+
+            #region private 
+            /// <summary>
+            /// A PropertySpec resprents information needed to fetch a property from 
+            /// and efficienctly.   Thus it represents a '.PROP' in a TransformSpec
+            /// (and a transformSpec has a list of these).  
+            /// </summary>
+            internal class PropertySpec
+            {
+                /// <summary>
+                /// Make a new PropertySpec for a property named 'propertyName'. 
+                /// For convinience you can set he 'next' field to form a linked
+                /// list of PropertySpecs. 
+                /// </summary>
+                public PropertySpec(string propertyName, PropertySpec next = null)
+                {
+                    Next = next;
+                    _propertyName = propertyName;
+                }
+
+                /// <summary>
+                /// Given an object fetch the property that this PropertySpec represents.  
+                /// </summary>
+                public object Fetch(object obj)
+                {
+                    Type objType = obj.GetType();
+                    if (objType != _expectedType)
+                    {
+                        var typeInfo = objType.GetTypeInfo();
+                        _fetchForExpectedType = PropertyFetch.FetcherForProperty(typeInfo.GetDeclaredProperty(_propertyName));
+                        _expectedType = objType;
+                    }
+                    return _fetchForExpectedType.Fetch(obj);
+                }
+
+                /// <summary>
+                /// A public field that can be used to form a linked list.   
+                /// </summary>
+                public PropertySpec Next;
+
+                #region private
+                /// <summary>
+                /// PropertyFetch is a helper class.  It takes a PropertyInfo and then knows how
+                /// to efficiently fetch that property from a .NET object (See Fetch method).  
+                /// It hides some slightly complex generic code.  
+                /// </summary>
+                class PropertyFetch
+                {
+                    /// <summary>
+                    /// Create a property fetcher from a .NET Reflection PropertyInfo class that
+                    /// represents a property of a paritcular type.  
+                    /// </summary>
+                    public static PropertyFetch FetcherForProperty(PropertyInfo propertyInfo)
+                    {
+                        if (propertyInfo == null)
+                            return new PropertyFetch();     // returns null on any fetch.
+
+                        var typedPropertyFetcher = typeof(TypedFetchProperty<,>);
+                        var instantiatedTypedPropertyFetcher = typedPropertyFetcher.GetTypeInfo().MakeGenericType(
+                            propertyInfo.DeclaringType, propertyInfo.PropertyType);
+                        return (PropertyFetch)Activator.CreateInstance(instantiatedTypedPropertyFetcher, propertyInfo);
+                    }
+
+                    /// <summary>
+                    /// Given an object, fetch the property that this propertyFech represents. 
+                    /// </summary>
+                    public virtual object Fetch(object obj) { return null; }
+
+                    #region private 
+
+                    private class TypedFetchProperty<TObject, TProperty> : PropertyFetch
+                    {
+                        public TypedFetchProperty(PropertyInfo property)
+                        {
+                            _propertyFetch = (Func<TObject, TProperty>)property.GetMethod.CreateDelegate(typeof(Func<TObject, TProperty>));
+                        }
+                        public override object Fetch(object obj)
+                        {
+                            return _propertyFetch((TObject)obj);
+                        }
+                        private readonly Func<TObject, TProperty> _propertyFetch;
+                    }
+                    #endregion
+                }
+
+                private string _propertyName;
+                private Type _expectedType;                 
+                private PropertyFetch _fetchForExpectedType;
+                #endregion
+            }
+
+            private string _outputName;
+            private PropertySpec _fetches;
+            #endregion
+        }
+
+        /// <summary>
+        /// CallbackObserver is a adapter class that creats an observer (which you can pass
+        /// to IObservable.Subscribe), and calls the given callback every time the 'next' 
+        /// operation on the IObserver happens. 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        internal class CallbackObserver<T> : IObserver<T>
+        {
+            public CallbackObserver(Action<T> callback) { _callback = callback; }
+
+            #region private 
+            public void OnCompleted() { }
+            public void OnError(Exception error) { }
+            public void OnNext(T value) { _callback(value); }
+
+            private Action<T> _callback;
+            #endregion
+        }
+
+        // A linked list of IObservable subscriptions (which are IDisposable).  
+        // We use this to keep track of the DiagnosticSource subscriptions.  
+        // We use this linked list for thread atomicity 
+        internal class Subscriptions
+        {
+            public Subscriptions(IDisposable subscription, Subscriptions next)
+            {
+                Subscription = subscription;
+                Next = next;
+            }
+            public IDisposable Subscription;
+            public Subscriptions Next;
+        }
+
+        #endregion
+
+        private FilterAndTransform _specs;      // Tranformation specifications that indicate which sources/events are forwarded.  
+        #endregion
     }
 }

--- a/src/System.Diagnostics.DiagnosticSource/src/project.json
+++ b/src/System.Diagnostics.DiagnosticSource/src/project.json
@@ -2,11 +2,23 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Diagnostics.Debug": "4.0.0",
-    "System.Diagnostics.Tracing": "4.0.0",
     "System.Runtime": "4.0.0",
-    "System.Threading": "4.0.0"
+    "System.Threading": "4.0.0",
+    "System.Reflection": "4.0.0",
+    "System.Collections": "4.0.0"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netstandard1.3": {
+      "dependencies": {
+        "System.Diagnostics.Tracing": "4.0.20"
+      },
+      "imports": [ "dotnet5.4" ]
+    },
+    "netstandard1.1": {
+      "dependencies": {
+        "System.Diagnostics.Tracing": "4.0.0"
+      },
+      "imports": [ "dotnet5.2" ]
+    }
   }
 }

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -1,0 +1,625 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+using System.Threading.Tasks;
+using System.Diagnostics.Tracing;
+using System.Text;
+
+// Turn off parallel execution of tests.   
+// TODO in theory can run the tests in parallel, however there has been some failures when we do this.   
+// Needs investigation.  traced by https://github.com/dotnet/corefx/issues/6872
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]
+
+namespace System.Diagnostics.Tests
+{
+    public class DiagnosticSourceEventSourceBridgeTests
+    {
+        /// <summary>
+        /// Tests the basic functionality of turning on specific EventSources and specifying 
+        /// the events you want.
+        /// </summary>
+        [Fact]
+        public void TestSpecificEvents()
+        {
+            using (var eventSourceListener = new TestDiagnosticSourceEventListener())
+            using (var diagnosticSourceListener = new DiagnosticListener("TestSpecificEventsSource"))
+            {
+                Assert.Equal(0, eventSourceListener.EventCount);
+
+                // Turn on events with both implicit and explicit types You can have whitespace 
+                // before and after each spec.  
+                eventSourceListener.Enable(
+                    "  TestSpecificEventsSource/TestEvent1:cls_Point_X=cls.Point.X;cls_Point_Y=cls.Point.Y\r\n" +
+                    "  TestSpecificEventsSource/TestEvent2:cls_Url=cls.Url\r\n"
+                    );
+
+                /***************************************************************************************/
+                // Emit an event that matches the first pattern. 
+                MyClass val = new MyClass() { Url = "MyUrl", Point = new MyPoint() { X = 3, Y = 5 } };
+                if (diagnosticSourceListener.IsEnabled("TestEvent1"))
+                    diagnosticSourceListener.Write("TestEvent1", new { propStr = "hi", propInt = 4, cls = val });
+
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("TestSpecificEventsSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent1", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(4, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("hi", eventSourceListener.LastEvent.Arguments["propStr"]);
+                Assert.Equal("4", eventSourceListener.LastEvent.Arguments["propInt"]);
+                Assert.Equal("3", eventSourceListener.LastEvent.Arguments["cls_Point_X"]);
+                Assert.Equal("5", eventSourceListener.LastEvent.Arguments["cls_Point_Y"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+
+                /***************************************************************************************/
+                // Emit an event that matches the second pattern. 
+                if (diagnosticSourceListener.IsEnabled("TestEvent2"))
+                    diagnosticSourceListener.Write("TestEvent2", new { prop2Str = "hello", prop2Int = 8, cls = val });
+
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.  
+                Assert.Equal("TestSpecificEventsSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent2", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(3, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("hello", eventSourceListener.LastEvent.Arguments["prop2Str"]);
+                Assert.Equal("8", eventSourceListener.LastEvent.Arguments["prop2Int"]);
+                Assert.Equal("MyUrl", eventSourceListener.LastEvent.Arguments["cls_Url"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+
+                // Emit an event that does not match either pattern.  (thus will be filtered out)
+                if (diagnosticSourceListener.IsEnabled("TestEvent3"))
+                    diagnosticSourceListener.Write("TestEvent3", new { propStr = "prop3", });
+                Assert.Equal(0, eventSourceListener.EventCount);        // No Event should be fired.  
+
+                /***************************************************************************************/
+                // Emit an event from another diagnostic source with the same event name.  
+                // It will be filtered out.  
+                using (var diagnosticSourceListener2 = new DiagnosticListener("TestSpecificEventsSource2"))
+                {
+                    if (diagnosticSourceListener2.IsEnabled("TestEvent1"))
+                        diagnosticSourceListener2.Write("TestEvent1", new { propStr = "hi", propInt = 4, cls = val });
+                }
+                Assert.Equal(0, eventSourceListener.EventCount);        // No Event should be fired.  
+
+                // Disable all the listener and insure that no more events come through.  
+                eventSourceListener.Disable();
+
+                diagnosticSourceListener.Write("TestEvent1", null);
+                diagnosticSourceListener.Write("TestEvent2", null);
+
+                Assert.Equal(0, eventSourceListener.EventCount);        // No Event should be received.  
+            }
+
+            // Make sure that there are no Diagnostic Listeners left over.  
+            DiagnosticListener.AllListeners.Subscribe(DiagnosticSourceTest.MakeObserver(delegate (DiagnosticListener listen)
+            {
+                Assert.True(!listen.Name.StartsWith("BuildTestSource"));
+            }));
+        }
+
+        /// <summary>
+        /// Test that things work properly for Linux newline conventions. 
+        /// </summary>
+        [Fact]
+        public void LinuxNewLineConventions()
+        {
+            using (var eventSourceListener = new TestDiagnosticSourceEventListener())
+            using (var diagnosticSourceListener = new DiagnosticListener("LinuxNewLineConventionsSource"))
+            {
+                Assert.Equal(0, eventSourceListener.EventCount);
+
+                // Turn on events with both implicit and explicit types You can have whitespace 
+                // before and after each spec.   Use \n rather than \r\n 
+                eventSourceListener.Enable(
+                    "  LinuxNewLineConventionsSource/TestEvent1:-cls_Point_X=cls.Point.X\n" + 
+                    "  LinuxNewLineConventionsSource/TestEvent2:-cls_Url=cls.Url\n"
+                    );
+
+                /***************************************************************************************/
+                // Emit an event that matches the first pattern. 
+                MyClass val = new MyClass() { Url = "MyUrl", Point = new MyPoint() { X = 3, Y = 5 } };
+                if (diagnosticSourceListener.IsEnabled("TestEvent1"))
+                    diagnosticSourceListener.Write("TestEvent1", new { propStr = "hi", propInt = 4, cls = val });
+
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("LinuxNewLineConventionsSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent1", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(1, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("3", eventSourceListener.LastEvent.Arguments["cls_Point_X"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+
+                /***************************************************************************************/
+                // Emit an event that matches the second pattern. 
+                if (diagnosticSourceListener.IsEnabled("TestEvent2"))
+                    diagnosticSourceListener.Write("TestEvent2", new { prop2Str = "hello", prop2Int = 8, cls = val });
+
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.  
+                Assert.Equal("LinuxNewLineConventionsSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent2", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(1, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("MyUrl", eventSourceListener.LastEvent.Arguments["cls_Url"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+
+                // Emit an event that does not match either pattern.  (thus will be filtered out)
+                if (diagnosticSourceListener.IsEnabled("TestEvent3"))
+                    diagnosticSourceListener.Write("TestEvent3", new { propStr = "prop3", });
+                Assert.Equal(0, eventSourceListener.EventCount);        // No Event should be fired.  
+            }
+
+            // Make sure that there are no Diagnostic Listeners left over.  
+            DiagnosticListener.AllListeners.Subscribe(DiagnosticSourceTest.MakeObserver(delegate (DiagnosticListener listen)
+            {
+                Assert.True(!listen.Name.StartsWith("BuildTestSource"));
+            }));
+        }
+
+        /// <summary>
+        /// Tests what happens when you wildcard the source name (empy string)
+        /// </summary>
+        [Fact]
+        public void TestWildCardSourceName()
+        {
+            using (var eventSourceListener = new TestDiagnosticSourceEventListener())
+            using (var diagnosticSourceListener1 = new DiagnosticListener("TestWildCardSourceName1"))
+            using (var diagnosticSourceListener2 = new DiagnosticListener("TestWildCardSourceName2"))
+            {
+                eventSourceListener.Filter = (DiagnosticSourceEvent evnt) => evnt.SourceName.StartsWith("TestWildCardSourceName");
+
+                // Turn On Everything.  Note that because of concurent testing, we may get other sources as well.
+                // but we filter them out because we set eventSourceListener.Filter.   
+                eventSourceListener.Enable("");
+
+                Assert.True(diagnosticSourceListener1.IsEnabled("TestEvent1"));
+                Assert.True(diagnosticSourceListener1.IsEnabled("TestEvent2"));
+                Assert.True(diagnosticSourceListener2.IsEnabled("TestEvent1"));
+                Assert.True(diagnosticSourceListener2.IsEnabled("TestEvent2"));
+
+                Assert.Equal(0, eventSourceListener.EventCount);
+
+                diagnosticSourceListener1.Write("TestEvent1", new { prop111 = "prop111Val", prop112 = 112 });
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("TestWildCardSourceName1", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent1", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(2, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("prop111Val", eventSourceListener.LastEvent.Arguments["prop111"]);
+                Assert.Equal("112", eventSourceListener.LastEvent.Arguments["prop112"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+
+                diagnosticSourceListener1.Write("TestEvent2", new { prop121 = "prop121Val", prop122 = 122 });
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("TestWildCardSourceName1", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent2", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(2, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("prop121Val", eventSourceListener.LastEvent.Arguments["prop121"]);
+                Assert.Equal("122", eventSourceListener.LastEvent.Arguments["prop122"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+
+                diagnosticSourceListener2.Write("TestEvent1", new { prop211 = "prop211Val", prop212 = 212 });
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("TestWildCardSourceName2", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent1", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(2, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("prop211Val", eventSourceListener.LastEvent.Arguments["prop211"]);
+                Assert.Equal("212", eventSourceListener.LastEvent.Arguments["prop212"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+
+                diagnosticSourceListener2.Write("TestEvent2", new { prop221 = "prop221Val", prop222 = 122 });
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("TestWildCardSourceName2", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent2", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(2, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("prop221Val", eventSourceListener.LastEvent.Arguments["prop221"]);
+                Assert.Equal("122", eventSourceListener.LastEvent.Arguments["prop222"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+            }
+        }
+
+        /// <summary>
+        /// Tests what happens when you wildcard event name (but not the source name) 
+        /// </summary>
+        [Fact]
+        public void TestWildCardEventName()
+        {
+            using (var eventSourceListener = new TestDiagnosticSourceEventListener())
+            using (var diagnosticSourceListener = new DiagnosticListener("TestWildCardEventNameSource"))
+            {
+                Assert.Equal(0, eventSourceListener.EventCount);
+
+                // Turn on events with both implicit and explicit types 
+                eventSourceListener.Enable("TestWildCardEventNameSource");
+
+                /***************************************************************************************/
+                // Emit an event, check that all implicit properties are generated
+                MyClass val = new MyClass() { Url = "MyUrl", Point = new MyPoint() { X = 3, Y = 5 } };
+                if (diagnosticSourceListener.IsEnabled("TestEvent1"))
+                    diagnosticSourceListener.Write("TestEvent1", new { propStr = "hi", propInt = 4, cls = val });
+
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("TestWildCardEventNameSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent1", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(2, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("hi", eventSourceListener.LastEvent.Arguments["propStr"]);
+                Assert.Equal("4", eventSourceListener.LastEvent.Arguments["propInt"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+
+                /***************************************************************************************/
+                // Emit the same event, with a different set of implicit properties 
+                if (diagnosticSourceListener.IsEnabled("TestEvent1"))
+                    diagnosticSourceListener.Write("TestEvent1", new { propStr2 = "hi2", cls = val });
+
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("TestWildCardEventNameSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent1", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(1, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("hi2", eventSourceListener.LastEvent.Arguments["propStr2"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+
+                /***************************************************************************************/
+                // Emit an event from another diagnostic source with the same event name.  
+                // It will be filtered out.  
+                using (var diagnosticSourceListener2 = new DiagnosticListener("TestWildCardEventNameSource2"))
+                {
+                    if (diagnosticSourceListener2.IsEnabled("TestEvent1"))
+                        diagnosticSourceListener2.Write("TestEvent1", new { propStr = "hi", propInt = 4, cls = val });
+                }
+                Assert.Equal(0, eventSourceListener.EventCount);        // No Event should be fired.  
+            }
+        }
+
+        /// <summary>
+        /// Test what happens when there are nulls passed in the event payloads
+        /// Bascially strings get turned into empty strings and other nulls are typically
+        /// ignored.  
+        /// </summary>
+        [Fact]
+        public void TestNulls()
+        {
+            using (var eventSourceListener = new TestDiagnosticSourceEventListener())
+            using (var diagnosticSourceListener = new DiagnosticListener("TestNullsTestSource"))
+            {
+                Assert.Equal(0, eventSourceListener.EventCount);
+
+                // Turn on events with both implicit and explicit types 
+                eventSourceListener.Enable("TestNullsTestSource/TestEvent1:cls.Url;cls_Point_X=cls.Point.X");
+
+                /***************************************************************************************/
+                // Emit a null arguments object. 
+
+                if (diagnosticSourceListener.IsEnabled("TestEvent1"))
+                    diagnosticSourceListener.Write("TestEvent1", null);
+
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("TestNullsTestSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent1", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(0, eventSourceListener.LastEvent.Arguments.Count);
+                eventSourceListener.ResetEventCountAndLastEvent();
+
+                /***************************************************************************************/
+                // Emit an arguments object with nulls in it.   
+
+                MyClass val = null;
+                string strVal = null;
+                if (diagnosticSourceListener.IsEnabled("TestEvent1"))
+                    diagnosticSourceListener.Write("TestEvent1", new { cls = val, propStr = "propVal1", propStrNull = strVal });
+
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("TestNullsTestSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent1", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(2, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("propVal1", eventSourceListener.LastEvent.Arguments["propStr"]);
+                Assert.Equal("", eventSourceListener.LastEvent.Arguments["propStrNull"]);   // null strings get turned into empty strings
+                eventSourceListener.ResetEventCountAndLastEvent();
+
+                /***************************************************************************************/
+                // Emit an arguments object that points at null things
+
+                MyClass val1 = new MyClass() { Url = "myUrlVal", Point = null };
+                if (diagnosticSourceListener.IsEnabled("TestEvent1"))
+                    diagnosticSourceListener.Write("TestEvent1", new { cls = val1, propStr = "propVal1" });
+
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("TestNullsTestSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent1", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(2, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("propVal1", eventSourceListener.LastEvent.Arguments["propStr"]);
+                Assert.Equal("myUrlVal", eventSourceListener.LastEvent.Arguments["Url"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+
+                /***************************************************************************************/
+                // Emit an arguments object that points at null things (variation 2)
+
+                MyClass val2 = new MyClass() { Url = null, Point = new MyPoint() { X = 8, Y = 9 } };
+                if (diagnosticSourceListener.IsEnabled("TestEvent1"))
+                    diagnosticSourceListener.Write("TestEvent1", new { cls = val2, propStr = "propVal1" });
+
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("TestNullsTestSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent1", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(2, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("propVal1", eventSourceListener.LastEvent.Arguments["propStr"]);
+                Assert.Equal("8", eventSourceListener.LastEvent.Arguments["cls_Point_X"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+            }
+        }
+
+        /// <summary>
+        /// Tests the feature that supresses the implicit inclusion of serialable properties 
+        /// of the payload object.  
+        /// </summary>
+        [Fact]
+        public void TestNoImplicitTransforms()
+        {
+            using (var eventSourceListener = new TestDiagnosticSourceEventListener())
+            using (var diagnosticSourceListener = new DiagnosticListener("TestNoImplictTransformsSource"))
+            {
+                Assert.Equal(0, eventSourceListener.EventCount);
+
+                // use the - prefix to supress the implicit properties.  Thus you should only get propStr and Url.  
+                eventSourceListener.Enable("TestNoImplictTransformsSource/TestEvent1:-propStr;cls.Url");
+
+                /***************************************************************************************/
+                // Emit an event that matches the first pattern. 
+                MyClass val = new MyClass() { Url = "MyUrl", Point = new MyPoint() { X = 3, Y = 5 } };
+                if (diagnosticSourceListener.IsEnabled("TestEvent1"))
+                    diagnosticSourceListener.Write("TestEvent1", new { propStr = "hi", propInt = 4, cls = val, propStr2 = "there" });
+
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("TestNoImplictTransformsSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent1", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(2, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("hi", eventSourceListener.LastEvent.Arguments["propStr"]);
+                Assert.Equal("MyUrl", eventSourceListener.LastEvent.Arguments["Url"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+            }
+        }
+
+        /// <summary>
+        /// Tests what happens when wacky characters are used in property specs.  
+        /// </summary>
+        [Fact]
+        public void TestBadProperties()
+        {
+            using (var eventSourceListener = new TestDiagnosticSourceEventListener())
+            using (var diagnosticSourceListener = new DiagnosticListener("TestBadPropertiesSource"))
+            {
+                Assert.Equal(0, eventSourceListener.EventCount);
+
+                // This has a syntax error in the Url case, so it should be ignored.  
+                eventSourceListener.Enable("TestBadPropertiesSource/TestEvent1:cls.Ur-+l");
+
+                /***************************************************************************************/
+                // Emit an event that matches the first pattern. 
+                MyClass val = new MyClass() { Url = "MyUrl", Point = new MyPoint() { X = 3, Y = 5 } };
+                if (diagnosticSourceListener.IsEnabled("TestEvent1"))
+                    diagnosticSourceListener.Write("TestEvent1", new { propStr = "hi", propInt = 4, cls = val });
+
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("TestBadPropertiesSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent1", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(2, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("hi", eventSourceListener.LastEvent.Arguments["propStr"]);
+                Assert.Equal("4", eventSourceListener.LastEvent.Arguments["propInt"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+            }
+        }
+
+        // Tests that messages about DiagnosticSourceEventSource make it out.  
+        [Fact]
+        public void TestMessages()
+        {
+            using (var eventSourceListener = new TestDiagnosticSourceEventListener())
+            using (var diagnosticSourceListener = new DiagnosticListener("TestMessagesSource"))
+            {
+                Assert.Equal(0, eventSourceListener.EventCount);
+
+                // This is just to make debugging easier.  
+                var messages = new List<string>();
+
+                eventSourceListener.OtherEventWritten += delegate(EventWrittenEventArgs evnt)
+                {
+                    if (evnt.EventName == "Message")
+                    {
+                        var message = (string)evnt.Payload[0];
+                        messages.Add(message);
+                    }
+                };
+
+                // This has a syntax error in the Url case, so it should be ignored.  
+                eventSourceListener.Enable("TestMessagesSource/TestEvent1:-cls.Url");
+                Assert.Equal(0, eventSourceListener.EventCount);
+                Assert.True(3 <= messages.Count);
+            }
+        }
+    }
+
+    /****************************************************************************/
+    // classes to make up data for the tests.  
+
+    /// <summary>
+    /// classes for test data. 
+    /// </summary>
+    internal class MyClass
+    {
+        public string Url { get; set; }
+        public MyPoint Point { get; set; }
+    }
+
+    /// <summary>
+    /// classes for test data. 
+    /// </summary>
+    internal class MyPoint
+    {
+        public int X { get; set; }
+        public int Y { get; set; }
+    }
+
+    /****************************************************************************/
+    // Harness infrastructure
+    /// <summary>
+    /// TestDiagnosticSourceEventListener installs a EventWritten callback that updates EventCount and LastEvent.  
+    /// </summary>
+    class TestDiagnosticSourceEventListener : DiagnosticSourceEventListener
+    {
+        public TestDiagnosticSourceEventListener()
+        {
+            EventWritten += UpdateLastEvent;
+        }
+
+        public int EventCount;
+        public DiagnosticSourceEvent LastEvent;
+        public DiagnosticSourceEvent SecondLast;
+        public DiagnosticSourceEvent ThirdLast;
+
+        /// <summary>
+        /// Sets the EventCount to 0 and LastEvent to null
+        /// </summary>
+        public void ResetEventCountAndLastEvent()
+        {
+            EventCount = 0;
+            LastEvent = null;
+            SecondLast = null;
+            ThirdLast = null;
+        }
+
+        /// <summary>
+        /// If present, will ignore events that don't cause this filter predicate to return true.  
+        /// </summary>
+        public Predicate<DiagnosticSourceEvent> Filter;
+
+        #region private 
+        private void UpdateLastEvent(DiagnosticSourceEvent anEvent)
+        {
+            if (Filter != null && !Filter(anEvent))
+                return;
+
+            ThirdLast = SecondLast;
+            SecondLast = LastEvent;
+
+            EventCount++;
+            LastEvent = anEvent;
+        }
+        #endregion
+    }
+
+    /// <summary>
+    /// Represents a single DiagnosticSource event.  
+    /// </summary>
+    class DiagnosticSourceEvent
+    {
+        public string SourceName;
+        public string EventName;
+        public Dictionary<string, string> Arguments;
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine("{");
+            sb.Append("  SourceName: \"").Append(SourceName ?? "").Append("\",").AppendLine();
+            sb.Append("  EventName: \"").Append(EventName ?? "").Append("\",").AppendLine();
+            sb.Append("  Arguments: ").Append("[").AppendLine();
+            bool first = true;
+            foreach (var keyValue in Arguments)
+            {
+                if (!first)
+                    sb.Append(",").AppendLine();
+                first = false;
+                sb.Append("    ").Append(keyValue.Key).Append(": \"").Append(keyValue.Value).Append("\"");
+            }
+            sb.AppendLine().AppendLine("  ]");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>
+    /// A helper class that listens to Diagnostic sources and send events to the 'EventWritten'
+    /// callback.   Standard use is to create the class set up the events of interested and
+    /// use 'Enable'.  .   
+    /// </summary>
+    class DiagnosticSourceEventListener : EventListener
+    {
+        public DiagnosticSourceEventListener() { }
+
+        /// <summary>
+        /// Will be called when a DiagnosticSource event is fired. 
+        /// </summary>
+        public event Action<DiagnosticSourceEvent> EventWritten;
+
+        /// <summary>
+        /// It is possible that there are other events besides those that are being forwarded from 
+        /// the DiagnosticSources.   These come here.   
+        /// </summary>
+        public event Action<EventWrittenEventArgs> OtherEventWritten;
+
+        public void Enable(string filterAndPayloadSpecs)
+        {
+            var args = new Dictionary<string, string>();
+            args.Add("FilterAndPayloadSpecs", filterAndPayloadSpecs);
+            EnableEvents(_diagnosticSourceEventSource, EventLevel.Verbose, EventKeywords.All, args);
+        }
+
+        public void Disable()
+        {
+            DisableEvents(_diagnosticSourceEventSource);
+        }
+
+        /// <summary>
+        /// Cleans this class up.  Among other things diables the DiagnosticSources being listened to.  
+        /// </summary>
+        public override void Dispose()
+        {
+            if (_diagnosticSourceEventSource != null)
+            {
+                Disable();
+                _diagnosticSourceEventSource = null;
+            }
+        }
+
+        #region private 
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            bool wroteEvent = false;
+            var eventWritten = EventWritten;
+            if (eventWritten != null)
+            {
+                if (eventData.EventName == "Event" && eventData.Payload.Count == 3)
+                {
+                    Debug.Assert(eventData.PayloadNames[0] == "SourceName");
+                    Debug.Assert(eventData.PayloadNames[1] == "EventName");
+                    Debug.Assert(eventData.PayloadNames[2] == "Arguments");
+
+                    var anEvent = new DiagnosticSourceEvent();
+                    anEvent.SourceName = eventData.Payload[0].ToString();
+                    anEvent.EventName = eventData.Payload[1].ToString();
+                    anEvent.Arguments = new Dictionary<string, string>();
+
+                    var asKeyValueList = eventData.Payload[2] as IEnumerable<object>;
+                    if (asKeyValueList != null)
+                    {
+                        foreach (IDictionary<string, object> keyvalue in asKeyValueList)
+                        {
+                            object key;
+                            keyvalue.TryGetValue("Key", out key);
+                            object value;
+                            keyvalue.TryGetValue("Value", out value);
+                            if (key != null && value != null)
+                                anEvent.Arguments[key.ToString()] = value.ToString();
+                        }
+                    }
+                    eventWritten(anEvent);
+                    wroteEvent = true;
+                }
+            }
+
+            var otherEventWritten = OtherEventWritten;
+            if (otherEventWritten != null && !wroteEvent)
+                otherEventWritten(eventData);
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name == "Microsoft-Diagnostics-DiagnosticSource")
+                _diagnosticSourceEventSource = eventSource;
+        }
+
+        EventSource _diagnosticSourceEventSource;
+        #endregion
+    }
+}

--- a/src/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
@@ -14,6 +14,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="DiagnosticSourceEventSourceBridgeTests.cs" />
     <Compile Include="DiagnosticSourceTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Diagnostics.DiagnosticSource/tests/project.json
+++ b/src/System.Diagnostics.DiagnosticSource/tests/project.json
@@ -3,6 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Collections": "4.0.10",
     "System.Diagnostics.Debug": "4.0.10",
+    "System.Diagnostics.Tracing": "4.0.20",
     "System.Runtime": "4.0.20",
     "System.Runtime.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",


### PR DESCRIPTION
Currently DiagnosticSource just goes to DiagnosticListeners.   We want to
be able to have the capabilty to pipe DiagnosticSource information to
EventSource consumers (ETW and EventListeners).  We do this with a new
DiagnosticSource EventSource called 'Microsoft-DiagnosticsSource'  If
EventListener / ETW subscribe to that EventSource they can get events
from any DiangnosticSouce.

See the comments in the code itself as well as the tests in the file
DiagnosticSourceEventSourceBridgeTests.cs for more on specifics of
using this new functionality.