### PR TITLE
Fixing bug #6866 that caused a truncation in the OS X FileSystemWatcher

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -172,6 +172,10 @@ namespace System.IO
 
             internal void Start()
             {
+                // Normalize the _fullDirectory path to have a trailing slash
+                if (_fullDirectory[_fullDirectory.Length - 1] != '/')
+                    _fullDirectory += "/";
+
                 // Make sure _fullPath doesn't contain a link or alias
                 // since the OS will give back the actual, non link'd or alias'd paths
                 _fullDirectory = Interop.Sys.RealPath(_fullDirectory);
@@ -326,9 +330,8 @@ namespace System.IO
                         string relativePath = null;
                         if (eventPaths[i].Equals(_fullDirectory, StringComparison.OrdinalIgnoreCase) == false)
                         {
-                            // Check if the event path, with the root directory removed, begins with a / and
-                            // if so, remove it; otherwise, just remove the root path (which contains a trailing /)
-                            relativePath = eventPaths[i].Remove(0, _fullDirectory.Length + (eventPaths[i][_fullDirectory.Length] == '/' ? 1 : 0));
+                            // Remove the root directory to get the relative path
+                            relativePath = eventPaths[i].Remove(0, _fullDirectory.Length);
                         }
 
                         // Check if this is a rename
@@ -348,9 +351,9 @@ namespace System.IO
                             }
                             else
                             {
-                                // Remove the base directory prefix (including trailing / that OS X adds) and 
-                                // add the paired event to the list of events to skip and notify the user of the rename
-                                string newPathRelativeName = eventPaths[pairedId].Remove(0, _fullDirectory.Length + 1);
+                                // Remove the base directory prefix and add the paired event to the list of 
+                                // events to skip and notify the user of the rename 
+                                string newPathRelativeName = eventPaths[pairedId].Remove(0, _fullDirectory.Length);
                                 watcher.NotifyRenameEventArgs(WatcherChangeTypes.Renamed, newPathRelativeName, relativePath);
 
                                 // Create a new list, if necessary, and add the event


### PR DESCRIPTION
The underlying issue was that the code to get the relative path name in a rename pair was going 1 character too far in the case that the root directory already contained a trailing slash. This was caused by the fact that if the root directory does not contain a trailing slash (which our tests do not) then OS X adds one to the paths. This change makes sure that when this situations arises, we do not go the extra character. I also added a test to validate it but it won't come online until #2684 is fixed to validate paths, not just the right events.

@stephentoub 

fyi @ jrieken 