### PR TITLE
Add Zlib-Intel Opimizations to Linux System.IO.Compression.Native.so

### DIFF
--- a/src/Native/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/Native/System.IO.Compression.Native/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(System.IO.Compression.Native)
 
-find_package(ZLIB REQUIRED)
-
 set(NATIVECOMPRESSION_SOURCES
     pal_zlib.cpp
 )
@@ -10,6 +8,60 @@ add_library(System.IO.Compression.Native
     SHARED
     ${NATIVECOMPRESSION_SOURCES}
 )
+
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL amd64 AND CMAKE_SYSTEM_NAME STREQUAL LINUX)
+
+	add_dependencies(System.IO.Compression.Native System.IO.Compression.Native-Static)
+
+	set(ZLIB_FLAGS 
+	    -w
+	    -mpclmul 
+	    -msse4
+	    -O3
+	    -fPIC
+	    -Ds_LARGEFILE64_SOURCE=1 
+	    -DHAVE_HIDDEN -DX86_64 
+	    -DUNALIGNED_OK 
+	    -DADLER32_UNROLL_LESS 
+	    -DCRC32_UNROLL_LESS 
+	    -UCHECK_SSE2 
+	    -DHAVE_SSE2 
+	    -DUSE_SSE4_2_CRC_HASH 
+	    -DHAVE_PCLMULQDQ 
+	    -DUSE_MEDIUM
+   	)
+
+	set(ZLIB_SOURCES)
+		../Windows/clrcompression/zlib-intel/adler32.c
+		../Windows/clrcompression/zlib-intel/crc_folding.c
+		../Windows/clrcompression/zlib-intel/crc32.c
+		../Windows/clrcompression/zlib-intel/deflate_quick.c
+		../Windows/clrcompression/zlib-intel/deflate.c
+		../Windows/clrcompression/zlib-intel/fill_window_sse.c
+		../Windows/clrcompression/zlib-intel/match.c
+		../Windows/clrcompression/zlib-intel/trees.c
+		../Windows/clrcompression/zlib-intel/x86.c
+		../Windows/clrcompression/zlib-intel/zutil.c
+		../Windows/clrcompression/zlib/compress.c 
+		../Windows/clrcompression/zlib/inffast.c
+		../Windows/clrcompression/zlib/inflate.c
+		../Windows/clrcompression/zlib/inftrees.c
+	)
+		
+	add_definitions(${ZLIB_FLAGS})
+        add_library(System.IO.Compression.Native-Static
+	    STATIC
+	    ${ZLIB_SOURCES}
+	)
+
+	
+	set(ZLIB_LIBRARIES 
+	    System.IO.Compression.Native-Static
+	)
+
+else()
+    find_package(ZLIB REQUIRED)
+endif()
 
 target_link_libraries(System.IO.Compression.Native
     ${ZLIB_LIBRARIES}


### PR DESCRIPTION
This PR extends the optimizations from #5674 by statically linking Zlib-Intel to System.IO.Compression.Native on x86/x64 platforms running Linux. Testing on an Intel i5-4690 with Ubuntu 14.04, I see for an average file in the Canterbury Corpus:
- +24% performance improvement for CompressionLevel.Optimal
- +9% performance improvement for CompressionLevel.Fastest
- Negligible/Unchanged performance for CompressionLevel.NoCompression


Iterations|File|CompressionLevel|Adler|Intel|Intel/Adler|
|:------------- |:------------- |:------------- |:------------- |:------------- |:------------- |
50|alice29.txt|Optimal|6.731896|4.995399|74.20%|76.58%|
50|cp.html|Optimal|0.549348|0.502904|91.55%|
50|fields.c|Optimal|0.263334|0.253578|96.30%|
50|lcet10.txt|Optimal|18.31165|13.59124|74.22%|	
50|asyoulik.txt|Optimal|6.086299|4.28945|70.48%|
50|kennedy.xls|Optimal|28.88515|12.32973|42.69%|	
50|sum|	Optimal|1.4116|0.8322659|58.96%|
50|ptt5	|Optimal|8.719625|5.636329|64.64%|
50|grammar.lsp|Optimal|0.12538|0.1282|102.25%|
50|plrabn12.txt|Optimal|27.5093|18.22937|66.27%|
50|xargs.1|Optimal|0.145356|0.146492|100.78%|
50|alice29.txt|Fastest|1.888226|1.792558|94.93%|
50|cp.html|Fastest|0.310862|0.293024|94.26%|
50|fields.c|Fastest|0.16198|0.160036|98.80%|
50|lcet10.txt|Fastest|5.153471|4.703264|91.26%|
50|asyoulik.txt|Fastest|1.611514|1.586706|98.46%|
50|kennedy.xls|Fastest|7.43489|5.414171|72.82%|
50|sum|Fastest|0.513908|0.4540399|88.35%|
50|ptt5|Fastest|2.982993|1.916446|64.25%|
50|grammar.lsp|Fastest|0.09776202|0.097928|100.17%|
50|plrabn12.txt|Fastest|6.750174|6.123339|90.71%|
50|xargs.1|Fastest|0.112222|0.119746|106.70%|


@stephentoub @ianhays 