### PR TITLE
System.Reflection.Metadata: Branch builder

### DIFF
--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -48,8 +48,10 @@
     <Compile Include="System\Reflection\Metadata\Decoding\CustomAttributeTypedArgument.cs" />
     <Compile Include="System\Reflection\Metadata\Decoding\CustomAttributeValue.cs" />
     <Compile Include="System\Reflection\Metadata\Decoding\ICustomAttributeTypeProvider.cs" />
+    <Compile Include="System\Reflection\Metadata\Ecma335\Blobs\BranchBuilder.cs" />
     <Compile Include="System\Reflection\Metadata\Ecma335\Blobs\ExceptionRegionEncoder.cs" />
     <Compile Include="System\Reflection\Metadata\Ecma335\Blobs\InstructionEncoder.cs" />
+    <Compile Include="System\Reflection\Metadata\Ecma335\Blobs\LabelHandle.cs" />
     <Compile Include="System\Reflection\Metadata\ILOpCode.cs" />
     <Compile Include="System\Reflection\Metadata\Ecma335\CodedIndex.cs" />
     <Compile Include="System\Reflection\Metadata\Ecma335\MetadataSerializer.cs" />
@@ -58,6 +60,7 @@
     <Compile Include="System\Reflection\Metadata\Ecma335\Blobs\MethodBodyEncoder.cs" />
     <Compile Include="System\Reflection\Metadata\Ecma335\MetadataSizes.cs" />
     <Compile Include="System\Reflection\Metadata\Ecma335\MetadataBuilder.Heaps.cs" />
+    <Compile Include="System\Reflection\Metadata\ILOpCodeExtensions.cs" />
     <Compile Include="System\Reflection\Metadata\Internal\HeapSizeFlag.cs" />
     <Compile Include="System\Reflection\Metadata\Internal\MetadataWriterUtilities.cs" />
     <Compile Include="System\Reflection\PortableExecutable\ContentId.cs" />

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Blobs/BranchBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Blobs/BranchBuilder.cs
@@ -1,0 +1,181 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+
+#if !SRM
+using Microsoft.CodeAnalysis.CodeGen;
+#endif
+
+#if SRM
+namespace System.Reflection.Metadata.Ecma335.Blobs
+#else
+namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
+#endif
+{
+#if SRM
+    public
+#endif
+    sealed class BranchBuilder
+    {
+        // internal for testing:
+        internal struct BranchInfo
+        {
+            internal readonly int ILOffset;
+            internal readonly LabelHandle Label;
+            internal readonly byte ShortOpCode;
+
+            internal BranchInfo(int ilOffset, LabelHandle label, byte shortOpCode)
+            {
+                ILOffset = ilOffset;
+                Label = label;
+                ShortOpCode = shortOpCode;
+            }
+
+            internal bool IsShortBranchDistance(ImmutableArray<int>.Builder labels, out int distance)
+            {
+                const int shortBranchSize = 2;
+                const int longBranchSize = 5;
+
+                int labelTargetOffset = labels[Label.Id - 1];
+
+                distance = labelTargetOffset - (ILOffset + shortBranchSize);
+                if (unchecked((sbyte)distance) == distance)
+                {
+                    return true;
+                }
+
+                distance = labelTargetOffset - (ILOffset + longBranchSize);
+                return false;
+            }
+        }
+
+        private readonly ImmutableArray<BranchInfo>.Builder _branches;
+        private readonly ImmutableArray<int>.Builder _labels;
+
+        public BranchBuilder()
+        {
+            _branches = ImmutableArray.CreateBuilder<BranchInfo>();
+            _labels = ImmutableArray.CreateBuilder<int>();
+        }
+
+        internal void Clear()
+        {
+            _branches.Clear();
+            _labels.Clear();
+        }
+
+        internal LabelHandle AddLabel()
+        {
+            _labels.Add(-1);
+            return new LabelHandle(_labels.Count);
+        }
+
+        internal void AddBranch(int ilOffset, LabelHandle label, byte shortOpCode)
+        {
+            Debug.Assert(ilOffset >= 0);
+            Debug.Assert(_branches.Count == 0 || ilOffset > _branches.Last().ILOffset);
+            ValidateLabel(label);
+            _branches.Add(new BranchInfo(ilOffset, label, shortOpCode));
+        }
+
+        internal void MarkLabel(int ilOffset, LabelHandle label)
+        {
+            Debug.Assert(ilOffset >= 0);
+            ValidateLabel(label);
+            _labels[label.Id - 1] = ilOffset;
+        }
+
+        private void ValidateLabel(LabelHandle label)
+        {
+            if (label.IsNil)
+            {
+                throw new ArgumentNullException(nameof(label));
+            }
+
+            if (label.Id > _labels.Count)
+            {
+                // TODO: localize
+                throw new ArgumentException("Label not defined", nameof(label));
+            }
+        }
+
+        // internal for testing:
+        internal IEnumerable<BranchInfo> Branches => _branches;
+
+        // internal for testing:
+        internal IEnumerable<int> Labels => _labels;
+
+        internal int BranchCount => _branches.Count;
+
+        internal void FixupBranches(BlobBuilder srcBuilder, BlobBuilder dstBuilder)
+        {
+            int srcOffset = 0;
+            var branch = _branches[0];
+            int branchIndex = 0;
+            int blobOffset = 0;
+            foreach (Blob blob in srcBuilder.GetBlobs())
+            {
+                Debug.Assert(blobOffset == 0 || blobOffset == 1 && blob.Buffer[blobOffset - 1] == 0xff);
+
+                while (true)
+                {
+                    // copy bytes preceding the next branch, or till the end of the blob:
+                    int chunkSize = Math.Min(branch.ILOffset - srcOffset, blob.Length - blobOffset);
+                    dstBuilder.WriteBytes(blob.Buffer, blobOffset, chunkSize);
+                    srcOffset += chunkSize;
+                    blobOffset += chunkSize;
+
+                    // there is no branch left in the blob:
+                    if (blobOffset == blob.Length)
+                    {
+                        blobOffset = 0;
+                        break;
+                    }
+
+                    Debug.Assert(blob.Buffer[blobOffset] == branch.ShortOpCode && (blobOffset + 1 == blob.Length || blob.Buffer[blobOffset + 1] == 0xff));
+                    srcOffset += sizeof(byte) + sizeof(sbyte);
+
+                    // write actual branch instruction:
+                    int branchDistance;
+                    if (branch.IsShortBranchDistance(_labels, out branchDistance))
+                    {
+                        dstBuilder.WriteByte(branch.ShortOpCode);
+                        dstBuilder.WriteSByte((sbyte)branchDistance);
+                    }
+                    else
+                    {
+                        dstBuilder.WriteByte((byte)((ILOpCode)branch.ShortOpCode).GetLongBranch());
+                        dstBuilder.WriteInt32(branchDistance);
+                    }
+
+                    // next branch:
+                    branchIndex++;
+                    if (branchIndex == _branches.Count)
+                    {
+                        branch = new BranchInfo(int.MaxValue, default(LabelHandle), 0);
+                    }
+                    else
+                    {
+                        branch = _branches[branchIndex];
+                    }
+
+                    // the branch starts at the very end and its operand is in the next blob:
+                    if (blobOffset == blob.Length - 1)
+                    {
+                        blobOffset = 1;
+                        break;
+                    }
+
+                    // skip fake branch instruction:
+                    blobOffset += sizeof(byte) + sizeof(sbyte);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Blobs/LabelHandle.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Blobs/LabelHandle.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+#if SRM
+namespace System.Reflection.Metadata.Ecma335.Blobs
+#else
+namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
+#endif
+{
+#if SRM
+    public
+#endif
+    struct LabelHandle : IEquatable<LabelHandle>
+    {
+        // 1-based
+        internal readonly int Id;
+
+        internal LabelHandle(int id)
+        {
+            Debug.Assert(id >= 1);
+            Id = id;
+        }
+
+        public bool IsNil => Id == 0;
+
+        public bool Equals(LabelHandle other) => Id == other.Id;
+        public override bool Equals(object obj) => obj is LabelHandle && Equals((LabelHandle)obj);
+        public override int GetHashCode() => Id.GetHashCode();
+
+        public static bool operator ==(LabelHandle left, LabelHandle right) => left.Equals(right);
+        public static bool operator !=(LabelHandle left, LabelHandle right) => !left.Equals(right);
+    }
+}

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Blobs/MethodBodyEncoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Blobs/MethodBodyEncoder.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 
@@ -97,7 +98,18 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
             _exceptionRegionCount = exceptionRegionCount;
         }
 
+        internal bool IsTiny(int codeSize)
+        {
+            return codeSize < 64 && _maxStack <= 8 && _localVariablesSignature.IsNil && _exceptionRegionCount == 0;
+        }
+
         private int WriteHeader(int codeSize)
+        {
+            Blob blob;
+            return WriteHeader(codeSize, false, out blob);
+        }
+
+        private int WriteHeader(int codeSize, bool codeSizeFixup, out Blob codeSizeBlob)
         {
             const int TinyFormat = 2;
             const int FatFormat = 3;
@@ -106,11 +118,13 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
 
             int offset;
 
-            bool isTiny = codeSize < 64 && _maxStack <= 8 && _localVariablesSignature.IsNil && _exceptionRegionCount == 0;
-            if (isTiny)
+            if (IsTiny(codeSize))
             {
                 offset = Builder.Count;
                 Builder.WriteByte((byte)((codeSize << 2) | TinyFormat));
+
+                Debug.Assert(!codeSizeFixup);
+                codeSizeBlob = default(Blob);
             }
             else
             {
@@ -131,7 +145,16 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
 
                 Builder.WriteUInt16((ushort)(_attributes | flags));
                 Builder.WriteUInt16(_maxStack);
-                Builder.WriteInt32(codeSize);
+                if (codeSizeFixup)
+                {
+                    codeSizeBlob = Builder.ReserveBytes(sizeof(int));
+                }
+                else
+                {
+                    codeSizeBlob = default(Blob);
+                    Builder.WriteInt32(codeSize);
+                }
+
                 Builder.WriteInt32(_localVariablesSignature.IsNil ? 0 : MetadataTokens.GetToken(_localVariablesSignature));
             }
 
@@ -146,25 +169,62 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
                 hasLargeRegions: (_attributes & (int)MethodBodyAttributes.LargeExceptionRegions) != 0);
         }
 
-        public ExceptionRegionEncoder WriteInstructions(ImmutableArray<byte> buffer, out int offset)
+        public ExceptionRegionEncoder WriteInstructions(ImmutableArray<byte> instructions, out int bodyOffset)
         {
-            offset = WriteHeader(buffer.Length);
-            Builder.WriteBytes(buffer);
+            bodyOffset = WriteHeader(instructions.Length);
+            Builder.WriteBytes(instructions);
             return CreateExceptionEncoder();
         }
 
-        public ExceptionRegionEncoder WriteInstructions(ImmutableArray<byte> buffer, out int offset, out Blob instructionBlob)
+        public ExceptionRegionEncoder WriteInstructions(ImmutableArray<byte> instructions, out int bodyOffset, out Blob instructionBlob)
         {
-            offset = WriteHeader(buffer.Length);
-            instructionBlob = Builder.ReserveBytes(buffer.Length);
-            new BlobWriter(instructionBlob).WriteBytes(buffer);
+            bodyOffset = WriteHeader(instructions.Length);
+            instructionBlob = Builder.ReserveBytes(instructions.Length);
+            new BlobWriter(instructionBlob).WriteBytes(instructions);
             return CreateExceptionEncoder();
         }
 
-        public ExceptionRegionEncoder WriteInstructions(BlobBuilder buffer, out int offset)
+        public ExceptionRegionEncoder WriteInstructions(BlobBuilder codeBuilder, out int bodyOffset)
         {
-            offset = WriteHeader(buffer.Count);
-            buffer.WriteContentTo(Builder);
+            bodyOffset = WriteHeader(codeBuilder.Count);
+            codeBuilder.WriteContentTo(Builder);
+            return CreateExceptionEncoder();
+        }
+
+        public ExceptionRegionEncoder WriteInstructions(BlobBuilder codeBuilder, BranchBuilder branchBuilder, out int bodyOffset)
+        {
+            if (branchBuilder == null || branchBuilder.BranchCount == 0)
+            {
+                return WriteInstructions(codeBuilder, out bodyOffset);
+            }
+            
+            // When emitting branches we emitted short branches.
+            int initialCodeSize = codeBuilder.Count;
+            Blob codeSizeFixup;
+            if (IsTiny(initialCodeSize))
+            {
+                // If the method is tiny so far then all branches have to be short 
+                // (the max distance between any label and a branch instruction is < 64).
+                bodyOffset = WriteHeader(initialCodeSize);
+                codeSizeFixup = default(Blob);
+            }
+            else
+            {
+                // Otherwise, it's fat format and we can fixup the size later on:
+                bodyOffset = WriteHeader(initialCodeSize, true, out codeSizeFixup);
+            }
+
+            int codeStartOffset = Builder.Count;
+            branchBuilder.FixupBranches(codeBuilder, Builder);
+            if (!codeSizeFixup.IsDefault)
+            {
+                new BlobWriter(codeSizeFixup).WriteInt32(Builder.Count - codeStartOffset);
+            }
+            else
+            {
+                Debug.Assert(initialCodeSize == Builder.Count - codeStartOffset);
+            }
+
             return CreateExceptionEncoder();
         }
     }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/ILOpCodeExtensions.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/ILOpCodeExtensions.cs
@@ -1,0 +1,251 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if !SRM
+using System;
+#endif
+
+#if SRM
+namespace System.Reflection.Metadata
+#else
+namespace Microsoft.CodeAnalysis.CodeGen
+#endif
+{
+#if SRM
+    public
+#endif
+    static partial class ILOpCodeExtensions
+    {
+        /// <summary>
+        /// Returns true of the specified op-code is a branch to a label.
+        /// </summary>
+        public static bool IsBranch(this ILOpCode opCode)
+        {
+            switch (opCode)
+            {
+                case ILOpCode.Br:
+                case ILOpCode.Br_s:
+                case ILOpCode.Brtrue:
+                case ILOpCode.Brtrue_s:
+                case ILOpCode.Brfalse:
+                case ILOpCode.Brfalse_s:
+                case ILOpCode.Beq:
+                case ILOpCode.Beq_s:
+                case ILOpCode.Bne_un:
+                case ILOpCode.Bne_un_s:
+                case ILOpCode.Bge:
+                case ILOpCode.Bge_s:
+                case ILOpCode.Bge_un:
+                case ILOpCode.Bge_un_s:
+                case ILOpCode.Bgt:
+                case ILOpCode.Bgt_s:
+                case ILOpCode.Bgt_un:
+                case ILOpCode.Bgt_un_s:
+                case ILOpCode.Ble:
+                case ILOpCode.Ble_s:
+                case ILOpCode.Ble_un:
+                case ILOpCode.Ble_un_s:
+                case ILOpCode.Blt:
+                case ILOpCode.Blt_s:
+                case ILOpCode.Blt_un:
+                case ILOpCode.Blt_un_s:
+                case ILOpCode.Leave:
+                case ILOpCode.Leave_s:
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Calculate the size of the specified branch instruction operand.
+        /// </summary>
+        /// <param name="opCode">Branch op-code.</param>
+        /// <returns>1 if <paramref name="opCode"/> is a short branch or 4 if it is a long branch.</returns>
+        /// <exception cref="ArgumentException">Specified <paramref name="opCode"/> is not a branch op-code.</exception>
+        public static int GetBranchOperandSize(this ILOpCode opCode)
+        {
+            switch (opCode)
+            {
+                case ILOpCode.Br_s:
+                case ILOpCode.Brfalse_s:
+                case ILOpCode.Brtrue_s:
+                case ILOpCode.Beq_s:
+                case ILOpCode.Bge_s:
+                case ILOpCode.Bgt_s:
+                case ILOpCode.Ble_s:
+                case ILOpCode.Blt_s:
+                case ILOpCode.Bne_un_s:
+                case ILOpCode.Bge_un_s:
+                case ILOpCode.Bgt_un_s:
+                case ILOpCode.Ble_un_s:
+                case ILOpCode.Blt_un_s:
+                case ILOpCode.Leave_s:
+                    return 1;
+
+                case ILOpCode.Br:
+                case ILOpCode.Brfalse:
+                case ILOpCode.Brtrue:
+                case ILOpCode.Beq:
+                case ILOpCode.Bge:
+                case ILOpCode.Bgt:
+                case ILOpCode.Ble:
+                case ILOpCode.Blt:
+                case ILOpCode.Bne_un:
+                case ILOpCode.Bge_un:
+                case ILOpCode.Bgt_un:
+                case ILOpCode.Ble_un:
+                case ILOpCode.Blt_un:
+                case ILOpCode.Leave:
+                    return 4;
+            }
+
+            throw new ArgumentException("Expected branch opcode.", nameof(opCode));
+        }
+
+        /// <summary>
+        /// Get a short form of the specified branch op-code.
+        /// </summary>
+        /// <param name="opCode">Branch op-code.</param>
+        /// <returns>Short form of the branch op-code.</returns>
+        /// <exception cref="ArgumentException">Specified <paramref name="opCode"/> is not a branch op-code.</exception>
+        public static ILOpCode GetShortBranch(this ILOpCode opCode)
+        {
+            switch (opCode)
+            {
+                case ILOpCode.Br_s:
+                case ILOpCode.Brfalse_s:
+                case ILOpCode.Brtrue_s:
+                case ILOpCode.Beq_s:
+                case ILOpCode.Bge_s:
+                case ILOpCode.Bgt_s:
+                case ILOpCode.Ble_s:
+                case ILOpCode.Blt_s:
+                case ILOpCode.Bne_un_s:
+                case ILOpCode.Bge_un_s:
+                case ILOpCode.Bgt_un_s:
+                case ILOpCode.Ble_un_s:
+                case ILOpCode.Blt_un_s:
+                case ILOpCode.Leave_s:
+                    return opCode;
+
+                case ILOpCode.Br:
+                    return ILOpCode.Br_s;
+
+                case ILOpCode.Brfalse:
+                    return ILOpCode.Brfalse_s;
+
+                case ILOpCode.Brtrue:
+                    return ILOpCode.Brtrue_s;
+
+                case ILOpCode.Beq:
+                    return ILOpCode.Beq_s;
+
+                case ILOpCode.Bge:
+                    return ILOpCode.Bge_s;
+
+                case ILOpCode.Bgt:
+                    return ILOpCode.Bgt_s;
+
+                case ILOpCode.Ble:
+                    return ILOpCode.Ble_s;
+
+                case ILOpCode.Blt:
+                    return ILOpCode.Blt_s;
+
+                case ILOpCode.Bne_un:
+                    return ILOpCode.Bne_un_s;
+
+                case ILOpCode.Bge_un:
+                    return ILOpCode.Bge_un_s;
+
+                case ILOpCode.Bgt_un:
+                    return ILOpCode.Bgt_un_s;
+
+                case ILOpCode.Ble_un:
+                    return ILOpCode.Ble_un_s;
+
+                case ILOpCode.Blt_un:
+                    return ILOpCode.Blt_un_s;
+
+                case ILOpCode.Leave:
+                    return ILOpCode.Leave_s;
+            }
+
+            throw new ArgumentException("Expected branch opcode.", nameof(opCode));
+        }
+
+        /// <summary>
+        /// Get a long form of the specified branch op-code.
+        /// </summary>
+        /// <param name="opCode">Branch op-code.</param>
+        /// <returns>Long form of the branch op-code.</returns>
+        /// <exception cref="ArgumentException">Specified <paramref name="opCode"/> is not a branch op-code.</exception>
+        public static ILOpCode GetLongBranch(this ILOpCode opCode)
+        {
+            switch (opCode)
+            {
+                case ILOpCode.Br:
+                case ILOpCode.Brfalse:
+                case ILOpCode.Brtrue:
+                case ILOpCode.Beq:
+                case ILOpCode.Bge:
+                case ILOpCode.Bgt:
+                case ILOpCode.Ble:
+                case ILOpCode.Blt:
+                case ILOpCode.Bne_un:
+                case ILOpCode.Bge_un:
+                case ILOpCode.Bgt_un:
+                case ILOpCode.Ble_un:
+                case ILOpCode.Blt_un:
+                case ILOpCode.Leave:
+                    return opCode;
+
+                case ILOpCode.Br_s:
+                    return ILOpCode.Br;
+
+                case ILOpCode.Brfalse_s:
+                    return ILOpCode.Brfalse;
+
+                case ILOpCode.Brtrue_s:
+                    return ILOpCode.Brtrue;
+
+                case ILOpCode.Beq_s:
+                    return ILOpCode.Beq;
+
+                case ILOpCode.Bge_s:
+                    return ILOpCode.Bge;
+
+                case ILOpCode.Bgt_s:
+                    return ILOpCode.Bgt;
+
+                case ILOpCode.Ble_s:
+                    return ILOpCode.Ble;
+
+                case ILOpCode.Blt_s:
+                    return ILOpCode.Blt;
+
+                case ILOpCode.Bne_un_s:
+                    return ILOpCode.Bne_un;
+
+                case ILOpCode.Bge_un_s:
+                    return ILOpCode.Bge_un;
+
+                case ILOpCode.Bgt_un_s:
+                    return ILOpCode.Bgt_un;
+
+                case ILOpCode.Ble_un_s:
+                    return ILOpCode.Ble_un;
+
+                case ILOpCode.Blt_un_s:
+                    return ILOpCode.Blt_un;
+
+                case ILOpCode.Leave_s:
+                    return ILOpCode.Leave;
+            }
+
+            throw new ArgumentException("Expected branch opcode.", nameof(opCode));
+        }
+    }
+}


### PR DESCRIPTION
BranchBuilder is a new class that holds on a couple of lists (branches and labels). It can be reused as necessary (cleared and/or pooled). InstructionEncoder is a struct that just provides encoding helpers that write to the underlying builders. That’s the pattern for all encoders we have. The main reason I separated the branch management to a BranchBuilder is memory management. InstructionEncoder doesn’t allocate anything. It’s up to the caller to provide BranchBuilder (allocate a new one, provide one from a pool, etc.)

Usage sample:
```C#
var codeBuilder = new BlobBuilder();
var branchBuilder = new BranchBuilder();
            
var il = new InstructionEncoder(codeBuilder, branchBuilder);
var endLabel = il.DefineLabel();

// .try
int tryOffset = il.Offset;

//   ldstr "hello"
il.LoadString(metadata.GetOrAddUserString("hello"));

//   call void [mscorlib]System.Console::WriteLine(string)
il.Call(consoleWriteLineMemberRef);

//   leave.s END
il.Branch(ILOpCode.Leave, endLabel);

// .finally
int handlerOffset = il.Offset;

//   ldstr "world"
il.LoadString(metadata.GetOrAddUserString("world"));

//   call void [mscorlib]System.Console::WriteLine(string)
il.Call(consoleWriteLineMemberRef);

// .endfinally
il.OpCode(ILOpCode.Endfinally);
int handlerEnd = il.Offset;

// END: 
il.MarkLabel(endLabel);

// ret
il.OpCode(ILOpCode.Ret);

var body = methodBodies.AddMethodBody(exceptionRegionCount: 1);
var eh = body.WriteInstructions(codeBuilder, branchBuilder, out mainBodyOffset);
eh.StartRegions();
eh.AddFinally(tryOffset, handlerOffset - tryOffset, handlerOffset, handlerEnd - handlerOffset);
eh.EndRegions();

codeBuilder.Clear();
branchBuilder.Clear();
```

Tests are currently in Roslyn repo. Will move once we move Roslyn over to SRM 1.3 (hopefully later this week).

