### PR TITLE
Fix dependency group of Private.DCS dependency

### DIFF
--- a/src/System.Runtime.Serialization.Json/pkg/System.Runtime.Serialization.Json.pkgproj
+++ b/src/System.Runtime.Serialization.Json/pkg/System.Runtime.Serialization.Json.pkgproj
@@ -17,7 +17,7 @@
     <InboxOnTargetFramework Include="xamarintvos10" />
     <InboxOnTargetFramework Include="xamarinwatchos10" />
     <ProjectReference Include="..\..\System.Private.DataContractSerialization\pkg\System.Private.DataContractSerialization.pkgproj">
-      <PackageTargetFramework>netstandardapp1.5</PackageTargetFramework>
+      <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Private.DataContractSerialization\pkg\System.Private.DataContractSerialization.pkgproj">
       <PackageTargetFramework>netcore50</PackageTargetFramework>

--- a/src/System.Runtime.Serialization.Xml/pkg/System.Runtime.Serialization.Xml.pkgproj
+++ b/src/System.Runtime.Serialization.Xml/pkg/System.Runtime.Serialization.Xml.pkgproj
@@ -20,7 +20,7 @@
     <InboxOnTargetFramework Include="xamarintvos10" />
     <InboxOnTargetFramework Include="xamarinwatchos10" />
     <ProjectReference Include="..\..\System.Private.DataContractSerialization\pkg\System.Private.DataContractSerialization.pkgproj">
-      <PackageTargetFramework>netstandardapp1.5</PackageTargetFramework>
+      <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Private.DataContractSerialization\pkg\System.Private.DataContractSerialization.pkgproj">
       <PackageTargetFramework>netcore50</PackageTargetFramework>


### PR DESCRIPTION
The manual dependency here should match the target moniker of the
implementation assembly.

Long term we should really not rely on a manual dependency here and
harvest this, but that will require a buildtools update.

/cc @weshaggard 