### PR TITLE
Fix version of S.Private.DataContractSerialization

### DIFF
--- a/src/System.Private.DataContractSerialization/pkg/System.Private.DataContractSerialization.pkgproj
+++ b/src/System.Private.DataContractSerialization/pkg/System.Private.DataContractSerialization.pkgproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <!-- Ideally we'd harvest this from the runtime dependencies -->
-    <Version>4.1.0</Version>
+    <Version>4.1.1</Version>
     <PreventImplementationReference>true</PreventImplementationReference>
   </PropertyGroup>
 


### PR DESCRIPTION
4.1.0 shipped in UWP we need to rev this to 4.1.1 so that it isn't built as stable.

/cc @chcosta @weshaggard 