### PR TITLE
Make SetActiveConnectionAndResult in SqlCommand synchronous to avoid validation race conditions.

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -830,6 +830,9 @@ namespace System.Data.SqlClient
                 try
                 { // InternalExecuteNonQuery already has reliability block, but if failure will not put stateObj back into pool.
                     Task execNQ = InternalExecuteNonQuery(completion, ADP.BeginExecuteNonQuery, false, timeout, asyncWrite);
+
+                    // must finish caching information before ReadSni which can activate the callback before returning
+                    cachedAsyncState.SetActiveConnectionAndResult(completion, ADP.EndExecuteNonQuery, _activeConnection);
                     if (execNQ != null)
                     {
                         AsyncHelper.ContinueTask(execNQ, completion, () => BeginExecuteNonQueryInternalReadStage(completion));
@@ -871,8 +874,6 @@ namespace System.Data.SqlClient
             // Read SNI does not have catches for async exceptions, handle here.
             try
             {
-                // must finish caching information before ReadSni which can activate the callback before returning
-                cachedAsyncState.SetActiveConnectionAndResult(completion, ADP.EndExecuteNonQuery, _activeConnection);
                 _stateObj.ReadSni(completion);
             }
             catch (Exception)
@@ -1166,6 +1167,8 @@ namespace System.Data.SqlClient
                     throw;
                 }
 
+                // must finish caching information before ReadSni which can activate the callback before returning
+                cachedAsyncState.SetActiveConnectionAndResult(completion, ADP.EndExecuteXmlReader, _activeConnection);
                 if (writeTask != null)
                 {
                     AsyncHelper.ContinueTask(writeTask, completion, () => BeginExecuteXmlReaderInternalReadStage(completion));
@@ -1194,8 +1197,6 @@ namespace System.Data.SqlClient
             // Read SNI does not have catches for async exceptions, handle here.
             try
             {
-                // must finish caching information before ReadSni which can activate the callback before returning
-                cachedAsyncState.SetActiveConnectionAndResult(completion, ADP.EndExecuteXmlReader, _activeConnection);
                 _stateObj.ReadSni(completion);
             }
             catch (Exception e)
@@ -1415,6 +1416,8 @@ namespace System.Data.SqlClient
                     throw;
                 }
 
+                // must finish caching information before ReadSni which can activate the callback before returning
+                cachedAsyncState.SetActiveConnectionAndResult(completion, ADP.EndExecuteReader, _activeConnection);
                 if (writeTask != null)
                 {
                     AsyncHelper.ContinueTask(writeTask, completion, () => BeginExecuteReaderInternalReadStage(completion));
@@ -1443,8 +1446,6 @@ namespace System.Data.SqlClient
             // Read SNI does not have catches for async exceptions, handle here.
             try
             {
-                // must finish caching information before ReadSni which can activate the callback before returning
-                cachedAsyncState.SetActiveConnectionAndResult(completion, ADP.EndExecuteReader, _activeConnection);
                 _stateObj.ReadSni(completion);
             }
             catch (Exception e)


### PR DESCRIPTION
SetActiveConnectionAndResult was being called in the async tasks for BeginExecute...ReadStage functions. This SetActiveConnection function sets the connection state that ValidateAsyncCommand checks before posting another async task. So if two async SqlCommand.Executes are called, the second might not see an active connection pending because the first's async task hasn't run yet to set the active connection in the first place. This inevitably causes problems when the two tasks run simultaneously and try to modify shared connection state.