### PR TITLE
Use TCSANOW instead of TCSAFLUSH to avoid losing input

### DIFF
--- a/src/Native/System.Native/pal_console.cpp
+++ b/src/Native/System.Native/pal_console.cpp
@@ -140,7 +140,7 @@ extern "C" void SystemNative_UninitializeConsoleAfterRead()
 
         int tmpErrno = errno; // preserve any errors from before uninitializing
         IncorporateBreak(&g_preReadTermios, g_signalForBreak);
-        int ret = tcsetattr(STDIN_FILENO, TCSAFLUSH, &g_preReadTermios);
+        int ret = tcsetattr(STDIN_FILENO, TCSANOW, &g_preReadTermios);
         assert(ret >= 0); // shouldn't fail, but if it does we don't want to fail in release
         (void)ret;
         errno = tmpErrno;
@@ -278,7 +278,7 @@ extern "C" int32_t SystemNative_SetSignalForBreak(int32_t signalForBreak)
     if (tcgetattr(STDIN_FILENO, &current) >= 0)
     {
         IncorporateBreak(&current, signalForBreak);
-        if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &current) >= 0)
+        if (tcsetattr(STDIN_FILENO, TCSANOW, &current) >= 0)
         {
             g_signalForBreak = signalForBreak;
             return 1;


### PR DESCRIPTION
TCSAFLUSH throws away unread input.  That can cause us to lose stdin data.

cc: @pallavit 