### PR TITLE
Fix Serialization Facades

### DIFF
--- a/src/System.Runtime.Serialization.Json/src/System.Runtime.Serialization.Json.builds
+++ b/src/System.Runtime.Serialization.Json/src/System.Runtime.Serialization.Json.builds
@@ -3,16 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Runtime.Serialization.Json.csproj" />
-    <!-- Net46 facade is currently inbox for 4.0 
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Runtime.Serialization.Json.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project> -->
-    <Project Include="System.Runtime.Serialization.Json.csproj">
-      <TargetGroup>netcore50</TargetGroup>
-    </Project>
-    <Project Include="System.Runtime.Serialization.Json.csproj">
-      <TargetGroup>netcore50aot</TargetGroup>
-    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Json/src/System.Runtime.Serialization.Json.csproj
+++ b/src/System.Runtime.Serialization.Json/src/System.Runtime.Serialization.Json.csproj
@@ -5,33 +5,21 @@
     <AssemblyName>System.Runtime.Serialization.Json</AssemblyName>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
 
-  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
-    <ProjectJson>netcore50aot/project.json</ProjectJson>
-    <ProjectLockJson>netcore50aot/project.lock.json</ProjectLockJson>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' == 'net46'" />
-    <TargetingPackReference Include="System.Runtime.Serialization" Condition="'$(TargetGroup)' == 'net46'" />
-    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
-    <TargetingPackReference Include="System.Private.DataContractSerialization" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+  <ItemGroup Condition="'$(TargetGroup)' == ''" >
+    <ProjectReference Include="$(SourceDir)System.Private.DataContractSerialization\src\System.Private.DataContractSerialization.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetGroup)' != 'netcore50aot' And '$(TargetGroup)' != 'net46'">
-    <ProjectReference Include="$(SourceDir)System.Private.DataContractSerialization\src\System.Private.DataContractSerialization.csproj" />
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+    <TargetingPackReference Include="System.Runtime.Serialization"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Runtime.Serialization.Json/src/netcore50aot/project.json
+++ b/src/System.Runtime.Serialization.Json/src/netcore50aot/project.json
@@ -1,9 +1,0 @@
-{
-  "frameworks": {
-    "netcore50": {
-      "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23910"
-      }
-    }
-  }
-}

--- a/src/System.Runtime.Serialization.Json/src/project.json
+++ b/src/System.Runtime.Serialization.Json/src/project.json
@@ -4,14 +4,10 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
         "System.Runtime": "4.0.20",
+        "System.Runtime.Serialization.Primitives": "4.1.1-rc3-23910",
         "System.Reflection": "4.0.10",
         "System.Reflection.TypeExtensions": "4.0.0",
         "System.Xml.XmlDocument": "4.0.0"
-      }
-    },
-    "netcore50": {
-      "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23910"
       }
     },
     "net46": {

--- a/src/System.Runtime.Serialization.Xml/src/System.Runtime.Serialization.Xml.builds
+++ b/src/System.Runtime.Serialization.Xml/src/System.Runtime.Serialization.Xml.builds
@@ -4,14 +4,8 @@
   <ItemGroup>
     <Project Include="System.Runtime.Serialization.Xml.csproj" />
     <Project Include="System.Runtime.Serialization.Xml.csproj">
-      <TargetGroup>netcore50</TargetGroup>
-    </Project>
-    <Project Include="System.Runtime.Serialization.Xml.csproj">
-      <TargetGroup>netcore50aot</TargetGroup>
-    </Project>
-    <Project Include="System.Runtime.Serialization.Xml.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>  
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Xml/src/System.Runtime.Serialization.Xml.csproj
+++ b/src/System.Runtime.Serialization.Xml/src/System.Runtime.Serialization.Xml.csproj
@@ -12,31 +12,14 @@
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
 
-  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
-    <ProjectJson>netcore50aot/project.json</ProjectJson>
-    <ProjectLockJson>netcore50aot/project.lock.json</ProjectLockJson>
-  </PropertyGroup>
-  
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcore50aot'" >
-    <TargetingPackReference Include="System.Private.CoreLib" />
-    <TargetingPackReference Include="System.Private.DataContractSerialization" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="$(SourceDir)System.Runtime.Serialization.Primitives\src\System.Runtime.Serialization.Primitives.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcore50' OR '$(TargetGroup)' == ''" >  
+  <ItemGroup Condition="'$(TargetGroup)' == ''" >
     <ProjectReference Include="$(SourceDir)System.Private.DataContractSerialization\src\System.Private.DataContractSerialization.csproj" />
-    <TargetingPackReference Include="mscorlib" />
-  </ItemGroup> 
-  <ItemGroup Condition="'$(TargetGroup)' == 'net46'" >
-    <TargetingPackReference Include="mscorlib" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Runtime.Serialization" />
     <Compile Include="$(SourceDir)System.Private.DataContractSerialization\src\System\Runtime\Serialization\DataContractSerializerExtensions.Desktop.cs" />

--- a/src/System.Runtime.Serialization.Xml/src/netcore50aot/project.json
+++ b/src/System.Runtime.Serialization.Xml/src/netcore50aot/project.json
@@ -1,9 +1,0 @@
-{
-  "frameworks": {
-    "netcore50": {
-      "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23910"
-      }
-    }
-  }
-}

--- a/src/System.Runtime.Serialization.Xml/src/project.json
+++ b/src/System.Runtime.Serialization.Xml/src/project.json
@@ -4,6 +4,7 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
         "System.Runtime": "4.0.20",
+        "System.Runtime.Serialization.Primitives": "4.1.1-rc3-23910",
         "System.Reflection": "4.0.10",
         "System.Reflection.TypeExtensions": "4.0.0",
         "System.Xml.XmlDocument": "4.0.0"
@@ -12,14 +13,10 @@
         "dotnet5.4"
       ]
     },
-    "netcore50": {
-      "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23910"
-      }
-    },
     "net46": {
       "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1",
+        "System.Runtime.Serialization.Primitives": "4.1.1-rc3-23910",
       }
     }
   }


### PR DESCRIPTION
We can build S.R.S.Xml and S.R.S.Json as facades directly against contracts
and System.Private.DataContractSerialization so we can eliminate all the platform
specific facades.

cc @venkat-raman251 @ericstj 

cc @khdang @SGuyGe 