### PR TITLE
Avoid failing in UnixFileStream if flock isn't supported

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -130,9 +130,11 @@ namespace System.IO
 
                 // Lock the file if requested via FileShare.  This is only advisory locking. FileShare.None implies an exclusive 
                 // lock on the file and all other modes use a shared lock.  While this is not as granular as Windows, not mandatory, 
-                // and not atomic with file opening, it's better than nothing.
+                // and not atomic with file opening, it's better than nothing.  Some kinds of files, e.g. FIFOs, don't support
+                // locking on some platforms, e.g. OSX, and so if flock returns ENOTSUP, we similarly treat it as a hint and ignore it,
+                // as we don't want to entirely prevent usage of a particular file simply because locking isn't supported.
                 Interop.Sys.LockOperations lockOperation = (share == FileShare.None) ? Interop.Sys.LockOperations.LOCK_EX : Interop.Sys.LockOperations.LOCK_SH;
-                CheckFileCall(Interop.Sys.FLock(_fileHandle, lockOperation | Interop.Sys.LockOperations.LOCK_NB));
+                CheckFileCall(Interop.Sys.FLock(_fileHandle, lockOperation | Interop.Sys.LockOperations.LOCK_NB), ignoreNotSupported: true);
 
                 // These provide hints around how the file will be accessed.  Specifying both RandomAccess
                 // and Sequential together doesn't make sense as they are two competing options on the same spectrum,

--- a/src/System.IO.FileSystem/tests/FileStream/Pipes.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Pipes.cs
@@ -41,6 +41,30 @@ namespace System.IO.Tests
             }
         }
 
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public async Task FifoReadWriteViaFileStream()
+        {
+            string fifoPath = GetTestFilePath();
+            Assert.Equal(0, mkfifo(fifoPath, 666));
+
+            await Task.WhenAll(
+                Task.Run(() =>
+                {
+                    using (FileStream fs = File.OpenRead(fifoPath))
+                    {
+                        Assert.Equal(42, fs.ReadByte());
+                    }
+                }),
+                Task.Run(() =>
+                {
+                    using (FileStream fs = File.OpenWrite(fifoPath))
+                    {
+                        fs.WriteByte(42);
+                        fs.Flush();
+                    }
+                }));
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]


### PR DESCRIPTION
flock on OSX can fail with ENOTSUP if "the referenced descriptor is not of the correct type", e.g. if it's a FIFO.  Since we don't want to entirely prevent usage of FileStream with such file types on OSX, and since locking is already advisory only, this change just ignores rather than throws when flock fails with ENOTSUP.

Fixes https://github.com/dotnet/corefx/issues/6929
cc: @ianhays, @paulmaybee