### PR TITLE
Report an error when trying to use integrated auth with SqlClient managed SNI enabled.

### DIFF
--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -1038,7 +1038,4 @@
   <data name="SNI_PN9" xml:space="preserve">
     <value>SQL Network Interfaces</value>
   </data>
-  <data name="ADP_FeatureNotSupportedOnNonWindowsPlatform" xml:space="preserve">
-    <value>{0} is not supported on non-Windows platform.</value>
-  </data>
 </root>

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolGroup.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolGroup.cs
@@ -160,13 +160,6 @@ namespace System.Data.ProviderBase
 
                 if (_poolGroupOptions.PoolByIdentity)
                 {
-                    // There is no concept of Windows identity on non-Windows platform. Hence we 
-                    // cannot support Windows authentication.
-                    if (!ADP.IsWindows)
-                    {
-                        throw new PlatformNotSupportedException(SR.GetString(SR.ADP_FeatureNotSupportedOnNonWindowsPlatform, DbConnectionStringKeywords.IntegratedSecurity));
-                    }
-
                     // if we're pooling by identity (because integrated security is
                     // being used for these connections) then we need to go out and
                     // search for the connectionPool that matches the current identity.

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
@@ -202,6 +202,12 @@ namespace System.Data.SqlClient
             }
 
             _integratedSecurity = ConvertValueToIntegratedSecurity();
+#if MANAGED_SNI
+            if(_integratedSecurity)
+            {
+                throw new PlatformNotSupportedException("Integrated security is not supported");
+            }
+#endif
 
             _encrypt = ConvertValueToBoolean(KEY.Encrypt, DEFAULT.Encrypt);
             _mars = ConvertValueToBoolean(KEY.MARS, DEFAULT.MARS);
@@ -360,6 +366,12 @@ namespace System.Data.SqlClient
         internal SqlConnectionString(SqlConnectionString connectionOptions, string dataSource, bool userInstance) : base(connectionOptions)
         {
             _integratedSecurity = connectionOptions._integratedSecurity;
+#if MANAGED_SNI
+            if (_integratedSecurity)
+            {
+                throw new PlatformNotSupportedException("Integrated security is not supported");
+            }
+#endif
             _encrypt = connectionOptions._encrypt;
 
             _mars = connectionOptions._mars;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
@@ -194,6 +194,9 @@ namespace System.Data.SqlClient
             ThrowUnsupportedIfKeywordSet(KEY.Context_Connection);
             ThrowUnsupportedIfKeywordSet(KEY.Enlist);
             ThrowUnsupportedIfKeywordSet(KEY.TransactionBinding);
+#if MANAGED_SNI
+            ThrowUnsupportedIfKeywordSet(KEY.Integrated_Security);
+#endif
 
             // Network Library has its own special error message
             if (ContainsKey(KEY.Network_Library))
@@ -202,13 +205,6 @@ namespace System.Data.SqlClient
             }
 
             _integratedSecurity = ConvertValueToIntegratedSecurity();
-#if MANAGED_SNI
-            if(_integratedSecurity)
-            {
-                throw new PlatformNotSupportedException("Integrated security is not supported");
-            }
-#endif
-
             _encrypt = ConvertValueToBoolean(KEY.Encrypt, DEFAULT.Encrypt);
             _mars = ConvertValueToBoolean(KEY.MARS, DEFAULT.MARS);
             _persistSecurityInfo = ConvertValueToBoolean(KEY.Persist_Security_Info, DEFAULT.Persist_Security_Info);
@@ -366,12 +362,6 @@ namespace System.Data.SqlClient
         internal SqlConnectionString(SqlConnectionString connectionOptions, string dataSource, bool userInstance) : base(connectionOptions)
         {
             _integratedSecurity = connectionOptions._integratedSecurity;
-#if MANAGED_SNI
-            if (_integratedSecurity)
-            {
-                throw new PlatformNotSupportedException("Integrated security is not supported");
-            }
-#endif
             _encrypt = connectionOptions._encrypt;
 
             _mars = connectionOptions._mars;


### PR DESCRIPTION
Currently integrated auth causes a failure in DbConnectionPoolGroup when checking for WindowsIdentity-based pooling, which isn't immediately clear is due to using integrated auth. This change makes the failure more clear by throwing an exception when integrated auth options are being set in the first place while using Managed SNI. Once managed integrated auth on Windows is added, these conditionals can be made platform-specific.