### PR TITLE
Shorten named pipe names in System.IO.Pipes.Tests

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -339,7 +339,7 @@ namespace System.IO.Pipes
 
         private static string EnsurePipeDirectoryPath()
         {
-            const string PipesFeatureName = "pipes";
+            const string PipesFeatureName = "pipe";
 
             // Ideally this would simply use PersistedFiles.GetTempFeatureDirectory(PipesFeatureName) and then
             // Directory.CreateDirectory to ensure it exists.  But this assembly doesn't reference System.IO.FileSystem.
@@ -347,7 +347,7 @@ namespace System.IO.Pipes
             // to create each of the individual directories as part of the path.  We instead access the named portions 
             // of the path directly and do the building of the path and directory structure manually.
 
-            // First ensure we know what the full path should be, e.g. /tmp/.dotnet/corefx/pipes/
+            // First ensure we know what the full path should be, e.g. /tmp/.dotnet/corefx/pipe/
             string fullPath = s_pipeDirectoryPath;
             string tempPath = null;
             if (fullPath == null)
@@ -383,7 +383,7 @@ namespace System.IO.Pipes
                 partialPath = Path.Combine(partialPath, PersistedFiles.SecondLevelDirectory);
                 CreateDirectory(partialPath);
 
-                // Create /tmp/.dotnet/corefx/pipes/ if it doesn't exist
+                // Create /tmp/.dotnet/corefx/pipe/ if it doesn't exist
                 CreateDirectory(fullPath);
             }
 

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CrossProcess.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CrossProcess.cs
@@ -14,8 +14,8 @@ namespace System.IO.Pipes.Tests
         public void PingPong_Sync()
         {
             // Create names for two pipes
-            string outName = Guid.NewGuid().ToString("N");
-            string inName = Guid.NewGuid().ToString("N");
+            string outName = Path.GetRandomFileName();
+            string inName = Path.GetRandomFileName();
 
             // Create the two named pipes, one for each direction, then create
             // another process with which to communicate
@@ -40,8 +40,8 @@ namespace System.IO.Pipes.Tests
         public async Task PingPong_Async()
         {
             // Create names for two pipes
-            string outName = Guid.NewGuid().ToString("N");
-            string inName = Guid.NewGuid().ToString("N");
+            string outName = Path.GetRandomFileName();
+            string inName = Path.GetRandomFileName();
 
             // Create the two named pipes, one for each direction, then create
             // another process with which to communicate

--- a/src/System.IO.Pipes/tests/PipeTestBase.cs
+++ b/src/System.IO.Pipes/tests/PipeTestBase.cs
@@ -55,12 +55,12 @@ namespace System.IO.Pipes.Tests
         }
 
         /// <summary>
-        /// Get a unique pipe name that is guaranteed not to be in use elsewhere
+        /// Get a unique pipe name very unlikely to be in use elsewhere.
         /// </summary>
         /// <returns></returns>
         protected static string GetUniquePipeName()
         {
-            return Guid.NewGuid().ToString();
+            return Path.GetRandomFileName();
         }
 
         /// <summary>


### PR DESCRIPTION
Tactical change to fix https://github.com/dotnet/corefx/issues/6918.  Separately I want to look into what we might be able to do to improve the situation in general.

cc: @ianhays, @ericeil