### PR TITLE
Dispose MMF invalid SafeHandles

### DIFF
--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Windows.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Windows.cs
@@ -46,6 +46,7 @@ namespace System.IO.MemoryMappedFiles
             }
             else // handle.IsInvalid
             {
+                handle.Dispose();
                 throw Win32Marshal.GetExceptionForWin32Error(errorCode);
             }
 
@@ -117,6 +118,7 @@ namespace System.IO.MemoryMappedFiles
                 }
                 else
                 {
+                    handle.Dispose();
                     int createErrorCode = Marshal.GetLastWin32Error();
                     if (createErrorCode != Interop.mincore.Errors.ERROR_ACCESS_DENIED)
                     {
@@ -136,6 +138,7 @@ namespace System.IO.MemoryMappedFiles
                 // didn't get valid handle; have to retry
                 else
                 {
+                    handle.Dispose();
                     int openErrorCode = Marshal.GetLastWin32Error();
                     if (openErrorCode != Interop.mincore.Errors.ERROR_FILE_NOT_FOUND)
                     {
@@ -231,6 +234,7 @@ namespace System.IO.MemoryMappedFiles
 
             if (handle.IsInvalid)
             {
+                handle.Dispose();
                 if (createOrOpen && (lastError == Interop.mincore.Errors.ERROR_FILE_NOT_FOUND))
                 {
                     throw new ArgumentException(SR.Argument_NewMMFWriteAccessNotAllowed, "access");

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
@@ -53,6 +53,7 @@ namespace System.IO.MemoryMappedFiles
                     (int)MemoryMappedFile.GetFileMapAccess(access), offsetHigh, offsetLow, new UIntPtr(nativeSize));
             if (viewHandle.IsInvalid)
             {
+                viewHandle.Dispose();
                 throw Win32Marshal.GetExceptionForLastWin32Error();
             }
 
@@ -79,6 +80,7 @@ namespace System.IO.MemoryMappedFiles
                 int lastError = Marshal.GetLastWin32Error();
                 if (viewHandle.IsInvalid)
                 {
+                    viewHandle.Dispose();
                     throw Win32Marshal.GetExceptionForWin32Error(lastError);
                 }
                 // again query the view for its new size


### PR DESCRIPTION
While investigating https://github.com/dotnet/corefx/issues/6911, I noticed that several thousand SafeHandles during the test run were being finalized.  This fixes it.

cc: @ianhays, @ericeil