### PR TITLE
Fix NamedPipe*Stream.OutBufferSize on OS X

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Unix.cs
@@ -28,7 +28,11 @@ namespace System.IO.Pipes
 
             // Configure the pipe.  For buffer size, the size applies to the pipe, rather than to 
             // just one end's file descriptor, so we only need to do this with one of the handles.
-            InitializeBufferSize(serverHandle, bufferSize);
+            // bufferSize is just advisory and ignored if platform does not support setting pipe capacity via fcntl.
+            if (bufferSize > 0 && Interop.Sys.Fcntl.CanGetSetPipeSz)
+            {
+                CheckPipeCall(Interop.Sys.Fcntl.SetPipeSz(serverHandle, bufferSize));
+            }
 
             // We're connected.  Finish initialization using the newly created handles.
             InitializeHandle(serverHandle, isExposed: false, isAsync: false);

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Unix.cs
@@ -69,6 +69,26 @@ namespace System.IO.Pipes
             }
         }
 
+        public override int InBufferSize
+        {
+            get
+            {
+                CheckPipePropertyOperations();
+                if (!CanRead) throw new NotSupportedException(SR.NotSupported_UnreadableStream);
+                return InternalHandle?.NamedPipeSocket?.ReceiveBufferSize ?? 0;
+            }
+        }
+
+        public override int OutBufferSize
+        {
+            get
+            {
+                CheckPipePropertyOperations();
+                if (!CanWrite) throw new NotSupportedException(SR.NotSupported_UnwritableStream);
+                return InternalHandle?.NamedPipeSocket?.SendBufferSize ?? 0;
+            }
+        }
+
         // -----------------------------
         // ---- PAL layer ends here ----
         // -----------------------------

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
@@ -179,6 +179,26 @@ namespace System.IO.Pipes
                 Interop.GetExceptionForIoErrno(error, _path);
         }
 
+        public override int InBufferSize
+        {
+            get
+            {
+                CheckPipePropertyOperations();
+                if (!CanRead) throw new NotSupportedException(SR.NotSupported_UnreadableStream);
+                return InternalHandle?.NamedPipeSocket?.ReceiveBufferSize ?? _inBufferSize;
+            }
+        }
+
+        public override int OutBufferSize
+        {
+            get
+            {
+                CheckPipePropertyOperations();
+                if (!CanWrite) throw new NotSupportedException(SR.NotSupported_UnwritableStream);
+                return InternalHandle?.NamedPipeSocket?.SendBufferSize ?? _outBufferSize;
+            }
+        }
+
         // -----------------------------
         // ---- PAL layer ends here ----
         // -----------------------------

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -427,7 +427,7 @@ namespace System.IO.Pipes
             writer.SetHandle(fds[Interop.Sys.WriteEndOfPipe]);
         }
 
-        private int CheckPipeCall(int result)
+        internal int CheckPipeCall(int result)
         {
             if (result == -1)
             {
@@ -442,30 +442,15 @@ namespace System.IO.Pipes
             return result;
         }
 
-        internal void InitializeBufferSize(SafePipeHandle handle, int bufferSize)
-        {
-            // bufferSize is just advisory and ignored if platform does not support setting pipe capacity via fcntl.
-            if (bufferSize > 0 && Interop.Sys.Fcntl.CanGetSetPipeSz)
-            {
-                CheckPipeCall(Interop.Sys.Fcntl.SetPipeSz(handle, bufferSize));
-            }
-        }
-
         private int GetPipeBufferSize()
         {
-            if (_handle?.NamedPipeSocket != null)
-            {
-                return _handle.NamedPipeSocket.ReceiveBufferSize;
-            }
-
             if (!Interop.Sys.Fcntl.CanGetSetPipeSz)
             {
                 throw new PlatformNotSupportedException();
             }
 
             // If we have a handle, get the capacity of the pipe (there's no distinction between in/out direction).
-            // If we don't, the pipe has been created but not yet connected (in the case of named pipes),
-            // so just return the buffer size that was passed to the constructor.
+            // If we don't, just return the buffer size that was passed to the constructor.
             return _handle != null ?
                 CheckPipeCall(Interop.Sys.Fcntl.GetPipeSz(_handle)) :
                 _outBufferSize;

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
@@ -394,22 +394,14 @@ namespace System.IO.Pipes.Tests
 
                 if (pair.writeToServer)
                 {
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                        Assert.Equal(0, server.OutBufferSize);
-                    else
-                        Assert.Throws<PlatformNotSupportedException>(() => server.OutBufferSize);
-
+                    Assert.Equal(0, server.OutBufferSize);
                     Assert.Throws<InvalidOperationException>(() => server.Write(buffer, 0, buffer.Length));
                     Assert.Throws<InvalidOperationException>(() => server.WriteByte(5));
                     Assert.Throws<InvalidOperationException>(() => { server.WriteAsync(buffer, 0, buffer.Length); });
                 }
                 else
                 {
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                        Assert.Equal(0, server.InBufferSize);
-                    else
-                        Assert.Throws<PlatformNotSupportedException>(() => server.InBufferSize);
-
+                    Assert.Equal(0, server.InBufferSize);
                     PipeTransmissionMode readMode = server.ReadMode;
                     Assert.Throws<InvalidOperationException>(() => server.Read(buffer, 0, buffer.Length));
                     Assert.Throws<InvalidOperationException>(() => server.ReadByte());


### PR DESCRIPTION
PipeStream.In/OutBufferSize were both using Socket.ReceiveBufferSize.  Not only could the in and out sizes be configured differently for a named pipe, for a one-directional pipe we shutdown the opposite direction of the socket when it's connected, and on OSX that results in that shutdown direction's buffer eventually (but not synchronously) becoming 0.  This was leading to spurious failures in buffer size tests on OS X when trying to get the OutBufferSize of a PipeDirection.Out stream, as we'd shutdown the receive side.

This commit overrides InBufferSize and OutBufferSize on NamedPipe*Stream to return ReceiveBufferSize and SendBufferSize, respectively.  This fixes the issue of returning the wrong buffer size if they happen to be different, avoids the OSX shutdown issue, and also avoids an issue where we'd end up trying to get the fcntl pipe size on the socket handle if the properties were used on an unconnected server stream.

cc: @ericeil, @ianhays 
Fixes #6956