### PR TITLE
Always specify RID for redist projects

### DIFF
--- a/src/System.AppContext/src/redist/project.json
+++ b/src/System.AppContext/src/redist/project.json
@@ -6,5 +6,8 @@
   "frameworks": {
     "net46": { },
     "netcore50": { }
+  },
+  "runtimes": {
+    "win8": { }
   }
 }

--- a/src/System.Collections.Concurrent/src/redist/project.json
+++ b/src/System.Collections.Concurrent/src/redist/project.json
@@ -5,5 +5,8 @@
   },
   "frameworks": {
     "netcore50": {}
+  },
+  "runtimes": {
+    "win8": { }
   }
 }

--- a/src/System.Linq/src/redist/project.json
+++ b/src/System.Linq/src/redist/project.json
@@ -5,5 +5,8 @@
   },
   "frameworks": {
     "netcore50": {}
+  },
+  "runtimes": {
+    "win8": { }
   }
 }

--- a/src/System.ObjectModel/src/redist/project.json
+++ b/src/System.ObjectModel/src/redist/project.json
@@ -5,5 +5,8 @@
   },
   "frameworks": {
     "netcore50": { }
+  },
+  "runtimes": {
+    "win8": { }
   }
 }

--- a/src/System.Text.RegularExpressions/src/redist/project.json
+++ b/src/System.Text.RegularExpressions/src/redist/project.json
@@ -5,5 +5,8 @@
   },
   "frameworks": {
     "netcore50": {}
+  },
+  "runtimes": {
+    "win8": { }
   }
 }


### PR DESCRIPTION
Though we don't need a RID to pull out the right asset we should
specify a RID to avoid failures on Unix where auto-rid chooses a Unix
RID which triggers guardrails since these old packages didn't support
x-plat.

Fixes https://github.com/dotnet/corefx/issues/6950

/cc @stephentoub @Priya91 @dagood