### PR TITLE
Undoing version update to fix perf build errors

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -7,8 +7,8 @@
     "coveralls.io": "1.4",
     "OpenCover": "4.6.519",
     "ReportGenerator": "2.4.3",
-    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0029",
-    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0028",
+    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0028",
     "xunit": "2.1.0",
     "xunit.console.netcore": "1.0.2-prerelease-00120",
     "xunit.runner.utility": "2.1.0"

--- a/src/System.Collections.NonGeneric/tests/project.json
+++ b/src/System.Collections.NonGeneric/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Collections": "4.0.10",
     "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Collections": "4.0.10",
     "System.Globalization": "4.0.10",

--- a/src/System.ComponentModel.TypeConverter/tests/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.ComponentModel": "4.0.0",
     "System.ComponentModel.Primitives": "4.0.0",

--- a/src/System.Console/tests/project.json
+++ b/src/System.Console/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Diagnostics.Process": "4.1.0-rc3-23910",
     "System.IO": "4.0.10",

--- a/src/System.Diagnostics.Process/tests/project.json
+++ b/src/System.Diagnostics.Process/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "Microsoft.Win32.Primitives": "4.0.0",
     "System.Collections": "4.0.10",

--- a/src/System.Diagnostics.Process/tests/win/project.json
+++ b/src/System.Diagnostics.Process/tests/win/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "Microsoft.Win32.Primitives": "4.0.0",
     "Microsoft.Win32.Registry": "4.0.0-rc3-23910",

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Globalization": "4.0.10",
     "System.Globalization.Calendars": "4.0.0",

--- a/src/System.Globalization/tests/project.json
+++ b/src/System.Globalization/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Globalization": "4.0.10",
     "System.Globalization.Calendars": "4.0.0",

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Collections": "4.0.10",
     "System.Console": "4.0.0-rc3-23910",

--- a/src/System.IO.FileSystem/tests/project.json
+++ b/src/System.IO.FileSystem/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Collections": "4.0.10",
     "System.Console": "4.0.0-rc3-23910",

--- a/src/System.IO.MemoryMappedFiles/tests/project.json
+++ b/src/System.IO.MemoryMappedFiles/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Diagnostics.Process": "4.1.0-rc3-23910",
     "System.IO": "4.0.10",

--- a/src/System.IO.Pipes/tests/project.json
+++ b/src/System.IO.Pipes/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Diagnostics.Debug": "4.0.10",
     "System.Diagnostics.Process": "4.1.0-rc3-23910",

--- a/src/System.Linq/tests/project.json
+++ b/src/System.Linq/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Collections": "4.0.10",
     "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.Numerics.Vectors/tests/project.json
+++ b/src/System.Numerics.Vectors/tests/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.CSharp": "4.0.0",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Dynamic.Runtime": "4.0.10",
     "System.Globalization": "4.0.10",

--- a/src/System.Runtime.Extensions/tests/project.json
+++ b/src/System.Runtime.Extensions/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Globalization": "4.0.10",
     "System.IO.FileSystem": "4.0.0",

--- a/src/System.Runtime.Serialization.Json/tests/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Collections": "4.0.10",
     "System.Collections.NonGeneric": "4.0.0",

--- a/src/System.Runtime.Serialization.Xml/tests/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Collections": "4.0.10",
     "System.Collections.Concurrent": "4.0.0",

--- a/src/System.Runtime/tests/project.json
+++ b/src/System.Runtime/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Console": "4.0.0-rc3-23910",
     "System.Globalization": "4.0.10",

--- a/src/System.Text.Encoding/tests/project.json
+++ b/src/System.Text.Encoding/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Globalization": "4.0.10",
     "System.Runtime": "4.0.20",

--- a/src/System.Threading/tests/project.json
+++ b/src/System.Threading/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Collections": "4.0.10",
     "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.Xml.XmlDocument/tests/project.json
+++ b/src/System.Xml.XmlDocument/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Runtime": "4.0.20",
     "System.Threading.Tasks": "4.0.10",

--- a/src/System.Xml.XmlSerializer/tests/project.json
+++ b/src/System.Xml.XmlSerializer/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23910",
     "System.Collections": "4.0.10",
     "System.Diagnostics.Debug": "4.0.10",


### PR DESCRIPTION
Undoing commit 7c983ea7555d72b5d18a329f55e48d751013e778 to unblock Perf build errors.
Updating package references here requires updating package reference for xunit.performance here: https://github.com/dotnet/buildtools/blob/master/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
As of now need build tools to be fixed before updating the version reference in CoreFX.

@brianrob