### PR TITLE
Registry not supported

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-1.0.25-prerelease-00199
+1.0.25-prerelease-00205

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -79,8 +79,13 @@
 
   <Target Name="GetFilesToPackage" DependsOnTargets="FilterProjects"
           Returns="@(FilesToPackage)">
+
+    <ItemGroup>
+      <_projectToPackage Include="@(Project)" Condition="'%(Project.ExcludeFromPackage)' != 'true'" />
+    </ItemGroup>
+
     <MSBuild Targets="GetFilesToPackage"
-             Projects="@(Project)"
+             Projects="@(_projectToPackage)"
              BuildInParallel="$(BuildInParallel)"
              Properties="$(ProjectProperties)"
              ContinueOnError="ErrorAndContinue" >

--- a/src/Microsoft.Win32.Registry/pkg/unix/Microsoft.Win32.Registry.pkgproj
+++ b/src/Microsoft.Win32.Registry/pkg/unix/Microsoft.Win32.Registry.pkgproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <IdPrefix>notsupported.unix.</IdPrefix>
+    <SkipValidatePackage>true</SkipValidatePackage>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Win32.Registry.csproj">
+      <OSGroup>Unix</OSGroup>
+    </ProjectReference>
+   </ItemGroup>
+  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.builds
+++ b/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.builds
@@ -6,6 +6,10 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="Microsoft.Win32.Registry.csproj">
+      <OSGroup>Unix</OSGroup>
+      <ExcludeFromPackage>true</ExcludeFromPackage>
+    </Project>
+    <Project Include="Microsoft.Win32.Registry.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project>
   </ItemGroup>

--- a/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
+++ b/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
@@ -11,15 +11,19 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
-    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net46'">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net46' AND '$(TargetsWindows)' == 'true'">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net46' AND '$(TargetsWindows)' == 'true'">
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>


### PR DESCRIPTION
This adds a new package: notsupported.unix.Microsoft.Win32.Registry

The package carries one assembly which is an implementation assembly
that throws PlatformNotSupported for every API.

Currently the package description is bad, we need to have a special description for these types of packages that I will add to buildtools separately.

/cc @Petermarcu