### PR TITLE
Add leading semicolons to appended connection string parameters in SqlClient tests, so that there won't be invalid connection parameter errors when appending to user-created connection strings.

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/DDBasics/AsyncTest/AsyncTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DDBasics/AsyncTest/AsyncTest.cs
@@ -13,7 +13,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public void OpenConnection_WithAsyncTrue_ThrowsNotSupportedException()
         {
-            var asyncConnectionString = DataTestClass.SQL2005_Northwind + "async=true";
+            var asyncConnectionString = DataTestClass.SQL2005_Northwind + ";async=true";
             Assert.Throws<NotSupportedException>(() => { new SqlConnection(asyncConnectionString); });
         }
 
@@ -70,7 +70,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             var executedProcessList = new List<string>();
 
             //for shared connection we need to add MARS capabilities
-            using (var conn = new SqlConnection(DataTestClass.SQL2005_Northwind + "MultipleActiveResultSets=true;"))
+            using (var conn = new SqlConnection(DataTestClass.SQL2005_Northwind + ";MultipleActiveResultSets=true;"))
             {
                 conn.Open();
                 var task1 = ExecuteCommandWithSharedConnectionAsync(conn, "C", "SELECT top 10 * FROM Orders", executedProcessList);

--- a/src/System.Data.SqlClient/tests/ManualTests/DDBasics/MARSTest/DDMARSTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DDBasics/MARSTest/DDMARSTest.cs
@@ -11,7 +11,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void TestMain()
         {
-            string connstr = DataTestClass.SQL2005_Northwind + "multipleactiveresultsets=true;";
+            string connstr = DataTestClass.SQL2005_Northwind + ";multipleactiveresultsets=true;";
             string cmdText1 = "select * from Orders; select count(*) from Customers";
             string cmdText2 = "select * from Customers; select count(*) from Orders";
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/WeakRefTest/WeakRefTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/WeakRefTest/WeakRefTest.cs
@@ -43,7 +43,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void TestReaderNonMars()
         {
-            string connString = DataTestClass.SQL2005_Pubs + "Max Pool Size=1";
+            string connString = DataTestClass.SQL2005_Pubs + ";Max Pool Size=1";
 
             TestReaderNonMarsCase("Case 1: ExecuteReader, Close, ExecuteReader.", connString, ReaderTestType.ReaderClose, ReaderVerificationType.ExecuteReader);
             TestReaderNonMarsCase("Case 2: ExecuteReader, Dispose, ExecuteReader.", connString, ReaderTestType.ReaderDispose, ReaderVerificationType.ExecuteReader);
@@ -67,7 +67,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [Fact]
         public static void TestTransactionSingle()
         {
-            string connString = DataTestClass.SQL2005_Pubs + "Max Pool Size=1";
+            string connString = DataTestClass.SQL2005_Pubs + ";Max Pool Size=1";
 
             TestTransactionSingleCase("Case 1: BeginTransaction, Rollback.", connString, TransactionTestType.TransactionRollback);
             TestTransactionSingleCase("Case 2: BeginTransaction, Dispose.", connString, TransactionTestType.TransactionDispose);


### PR DESCRIPTION
For example: "...;Encrypt=true" + "MultipleActiveResultSets=true;" would make Encrypt's value "trueMultipleActiveResultSets=true;". Adding a leading semicolon to the second parameter would correctly separate the values.