### PR TITLE
Fix MemberData in System.Collections.

### DIFF
--- a/src/Common/tests/System/Collections/ICollection.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/ICollection.Generic.Tests.cs
@@ -99,7 +99,7 @@ namespace System.Collections.Tests
         #region IsReadOnly
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_IsReadOnly_Validity(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -111,7 +111,7 @@ namespace System.Collections.Tests
         #region Count
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Count_Validity(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -123,7 +123,7 @@ namespace System.Collections.Tests
         #region Add
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Add_DefaultValue(int count)
         {
             if (DefaultValueAllowed && !IsReadOnly)
@@ -135,7 +135,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Add_InvalidValueToMiddleOfCollection(int count)
         {
             if (!IsReadOnly)
@@ -152,7 +152,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Add_InvalidValueToBeginningOfCollection(int count)
         {
             if (!IsReadOnly)
@@ -169,7 +169,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Add_InvalidValueToEndOfCollection(int count)
         {
             if (!IsReadOnly)
@@ -184,7 +184,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Add_DuplicateValue(int count)
         {
             if (!IsReadOnly && DuplicateValuesAllowed)
@@ -198,7 +198,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Add_AfterCallingClear(int count)
         {
             if (!IsReadOnly)
@@ -211,7 +211,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Add_AfterRemovingAnyValue(int count)
         {
             if (!IsReadOnly)
@@ -236,7 +236,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Add_AfterRemovingAllItems(int count)
         {
             if (!IsReadOnly)
@@ -251,7 +251,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Add_ToReadOnlyCollection(int count)
         {
             if (IsReadOnly)
@@ -263,7 +263,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Add_AfterRemoving(int count)
         {
             if (!IsReadOnly)
@@ -284,7 +284,7 @@ namespace System.Collections.Tests
         #region Clear
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Clear(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -301,7 +301,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Clear_Repeatedly(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -326,7 +326,7 @@ namespace System.Collections.Tests
         #region Contains
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Contains_ValidValueOnCollectionNotContainingThatValue(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -338,7 +338,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Contains_ValidValueOnCollectionContainingThatValue(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -347,7 +347,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Contains_DefaultValueOnCollectionNotContainingDefaultValue(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -356,7 +356,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Contains_DefaultValueOnCollectionContainingDefaultValue(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -368,7 +368,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Contains_ValidValueThatExistsTwiceInTheCollection(int count)
         {
             if (DuplicateValuesAllowed && !IsReadOnly)
@@ -382,7 +382,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Contains_InvalidValue_ThrowsArgumentException(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -392,7 +392,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public virtual void ICollection_Generic_Contains_DefaultValueWhenNotAllowed(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -410,7 +410,7 @@ namespace System.Collections.Tests
         #region CopyTo
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_CopyTo_NullArray_ThrowsArgumentNullException(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -418,7 +418,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_CopyTo_NegativeIndex_ThrowsArgumentOutOfRangeException(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -428,7 +428,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_CopyTo_IndexEqualToArrayCount_ThrowsArgumentException(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -440,7 +440,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_CopyTo_IndexLargerThanArrayCount_ThrowsAnyArgumentException(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -449,7 +449,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_CopyTo_NotEnoughSpaceInOffsettedArray_ThrowsArgumentException(int count)
         {
             if (count > 0) // Want the T array to have at least 1 element
@@ -461,7 +461,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_CopyTo_ExactlyEnoughSpaceInArray(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -471,7 +471,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_CopyTo_ArrayIsLargerThanCollection(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -485,7 +485,7 @@ namespace System.Collections.Tests
         #region Remove
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Remove_OnReadOnlyCollection_ThrowsNotSupportedException(int count)
         {
             if (IsReadOnly)
@@ -496,7 +496,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Remove_DefaultValueNotContainedInCollection(int count)
         {
             if (!IsReadOnly && DefaultValueAllowed && !Enumerable.Contains(InvalidValues, default(T)))
@@ -515,7 +515,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Remove_NonDefaultValueNotContainedInCollection(int count)
         {
             if (!IsReadOnly)
@@ -531,7 +531,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Remove_DefaultValueContainedInCollection(int count)
         {
             if (!IsReadOnly && DefaultValueAllowed && !Enumerable.Contains(InvalidValues, default(T)))
@@ -550,7 +550,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Remove_NonDefaultValueContainedInCollection(int count)
         {
             if (!IsReadOnly)
@@ -569,7 +569,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Remove_ValueThatExistsTwiceInCollection(int count)
         {
             if (!IsReadOnly && DuplicateValuesAllowed)
@@ -587,7 +587,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Remove_EveryValue(int count)
         {
             if (!IsReadOnly)
@@ -602,7 +602,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Remove_InvalidValue_ThrowsArgumentException(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
@@ -614,7 +614,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Remove_DefaultValueWhenNotAllowed(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);

--- a/src/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
@@ -64,7 +64,7 @@ namespace System.Collections.Tests
         #region Count
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Count_Validity(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
@@ -76,7 +76,7 @@ namespace System.Collections.Tests
         #region IsSynchronized
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_IsSynchronized(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
@@ -88,7 +88,7 @@ namespace System.Collections.Tests
         #region SyncRoot
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_SyncRoot_NonNull(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
@@ -96,7 +96,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_SyncRootConsistent(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
@@ -106,7 +106,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_SyncRootUnique(int count)
         {
             ICollection collection1 = NonGenericICollectionFactory(count);
@@ -119,7 +119,7 @@ namespace System.Collections.Tests
         #region CopyTo
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo_NullArray_ThrowsArgumentNullException(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
@@ -127,7 +127,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo_TwoDimensionArray_ThrowsArgumentException(int count)
         {
             if (count > 0)
@@ -140,7 +140,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo_NonZeroLowerBound(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
@@ -151,7 +151,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public virtual void ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType(int count)
         {
             if (count > 0)
@@ -163,7 +163,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType(int count)
         {
             if (count > 0)
@@ -175,7 +175,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public virtual void ICollection_NonGeneric_CopyTo_ArrayOfEnumType(int count)
         {
             Array enumArr = Enum.GetValues(typeof(EnumerableType));
@@ -190,7 +190,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo_NegativeIndex_ThrowsArgumentOutOfRangeException(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
@@ -200,7 +200,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo_IndexEqualToArrayCount_ThrowsArgumentException(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
@@ -212,7 +212,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowsAnyArgumentException(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
@@ -221,7 +221,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo_NotEnoughSpaceInOffsettedArray_ThrowsArgumentException(int count)
         {
             if (count > 0) // Want the T array to have at least 1 element
@@ -233,7 +233,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo_ExactlyEnoughSpaceInArray(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
@@ -245,7 +245,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo_ArrayIsLargerThanCollection(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);

--- a/src/Common/tests/System/Collections/IDictionary.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/IDictionary.Generic.Tests.cs
@@ -198,7 +198,7 @@ namespace System.Collections.Tests
         #region Item Getter
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_ItemGet_DefaultKey(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -215,7 +215,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_ItemGet_MissingNonDefaultKey_ThrowsKeyNotFoundException(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -224,7 +224,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_ItemGet_MissingDefaultKey_ThrowsKeyNotFoundException(int count)
         {
             if (DefaultValueAllowed)
@@ -238,7 +238,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_ItemGet_PresentKeyReturnsCorrectValue(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -253,7 +253,7 @@ namespace System.Collections.Tests
         #region Item Setter
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_ItemSet_DefaultKey(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -270,7 +270,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_ItemSet_OnReadOnlyDictionary_ThrowsNotSupportedException(int count)
         {
             if (IsReadOnly)
@@ -282,7 +282,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_ItemSet_AddsNewValueWhenNotPresent(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -292,7 +292,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_ItemSet_ReplacesExistingValueWhenPresent(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -309,7 +309,7 @@ namespace System.Collections.Tests
         #region Keys
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Keys_ContainsAllCorrectKeys(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -318,7 +318,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Keys_ModifyingTheDictionaryUpdatesTheCollection(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -330,7 +330,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Keys_Enumeration_ParentDictionaryModifiedInvalidates(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -343,7 +343,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Keys_IsReadOnly(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -355,7 +355,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Keys_Enumeration_Reset(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -372,7 +372,7 @@ namespace System.Collections.Tests
         #region Values
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Values_ContainsAllCorrectValues(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -381,7 +381,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Values_IncludeDuplicatesMultipleTimes(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -397,7 +397,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Values_ModifyingTheDictionaryUpdatesTheCollection(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -409,7 +409,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Values_Enumeration_ParentDictionaryModifiedInvalidates(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -422,7 +422,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Values_IsReadOnly(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -434,7 +434,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Values_Enumeration_Reset(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -451,7 +451,7 @@ namespace System.Collections.Tests
         #region Add(TKey, TValue)
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Add_OnReadOnlyDictionary_ThrowsNotSupportedException(int count)
         {
             if (IsReadOnly)
@@ -462,7 +462,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Add_DefaultKey_DefaultValue(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -481,7 +481,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Add_DefaultKey_NonDefaultValue(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -500,7 +500,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Add_NonDefaultKey_DefaultValue(int count)
         {
             if (!IsReadOnly)
@@ -515,7 +515,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Add_NonDefaultKey_NonDefaultValue(int count)
         {
             if (!IsReadOnly)
@@ -530,7 +530,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Add_DuplicateValue(int count)
         {
             if (!IsReadOnly)
@@ -547,7 +547,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_Add_DuplicateKey(int count)
         {
             if (!IsReadOnly)
@@ -564,7 +564,7 @@ namespace System.Collections.Tests
         #region ContainsKey
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_ContainsKey_ValidKeyNotContainedInDictionary(int count)
         {
             if (!IsReadOnly)
@@ -576,7 +576,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_ContainsKey_ValidKeyContainedInDictionary(int count)
         {
             if (!IsReadOnly)
@@ -589,7 +589,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_ContainsKey_DefaultKeyNotContainedInDictionary(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -609,7 +609,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_ContainsKey_DefaultKeyContainedInDictionary(int count)
         {
             if (DefaultValueAllowed && !IsReadOnly)
@@ -627,7 +627,7 @@ namespace System.Collections.Tests
         #region Remove(TKey)
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_RemoveKey_OnReadOnlyDictionary_ThrowsNotSupportedException(int count)
         {
             if (IsReadOnly)
@@ -638,7 +638,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_RemoveKey_EveryKey(int count)
         {
             if (!IsReadOnly)
@@ -653,7 +653,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_RemoveKey_ValidKeyNotContainedInDictionary(int count)
         {
             if (!IsReadOnly)
@@ -666,7 +666,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_RemoveKey_ValidKeyContainedInDictionary(int count)
         {
             if (!IsReadOnly)
@@ -680,7 +680,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_RemoveKey_DefaultKeyNotContainedInDictionary(int count)
         {
             if (!IsReadOnly)
@@ -701,7 +701,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_RemoveKey_DefaultKeyContainedInDictionary(int count)
         {
             if (DefaultValueAllowed && !IsReadOnly)
@@ -719,7 +719,7 @@ namespace System.Collections.Tests
         #region TryGetValue
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_TryGetValue_ValidKeyNotContainedInDictionary(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -730,7 +730,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_TryGetValue_ValidKeyContainedInDictionary(int count)
         {
             if (!IsReadOnly)
@@ -747,7 +747,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_TryGetValue_DefaultKeyNotContainedInDictionary(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -766,7 +766,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_Generic_TryGetValue_DefaultKeyContainedInDictionary(int count)
         {
             if (DefaultValueAllowed && !IsReadOnly)
@@ -787,7 +787,7 @@ namespace System.Collections.Tests
         #region ICollection<KeyValuePair<TKey, TValue>>
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Contains_ValidPresentKeyWithDefaultValue(int count)
         {
             if (!IsReadOnly)
@@ -800,7 +800,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Remove_ValidPresentKeyWithDifferentValue(int count)
         {
             if (!IsReadOnly)
@@ -817,7 +817,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Contains_ValidPresentKeyWithDifferentValue(int count)
         {
             if (!IsReadOnly)
@@ -838,7 +838,7 @@ namespace System.Collections.Tests
         #region ICollection
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -851,7 +851,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_Generic_Contains_DefaultValueWhenNotAllowed(int count)
         {
             ICollection<KeyValuePair<TKey, TValue>> collection = GenericIDictionaryFactory(count);

--- a/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.cs
@@ -154,7 +154,7 @@ namespace System.Collections.Tests
         #region IsFixedSize
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_IsFixedSize_Validity(int count)
         {
             IDictionary collection = NonGenericIDictionaryFactory(count);
@@ -166,7 +166,7 @@ namespace System.Collections.Tests
         #region IsReadOnly
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_IsReadOnly_Validity(int count)
         {
             IDictionary collection = NonGenericIDictionaryFactory(count);
@@ -178,7 +178,7 @@ namespace System.Collections.Tests
         #region Item Getter
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemGet_NullKey(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
@@ -195,7 +195,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemGet_MissingNonNullKey_ThrowsKeyNotFoundException(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
@@ -204,7 +204,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemGet_MissingNullKey_ThrowsKeyNotFoundException(int count)
         {
             if (NullAllowed)
@@ -218,7 +218,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemGet_PresenobjectReturnsCorrecobject(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
@@ -233,7 +233,7 @@ namespace System.Collections.Tests
         #region Item Setter
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemSet_NullKey(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
@@ -250,7 +250,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemSet_OnReadOnlyDictionary_ThrowsNotSupportedException(int count)
         {
             if (IsReadOnly)
@@ -262,7 +262,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemSet_AddsNewValueWhenNotPresent(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
@@ -272,7 +272,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemSet_ReplacesExistingValueWhenPresent(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
@@ -289,7 +289,7 @@ namespace System.Collections.Tests
         #region Keys
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Keys_ContainsAllCorrectobjects(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
@@ -301,7 +301,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Keys_ModifyingTheDictionaryUpdatesTheCollection(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
@@ -311,7 +311,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Keys_Enumeration_ParentDictionaryModifiedInvalidatesEnumerator(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
@@ -324,7 +324,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Keys_Enumeration_Reset(int count)
         {
             IEnumerator enumerator = NonGenericIDictionaryFactory(count).Keys.GetEnumerator();
@@ -339,7 +339,7 @@ namespace System.Collections.Tests
         #region Values
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Values_ContainsAllCorrecobjects(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
@@ -351,7 +351,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Values_IncludeDuplicatesMultipleTimes(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
@@ -368,7 +368,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Values_ModifyingTheDictionaryUpdatesTheCollection(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
@@ -378,7 +378,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public virtual void IDictionary_NonGeneric_Values_Enumeration_ParentDictionaryModifiedInvalidatesEnumerator(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
@@ -391,7 +391,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Values_Enumeration_Reset(int count)
         {
             IEnumerator enumerator = NonGenericIDictionaryFactory(count).Values.GetEnumerator();
@@ -406,7 +406,7 @@ namespace System.Collections.Tests
         #region Add
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Add_OnReadOnlyDictionary_ThrowsNotSupportedException(int count)
         {
             if (IsReadOnly)
@@ -417,7 +417,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Add_NullKey_NullValue(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
@@ -436,7 +436,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Add_NullKey_NonNullValue(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
@@ -455,7 +455,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Add_NonNullKey_NullValue(int count)
         {
             if (!IsReadOnly)
@@ -470,7 +470,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Add_NonNullKey_NonNulValue(int count)
         {
             if (!IsReadOnly)
@@ -485,7 +485,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Add_DuplicateKey(int count)
         {
             if (!IsReadOnly)
@@ -502,7 +502,7 @@ namespace System.Collections.Tests
         #region Clear
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Clear(int count)
         {
             IDictionary collection = NonGenericIDictionaryFactory(count);
@@ -523,7 +523,7 @@ namespace System.Collections.Tests
         #region Contains
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Contains_ValidKeyNotContainedInDictionary(int count)
         {
             if (!IsReadOnly)
@@ -535,7 +535,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Contains_ValidKeyContainedInDictionary(int count)
         {
             if (!IsReadOnly)
@@ -548,7 +548,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Contains_NullKeyNotContainedInDictionary(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
@@ -568,7 +568,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Contains_NullKeyContainedInDictionary(int count)
         {
             if (NullAllowed && !IsReadOnly)
@@ -586,7 +586,7 @@ namespace System.Collections.Tests
         #region IDictionaryEnumerator
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_IDictionaryEnumerator_Current_FromStartToFinish(int count)
         {
             IDictionaryEnumerator enumerator = NonGenericIDictionaryFactory(count).GetEnumerator();
@@ -601,7 +601,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_IDictionaryEnumerator_Current_ReturnsSameValueOnRepeatedCalls(int count)
         {
             IDictionaryEnumerator enumerator = NonGenericIDictionaryFactory(count).GetEnumerator();
@@ -615,7 +615,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public virtual void IDictionary_NonGeneric_IDictionaryEnumerator_Current_BeforeFirstMoveNext_UndefinedBehavior(int count)
         {
             object current, key, value, entry;
@@ -637,7 +637,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public virtual void IDictionary_NonGeneric_IDictionaryEnumerator_Current_AfterEndOfEnumerable_UndefinedBehavior(int count)
         {
             object current, key, value, entry;
@@ -660,7 +660,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public virtual void IDictionary_NonGeneric_IDictionaryEnumerator_Current_ModifiedDuringEnumeration_UndefinedBehavior(int count)
         {
             Assert.All(ModifyEnumerables, ModifyEnumerable =>

--- a/src/Common/tests/System/Collections/IEnumerable.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/IEnumerable.Generic.Tests.cs
@@ -287,7 +287,7 @@ namespace System.Collections.Tests
         #region GetEnumerator()
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_Generic_GetEnumerator_NoExceptionsWhileGetting(int count)
         {
             IEnumerable<T> enumerable = GenericIEnumerableFactory(count);
@@ -295,7 +295,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_Generic_GetEnumerator_ReturnsUniqueEnumerator(int count)
         {
             //Tests that the enumerators returned by GetEnumerator operate independently of one another
@@ -313,7 +313,7 @@ namespace System.Collections.Tests
         #region Enumerator.MoveNext
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_Generic_Enumerator_MoveNext_FromStartToFinish(int count)
         {
             int iterations = 0;
@@ -331,7 +331,7 @@ namespace System.Collections.Tests
         /// specify neither of these as being strictly correct, we leave the method virtual.
         /// </summary>
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public virtual void Enumerator_MoveNext_AfterDisposal(int count)
         {
             IEnumerator<T> enumerator = GenericIEnumerableFactory(count).GetEnumerator();
@@ -342,7 +342,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_Generic_Enumerator_MoveNext_AfterEndOfCollection(int count)
         {
             using (IEnumerator<T> enumerator = GenericIEnumerableFactory(count).GetEnumerator())
@@ -355,7 +355,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_Generic_Enumerator_MoveNext_ModifiedBeforeEnumeration_ThrowsInvalidOperationException(int count)
         {
             Assert.All(ModifyEnumerables, ModifyEnumerable =>
@@ -370,7 +370,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_Generic_Enumerator_MoveNext_ModifiedDuringEnumeration_ThrowsInvalidOperationException(int count)
         {
             Assert.All(ModifyEnumerables, ModifyEnumerable =>
@@ -387,7 +387,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_Generic_Enumerator_MoveNext_ModifiedAfterEnumeration_ThrowsInvalidOperationException(int count)
         {
             Assert.All(ModifyEnumerables, ModifyEnumerable =>
@@ -477,7 +477,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_Generic_Enumerator_Current_ReturnsSameValueOnRepeatedCalls(int count)
         {
             using (IEnumerator<T> enumerator = GenericIEnumerableFactory(count).GetEnumerator())
@@ -493,7 +493,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_Generic_Enumerator_Current_ReturnsSameObjectsOnDifferentEnumerators(int count)
         {
             // Ensures that the elements returned from enumeration are exactly the same collection of
@@ -511,7 +511,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_Generic_Enumerator_Current_BeforeFirstMoveNext_UndefinedBehavior(int count)
         {
             T current;
@@ -526,7 +526,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_Generic_Enumerator_Current_AfterEndOfEnumerable_UndefinedBehavior(int count)
         {
             T current;
@@ -542,7 +542,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_Generic_Enumerator_Current_ModifiedDuringEnumeration_UndefinedBehavior(int count)
         {
             Assert.All(ModifyEnumerables, ModifyEnumerable =>
@@ -567,7 +567,7 @@ namespace System.Collections.Tests
         #region Enumerator.Reset
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_Generic_Enumerator_Reset_BeforeIteration_Support(int count)
         {
             using (IEnumerator<T> enumerator = GenericIEnumerableFactory(count).GetEnumerator())
@@ -580,7 +580,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_Generic_Enumerator_Reset_ModifiedBeforeEnumeration_ThrowsInvalidOperationException(int count)
         {
             Assert.All(ModifyEnumerables, ModifyEnumerable =>
@@ -595,7 +595,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_Generic_Enumerator_Reset_ModifiedDuringEnumeration_ThrowsInvalidOperationException(int count)
         {
             Assert.All(ModifyEnumerables, ModifyEnumerable =>
@@ -612,7 +612,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_Generic_Enumerator_Reset_ModifiedAfterEnumeration_ThrowsInvalidOperationException(int count)
         {
             Assert.All(ModifyEnumerables, ModifyEnumerable =>

--- a/src/Common/tests/System/Collections/IEnumerable.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IEnumerable.NonGeneric.Tests.cs
@@ -62,7 +62,7 @@ namespace System.Collections.Tests
         #region GetEnumerator()
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_NonGeneric_GetEnumerator_NoExceptionsWhileGetting(int count)
         {
             IEnumerable enumerable = NonGenericIEnumerableFactory(count);
@@ -70,7 +70,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_NonGeneric_GetEnumerator_ReturnsUniqueEnumerator(int count)
         {
             //Tests that the enumerators returned by GetEnumerator operate independently of one another
@@ -88,7 +88,7 @@ namespace System.Collections.Tests
         #region Enumerator.MoveNext
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_NonGeneric_Enumerator_MoveNext_FromStartToFinish(int count)
         {
             int iterations = 0;
@@ -100,7 +100,7 @@ namespace System.Collections.Tests
 
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_NonGeneric_Enumerator_MoveNext_AfterEndOfCollection(int count)
         {
             IEnumerator enumerator = NonGenericIEnumerableFactory(count).GetEnumerator();
@@ -111,7 +111,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_NonGeneric_Enumerator_MoveNext_ModifiedBeforeEnumeration_ThrowsInvalidOperationException(int count)
         {
             Assert.All(ModifyEnumerables, ModifyEnumerable =>
@@ -124,7 +124,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_NonGeneric_Enumerator_MoveNext_ModifiedDuringEnumeration_ThrowsInvalidOperationException(int count)
         {
             Assert.All(ModifyEnumerables, ModifyEnumerable =>
@@ -139,7 +139,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_NonGeneric_Enumerator_MoveNext_ModifiedAfterEnumeration_ThrowsInvalidOperationException(int count)
         {
             Assert.All(ModifyEnumerables, ModifyEnumerable =>
@@ -157,7 +157,7 @@ namespace System.Collections.Tests
         #region Enumerator.Current
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_NonGeneric_Enumerator_Current_FromStartToFinish(int count)
         {
             IEnumerator enumerator = NonGenericIEnumerableFactory(count).GetEnumerator();
@@ -167,7 +167,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_NonGeneric_Enumerator_Current_ReturnsSameValueOnRepeatedCalls(int count)
         {
             IEnumerator enumerator = NonGenericIEnumerableFactory(count).GetEnumerator();
@@ -181,7 +181,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_NonGeneric_Enumerator_Current_ReturnsSameObjectsOnDifferentEnumerators(int count)
         {
             // Ensures that the elements returned from enumeration are exactly the same collection of
@@ -199,7 +199,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public virtual void Enumerator_Current_BeforeFirstMoveNext_UndefinedBehavior(int count)
         {
             object current;
@@ -212,7 +212,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public virtual void Enumerator_Current_AfterEndOfEnumerable_UndefinedBehavior(int count)
         {
             object current;
@@ -226,7 +226,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public virtual void Enumerator_Current_ModifiedDuringEnumeration_UndefinedBehavior(int count)
         {
             Assert.All(ModifyEnumerables, ModifyEnumerable =>
@@ -249,7 +249,7 @@ namespace System.Collections.Tests
         #region Enumerator.Reset
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_NonGeneric_Enumerator_Reset_BeforeIteration_Support(int count)
         {
             IEnumerator enumerator = NonGenericIEnumerableFactory(count).GetEnumerator();
@@ -260,7 +260,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_NonGeneric_Enumerator_Reset_ModifiedBeforeEnumeration_ThrowsInvalidOperationException(int count)
         {
             Assert.All(ModifyEnumerables, ModifyEnumerable =>
@@ -273,7 +273,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_NonGeneric_Enumerator_Reset_ModifiedDuringEnumeration_ThrowsInvalidOperationException(int count)
         {
             Assert.All(ModifyEnumerables, ModifyEnumerable =>
@@ -288,7 +288,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IEnumerable_NonGeneric_Enumerator_Reset_ModifiedAfterEnumeration_ThrowsInvalidOperationException(int count)
         {
             Assert.All(ModifyEnumerables, ModifyEnumerable =>

--- a/src/Common/tests/System/Collections/IGenericSharedAPI.Tests.cs
+++ b/src/Common/tests/System/Collections/IGenericSharedAPI.Tests.cs
@@ -94,7 +94,7 @@ namespace System.Collections.Tests
         #region Count
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_Count_Validity(int count)
         {
             IEnumerable<T> collection = GenericIEnumerableFactory(count);
@@ -106,7 +106,7 @@ namespace System.Collections.Tests
         #region Add
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_Add_DefaultValue(int count)
         {
             if (DefaultValueAllowed && !IsReadOnly)
@@ -118,7 +118,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_Add_InvalidValueToMiddleOfCollection(int count)
         {
             if (!IsReadOnly)
@@ -135,7 +135,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_Add_InvalidValueToBeginningOfCollection(int count)
         {
             if (!IsReadOnly)
@@ -152,7 +152,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_Add_InvalidValueToEndOfCollection(int count)
         {
             if (!IsReadOnly)
@@ -167,7 +167,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_Add_DuplicateValue(int count)
         {
             if (!IsReadOnly)
@@ -184,7 +184,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_Add_AfterCallingClear(int count)
         {
             if (!IsReadOnly)
@@ -197,7 +197,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_Add_AfterRemovingAnyValue(int count)
         {
             if (!IsReadOnly)
@@ -220,7 +220,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_Add_AfterRemovingAllItems(int count)
         {
             if (!IsReadOnly)
@@ -239,7 +239,7 @@ namespace System.Collections.Tests
         #region Clear
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_Clear(int count)
         {
             IEnumerable<T> collection = GenericIEnumerableFactory(count);
@@ -260,7 +260,7 @@ namespace System.Collections.Tests
         #region Contains
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_Contains_ValidValueOnCollectionNotContainingThatValue(int count)
         {
             IEnumerable<T> collection = GenericIEnumerableFactory(count);
@@ -272,7 +272,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_IGenericSharedAPI_Contains_ValidValueOnCollectionContainingThatValue(int count)
         {
             IEnumerable<T> collection = GenericIEnumerableFactory(count);
@@ -281,7 +281,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_Contains_DefaultValueOnCollectionNotContainingDefaultValue(int count)
         {
             IEnumerable<T> collection = GenericIEnumerableFactory(count);
@@ -290,7 +290,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_Contains_DefaultValueOnCollectionContainingDefaultValue(int count)
         {
             IEnumerable<T> collection = GenericIEnumerableFactory(count);
@@ -302,7 +302,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_Contains_ValidValueThatExistsTwiceInTheCollection(int count)
         {
             if (DuplicateValuesAllowed && !IsReadOnly)
@@ -316,7 +316,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_Contains_InvalidValue_ThrowsArgumentException(int count)
         {
             IEnumerable<T> collection = GenericIEnumerableFactory(count);
@@ -326,7 +326,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public virtual void IGenericSharedAPI_Contains_DefaultValueWhenNotAllowed(int count)
         {
             IEnumerable<T> collection = GenericIEnumerableFactory(count);
@@ -344,7 +344,7 @@ namespace System.Collections.Tests
         #region CopyTo
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_CopyTo_NullArray_ThrowsArgumentNullException(int count)
         {
             IEnumerable<T> collection = GenericIEnumerableFactory(count);
@@ -352,7 +352,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_CopyTo_NegativeIndex_ThrowsArgumentOutOfRangeException(int count)
         {
             IEnumerable<T> collection = GenericIEnumerableFactory(count);
@@ -362,7 +362,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_CopyTo_IndexEqualToArrayCount_ThrowsArgumentException(int count)
         {
             IEnumerable<T> collection = GenericIEnumerableFactory(count);
@@ -374,7 +374,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_CopyTo_IndexLargerThanArrayCount_ThrowsAnyArgumentException(int count)
         {
             IEnumerable<T> collection = GenericIEnumerableFactory(count);
@@ -383,7 +383,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_CopyTo_NotEnoughSpaceInOffsettedArray_ThrowsArgumentException(int count)
         {
             if (count > 0) // Want the T array to have at least 1 element
@@ -395,7 +395,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_CopyTo_ExactlyEnoughSpaceInArray(int count)
         {
             IEnumerable<T> collection = GenericIEnumerableFactory(count);
@@ -405,7 +405,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IGenericSharedAPI_CopyTo_ArrayIsLargerThanCollection(int count)
         {
             IEnumerable<T> collection = GenericIEnumerableFactory(count);

--- a/src/Common/tests/System/Collections/IList.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/IList.Generic.Tests.cs
@@ -115,7 +115,7 @@ namespace System.Collections.Tests
         #region Item Getter
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_ItemGet_NegativeIndex_ThrowsArgumentOutOfRangeException(int count)
         {
             IList<T> list = GenericIListFactory(count);
@@ -124,7 +124,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_ItemGet_IndexGreaterThanListCount_ThrowsArgumentOutOfRangeException(int count)
         {
             IList<T> list = GenericIListFactory(count);
@@ -133,7 +133,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_ItemGet_ValidGetWithinListBounds(int count)
         {
             IList<T> list = GenericIListFactory(count);
@@ -146,7 +146,7 @@ namespace System.Collections.Tests
         #region Item Setter
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_ItemSet_NegativeIndex_ThrowsArgumentOutOfRangeException(int count)
         {
             if (!IsReadOnly)
@@ -160,7 +160,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_ItemSet_IndexGreaterThanListCount_ThrowsArgumentOutOfRangeException(int count)
         {
             if (!IsReadOnly)
@@ -174,7 +174,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_ItemSet_OnReadOnlyList(int count)
         {
             if (IsReadOnly && count > 0)
@@ -187,7 +187,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_ItemSet_FirstItemToNonDefaultValue(int count)
         {
             if (count > 0 && !IsReadOnly)
@@ -200,7 +200,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_ItemSet_FirstItemToDefaultValue(int count)
         {
             if (count > 0 && !IsReadOnly)
@@ -220,7 +220,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_ItemSet_LastItemToNonDefaultValue(int count)
         {
             if (count > 0 && !IsReadOnly)
@@ -234,7 +234,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_ItemSet_LastItemToDefaultValue(int count)
         {
             if (count > 0 && !IsReadOnly && DefaultValueAllowed)
@@ -255,7 +255,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_ItemSet_DuplicateValues(int count)
         {
             if (count >= 2 && !IsReadOnly && DuplicateValuesAllowed)
@@ -270,7 +270,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_ItemSet_InvalidValue(int count)
         {
             if (!IsReadOnly)
@@ -288,7 +288,7 @@ namespace System.Collections.Tests
         #region IndexOf
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_IndexOf_DefaultValueNotContainedInList(int count)
         {
             if (DefaultValueAllowed)
@@ -311,7 +311,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_IndexOf_DefaultValueContainedInList(int count)
         {
             if (count > 0 && DefaultValueAllowed)
@@ -329,7 +329,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_IndexOf_ValidValueNotContainedInList(int count)
         {
             IList<T> list = GenericIListFactory(count);
@@ -341,7 +341,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_IndexOf_ValueInCollectionMultipleTimes(int count)
         {
             if (count > 0 && !IsReadOnly && DuplicateValuesAllowed)
@@ -356,7 +356,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_IndexOf_EachValueNoDuplicates(int count)
         {
             // Assumes no duplicate elements contained in the list returned by GenericIListFactory
@@ -368,7 +368,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_IndexOf_InvalidValue(int count)
         {
             if (!IsReadOnly)
@@ -382,7 +382,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_IndexOf_ReturnsFirstMatchingValue(int count)
         {
             if (!IsReadOnly)
@@ -403,7 +403,7 @@ namespace System.Collections.Tests
         #region Insert
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_Insert_NegativeIndex_ThrowsArgumentOutOfRangeException(int count)
         {
             if (!IsReadOnly)
@@ -417,7 +417,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_Insert_IndexGreaterThanListCount_Appends(int count)
         {
             if (!IsReadOnly)
@@ -431,7 +431,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_Insert_ToReadOnlyList(int count)
         {
             if (IsReadOnly)
@@ -443,7 +443,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_Insert_FirstItemToNonDefaultValue(int count)
         {
             if (!IsReadOnly)
@@ -457,7 +457,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_Insert_FirstItemToDefaultValue(int count)
         {
             if (!IsReadOnly && DefaultValueAllowed)
@@ -471,7 +471,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_Insert_LastItemToNonDefaultValue(int count)
         {
             if (!IsReadOnly)
@@ -486,7 +486,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_Insert_LastItemToDefaultValue(int count)
         {
             if (!IsReadOnly && DefaultValueAllowed)
@@ -501,7 +501,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_Insert_DuplicateValues(int count)
         {
             if (!IsReadOnly && DuplicateValuesAllowed)
@@ -517,7 +517,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_Insert_InvalidValue(int count)
         {
             if (!IsReadOnly)
@@ -535,7 +535,7 @@ namespace System.Collections.Tests
         #region RemoveAt
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_RemoveAt_NegativeIndex_ThrowsArgumentOutOfRangeException(int count)
         {
             if (!IsReadOnly)
@@ -549,7 +549,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_RemoveAt_IndexGreaterThanListCount_ThrowsArgumentOutOfRangeException(int count)
         {
             if (!IsReadOnly)
@@ -563,7 +563,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_RemoveAt_OnReadOnlyList(int count)
         {
             if (IsReadOnly)
@@ -575,7 +575,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_RemoveAt_AllValidIndices(int count)
         {
             if (!IsReadOnly)
@@ -591,7 +591,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_Generic_RemoveAt_ZeroMultipleTimes(int count)
         {
             if (!IsReadOnly)

--- a/src/Common/tests/System/Collections/IList.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IList.NonGeneric.Tests.cs
@@ -142,7 +142,7 @@ namespace System.Collections.Tests
         #region IsFixedSize
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_IsFixedSize_Validity(int count)
         {
             IList collection = NonGenericIListFactory(count);
@@ -154,7 +154,7 @@ namespace System.Collections.Tests
         #region IsReadOnly
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_IsReadOnly_Validity(int count)
         {
             IList collection = NonGenericIListFactory(count);
@@ -166,7 +166,7 @@ namespace System.Collections.Tests
         #region Item Getter
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_ItemGet_NegativeIndex_ThrowsArgumentOutOfRangeException(int count)
         {
             IList list = NonGenericIListFactory(count);
@@ -175,7 +175,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_ItemGet_IndexGreaterThanListCount_ThrowsArgumentOutOfRangeException(int count)
         {
             IList list = NonGenericIListFactory(count);
@@ -184,7 +184,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_ItemGet_ValidGetWithinListBounds(int count)
         {
             IList list = NonGenericIListFactory(count);
@@ -197,7 +197,7 @@ namespace System.Collections.Tests
         #region Item Setter
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_ItemSet_NegativeIndex_ThrowsArgumentOutOfRangeException(int count)
         {
             if (!IsReadOnly)
@@ -211,7 +211,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_ItemSet_IndexGreaterThanListCount_ThrowsArgumentOutOfRangeException(int count)
         {
             if (!IsReadOnly)
@@ -225,7 +225,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_ItemSet_OnReadOnlyList(int count)
         {
             if (IsReadOnly)
@@ -237,7 +237,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_ItemSet_FirstItemToNonNull(int count)
         {
             if (count > 0 && !IsReadOnly)
@@ -250,7 +250,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_ItemSet_FirstItemToNull(int count)
         {
             if (count > 0 && !IsReadOnly && NullAllowed)
@@ -263,7 +263,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_ItemSet_LastItemToNonNull(int count)
         {
             if (count > 0 && !IsReadOnly)
@@ -277,7 +277,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_ItemSet_LastItemToNull(int count)
         {
             if (count > 0 && !IsReadOnly && NullAllowed)
@@ -291,7 +291,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_ItemSet_DuplicateValues(int count)
         {
             if (count >= 2 && !IsReadOnly && DuplicateValuesAllowed)
@@ -306,7 +306,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_ItemSet_InvalidValue(int count)
         {
             if (!IsReadOnly)
@@ -324,7 +324,7 @@ namespace System.Collections.Tests
         #region Add
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Add_Null(int count)
         {
             if (NullAllowed && !IsReadOnly)
@@ -336,7 +336,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Add_InvalidValueToMiddleOfCollection(int count)
         {
             if (!IsReadOnly)
@@ -353,7 +353,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Add_InvalidValueToBeginningOfCollection(int count)
         {
             if (!IsReadOnly)
@@ -370,7 +370,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Add_InvalidValueToEndOfCollection(int count)
         {
             if (!IsReadOnly)
@@ -385,7 +385,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Add_DuplicateValue(int count)
         {
             if (!IsReadOnly)
@@ -402,7 +402,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Add_AfterCallingClear(int count)
         {
             if (!IsReadOnly)
@@ -415,7 +415,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Add_AfterRemovingAnyValue(int count)
         {
             if (!IsReadOnly)
@@ -439,7 +439,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Add_AfterRemovingAllItems(int count)
         {
             if (!IsReadOnly)
@@ -455,7 +455,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Add_ToReadOnlyCollection(int count)
         {
             if (IsReadOnly)
@@ -467,7 +467,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Add_AfterRemoving(int count)
         {
             if (!IsReadOnly)
@@ -488,7 +488,7 @@ namespace System.Collections.Tests
         #region Clear
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Clear(int count)
         {
             IList collection = NonGenericIListFactory(count);
@@ -509,7 +509,7 @@ namespace System.Collections.Tests
         #region Contains
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Contains_ValidValueOnCollectionNotContainingThatValue(int count)
         {
             IList collection = NonGenericIListFactory(count);
@@ -521,7 +521,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_ICollection_NonGeneric_Contains_ValidValueOnCollectionContainingThatValue(int count)
         {
             IList collection = NonGenericIListFactory(count);
@@ -530,7 +530,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Contains_NullOnCollectionNotContainingNull(int count)
         {
             IList collection = NonGenericIListFactory(count);
@@ -539,7 +539,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Contains_NullOnCollectionContainingNull(int count)
         {
             IList collection = NonGenericIListFactory(count);
@@ -551,7 +551,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Contains_ValidValueThatExistsTwiceInTheCollection(int count)
         {
             if (DuplicateValuesAllowed && !IsReadOnly)
@@ -565,7 +565,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Contains_InvalidValue_ThrowsArgumentException(int count)
         {
             IList collection = NonGenericIListFactory(count);
@@ -579,7 +579,7 @@ namespace System.Collections.Tests
         #region IndexOf
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_IndexOf_NullNotContainedInList(int count)
         {
             if (NullAllowed)
@@ -597,7 +597,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_IndexOf_NullContainedInList(int count)
         {
             if (count > 0 && NullAllowed)
@@ -615,7 +615,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_IndexOf_ValueInCollectionMultipleTimes(int count)
         {
             if (count > 0 && !IsReadOnly && DuplicateValuesAllowed)
@@ -630,7 +630,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_IndexOf_EachValueNoDuplicates(int count)
         {
             // Assumes no duplicate elements contained in the list returned by NonGenericIListFactory
@@ -642,7 +642,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_IndexOf_InvalidValue(int count)
         {
             if (!IsReadOnly)
@@ -656,7 +656,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_IndexOf_ReturnsFirstMatchingValue(int count)
         {
             if (!IsReadOnly)
@@ -682,7 +682,7 @@ namespace System.Collections.Tests
         #region Insert
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_Insert_NegativeIndex_ThrowsArgumentOutOfRangeException(int count)
         {
             if (!IsReadOnly)
@@ -697,7 +697,7 @@ namespace System.Collections.Tests
 
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_Insert_IndexGreaterThanListCount_Appends(int count)
         {
             if (!IsReadOnly)
@@ -711,7 +711,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_Insert_ToReadOnlyList(int count)
         {
             if (IsReadOnly)
@@ -723,7 +723,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_Insert_FirstItemToNonNull(int count)
         {
             if (!IsReadOnly)
@@ -737,7 +737,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_Insert_FirstItemToNull(int count)
         {
             if (!IsReadOnly && NullAllowed)
@@ -751,7 +751,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_Insert_LastItemToNonNull(int count)
         {
             if (!IsReadOnly)
@@ -766,7 +766,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_Insert_LastItemToNull(int count)
         {
             if (!IsReadOnly && NullAllowed)
@@ -781,7 +781,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_Insert_DuplicateValues(int count)
         {
             if (!IsReadOnly && DuplicateValuesAllowed)
@@ -797,7 +797,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_Insert_InvalidValue(int count)
         {
             if (!IsReadOnly)
@@ -815,7 +815,7 @@ namespace System.Collections.Tests
         #region Remove
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Remove_OnReadOnlyCollection_ThrowsNotSupportedException(int count)
         {
             if (IsReadOnly)
@@ -826,7 +826,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Remove_NullNotContainedInCollection(int count)
         {
             if (!IsReadOnly && NullAllowed && !Enumerable.Contains(InvalidValues, null))
@@ -845,7 +845,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Remove_NonNullNotContainedInCollection(int count)
         {
             if (!IsReadOnly)
@@ -861,7 +861,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Remove_NullContainedInCollection(int count)
         {
             if (!IsReadOnly && NullAllowed && !Enumerable.Contains(InvalidValues, null))
@@ -880,7 +880,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Remove_NonNullContainedInCollection(int count)
         {
             if (!IsReadOnly)
@@ -899,7 +899,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Remove_ValueThatExistsTwiceInCollection(int count)
         {
             if (!IsReadOnly && DuplicateValuesAllowed)
@@ -917,7 +917,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Remove_EveryValue(int count)
         {
             if (!IsReadOnly)
@@ -934,7 +934,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_Remove_InvalidValue_ThrowsArgumentException(int count)
         {
             IList collection = NonGenericIListFactory(count);
@@ -950,7 +950,7 @@ namespace System.Collections.Tests
         #region RemoveAt
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_RemoveAt_NegativeIndex_ThrowsArgumentOutOfRangeException(int count)
         {
             if (!IsReadOnly)
@@ -964,7 +964,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_RemoveAt_IndexGreaterThanListCount_ThrowsArgumentOutOfRangeException(int count)
         {
             if (!IsReadOnly)
@@ -978,7 +978,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_RemoveAt_OnReadOnlyList(int count)
         {
             if (IsReadOnly)
@@ -990,7 +990,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_RemoveAt_AllValidIndices(int count)
         {
             if (!IsReadOnly)
@@ -1006,7 +1006,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IList_NonGeneric_RemoveAt_ZeroMultipleTimes(int count)
         {
             if (!IsReadOnly)

--- a/src/Common/tests/System/Collections/ISet.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/ISet.Generic.Tests.cs
@@ -78,7 +78,7 @@ namespace System.Collections.Tests
         #region ICollection_Generic
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Add_ReturnValue(int count)
         {
             if (!IsReadOnly)
@@ -97,7 +97,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_Generic_Add_DuplicateValue_DoesNothing(int count)
         {
             if (!IsReadOnly)
@@ -305,7 +305,7 @@ namespace System.Collections.Tests
         #region Set Function tests
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ISet_Generic_NullEnumerableArgument(int count)
         {
             ISet<T> set = GenericISetFactory(count);
@@ -322,7 +322,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void ISet_Generic_ExceptWith(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -331,7 +331,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void ISet_Generic_IntersectWith(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -340,7 +340,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void ISet_Generic_IsProperSubsetOf(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -349,7 +349,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void ISet_Generic_IsProperSupersetOf(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -358,7 +358,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void ISet_Generic_IsSubsetOf(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -367,7 +367,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void ISet_Generic_IsSupersetOf(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -376,7 +376,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void ISet_Generic_Overlaps(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -385,7 +385,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void ISet_Generic_SetEquals(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -394,7 +394,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void ISet_Generic_SymmetricExceptWith(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -403,7 +403,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void ISet_Generic_UnionWith(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -416,7 +416,7 @@ namespace System.Collections.Tests
         #region Set Function tests on itself
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ISet_Generic_ExceptWith_Itself(int setLength)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -424,7 +424,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ISet_Generic_IntersectWith_Itself(int setLength)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -432,7 +432,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ISet_Generic_IsProperSubsetOf_Itself(int setLength)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -440,7 +440,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ISet_Generic_IsProperSupersetOf_Itself(int setLength)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -448,7 +448,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ISet_Generic_IsSubsetOf_Itself(int setLength)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -456,7 +456,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ISet_Generic_IsSupersetOf_Itself(int setLength)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -464,7 +464,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ISet_Generic_Overlaps_Itself(int setLength)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -472,7 +472,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ISet_Generic_SetEquals_Itself(int setLength)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -480,7 +480,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ISet_Generic_SymmetricExceptWith_Itself(int setLength)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -488,7 +488,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ISet_Generic_UnionWith_Itself(int setLength)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -594,7 +594,7 @@ namespace System.Collections.Tests
         #region Other misc ISet test Scenarios
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void ISet_Generic_SymmetricExceptWith_AfterRemovingElements(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Keys.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Keys.cs
@@ -38,14 +38,14 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_KeyCollection_Constructor_NullDictionary(int count)
         {
             Assert.Throws<ArgumentNullException>(() => new Dictionary<string, string>.KeyCollection(null));
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_KeyCollection_GetEnumerator(int count)
         {
             Dictionary<string, string> dictionary = new Dictionary<string, string>();
@@ -95,7 +95,7 @@ namespace System.Collections.Tests
         protected override IEnumerable<ModifyEnumerable> ModifyEnumerables { get { return new List<ModifyEnumerable>(); } }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_KeyCollection_CopyTo_ExactlyEnoughSpaceInTypeCorrectArray(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Values.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Values.cs
@@ -39,14 +39,14 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_ValueCollection_Constructor_NullDictionary(int count)
         {
             Assert.Throws<ArgumentNullException>(() => new Dictionary<string, string>.ValueCollection(null));
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_ValueCollection_GetEnumerator(int count)
         {
             Dictionary<string, string> dictionary = new Dictionary<string, string>();
@@ -94,7 +94,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_ValueCollection_CopyTo_ExactlyEnoughSpaceInTypeCorrectArray(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.cs
@@ -26,7 +26,7 @@ namespace System.Collections.Tests
         #region Constructors
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_Constructor_IDictionary(int count)
         {
             IDictionary<TKey, TValue> source = GenericIDictionaryFactory(count);
@@ -35,7 +35,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_Constructor_IDictionary_IEqualityComparer(int count)
         {
             IEqualityComparer<TKey> comparer = GetKeyIEqualityComparer();
@@ -47,7 +47,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_Constructor_IEqualityComparer(int count)
         {
             IEqualityComparer<TKey> comparer = GetKeyIEqualityComparer();
@@ -59,7 +59,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_Constructor_int(int count)
         {
             IDictionary<TKey, TValue> dictionary = new Dictionary<TKey, TValue>(count);
@@ -67,7 +67,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_Constructor_int_IEqualityComparer(int count)
         {
             IEqualityComparer<TKey> comparer = GetKeyIEqualityComparer();
@@ -83,7 +83,7 @@ namespace System.Collections.Tests
         #region ContainsValue
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_ContainsValue_NotPresent(int count)
         {
             Dictionary<TKey, TValue> dictionary = (Dictionary < TKey, TValue> )GenericIDictionaryFactory(count);
@@ -95,7 +95,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_ContainsValue_Present(int count)
         {
             Dictionary<TKey, TValue> dictionary = (Dictionary<TKey, TValue>)GenericIDictionaryFactory(count);
@@ -108,7 +108,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_ContainsValue_DefaultValueNotPresent(int count)
         {
             Dictionary<TKey, TValue> dictionary = (Dictionary<TKey, TValue>)GenericIDictionaryFactory(count);
@@ -116,7 +116,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_ContainsValue_DefaultValuePresent(int count)
         {
             Dictionary<TKey, TValue> dictionary = (Dictionary<TKey, TValue>)GenericIDictionaryFactory(count);
@@ -133,7 +133,7 @@ namespace System.Collections.Tests
         #region IReadOnlyDictionary<TKey, TValue>.Keys
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IReadOnlyDictionary_Generic_Keys_ContainsAllCorrectKeys(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -143,7 +143,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IReadOnlyDictionary_Generic_Values_ContainsAllCorrectValues(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
@@ -42,7 +42,7 @@ namespace System.Collections.Tests
         #region IDictionary tests
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemSet_NullValueWhenDefaultValueIsNonNull(int count)
         {
             IDictionary dictionary = new Dictionary<string, int>();
@@ -50,7 +50,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemSet_KeyOfWrongType(int count)
         {
             if (!IsReadOnly)
@@ -62,7 +62,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemSet_ValueOfWrongType(int count)
         {
             if (!IsReadOnly)
@@ -75,7 +75,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Add_KeyOfWrongType(int count)
         {
             if (!IsReadOnly)
@@ -88,7 +88,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Add_ValueOfWrongType(int count)
         {
             if (!IsReadOnly)
@@ -101,7 +101,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Add_NullValueWhenDefaultTValueIsNonNull(int count)
         {
             if (!IsReadOnly)
@@ -114,7 +114,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Contains_KeyOfWrongType(int count)
         {
             if (!IsReadOnly)
@@ -129,7 +129,7 @@ namespace System.Collections.Tests
         #region ICollection tests
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo_ArrayOfIncorrectKeyValuePairType(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
@@ -138,7 +138,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo_ArrayOfCorrectKeyValuePairType(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
@@ -72,7 +72,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void HashSet_Generic_Constructor_IEnumerable(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, numberOfDuplicateElements);
@@ -81,7 +81,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void HashSet_Generic_Constructor_IEnumerable_WithManyDuplicates(int count)
         {
             IEnumerable<T> items = CreateEnumerable(EnumerableType.List, null, count, 0, 0);
@@ -91,7 +91,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void HashSet_Generic_Constructor_HashSet_SparselyFilled(int count)
         {
             HashSet<T> source = (HashSet <T>)CreateEnumerable(EnumerableType.HashSet, null, count, 0, 0);
@@ -112,7 +112,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void HashSet_Generic_Constructor_IEnumerable_IEqualityComparer(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, 0);
@@ -125,7 +125,7 @@ namespace System.Collections.Tests
         #region RemoveWhere
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void HashSet_Generic_RemoveWhere_AllElements(int setLength)
         {
             HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
@@ -134,7 +134,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void HashSet_Generic_RemoveWhere_NoElements(int setLength)
         {
             HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
@@ -144,7 +144,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void HashSet_Generic_RemoveWhere_NewObject(int setLength) // Regression Dev10_624201
         {
             object[] array = new object[2];
@@ -159,7 +159,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void HashSet_Generic_RemoveWhere_NullMatchPredicate(int setLength)
         {
             HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
@@ -171,7 +171,7 @@ namespace System.Collections.Tests
         #region TrimExcess
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void HashSet_Generic_TrimExcess_OnValidSetThatHasntBeenRemovedFrom(int setLength)
         {
             HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
@@ -179,7 +179,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void HashSet_Generic_TrimExcess_Repeatedly(int setLength)
         {
             HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
@@ -191,7 +191,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void HashSet_Generic_TrimExcess_AfterRemovingOneElement(int setLength)
         {
             if (setLength > 0)
@@ -210,7 +210,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void HashSet_Generic_TrimExcess_AfterClearingAndAddingSomeElementsBack(int setLength)
         {
             if (setLength > 0)
@@ -228,7 +228,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void HashSet_Generic_TrimExcess_AfterClearingAndAddingAllElementsBack(int setLength)
         {
             if (setLength > 0)
@@ -250,7 +250,7 @@ namespace System.Collections.Tests
         #region CopyTo
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void HashSet_Generic_CopyTo_NegativeCount_ThrowsArgumentOutOfRangeException(int count)
         {
             HashSet<T> set = (HashSet<T>)GenericISetFactory(count);
@@ -260,7 +260,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void HashSet_Generic_CopyTo_NoIndexDefaultsToZero(int count)
         {
             HashSet<T> set = (HashSet<T>)GenericISetFactory(count);

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.AsNonGenericICollection.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.AsNonGenericICollection.cs
@@ -81,7 +81,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void LinkedList_ICollection_NonGeneric_CopyTo_ExactlyEnoughSpaceInTypeCorrectArray(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.cs
@@ -487,7 +487,7 @@ namespace System.Collections.Tests
         #region Constructor_IEnumerable
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void LinkedList_Generic_Constructor_IEnumerable(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, numberOfDuplicateElements);

--- a/src/System.Collections/tests/Generic/List/List.Generic.Tests.Find.cs
+++ b/src/System.Collections/tests/Generic/List/List.Generic.Tests.Find.cs
@@ -18,7 +18,7 @@ namespace System.Collections.Tests
         private readonly Predicate<T> AlwaysFalseDelegate = (T item) => { return false; };
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindVerifyExceptions(int count)
         {
             List<T> list = GenericListFactory(count);
@@ -38,7 +38,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindLastIndexInt_VerifyExceptions(int count)
         {
             List<T> list = GenericListFactory(count);
@@ -72,7 +72,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindIndexIntInt_VerifyExceptions(int count)
         {
             List<T> list = GenericListFactory(count);
@@ -130,7 +130,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindLastIndexIntInt_VerifyExceptions(int count)
         {
             List<T> list = GenericListFactory(count);
@@ -190,7 +190,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindIndexInt_VerifyExceptions(int count)
         {
             List<T> list = GenericListFactory(count);
@@ -219,7 +219,7 @@ namespace System.Collections.Tests
         #region Find
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Find_VerifyVanilla(int count)
         {
             List<T> list = GenericListFactory(count);
@@ -253,7 +253,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Find_VerifyDuplicates(int count)
         {
             T expectedItem = default(T);
@@ -293,7 +293,7 @@ namespace System.Collections.Tests
         #region FindLast
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindLast_VerifyVanilla(int count)
         {
             List<T> list = GenericListFactory(count);
@@ -331,7 +331,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindLast_VerifyDuplicates(int count)
         {
             T expectedItem = default(T);
@@ -370,7 +370,7 @@ namespace System.Collections.Tests
         #region FindIndex
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindIndex_VerifyVanilla(int count)
         {
             T expectedItem = default(T);
@@ -401,7 +401,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindIndex_VerifyDuplicates(int count)
         {
             List<T> list = GenericListFactory(count);
@@ -436,7 +436,7 @@ namespace System.Collections.Tests
         #region FindIndex(int, pred<T>)
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindIndexInt_VerifyVanilla(int count)
         {
             T expectedItem = default(T);
@@ -489,7 +489,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindIndexInt_VerifyDuplicates(int count)
         {
             T expectedItem = default(T);
@@ -534,7 +534,7 @@ namespace System.Collections.Tests
         #region FindIndex(int, int, pred<T>)
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindIndexIntInt_VerifyVanilla(int count)
         {
             T expectedItem = default(T);
@@ -612,7 +612,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindIndexIntInt_VerifyDuplicates(int count)
         {
             T expectedItem = default(T);
@@ -657,7 +657,7 @@ namespace System.Collections.Tests
         #region FindLastIndex
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindLastIndex_VerifyVanilla(int count)
         {
             T expectedItem = default(T);
@@ -686,7 +686,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindLastIndex_VerifyDuplicates(int count)
         {
             T expectedItem = default(T);
@@ -721,7 +721,7 @@ namespace System.Collections.Tests
         #region FindLastIndex(int, pred<T>)
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindLastIndexInt_VerifyVanilla(int count)
         {
             T expectedItem = default(T);
@@ -773,7 +773,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindLastIndexInt_VerifyDuplicates(int count)
         {
             T expectedItem = default(T);
@@ -818,7 +818,7 @@ namespace System.Collections.Tests
         #region FindLastIndex(int, int, pred<T>)
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindLastIndexIntInt_VerifyVanilla(int count)
         {
             T expectedItem = default(T);
@@ -899,7 +899,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindLastIndexIntInt_VerifyDuplicates(int count)
         {
             T expectedItem = default(T);
@@ -934,7 +934,7 @@ namespace System.Collections.Tests
         #region FindAll
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindAll_VerifyVanilla(int count)
         {
             List<T> list = GenericListFactory(count);
@@ -958,7 +958,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void FindAll_VerifyDuplicates(int count)
         {
             List<T> list = GenericListFactory(count);

--- a/src/System.Collections/tests/Generic/List/List.Generic.Tests.ForEach.cs
+++ b/src/System.Collections/tests/Generic/List/List.Generic.Tests.ForEach.cs
@@ -15,7 +15,7 @@ namespace System.Collections.Tests
     public abstract partial class List_Generic_Tests<T> : IList_Generic_Tests<T>
     {
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ForEach_Verify(int count)
         {
             List<T> list = GenericListFactory(count);

--- a/src/System.Collections/tests/Generic/Queue/Queue.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Queue/Queue.Generic.Tests.cs
@@ -57,7 +57,7 @@ namespace System.Collections.Tests
         #region Constructor_IEnumerable
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void Queue_Generic_Constructor_IEnumerable(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, numberOfDuplicateElements);
@@ -76,7 +76,7 @@ namespace System.Collections.Tests
         #region Constructor_Capacity
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Queue_Generic_Constructor_int(int count)
         {
             Queue<T> queue = new Queue<T>(count);
@@ -97,7 +97,7 @@ namespace System.Collections.Tests
         #region Dequeue
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Queue_Generic_Dequeue_AllElements(int count)
         {
             Queue<T> queue = GenericQueueFactory(count);
@@ -153,7 +153,7 @@ namespace System.Collections.Tests
         #region ToArray
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Queue_Generic_ToArray(int count)
         {
             Queue<T> queue = GenericQueueFactory(count);
@@ -161,7 +161,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Queue_Generic_ToArray_NonWrappedQueue(int count)
         {
             Queue<T> collection = new Queue<T>(count + 1);
@@ -176,7 +176,7 @@ namespace System.Collections.Tests
         #region Peek
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Queue_Generic_Peek_AllElements(int count)
         {
             Queue<T> queue = GenericQueueFactory(count);
@@ -199,7 +199,7 @@ namespace System.Collections.Tests
         #region TrimExcess
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Queue_Generic_TrimExcess_OnValidQueueThatHasntBeenRemovedFrom(int count)
         {
             Queue<T> queue = GenericQueueFactory(count);
@@ -207,7 +207,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Queue_Generic_TrimExcess_Repeatedly(int count)
         {
             Queue<T> queue = GenericQueueFactory(count); ;
@@ -219,7 +219,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Queue_Generic_TrimExcess_AfterRemovingOneElement(int count)
         {
             if (count > 0)
@@ -236,7 +236,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Queue_Generic_TrimExcess_AfterClearingAndAddingSomeElementsBack(int count)
         {
             if (count > 0)
@@ -254,7 +254,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Queue_Generic_TrimExcess_AfterClearingAndAddingAllElementsBack(int count)
         {
             if (count > 0)

--- a/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Generic.Tests.Keys.cs
+++ b/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Generic.Tests.Keys.cs
@@ -39,14 +39,14 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedDictionary_Generic_KeyCollection_Constructor_NullDictionary(int count)
         {
             Assert.Throws<ArgumentNullException>(() => new SortedDictionary<string, string>.KeyCollection(null));
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedDictionary_Generic_KeyCollection_GetEnumerator(int count)
         {
             SortedDictionary<string, string> dictionary = new SortedDictionary<string, string>();
@@ -93,7 +93,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
@@ -102,7 +102,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedDictionary_Generic_KeyCollection_CopyTo_ExactlyEnoughSpaceInTypeCorrectArray(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);

--- a/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Generic.Tests.Values.cs
+++ b/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Generic.Tests.Values.cs
@@ -39,14 +39,14 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedDictionary_Generic_ValueCollection_Constructor_NullDictionary(int count)
         {
             Assert.Throws<ArgumentNullException>(() => new SortedDictionary<string, string>.ValueCollection(null));
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedDictionary_Generic_ValueCollection_GetEnumerator(int count)
         {
             SortedDictionary<string, string> dictionary = new SortedDictionary<string, string>();
@@ -94,7 +94,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
@@ -103,7 +103,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedDictionary_Generic_ValueCollection_CopyTo_ExactlyEnoughSpaceInTypeCorrectArray(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);

--- a/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Generic.Tests.cs
@@ -28,7 +28,7 @@ namespace System.Collections.Tests
         #region Constructors
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedDictionary_Generic_Constructor_IComparer(int count)
         {
             IComparer<TKey> comparer = GetKeyIComparer();
@@ -39,7 +39,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedDictionary_Generic_Constructor_IDictionary(int count)
         {
             IDictionary<TKey, TValue> source = GenericIDictionaryFactory(count);
@@ -48,14 +48,14 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedDictionary_Generic_Constructor_NullIDictionary_ThrowsArgumentNullException(int count)
         {
             Assert.Throws<ArgumentNullException>(() => new SortedDictionary<TKey, TValue>((IDictionary<TKey, TValue>)null));
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedDictionary_Generic_Constructor_IDictionary_IComparer(int count)
         {
             IComparer<TKey> comparer = GetKeyIComparer();
@@ -70,7 +70,7 @@ namespace System.Collections.Tests
         #region ContainsValue
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedDictionary_Generic_ContainsValue_NotPresent(int count)
         {
             SortedDictionary<TKey, TValue> dictionary = (SortedDictionary<TKey, TValue>)GenericIDictionaryFactory(count);
@@ -82,7 +82,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedDictionary_Generic_ContainsValue_Present(int count)
         {
             SortedDictionary<TKey, TValue> dictionary = (SortedDictionary<TKey, TValue>)GenericIDictionaryFactory(count);
@@ -95,7 +95,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedDictionary_Generic_ContainsValue_DefaultValueNotPresent(int count)
         {
             SortedDictionary<TKey, TValue> dictionary = (SortedDictionary<TKey, TValue>)GenericIDictionaryFactory(count);
@@ -103,7 +103,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedDictionary_Generic_ContainsValue_DefaultValuePresent(int count)
         {
             SortedDictionary<TKey, TValue> dictionary = (SortedDictionary<TKey, TValue>)GenericIDictionaryFactory(count);
@@ -120,7 +120,7 @@ namespace System.Collections.Tests
         #region Ordering
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedDictionary_Generic_DictionaryIsProperlySortedAccordingToComparer(int setLength)
         {
             SortedDictionary<TKey, TValue> set = (SortedDictionary<TKey, TValue>)GenericIDictionaryFactory(setLength);
@@ -136,7 +136,7 @@ namespace System.Collections.Tests
         #region IReadOnlyDictionary<TKey, TValue>.Keys
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IReadOnlyDictionary_Generic_Keys_ContainsAllCorrectKeys(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -146,7 +146,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IReadOnlyDictionary_Generic_Values_ContainsAllCorrectValues(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);

--- a/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Tests.cs
@@ -47,7 +47,7 @@ namespace System.Collections.Tests
         #region IDictionary tests
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemSet_NullValueWhenDefaultValueIsNonNull(int count)
         {
             IDictionary dictionary = new SortedDictionary<string, int>();
@@ -55,7 +55,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemSet_KeyOfWrongType(int count)
         {
             if (!IsReadOnly)
@@ -67,7 +67,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemSet_ValueOfWrongType(int count)
         {
             if (!IsReadOnly)
@@ -80,7 +80,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Add_KeyOfWrongType(int count)
         {
             if (!IsReadOnly)
@@ -93,7 +93,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Add_ValueOfWrongType(int count)
         {
             if (!IsReadOnly)
@@ -106,7 +106,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Add_NullValueWhenDefaultTValueIsNonNull(int count)
         {
             if (!IsReadOnly)
@@ -119,7 +119,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Contains_KeyOfWrongType(int count)
         {
             if (!IsReadOnly)
@@ -134,7 +134,7 @@ namespace System.Collections.Tests
         #region ICollection tests
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo_ArrayOfIncorrectKeyValuePairType(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
@@ -143,7 +143,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo_ArrayOfCorrectKeyValuePairType(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);

--- a/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.Keys.cs
+++ b/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.Keys.cs
@@ -40,7 +40,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public override void Enumerator_MoveNext_AfterDisposal(int count)
         {
             // Disposal of the enumerator is treated the same as a Reset call

--- a/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.Values.cs
+++ b/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.Values.cs
@@ -39,7 +39,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public override void Enumerator_MoveNext_AfterDisposal(int count)
         {
             // Disposal of the enumerator is treated the same as a Reset call

--- a/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.cs
@@ -22,7 +22,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public override void Enumerator_MoveNext_AfterDisposal(int count)
         {
             // Disposal of the enumerator is treated the same as a Reset call
@@ -39,7 +39,7 @@ namespace System.Collections.Tests
         #region Constructor_IComparer
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_Constructor_IComparer(int count)
         {
             IComparer<TKey> comparer = GetKeyIComparer();
@@ -54,7 +54,7 @@ namespace System.Collections.Tests
         #region Constructor_IDictionary
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_Constructor_IDictionary(int count)
         {
             IDictionary<TKey, TValue> source = GenericIDictionaryFactory(count);
@@ -63,7 +63,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_Constructor_NullIDictionary_ThrowsArgumentNullException(int count)
         {
             Assert.Throws<ArgumentNullException>(() => new SortedList<TKey, TValue>((IDictionary<TKey, TValue>)null));
@@ -74,7 +74,7 @@ namespace System.Collections.Tests
         #region Constructor_IDictionary_IComparer
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_Constructor_IDictionary_IComparer(int count)
         {
             IComparer<TKey> comparer = GetKeyIComparer();
@@ -89,7 +89,7 @@ namespace System.Collections.Tests
         #region Constructor_int
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_Constructor_int(int count)
         {
             SortedList<TKey, TValue> dictionary = new SortedList<TKey, TValue>(count);
@@ -98,7 +98,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_Constructor_NegativeCapacity_ThrowsArgumentOutOfRangeException(int count)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => new SortedList<TKey, TValue>(-1));
@@ -110,7 +110,7 @@ namespace System.Collections.Tests
         #region Constructor_int_IComparer
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_Constructor_int_IComparer(int count)
         {
             IComparer<TKey> comparer = GetKeyIComparer();
@@ -125,7 +125,7 @@ namespace System.Collections.Tests
         #region Capacity
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_Capacity_setRoundTrips(int count)
         {
             SortedList<TKey, TValue> dictionary = (SortedList<TKey, TValue>)GenericIDictionaryFactory(count);
@@ -137,7 +137,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_Capacity_NegativeValue_ThrowsArgumentOutOfRangeException(int count)
         {
             SortedList<TKey, TValue> dictionary = (SortedList<TKey, TValue>)GenericIDictionaryFactory(count);
@@ -147,7 +147,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_Capacity_LessThanCount_ThrowsArgumentOutOfRangeException(int count)
         {
             SortedList<TKey, TValue> dictionary = (SortedList<TKey, TValue>)GenericIDictionaryFactory();
@@ -159,7 +159,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_Capacity_GrowsDuringAdds(int count)
         {
             SortedList<TKey, TValue> dictionary = (SortedList<TKey, TValue>)GenericIDictionaryFactory();
@@ -179,7 +179,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_Capacity_ClearDoesntTrim(int count)
         {
             SortedList<TKey, TValue> dictionary = (SortedList<TKey, TValue>)GenericIDictionaryFactory();
@@ -200,7 +200,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_Capacity_ClearTrimsToInitialCapacity(int count)
         {
             SortedList<TKey, TValue> dictionary = new SortedList<TKey, TValue>(count);
@@ -214,7 +214,7 @@ namespace System.Collections.Tests
         #region ContainsValue
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_ContainsValue_NotPresent(int count)
         {
             SortedList<TKey, TValue> dictionary = (SortedList<TKey, TValue>)GenericIDictionaryFactory(count);
@@ -226,7 +226,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_ContainsValue_Present(int count)
         {
             SortedList<TKey, TValue> dictionary = (SortedList<TKey, TValue>)GenericIDictionaryFactory(count);
@@ -239,7 +239,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_ContainsValue_DefaultValueNotPresent(int count)
         {
             SortedList<TKey, TValue> dictionary = (SortedList<TKey, TValue>)GenericIDictionaryFactory(count);
@@ -247,7 +247,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_ContainsValue_DefaultValuePresent(int count)
         {
             SortedList<TKey, TValue> dictionary = (SortedList<TKey, TValue>)GenericIDictionaryFactory(count);
@@ -264,7 +264,7 @@ namespace System.Collections.Tests
         #region IndexOfKey
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_IndexOf_DefaultKeyNotContainedInSortedList(int count)
         {
             if (DefaultValueAllowed)
@@ -282,7 +282,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_IndexOfKey_EachKey(int count)
         {
             // Assumes no duplicate elements contained in the dictionary returned by GenericIListFactory
@@ -299,7 +299,7 @@ namespace System.Collections.Tests
         #region IndexOfValue
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_IndexOfValue_DefaultValueNotContainedInList(int count)
         {
             SortedList<TKey, TValue> dictionary = (SortedList<TKey, TValue>)GenericIDictionaryFactory(count);
@@ -314,7 +314,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_IndexOfValue_DefaultValueContainedInList(int count)
         {
             if (!IsReadOnly)
@@ -335,7 +335,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_IndexOfValue_ValueInCollectionMultipleTimes(int count)
         {
             if (!IsReadOnly)
@@ -365,7 +365,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_IndexOfValue_EachValue(int count)
         {
             // Assumes no duplicate elements contained in the dictionary returned by GenericIListFactory
@@ -387,7 +387,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_RemoveAt_OnReadOnlySortedList_ThrowsNotSupportedException(int count)
         {
             if (IsReadOnly)
@@ -398,7 +398,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_RemoveAt_NonDefaultValueContainedInCollection(int count)
         {
             if (!IsReadOnly)
@@ -417,7 +417,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_RemoveAt_EveryValue(int count)
         {
             if (!IsReadOnly)
@@ -432,7 +432,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_RemoveAt_OutOfRangeValues(int count)
         {
             if (!IsReadOnly)
@@ -450,7 +450,7 @@ namespace System.Collections.Tests
         #region TrimExcess
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_TrimExcess_OnValidSortedListThatHasntBeenRemovedFrom(int dictionaryLength)
         {
             SortedList<TKey, TValue> dictionary = (SortedList<TKey, TValue>)GenericIDictionaryFactory(dictionaryLength);
@@ -458,7 +458,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_TrimExcess_Repeatedly(int dictionaryLength)
         {
             SortedList<TKey, TValue> dictionary = (SortedList<TKey, TValue>)GenericIDictionaryFactory(dictionaryLength);
@@ -470,7 +470,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_TrimExcess_AfterRemovingOneElement(int dictionaryLength)
         {
             if (dictionaryLength > 0)
@@ -489,7 +489,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_TrimExcess_AfterClearingAndAddingSomeElementsBack(int dictionaryLength)
         {
             if (dictionaryLength > 0)
@@ -507,7 +507,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_TrimExcess_AfterClearingAndAddingAllElementsBack(int dictionaryLength)
         {
             if (dictionaryLength > 0)
@@ -529,7 +529,7 @@ namespace System.Collections.Tests
         #region Ordering
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedList_Generic_DictionaryIsProperlySortedAccordingToComparer(int setLength)
         {
             SortedList<TKey, TValue> set = (SortedList<TKey, TValue>)GenericIDictionaryFactory(setLength);
@@ -545,7 +545,7 @@ namespace System.Collections.Tests
         #region IReadOnlyDictionary<TKey, TValue>.Keys
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IReadOnlyDictionary_Generic_Keys_ContainsAllCorrectKeys(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
@@ -555,7 +555,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IReadOnlyDictionary_Generic_Values_ContainsAllCorrectValues(int count)
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);

--- a/src/System.Collections/tests/Generic/SortedList/SortedList.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedList/SortedList.Tests.cs
@@ -36,7 +36,7 @@ namespace System.Collections.Tests
         #region IDictionary tests
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemSet_NullValueWhenDefaultValueIsNonNull(int count)
         {
             IDictionary dictionary = new SortedList<string, int>();
@@ -44,7 +44,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemSet_KeyOfWrongType(int count)
         {
             if (!IsReadOnly)
@@ -56,7 +56,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemSet_ValueOfWrongType(int count)
         {
             if (!IsReadOnly)
@@ -69,7 +69,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Add_KeyOfWrongType(int count)
         {
             if (!IsReadOnly)
@@ -82,7 +82,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Add_ValueOfWrongType(int count)
         {
             if (!IsReadOnly)
@@ -95,7 +95,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Add_NullValueWhenDefaultTValueIsNonNull(int count)
         {
             if (!IsReadOnly)
@@ -108,7 +108,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Contains_KeyOfWrongType(int count)
         {
             if (!IsReadOnly)
@@ -123,7 +123,7 @@ namespace System.Collections.Tests
         #region ICollection tests
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo_ArrayOfIncorrectKeyValuePairType(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
@@ -132,7 +132,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_CopyTo_ArrayOfCorrectKeyValuePairType(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -51,7 +51,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void SortedSet_Generic_Constructor_IEnumerable(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, numberOfDuplicateElements);
@@ -67,7 +67,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void SortedSet_Generic_Constructor_IEnumerable_IComparer(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, 0);
@@ -80,7 +80,7 @@ namespace System.Collections.Tests
         #region Max and Min
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedSet_Generic_MaxAndMin(int setLength)
         {
             if (setLength > 0)
@@ -98,7 +98,7 @@ namespace System.Collections.Tests
         #region GetViewBetween
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedSet_Generic_GetViewBetween_EntireSet(int setLength)
         {
             if (setLength > 0)
@@ -113,7 +113,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedSet_Generic_GetViewBetween_MiddleOfSet(int setLength)
         {
             if (setLength >= 3)
@@ -137,7 +137,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedSet_Generic_GetViewBetween_LowerValueGreaterThanUpperValue_ThrowsArgumentException(int setLength)
         {
             if (setLength >= 2)
@@ -154,7 +154,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedSet_Generic_GetViewBetween_SubsequentOutOfRangeCall_ThrowsArgumentOutOfRangeException(int setLength)
         {
             if (setLength >= 3)
@@ -179,7 +179,7 @@ namespace System.Collections.Tests
         #region RemoveWhere
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedSet_Generic_RemoveWhere_AllElements(int setLength)
         {
             SortedSet<T> set = (SortedSet<T>)GenericISetFactory(setLength);
@@ -188,7 +188,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedSet_Generic_RemoveWhere_NoElements(int setLength)
         {
             SortedSet<T> set = (SortedSet<T>)GenericISetFactory(setLength);
@@ -202,7 +202,7 @@ namespace System.Collections.Tests
         #region Enumeration and Ordering
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedSet_Generic_SetIsProperlySortedAccordingToComparer(int setLength)
         {
             SortedSet<T> set = (SortedSet<T>)GenericISetFactory(setLength);
@@ -214,7 +214,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedSet_Generic_ReverseSetIsProperlySortedAccordingToComparer(int setLength)
         {
             SortedSet<T> set = (SortedSet<T>)GenericISetFactory(setLength);
@@ -248,7 +248,7 @@ namespace System.Collections.Tests
         #region CopyTo
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedSet_Generic_CopyTo_WithoutIndex(int setLength)
         {
             SortedSet<T> set = (SortedSet<T>)GenericISetFactory(setLength);
@@ -260,7 +260,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedSet_Generic_CopyTo_WithValidFullCount(int setLength)
         {
             SortedSet<T> set = (SortedSet<T>)GenericISetFactory(setLength);
@@ -272,7 +272,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void SortedSet_Generic_CopyTo_NegativeCount_ThrowsArgumentOutOfRangeException(int setLength)
         {
             SortedSet<T> set = (SortedSet<T>)GenericISetFactory(setLength);

--- a/src/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
@@ -61,7 +61,7 @@ namespace System.Collections.Tests
         #region Constructor_IEnumerable
 
         [Theory]
-        [MemberData("EnumerableTestData")]
+        [MemberData(nameof(EnumerableTestData))]
         public void Stack_Generic_Constructor_IEnumerable(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, numberOfDuplicateElements);
@@ -80,7 +80,7 @@ namespace System.Collections.Tests
         #region Constructor_Capacity
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Stack_Generic_Constructor_int(int count)
         {
             Stack<T> stack = new Stack<T>(count);
@@ -99,7 +99,7 @@ namespace System.Collections.Tests
         #region Pop
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Stack_Generic_Pop_AllElements(int count)
         {
             Stack<T> stack = GenericStackFactory(count);
@@ -119,7 +119,7 @@ namespace System.Collections.Tests
         #region ToArray
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Stack_Generic_ToArray(int count)
         {
             Stack<T> stack = GenericStackFactory(count);
@@ -131,7 +131,7 @@ namespace System.Collections.Tests
         #region Peek
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Stack_Generic_Peek_AllElements(int count)
         {
             Stack<T> stack = GenericStackFactory(count);
@@ -154,7 +154,7 @@ namespace System.Collections.Tests
         #region TrimExcess
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Stack_Generic_TrimExcess_OnValidStackThatHasntBeenRemovedFrom(int count)
         {
             Stack<T> stack = GenericStackFactory(count);
@@ -162,7 +162,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Stack_Generic_TrimExcess_Repeatedly(int count)
         {
             Stack<T> stack = GenericStackFactory(count);;
@@ -174,7 +174,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Stack_Generic_TrimExcess_AfterRemovingOneElement(int count)
         {
             if (count > 0)
@@ -193,7 +193,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Stack_Generic_TrimExcess_AfterClearingAndAddingSomeElementsBack(int count)
         {
             if (count > 0)
@@ -211,7 +211,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [MemberData("ValidCollectionSizes")]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Stack_Generic_TrimExcess_AfterClearingAndAddingAllElementsBack(int count)
         {
             if (count > 0)


### PR DESCRIPTION
Some of the files in System.Collections don't use nameof for their memberdata declaration.

@stephentoub