### PR TITLE
Fix XDocument writer DateTime serialization behavior mismatch with full .NET

### DIFF
--- a/src/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
+++ b/src/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
@@ -461,6 +461,7 @@ namespace System.Xml
         public abstract void WriteSurrogateCharEntity(char lowChar, char highChar);
         public virtual System.Threading.Tasks.Task WriteSurrogateCharEntityAsync(char lowChar, char highChar) { return default(System.Threading.Tasks.Task); }
         public virtual void WriteValue(bool value) { }
+        public virtual void WriteValue(System.DateTime value) { }
         public virtual void WriteValue(System.DateTimeOffset value) { }
         public virtual void WriteValue(decimal value) { }
         public virtual void WriteValue(double value) { }

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlAsyncCheckWriter.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlAsyncCheckWriter.cs
@@ -263,7 +263,7 @@ namespace System.Xml
             _coreWriter.WriteValue(value);
         }
 
-        internal override void WriteValue(DateTime value)
+        public override void WriteValue(DateTime value)
         {
             CheckAsync();
             _coreWriter.WriteValue(value);

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlWriter.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlWriter.cs
@@ -286,7 +286,7 @@ namespace System.Xml
         }
 
         // Writes out the specified value.
-        internal virtual void WriteValue(DateTime value)
+        public virtual void WriteValue(DateTime value)
         {
             WriteString(XmlConvert.ToString(value, XmlDateTimeSerializationMode.RoundtripKind));
         }

--- a/src/System.Xml.XDocument/tests/xNodeBuilder/CommonTests.cs
+++ b/src/System.Xml.XDocument/tests/xNodeBuilder/CommonTests.cs
@@ -4964,7 +4964,34 @@ namespace CoreXml.Test.XLinq
                 //[Variation(Id = 2, Desc = "WriteValue(DateTime)", Priority = 1)]
                 public void writeValue_2()
                 {
-                    Calendar myCal = CultureInfo.InvariantCulture.Calendar;
+                    DateTime myDT = new DateTime(2002, 4, 3);
+                    XDocument doc = new XDocument();
+                    XmlWriter w = CreateWriter(doc);
+                    w.WriteStartElement("Root");
+                    w.WriteValue(myDT);
+                    w.WriteEndElement();
+                    w.Dispose();
+
+                    if (!CompareReader(doc, "<Root>2002-04-03T00:00:00</Root>")) throw new TestException(TestResult.Failed, "");
+                }
+
+                //[Variation(Id = 2, Desc = "WriteValue(DateTime), with time", Priority = 1)]
+                public void writeValue_2_WithTime()
+                {
+                    DateTime myDT = new DateTime(2002, 4, 3, 0, 0, 0);
+                    XDocument doc = new XDocument();
+                    XmlWriter w = CreateWriter(doc);
+                    w.WriteStartElement("Root");
+                    w.WriteValue(myDT);
+                    w.WriteEndElement();
+                    w.Dispose();
+
+                    if (!CompareReader(doc, "<Root>2002-04-03T00:00:00</Root>")) throw new TestException(TestResult.Failed, "");
+                }
+
+                //[Variation(Id = 2, Desc = "WriteValue(DateTime), UTC Timezone", Priority = 1)]
+                public void writeValue_2_Utc()
+                {
                     DateTime myDT = new DateTime(2002, 4, 3, 0, 0, 0, DateTimeKind.Utc);
                     XDocument doc = new XDocument();
                     XmlWriter w = CreateWriter(doc);
@@ -4974,6 +5001,34 @@ namespace CoreXml.Test.XLinq
                     w.Dispose();
 
                     if (!CompareReader(doc, "<Root>2002-04-03T00:00:00Z</Root>")) throw new TestException(TestResult.Failed, "");
+                }
+
+                //[Variation(Id = 2, Desc = "WriteValue(DateTime), Unspecified Timezone", Priority = 1)]
+                public void writeValue_2_Unspecified()
+                {
+                    DateTime myDT = new DateTime(2002, 4, 3, 0, 0, 0, DateTimeKind.Unspecified);
+                    XDocument doc = new XDocument();
+                    XmlWriter w = CreateWriter(doc);
+                    w.WriteStartElement("Root");
+                    w.WriteValue(myDT);
+                    w.WriteEndElement();
+                    w.Dispose();
+
+                    if (!CompareReader(doc, "<Root>2002-04-03T00:00:00</Root>")) throw new TestException(TestResult.Failed, "");
+                }
+
+                //[Variation(Id = 2, Desc = "WriteValue(DateTime), Local Timezone", Priority = 1)]
+                public void writeValue_2_local()
+                {
+                    DateTime myDT = new DateTime(2002, 4, 3, 0, 0, 0, DateTimeKind.Local);
+                    XDocument doc = new XDocument();
+                    XmlWriter w = CreateWriter(doc);
+                    w.WriteStartElement("Root");
+                    w.WriteValue(myDT);
+                    w.WriteEndElement();
+                    w.Dispose();
+
+                    if (!CompareReader(doc, "<Root>2002-04-03T00:00:00-08:00</Root>")) throw new TestException(TestResult.Failed, "");
                 }
 
                 //[Variation(Id = 3, Desc = "WriteValue(decimal)", Priority = 1)]

--- a/src/System.Xml.XDocument/tests/xNodeBuilder/FunctionalTests.cs
+++ b/src/System.Xml.XDocument/tests/xNodeBuilder/FunctionalTests.cs
@@ -568,6 +568,11 @@ namespace CoreXml.Test.XLinq
                 {
                     this.AddChild(new TestVariation(writeValue_1) { Attribute = new VariationAttribute("WriteValue(boolean)") { Id = 1, Priority = 1 } });
                     this.AddChild(new TestVariation(writeValue_2) { Attribute = new VariationAttribute("WriteValue(DateTime)") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_2) { Attribute = new VariationAttribute("WriteValue(DateTime)") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_2_WithTime) { Attribute = new VariationAttribute("WriteValue(DateTime), with time") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_2_Utc) { Attribute = new VariationAttribute("WriteValue(DateTime), UTC Timezone") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_2_Unspecified) { Attribute = new VariationAttribute("WriteValue(DateTime), Unspecified Timezone") { Id = 2, Priority = 1 } });
+                    this.AddChild(new TestVariation(writeValue_2_local) { Attribute = new VariationAttribute("WriteValue(DateTime), Local Timezone") { Id = 2, Priority = 1 } });
                     this.AddChild(new TestVariation(writeValue_3) { Attribute = new VariationAttribute("WriteValue(decimal)") { Id = 3, Priority = 1 } });
                     this.AddChild(new TestVariation(writeValue_4) { Attribute = new VariationAttribute("WriteValue(double)") { Id = 4, Priority = 1 } });
                     this.AddChild(new TestVariation(writeValue_5) { Attribute = new VariationAttribute("WriteValue(int32)") { Id = 5, Priority = 1 } });


### PR DESCRIPTION
There was a behavior difference in XDocument writer DateTime serialization between CoreCLR and full .NET (https://github.com/dotnet/corefx/issues/6693). To fix, I'm exposing the WriteValue(DateTime) in XmlWriter like it was in full .NET.
Previously, since there was no such method, WriteValue(DateTimeOffset) was getting called, due to an implicit conversion.