### PR TITLE
Changes required to use versioning changes in buildtools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ syntax: glob
 # Tool Runtime Dir
 [Tt]ools/
 
+# Generated props files
+BuildVersion.props
+
 # User-specific files
 *.suo
 *.user

--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-1.0.25-prerelease-00199
+1.0.25-prerelease-00198

--- a/build.proj
+++ b/build.proj
@@ -46,6 +46,7 @@
     <TraversalBuildDependsOn>
       ValidateAllProjectDependencies;
       BatchRestorePackages;
+      CreateOrUpdateCurrentVersionFile;
       $(TraversalBuildDependsOn);
     </TraversalBuildDependsOn>
   </PropertyGroup>

--- a/build.proj
+++ b/build.proj
@@ -45,7 +45,6 @@
   <PropertyGroup Condition="'$(RestoreDuringBuild)'=='true'">
     <TraversalBuildDependsOn>
       ValidateAllProjectDependencies;
-      BatchRestorePackages;
       CreateOrUpdateCurrentVersionFile;
       $(TraversalBuildDependsOn);
     </TraversalBuildDependsOn>

--- a/dir.props
+++ b/dir.props
@@ -1,6 +1,11 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition="Exists('..\dir.props')" Project="..\dir.props" />
   <Import Project="src\BuildValues.props" />
+  <!-- Importing Build Version File -->
+  <PropertyGroup>
+    <BuildVersionFile Condition="'$(BuildVersionFile)'==''">$(MSBuildThisFileDirectory)/BuildVersion.props</BuildVersionFile>
+  </PropertyGroup>
+  <Import Condition="Exists('$(BuildVersionFile)')" Project="$(BuildVersionFile)" />
 
   <!--
     $(OS) is set to Unix/Windows_NT. This comes from an environment variable on Windows and MSBuild on Unix.

--- a/dir.props
+++ b/dir.props
@@ -1,11 +1,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition="Exists('..\dir.props')" Project="..\dir.props" />
   <Import Project="src\BuildValues.props" />
-  <!-- Importing Build Version File -->
-  <PropertyGroup>
-    <BuildVersionFile Condition="'$(BuildVersionFile)'==''">$(MSBuildThisFileDirectory)/BuildVersion.props</BuildVersionFile>
-  </PropertyGroup>
-  <Import Condition="Exists('$(BuildVersionFile)')" Project="$(BuildVersionFile)" />
 
   <!--
     $(OS) is set to Unix/Windows_NT. This comes from an environment variable on Windows and MSBuild on Unix.
@@ -47,6 +42,7 @@
     <!-- Output directories -->
     <BinDir Condition="'$(BinDir)'==''">$(ProjectDir)bin/</BinDir>
     <ObjDir Condition="'$(ObjDir)'==''">$(BinDir)obj/</ObjDir>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'==''">$(ObjDir)</BaseIntermediateOutputPath>
     <TestWorkingDir Condition="'$(TestWorkingDir)'==''">$(BinDir)tests/</TestWorkingDir>
     <PackagesOutDir Condition="'$(PackagesOutDir)'==''">$(BinDir)packages/</PackagesOutDir>
 
@@ -64,6 +60,8 @@
   <PropertyGroup Condition="'$(UseRoslynCompilers)'!='false'">
     <UseSharedCompilation>true</UseSharedCompilation>
   </PropertyGroup>
+  
+  <Import Project="$(ToolRuntimePath)/BuildVersion.targets" Condition="'$(SkipVersionGeneration)'!='true'" />
   <Import Project="$(ToolRuntimePath)/net45/roslyn/build/Microsoft.Net.Compilers.props" Condition="'$(UseRoslynCompilers)'!='false'" />
 
   <!-- Import packaging props -->
@@ -434,7 +432,6 @@
     <BaseOutputPath Condition="'$(BaseOutputPath)'==''">$(BinDir)</BaseOutputPath>
     <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)$(OSPlatformConfig)/$(MSBuildProjectName)/$(TargetOutputRelPath)</OutputPath>
 
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'==''">$(ObjDir)</BaseIntermediateOutputPath>
     <IntermediateOutputRootPath Condition="'$(IntermediateOutputRootPath)' == ''">$(BaseIntermediateOutputPath)$(OSPlatformConfig)/</IntermediateOutputRootPath>
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(IntermediateOutputRootPath)$(MSBuildProjectName)/$(TargetOutputRelPath)</IntermediateOutputPath>
 


### PR DESCRIPTION
Once dotnet/buildtools#542 is merged and a new package is generated, this are the changes that are required for using versioning when building in the open.

Generating a new file that contains the build version number seemed like the cleanest and best solution for now so I decided to do that, but I'm open to suggestions if anybody feels like doing something else would be better.

CC: @weshaggard @gkhanna79 @jhendrixMSFT @ericstj @markwilkie