### PR TITLE
Fix MMF test failure due to inheritable handles

### DIFF
--- a/src/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
@@ -43,6 +43,7 @@
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>
     </Compile>
+    <Compile Include="XunitAssemblyAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.IO.MemoryMappedFiles/tests/XunitAssemblyAttributes.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/XunitAssemblyAttributes.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+// Some tests launch processes.  If other tests that run concurrently create inheritable maps and the launched
+// process inherits it, then the lifetime of those maps will be extended beyond when the test expects, leading
+// to failures due to naming conflicts and the like.
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]


### PR DESCRIPTION
Some tests create maps with inheritable handles.  Other tests launch processes.  If those tests end up running concurrently in a manner where the launched process inherits the handle, it'll end up extending the lifetime of the map beyond what the tests were expecting.  This has been leading to random test failures like "Cannot create a file when that file already exists".

This commit simply disables parallelization of the MMF tests.  This has little impact on the running time of the tests, but if in the future we add the ability to disable inheriting handles when using Process.Start, we could use that instead.

Fixes https://github.com/dotnet/corefx/issues/6911
cc: @ericeil, @ianhays