### PR TITLE
Fix unix System.Private.Uri package

### DIFF
--- a/src/System.Private.Uri/pkg/unix/System.Private.Uri.pkgproj
+++ b/src/System.Private.Uri/pkg/unix/System.Private.Uri.pkgproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Private.Uri.csproj" >
-      <AdditionalProperties>FilterToOSGroup=Linux</AdditionalProperties>
+      <OSGroup>Unix</OSGroup>
     </ProjectReference>
 
     <ProjectReference Include="$(NativePackagePath)\runtime.native.System\runtime.native.System.pkgproj" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/6883

When we turned off OSGroup filtering we didn't pass the correct
OSGroup from the pkgproj so we ended up with the default OSGroup
which is windows and so we ended up with a window version of this
library in runtime.unix.System.Private.Uri package. Which means
unix didn't have a version of this library.

cc @ericstj @chcosta