### PR TITLE
Add dummy impl for platform specific API

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-1.0.25-prerelease-00205
+1.0.25-prerelease-00206

--- a/src/Microsoft.Win32.Registry.AccessControl/pkg/Microsoft.Win32.Registry.AccessControl.builds
+++ b/src/Microsoft.Win32.Registry.AccessControl/pkg/Microsoft.Win32.Registry.AccessControl.builds
@@ -2,9 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="Microsoft.Win32.Registry.AccessControl.pkgproj">
-      <OSGroup>Windows_NT</OSGroup>
-    </Project>
+    <Project Include="Microsoft.Win32.Registry.AccessControl.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Microsoft.Win32.Registry.AccessControl/pkg/Microsoft.Win32.Registry.AccessControl.pkgproj
+++ b/src/Microsoft.Win32.Registry.AccessControl/pkg/Microsoft.Win32.Registry.AccessControl.pkgproj
@@ -11,13 +11,6 @@
     <NotSupportedOnTargetFramework Include="netcore50">
       <PackageTargetRuntime>win</PackageTargetRuntime>
     </NotSupportedOnTargetFramework>
-
-    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
-    <!-- Only supported on windows, so overriding
-         the validation RID's -->
-    <ValidateFramework Include="netstandardapp1.5"> 
-      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
-    </ValidateFramework> 
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Microsoft.Win32.Registry.AccessControl/src/Microsoft.Win32.Registry.AccessControl.builds
+++ b/src/Microsoft.Win32.Registry.AccessControl/src/Microsoft.Win32.Registry.AccessControl.builds
@@ -6,6 +6,9 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="Microsoft.Win32.Registry.AccessControl.csproj">
+      <OSGroup>Unix</OSGroup>
+    </Project>
+    <Project Include="Microsoft.Win32.Registry.AccessControl.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project>
   </ItemGroup>

--- a/src/Microsoft.Win32.Registry.AccessControl/src/Microsoft.Win32.Registry.AccessControl.csproj
+++ b/src/Microsoft.Win32.Registry.AccessControl/src/Microsoft.Win32.Registry.AccessControl.csproj
@@ -10,14 +10,16 @@
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net46'">None</ResourcesSourceOutputDirectory>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
-    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net46'">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net46' AND '$(TargetsWindows)' == 'true'">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' == ''">
+  <ItemGroup Condition="'$(TargetGroup)' == '' AND '$(TargetsWindows)' == 'true'">
     <Compile Include="Microsoft\Win32\RegistryAclExtensions.cs" />
     <Compile Include="System\Security\AccessControl\RegistrySecurity.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.Errors.cs">

--- a/src/Microsoft.Win32.Registry/pkg/Microsoft.Win32.Registry.builds
+++ b/src/Microsoft.Win32.Registry/pkg/Microsoft.Win32.Registry.builds
@@ -2,9 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="Microsoft.Win32.Registry.pkgproj">
-      <OSGroup>Windows_NT</OSGroup>
-    </Project>
+    <Project Include="Microsoft.Win32.Registry.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Microsoft.Win32.Registry/pkg/Microsoft.Win32.Registry.pkgproj
+++ b/src/Microsoft.Win32.Registry/pkg/Microsoft.Win32.Registry.pkgproj
@@ -11,13 +11,6 @@
     <NotSupportedOnTargetFramework Include="netcore50">
       <PackageTargetRuntime>win</PackageTargetRuntime>
     </NotSupportedOnTargetFramework>
-
-    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
-    <!-- Only supported on windows, so overriding
-         the validation RID's -->
-    <ValidateFramework Include="netstandardapp1.5"> 
-      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
-    </ValidateFramework> 
   </ItemGroup>
   
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.builds
+++ b/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.builds
@@ -6,6 +6,9 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="Microsoft.Win32.Registry.csproj">
+      <OSGroup>Unix</OSGroup>
+    </Project>
+    <Project Include="Microsoft.Win32.Registry.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project>
   </ItemGroup>

--- a/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
+++ b/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
@@ -11,15 +11,19 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
-    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net46'">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net46' AND '$(TargetsWindows)' == 'true'">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net46' AND '$(TargetsWindows)' == 'true'">
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem.AccessControl/pkg/System.IO.FileSystem.AccessControl.pkgproj
+++ b/src/System.IO.FileSystem.AccessControl/pkg/System.IO.FileSystem.AccessControl.pkgproj
@@ -11,12 +11,6 @@
     <NotSupportedOnTargetFramework Include="netcore50">
       <PackageTargetRuntime>win</PackageTargetRuntime>
     </NotSupportedOnTargetFramework>
-    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
-    <!-- Only supported on windows, so overriding
-         the validation RID's -->
-    <ValidateFramework Include="netstandardapp1.5"> 
-      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
-    </ValidateFramework> 
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.IO.FileSystem.AccessControl/src/System.IO.FileSystem.AccessControl.builds
+++ b/src/System.IO.FileSystem.AccessControl/src/System.IO.FileSystem.AccessControl.builds
@@ -2,7 +2,12 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.IO.FileSystem.AccessControl.csproj" />
+    <Project Include="System.IO.FileSystem.AccessControl.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="System.IO.FileSystem.AccessControl.csproj" >
+      <OSGroup>Unix</OSGroup>
+    </Project>
     <Project Include="System.IO.FileSystem.AccessControl.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project>

--- a/src/System.IO.FileSystem.AccessControl/src/System.IO.FileSystem.AccessControl.csproj
+++ b/src/System.IO.FileSystem.AccessControl/src/System.IO.FileSystem.AccessControl.csproj
@@ -7,7 +7,9 @@
     <ProjectGuid>{D77FBA6C-1AA6-45A4-93E2-97A370672C53}</ProjectGuid>
     <AllowUnsafeBlocks Condition="'$(TargetGroup)'==''">true</AllowUnsafeBlocks>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.3</PackageTargetFramework>
-    <PackageTargetRuntime  Condition="'$(TargetGroup)' == ''">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net46' AND '$(TargetsWindows)' == 'true'">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
@@ -16,7 +18,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)'!='net46'">
+  <ItemGroup Condition="'$(TargetGroup)'!='net46' AND '$(TargetsWindows)'=='true'">
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.Errors.cs">
       <Link>Common\Interop\Windows\mincore\Interop.Errors.cs</Link>
     </Compile>

--- a/src/System.Net.Http.WinHttpHandler/pkg/System.Net.Http.WinHttpHandler.builds
+++ b/src/System.Net.Http.WinHttpHandler/pkg/System.Net.Http.WinHttpHandler.builds
@@ -2,9 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Net.Http.WinHttpHandler.pkgproj">
-      <OSGroup>Windows_NT</OSGroup>
-    </Project>
+    <Project Include="System.Net.Http.WinHttpHandler.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Net.Http.WinHttpHandler/pkg/System.Net.Http.WinHttpHandler.pkgproj
+++ b/src/System.Net.Http.WinHttpHandler/pkg/System.Net.Http.WinHttpHandler.pkgproj
@@ -11,12 +11,6 @@
     <NotSupportedOnTargetFramework Include="netcore50">
       <PackageTargetRuntime>win</PackageTargetRuntime>
     </NotSupportedOnTargetFramework>
-    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
-    <!-- Only supported on windows, so overriding
-         the validation RID's -->
-    <ValidateFramework Include="netstandardapp1.5"> 
-      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
-    </ValidateFramework> 
   </ItemGroup>
   
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.builds
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.builds
@@ -6,6 +6,9 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="System.Net.Http.WinHttpHandler.csproj">
+      <OSGroup>Unix</OSGroup>
+    </Project>
+    <Project Include="System.Net.Http.WinHttpHandler.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project>
   </ItemGroup>

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
@@ -12,7 +12,9 @@
     <AssemblyName>System.Net.Http.WinHttpHandler</AssemblyName>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
-    <PackageTargetRuntime Condition="'$(PackageTargetFramework)' == ''">win</PackageTargetRuntime> 
+    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net46' AND '$(TargetsWindows)' == 'true'">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   

--- a/src/System.Runtime.InteropServices.WindowsRuntime/pkg/System.Runtime.InteropServices.WindowsRuntime.builds
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/pkg/System.Runtime.InteropServices.WindowsRuntime.builds
@@ -2,9 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Runtime.InteropServices.WindowsRuntime.pkgproj">
-      <OSGroup>Windows_NT</OSGroup>
-    </Project>
+    <Project Include="System.Runtime.InteropServices.WindowsRuntime.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime.InteropServices.WindowsRuntime/pkg/System.Runtime.InteropServices.WindowsRuntime.pkgproj
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/pkg/System.Runtime.InteropServices.WindowsRuntime.pkgproj
@@ -13,12 +13,6 @@
     <InboxOnTargetFramework Include="win8" />
     <InboxOnTargetFramework Include="wp80" />
     <InboxOnTargetFramework Include="wpa81" />
-    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
-    <!-- Only supported on win8 and higher, so overriding
-         the validation RID's -->
-    <ValidateFramework Include="netstandardapp1.5">
-      <RuntimeIDs>win8-x86;win8-x64</RuntimeIDs>
-    </ValidateFramework>
     <NotSupportedOnTargetFramework Include="xamarinios1" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/System.Runtime.InteropServices.WindowsRuntime.builds
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/System.Runtime.InteropServices.WindowsRuntime.builds
@@ -2,9 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Runtime.InteropServices.WindowsRuntime.csproj">
-      <OSGroup>Windows_NT</OSGroup>
-    </Project>
+    <Project Include="System.Runtime.InteropServices.WindowsRuntime.csproj"/>
     <!-- Net46 facade is currently inbox for 4.0 
     <Project Include="System.Runtime.InteropServices.WindowsRuntime.csproj">
       <TargetGroup>net46</TargetGroup>

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/System.Runtime.InteropServices.WindowsRuntime.csproj
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/System.Runtime.InteropServices.WindowsRuntime.csproj
@@ -10,7 +10,6 @@
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
-    <PackageTargetRuntime>win8</PackageTargetRuntime>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />

--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
@@ -37,7 +37,9 @@
     <ProjectReference Include="..\..\System.Diagnostics.Tools\src\System.Diagnostics.Tools.csproj" />
     <ProjectReference Include="..\..\System.ObjectModel\src\System.ObjectModel.csproj"/>
     <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.csproj" />
-    <ProjectReference Include="..\..\System.Runtime.InteropServices.WindowsRuntime\src\System.Runtime.InteropServices.WindowsRuntime.csproj" />
+    <ProjectReference Include="..\..\System.Runtime.InteropServices.WindowsRuntime\src\System.Runtime.InteropServices.WindowsRuntime.csproj">
+      <UndefineProperties>OSGroup</UndefineProperties>
+    </ProjectReference>
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
     <Compile Include="System\IO\StreamOperationAsyncResult.netstandard.cs" />
     <Compile Include="System\Runtime\InteropServices\WindowsRuntime\MarshalingHelpers.cs" />

--- a/src/System.Security.AccessControl/pkg/System.Security.AccessControl.pkgproj
+++ b/src/System.Security.AccessControl/pkg/System.Security.AccessControl.pkgproj
@@ -9,14 +9,7 @@
 
     <NotSupportedOnTargetFramework Include="netcore50">
       <PackageTargetRuntime>win</PackageTargetRuntime>
-    </NotSupportedOnTargetFramework>
-
-    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
-    <!-- Only supported on windows, so overriding
-         the validation RID's -->
-    <ValidateFramework Include="netstandardapp1.5"> 
-      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
-    </ValidateFramework> 
+    </NotSupportedOnTargetFramework> 
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Security.AccessControl/src/System.Security.AccessControl.builds
+++ b/src/System.Security.AccessControl/src/System.Security.AccessControl.builds
@@ -2,7 +2,12 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Security.AccessControl.csproj" />
+    <Project Include="System.Security.AccessControl.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="System.Security.AccessControl.csproj">
+      <OSGroup>Unix</OSGroup>
+    </Project>
     <Project Include="System.Security.AccessControl.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project>

--- a/src/System.Security.AccessControl/src/System.Security.AccessControl.csproj
+++ b/src/System.Security.AccessControl/src/System.Security.AccessControl.csproj
@@ -6,8 +6,10 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46'" >true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
-    <PackageTargetRuntime Condition="'$(TargetGroup)' == ''">win</PackageTargetRuntime>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net46' AND '$(TargetsWindows)' == 'true'">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
 
@@ -20,7 +22,7 @@
   <ItemGroup Condition="'$(TargetGroup)'=='net46'" >
     <TargetingPackReference Include="mscorlib" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'==''">
+  <ItemGroup Condition="'$(TargetGroup)'=='' AND '$(TargetsWindows)'=='true'">
     <Compile Include="System\Security\AccessControl\ACE.cs" />
     <Compile Include="System\Security\AccessControl\ACL.cs" />
     <Compile Include="System\Security\AccessControl\CommonObjectSecurity.cs" />

--- a/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
+++ b/src/System.Security.Cryptography.Cng/pkg/System.Security.Cryptography.Cng.pkgproj
@@ -10,13 +10,6 @@
       <SupportedFramework>net461;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Cng.builds" />
-
-    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
-    <!-- Only supported on windows, so overriding
-         the validation RID's -->
-    <ValidateFramework Include="netstandardapp1.5">
-      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs>
-    </ValidateFramework>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.builds
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.builds
@@ -2,7 +2,12 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Security.Cryptography.Cng.csproj" />
+    <Project Include="System.Security.Cryptography.Cng.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="System.Security.Cryptography.Cng.csproj">
+      <OSGroup>Unix</OSGroup>
+    </Project>
     <Project Include="System.Security.Cryptography.Cng.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project>

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -13,13 +13,15 @@
     <ResourcesSourceOutputDirectory Condition="'$(IsPartialFacadeAssembly)' == 'true'">None</ResourcesSourceOutputDirectory>
     <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.4</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.4</NuGetTargetMoniker>
-    <PackageTargetRuntime Condition="'$(TargetGroup)' == ''">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net46' AND '$(TargetsWindows)' == 'true'">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true' AND '$(TargetsWindows)' == 'true'">
     <Compile Include="System\Security\Cryptography\AesCng.cs" />
     <Compile Include="System\Security\Cryptography\CngAlgorithm.cs" />
     <Compile Include="System\Security\Cryptography\CngAlgorithmGroup.cs" />

--- a/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -20,20 +20,14 @@
     <Compile Include="CreateTests.cs" />
     <Compile Include="HandleTests.cs" />
     <Compile Include="OpenTests.cs" />
-    <Compile Include="InvasiveCngTests.cs" />
     <Compile Include="ImportExportTests.cs" />
     <Compile Include="PropertyTests.cs" />
     <Compile Include="RsaCngTests.cs" />
     <Compile Include="ECDsaCngTests.cs" />
     <Compile Include="TestData.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
-      <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\CryptoUtils.cs">
-      <Link>CommonTest\System\Security\Cryptography\CryptoUtils.cs</Link>
-    </Compile>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+    <Compile Include="InvasiveCngTests.cs" />
 
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesCipherTests.Data.cs">
       <Link>CommonTest\AlgorithmImplementations\AES\AesCipherTests.Data.cs</Link>
@@ -67,6 +61,14 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESReusabilityTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESReusabilityTests.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
+      <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\CryptoUtils.cs">
+      <Link>CommonTest\System\Security\Cryptography\CryptoUtils.cs</Link>
     </Compile>
 
     <Compile Include="RSACngProvider.cs" />

--- a/src/System.Security.Cryptography.Csp/pkg/System.Security.Cryptography.Csp.pkgproj
+++ b/src/System.Security.Cryptography.Csp/pkg/System.Security.Cryptography.Csp.pkgproj
@@ -9,12 +9,6 @@
     <NotSupportedOnTargetFramework Include="netcore50">
       <PackageTargetRuntime>win</PackageTargetRuntime>
     </NotSupportedOnTargetFramework>
-    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
-    <!-- Only supported on windows, so overriding
-         the validation RID's -->
-    <ValidateFramework Include="netstandardapp1.5">
-      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs>
-    </ValidateFramework>
   </ItemGroup>
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.builds
+++ b/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.builds
@@ -2,7 +2,12 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Security.Cryptography.Csp.csproj" />
+    <Project Include="System.Security.Cryptography.Csp.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="System.Security.Cryptography.Csp.csproj">
+      <OSGroup>Unix</OSGroup>
+    </Project>
     <Project Include="System.Security.Cryptography.Csp.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project>

--- a/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
+++ b/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
@@ -10,14 +10,16 @@
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net46'">None</ResourcesSourceOutputDirectory>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
-    <PackageTargetRuntime Condition="'$(TargetGroup)' == ''">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net46' AND '$(TargetsWindows)' == 'true'">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net46' AND '$(TargetsWindows)' == 'true'">
     <Compile Include="System\Security\Cryptography\CspProviderFlags.cs" />
     <Compile Include="System\Security\Cryptography\ICspAsymmetricAlgorithm.cs" />
     <Compile Include="System\Security\Cryptography\KeyNumber.cs" />

--- a/src/System.Security.Cryptography.OpenSsl/pkg/System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/System.Security.Cryptography.OpenSsl/pkg/System.Security.Cryptography.OpenSsl.pkgproj
@@ -4,20 +4,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Security.Cryptography.OpenSsl.csproj">
-      <SupportedFramework>netstandardapp1.5</SupportedFramework>
+      <SupportedFramework>netstandardapp1.5;net461;netcore50</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Security.Cryptography.OpenSsl.csproj" >
-      <OSGroup>Linux</OSGroup>
-    </ProjectReference>
+    <ProjectReference Include="..\src\System.Security.Cryptography.OpenSsl.builds" />
 
     <ProjectReference Include="$(NativePackagePath)\runtime.native.System.Security.Cryptography\runtime.native.System.Security.Cryptography.pkgproj" />
-
-    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
-    <!-- Only supported on windows, so overriding
-         the validation RID's -->
-    <ValidateFramework Include="netstandardapp1.5">
-      <RuntimeIDs>osx.10.11-x64;centos.7.1-x64;ubuntu.14.04-x64;linuxmint.17-x64</RuntimeIDs>
-    </ValidateFramework>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.builds
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.builds
@@ -3,13 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Security.Cryptography.OpenSsl.csproj">
-      <OSGroup>FreeBSD</OSGroup>
+      <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="System.Security.Cryptography.OpenSsl.csproj">
-      <OSGroup>Linux</OSGroup>
-    </Project>
-    <Project Include="System.Security.Cryptography.OpenSsl.csproj">
-      <OSGroup>OSX</OSGroup>
+      <OSGroup>Unix</OSGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">Linux_Debug</Configuration>
+    <Configuration Condition="'$(Configuration)'==''">Unix_Debug</Configuration>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -13,17 +13,13 @@
     <CLSCompliant>false</CLSCompliant>
     <PackageTargetFramework>netstandard1.4</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.4</NuGetTargetMoniker>
-    <!-- Temporarily remove the RID from this package until we have a  
-         cross platform API to use RSA https://github.com/dotnet/corefx/issues/2953 -->  
-    <PackageTargetRuntime Condition="'$(TargetGroup)' == ''">unix</PackageTargetRuntime>  
+    <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetsWindows)' == 'true'">win</PackageTargetRuntime>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsWindows)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX_Release|AnyCPU'" />
-  <ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Compile Include="System\Security\Cryptography\ECDsaOpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\RSAOpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\SafeEvpPKeyHandle.Unix.cs" />

--- a/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.builds
+++ b/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.builds
@@ -6,6 +6,9 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="System.Security.Principal.Windows.csproj">
+      <OSGroup>Unix</OSGroup>
+    </Project>
+    <Project Include="System.Security.Principal.Windows.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project>
   </ItemGroup>

--- a/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
+++ b/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
@@ -12,9 +12,9 @@
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net46'">None</ResourcesSourceOutputDirectory>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
-    <!-- Temporarily remove the RID from this package until nuget has a way for folks
-         to consume platform-specific packages https://github.com/dotnet/corefx/issues/4925 -->
-    <!-- PackageTargetRuntime>win7</PackageTargetRuntime -->
+    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net46' AND '$(TargetsWindows)' == 'true'">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
   </PropertyGroup>
 
   <!-- Default configurations to help VS understand the options -->
@@ -23,7 +23,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
 
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net46' AND '$(TargetsWindows)' == 'true'">
     <Compile Include="Microsoft\Win32\SafeHandles\SafeAccessTokenHandle.cs"/>
     <Compile Include="Microsoft\Win32\SafeHandles\SafeSecurityHandles.cs"/>
     <Compile Include="System\Security\Principal\IdentityNotMappedException.cs"/>

--- a/src/System.ServiceProcess.ServiceController/pkg/System.ServiceProcess.ServiceController.builds
+++ b/src/System.ServiceProcess.ServiceController/pkg/System.ServiceProcess.ServiceController.builds
@@ -2,9 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.ServiceProcess.ServiceController.pkgproj">
-      <OSGroup>Windows_NT</OSGroup>
-    </Project>
+    <Project Include="System.ServiceProcess.ServiceController.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.ServiceProcess.ServiceController/pkg/System.ServiceProcess.ServiceController.pkgproj
+++ b/src/System.ServiceProcess.ServiceController/pkg/System.ServiceProcess.ServiceController.pkgproj
@@ -11,12 +11,6 @@
     <NotSupportedOnTargetFramework Include="netcore50">
       <PackageTargetRuntime>win</PackageTargetRuntime>
     </NotSupportedOnTargetFramework>
-    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
-    <!-- Only supported on windows, so overriding
-         the validation RID's -->
-    <ValidateFramework Include="netstandardapp1.5"> 
-      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
-    </ValidateFramework>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.ServiceProcess.ServiceController/src/System.ServiceProcess.ServiceController.builds
+++ b/src/System.ServiceProcess.ServiceController/src/System.ServiceProcess.ServiceController.builds
@@ -6,6 +6,9 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="System.ServiceProcess.ServiceController.csproj">
+      <OSGroup>Unix</OSGroup>
+    </Project>
+    <Project Include="System.ServiceProcess.ServiceController.csproj">
       <TargetGroup>net461</TargetGroup>
     </Project>
   </ItemGroup>

--- a/src/System.ServiceProcess.ServiceController/src/System.ServiceProcess.ServiceController.csproj
+++ b/src/System.ServiceProcess.ServiceController/src/System.ServiceProcess.ServiceController.csproj
@@ -13,14 +13,16 @@
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net461'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net461'">None</ResourcesSourceOutputDirectory>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.5</PackageTargetFramework>
-    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net461'">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net461' AND '$(TargetsWindows)' == 'true'">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net461_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net461_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'net461'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net461' AND '$(TargetsWindows)' == 'true'">
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>

--- a/src/System.Threading.AccessControl/pkg/System.Threading.AccessControl.pkgproj
+++ b/src/System.Threading.AccessControl/pkg/System.Threading.AccessControl.pkgproj
@@ -11,13 +11,6 @@
     <NotSupportedOnTargetFramework Include="netcore50">
       <PackageTargetRuntime>win</PackageTargetRuntime>
     </NotSupportedOnTargetFramework>
-
-    <ExcludeDefaultValidateFramework Include="netstandardapp1.5" />
-    <!-- Only supported on windows, so overriding
-         the validation RID's -->
-    <ValidateFramework Include="netstandardapp1.5"> 
-      <RuntimeIDs>win7-x86;win7-x64</RuntimeIDs> 
-    </ValidateFramework> 
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Threading.AccessControl/src/System.Threading.AccessControl.builds
+++ b/src/System.Threading.AccessControl/src/System.Threading.AccessControl.builds
@@ -2,7 +2,12 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Threading.AccessControl.csproj" />
+    <Project Include="System.Threading.AccessControl.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="System.Threading.AccessControl.csproj">
+      <OSGroup>Unix</OSGroup>
+    </Project>
     <Project Include="System.Threading.AccessControl.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project>

--- a/src/System.Threading.AccessControl/src/System.Threading.AccessControl.csproj
+++ b/src/System.Threading.AccessControl/src/System.Threading.AccessControl.csproj
@@ -6,7 +6,9 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <ProjectGuid>{E3ED83FD-3015-4BD8-A1B8-6294986E6CFA}</ProjectGuid>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
-    <PackageTargetRuntime Condition="'$(TargetGroup)' == ''">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' != 'net46' AND '$(TargetsWindows)' == 'true'">win</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
@@ -16,7 +18,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
   
-  <ItemGroup Condition="'$(TargetGroup)'==''">
+  <ItemGroup Condition="'$(TargetGroup)'=='' AND '$(TargetsWindows)'=='true'">
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>


### PR DESCRIPTION
This adds dummy implementations for platform specific API.  The
implementation assemblies throw PlatformNotSupported for all methods.

This will satisfy NuGet's guardrails check and also let folks compile
against these assemblies and load them at runtime without JIT failures.

We will not be placing these packages in any of the shared-framework
layouts, nor should any of these ever be depended on by CoreFx
libraries.  But we will provide them to enable folks to write platform
lightup code without having to worry about using reflection or guarding
calls in separate methods disabling JIT inlining.

These assemblies are marked with AssemblyMetadata("NotSupported",
"True"), so that future dev-time tooling can detect them and warn/error
in the case of accidental dependence on platform specific API.

One notable difference is
System.Runtime.InteropSerivices.WindowsRuntime: this assembly was
previously part of portable profiles and implementation exists in
mscorlib.  For this we will forward to mscorlib on all platforms and it
is up to mscorlib to determine implementation (throw vs noop).
Fixes dotnet#6684

Other platform specific contracts that have been excluded:
System.IO.IsolatedStorage: currently only supported for netcore50 so no
need to address this problem for x-plat.
System.Runtime.WindowsRuntime & System.Runtime.WindowsRuntime.UI.Xaml:
both are WinRT specific and not exposed in any PCL profiles that we
expect folks to use with x-plat NET core.