### PR TITLE
Kerberos sign only interop issue

### DIFF
--- a/src/Native/Common/pal_config.h.in
+++ b/src/Native/Common/pal_config.h.in
@@ -49,6 +49,7 @@
 #cmakedefine01 HAVE_OPEN_MAX
 #cmakedefine01 HAVE_GSSFW_HEADERS
 #cmakedefine01 HAVE_GSS_SPNEGO_MECHANISM
+#cmakedefine01 HAVE_GSS_KRB5_CRED_NO_CI_FLAGS_X
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/Native/System.Net.Security.Native/pal_gssapi.cpp
+++ b/src/Native/System.Net.Security.Native/pal_gssapi.cpp
@@ -63,8 +63,19 @@ static uint32_t NetSecurityNative_AcquireCredSpNego(uint32_t* minorStatus,
     gss_OID_desc gss_mech_spnego_OID_desc = {.length = 6, .elements = static_cast<void*>(gss_mech_value)};
     gss_OID_set_desc gss_mech_spnego_OID_set_desc = {.count = 1, .elements = &gss_mech_spnego_OID_desc};
 #endif
-    return gss_acquire_cred(
+    uint32_t majorStatus = gss_acquire_cred(
         minorStatus, desiredName, 0, &gss_mech_spnego_OID_set_desc, credUsage, outputCredHandle, nullptr, nullptr);
+
+    // call gss_set_cred_option with GSS_KRB5_CRED_NO_CI_FLAGS_X to support Kerberos Sign Only option from *nix client against a windows server
+#if HAVE_GSS_KRB5_CRED_NO_CI_FLAGS_X
+    if (majorStatus == GSS_S_COMPLETE)
+    {
+        GssBuffer emptyBuffer = GSS_C_EMPTY_BUFFER;
+        majorStatus = gss_set_cred_option(minorStatus, outputCredHandle, GSS_KRB5_CRED_NO_CI_FLAGS_X, &emptyBuffer);
+    }
+#endif
+
+    return majorStatus;
 }
 
 extern "C" uint32_t
@@ -294,8 +305,19 @@ static uint32_t NetSecurityNative_AcquireCredWithPassword(uint32_t* minorStatus,
     assert(outputCredHandle != nullptr);
 
     GssBuffer passwordBuffer{.length = passwdLen, .value = password};
-    return gss_acquire_cred_with_password(
+    uint32_t majorStatus = gss_acquire_cred_with_password(
         minorStatus, desiredName, &passwordBuffer, 0, nullptr, credUsage, outputCredHandle, nullptr, nullptr);
+
+    // call gss_set_cred_option with GSS_KRB5_CRED_NO_CI_FLAGS_X to support Kerberos Sign Only option from *nix client against a windows server
+#if HAVE_GSS_KRB5_CRED_NO_CI_FLAGS_X
+    if (majorStatus == GSS_S_COMPLETE)
+    {
+        GssBuffer emptyBuffer = GSS_C_EMPTY_BUFFER;
+        majorStatus = gss_set_cred_option(minorStatus, outputCredHandle, GSS_KRB5_CRED_NO_CI_FLAGS_X, &emptyBuffer);
+    }
+#endif
+
+    return majorStatus;
 }
 
 extern "C" uint32_t NetSecurityNative_InitiateCredWithPassword(

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -353,6 +353,17 @@ else ()
         HAVE_GSS_SPNEGO_MECHANISM)
 endif ()
 
+if (HAVE_GSSFW_HEADERS)
+    check_symbol_exists(
+        GSS_KRB5_CRED_NO_CI_FLAGS_X
+        "GSS/GSS.h"
+        HAVE_GSS_KRB5_CRED_NO_CI_FLAGS_X)
+else ()
+    check_symbol_exists(
+        GSS_KRB5_CRED_NO_CI_FLAGS_X
+        "gssapi/gssapi_krb5.h"
+        HAVE_GSS_KRB5_CRED_NO_CI_FLAGS_X)
+endif ()
 
 
 set (CMAKE_REQUIRED_LIBRARIES)

--- a/src/System.Net.Security/src/Resources/Strings.resx
+++ b/src/System.Net.Security/src/Resources/Strings.resx
@@ -441,4 +441,7 @@
   <data name="net_nego_server_not_supported" xml:space="preserve">
     <value>Server implementation is not supported</value>
   </data>
+  <data name="net_nego_protection_level_not_supported" xml:space="preserve">
+    <value>Requested protection level is not supported with the gssapi implementation currently installed.</value>
+  </data>
 </root>


### PR DESCRIPTION
When kerberos is negotiated with Sign Only protection level from *nix
client against a windows server, *nix client interprets the session flags
as supported and hence always set CONFIDENTIALITY flag irrespective of
the requested flags/protection level. This, in windows server which
interprets the flags as required, causes the windows server to expect all
further communication to be encrypted, which is not the case and hence
server side processing fails.
To override this behavior, starting MIT Kerberos 1.14 and heimdal
implementation, we need to call gss_set_cred_option with
GSS_KRB5_CRED_NO_CI_FLAGS_X. When not available, the windows server should
fail in negotiating Sign Only.

@stephentoub @bartonjs @vijaykota @kapilash @shrutigarg