### PR TITLE
fixing bug in contextflag mapping

### DIFF
--- a/src/System.Net.Security/src/System/Net/ContextFlagsAdapterPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/ContextFlagsAdapterPal.Unix.cs
@@ -22,8 +22,6 @@ namespace System.Net
 
         private static readonly ContextFlagMapping[] s_contextFlagMapping = new[]
         {
-            // GSS_C_INTEG_FLAG is set if either AcceptIntegrity (used by server) or InitIntegrity (used by client) is set
-            new ContextFlagMapping(Interop.NetSecurityNative.GssFlags.GSS_C_INTEG_FLAG, ContextFlagsPal.AcceptIntegrity | ContextFlagsPal.InitIntegrity),
             new ContextFlagMapping(Interop.NetSecurityNative.GssFlags.GSS_C_CONF_FLAG, ContextFlagsPal.Confidentiality),
             new ContextFlagMapping(Interop.NetSecurityNative.GssFlags.GSS_C_IDENTIFY_FLAG, ContextFlagsPal.InitIdentify),
             new ContextFlagMapping(Interop.NetSecurityNative.GssFlags.GSS_C_MUTUAL_FLAG, ContextFlagsPal.MutualAuth),
@@ -32,9 +30,16 @@ namespace System.Net
         };
 
 
-        internal static ContextFlagsPal GetContextFlagsPalFromInterop(Interop.NetSecurityNative.GssFlags gssFlags)
+        internal static ContextFlagsPal GetContextFlagsPalFromInterop(Interop.NetSecurityNative.GssFlags gssFlags, bool isServer)
         {
             ContextFlagsPal flags = ContextFlagsPal.Zero;
+
+            // GSS_C_INTEG_FLAG is handled separately as its value can either be AcceptIntegrity (used by server) or InitIntegrity (used by client)
+            if ((gssFlags & Interop.NetSecurityNative.GssFlags.GSS_C_INTEG_FLAG) != 0)
+            {
+                flags |= isServer ? ContextFlagsPal.AcceptIntegrity : ContextFlagsPal.InitIntegrity;
+            }
+
             foreach (ContextFlagMapping mapping in s_contextFlagMapping)
             {
                 if ((gssFlags & mapping.GssFlags) != 0)
@@ -46,9 +51,26 @@ namespace System.Net
             return flags;
         }
 
-        internal static Interop.NetSecurityNative.GssFlags GetInteropFromContextFlagsPal(ContextFlagsPal flags)
+        internal static Interop.NetSecurityNative.GssFlags GetInteropFromContextFlagsPal(ContextFlagsPal flags, bool isServer)
         {
             Interop.NetSecurityNative.GssFlags gssFlags = (Interop.NetSecurityNative.GssFlags)0;
+
+            // GSS_C_INTEG_FLAG is set if either AcceptIntegrity (used by server) or InitIntegrity (used by client) is set
+            if (isServer)
+            {
+                if ((flags & ContextFlagsPal.AcceptIntegrity) != 0)
+                {
+                    gssFlags |= Interop.NetSecurityNative.GssFlags.GSS_C_INTEG_FLAG;
+                }
+            }
+            else
+            {
+                if ((flags & ContextFlagsPal.InitIntegrity) != 0)
+                {
+                    gssFlags |= Interop.NetSecurityNative.GssFlags.GSS_C_INTEG_FLAG;
+                }
+            }
+
             foreach (ContextFlagMapping mapping in s_contextFlagMapping)
             {
                 if ((flags & mapping.ContextFlag) != 0)

--- a/src/System.Net.Security/src/System/Net/NegotiateStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/NegotiateStreamPal.Unix.cs
@@ -253,7 +253,7 @@ namespace System.Net.Security
             SafeDeleteNegoContext negoContext = (SafeDeleteNegoContext)context;
             try
             {
-                Interop.NetSecurityNative.GssFlags inputFlags = ContextFlagsAdapterPal.GetInteropFromContextFlagsPal(inFlags);
+                Interop.NetSecurityNative.GssFlags inputFlags = ContextFlagsAdapterPal.GetInteropFromContextFlagsPal(inFlags, isServer:false);
                 uint outputFlags;
                 SafeGssContextHandle contextHandle = negoContext.GssContext;
                 bool done = Interop.GssApi.EstablishSecurityContext(
@@ -270,7 +270,7 @@ namespace System.Net.Security
                 outputBuffer.size = outputBuffer.token.Length;
                 outputBuffer.offset = 0;
 
-                outFlags = ContextFlagsAdapterPal.GetContextFlagsPalFromInterop((Interop.NetSecurityNative.GssFlags)outputFlags);
+                outFlags = ContextFlagsAdapterPal.GetContextFlagsPalFromInterop((Interop.NetSecurityNative.GssFlags)outputFlags, isServer:false);
                 Debug.Assert(negoContext.GssContext == null || contextHandle == negoContext.GssContext);
                 
                 // Save the inner context handle for further calls to NetSecurity


### PR DESCRIPTION
Since ContextFlagsPal enum has AcceptIntegrity flag  and InitIdentify flag with same value.. mapping of that to Native flag returns some invalid flag for a context.
Values being same is not an issue as these flags are used in independent contexts. we will have to limit the mapping by reading whether it is server or client context.