### PR TITLE
Query for the right proxy creds in HttpClient

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
@@ -171,10 +171,23 @@ namespace System.Net.Http
             // 407-401-407-401- loop.
             if (proxyAuthScheme != 0)
             {
+                ICredentials proxyCredentials;
+                Uri proxyUri;
+                if (state.Proxy != null)
+                {
+                    proxyCredentials = state.Proxy.Credentials;
+                    proxyUri = state.Proxy.GetProxy(state.RequestMessage.RequestUri);
+                }
+                else
+                {
+                    proxyCredentials = state.DefaultProxyCredentials;
+                    proxyUri = state.RequestMessage.RequestUri;
+                }
+
                 SetWinHttpCredential(
                     state.RequestHandle,
-                    state.Proxy == null ? state.DefaultProxyCredentials : state.Proxy.Credentials,
-                    state.RequestMessage.RequestUri,
+                    proxyCredentials,
+                    proxyUri,
                     proxyAuthScheme,
                     Interop.WinHttp.WINHTTP_AUTH_TARGET_PROXY);
             }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -363,7 +363,7 @@ namespace System.Net.Http
                 SetCurlOption(CURLoption.CURLOPT_PROXYPORT, proxyUri.Port);
                 EventSourceTrace("Proxy: {0}", proxyUri);
 
-                KeyValuePair<NetworkCredential, CURLAUTH> credentialScheme = GetCredentials(_requestMessage.RequestUri, _handler.Proxy.Credentials, AuthTypesPermittedByCredentialKind(_handler.Proxy.Credentials));
+                KeyValuePair<NetworkCredential, CURLAUTH> credentialScheme = GetCredentials(proxyUri, _handler.Proxy.Credentials, AuthTypesPermittedByCredentialKind(_handler.Proxy.Credentials));
                 NetworkCredential credentials = credentialScheme.Key;
                 if (credentials == CredentialCache.DefaultCredentials)
                 {


### PR DESCRIPTION
Both the WinHttp and libcurl implementations are using the target Uri to lookup the right proxy credentials rather than using the proxy's Uri.

cc: @davidsh, @alpaix, @ericeil, @cipop, @kapilash