### PR TITLE
Use localisable form of some exceptions in interpreter.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -932,7 +932,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// InvalidOperationException with message like "Invalid lvalue for assignment: {0}."
         /// </summary>
-        internal static Exception InvalidLvalue(object p0)
+        internal static Exception InvalidLvalue(ExpressionType p0)
         {
             return new InvalidOperationException(Strings.InvalidLvalue(p0));
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LabelInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LabelInfo.cs
@@ -68,7 +68,7 @@ namespace System.Linq.Expressions.Interpreter
             {
                 if (j.ContainsTarget(_node))
                 {
-                    throw new InvalidOperationException(String.Format(CultureInfo.InvariantCulture, "Label target already defined: {0}", _node.Name));
+                    Error.LabelTargetAlreadyDefined(_node.Name);
                 }
             }
 
@@ -89,7 +89,7 @@ namespace System.Linq.Expressions.Interpreter
                 // now invalid
                 if (_acrossBlockJump)
                 {
-                    throw new InvalidOperationException("Ambiguous jump");
+                    throw Error.AmbiguousJump(_node.Name);
                 }
                 // For local jumps, we need a new IL label
                 // This is okay because:
@@ -119,7 +119,7 @@ namespace System.Linq.Expressions.Interpreter
 
             if (HasMultipleDefinitions)
             {
-                throw new InvalidOperationException(String.Format(CultureInfo.InvariantCulture, "Ambiguous jump {0}", _node.Name));
+                throw Error.AmbiguousJump(_node.Name);
             }
 
             // We didn't find an outward jump. Look for a jump across blocks
@@ -131,11 +131,11 @@ namespace System.Linq.Expressions.Interpreter
             {
                 if (j.Kind == LabelScopeKind.Finally)
                 {
-                    throw new InvalidOperationException("Control cannot leave finally");
+                    throw Error.ControlCannotLeaveFinally();
                 }
                 if (j.Kind == LabelScopeKind.Filter)
                 {
-                    throw new InvalidOperationException("Control cannot leave filter test");
+                    throw Error.ControlCannotLeaveFilterTest();
                 }
             }
 
@@ -146,11 +146,11 @@ namespace System.Linq.Expressions.Interpreter
                 {
                     if (j.Kind == LabelScopeKind.Expression)
                     {
-                        throw new InvalidOperationException("Control cannot enter an expression");
+                        throw Error.ControlCannotEnterExpression();
                     }
                     else
                     {
-                        throw new InvalidOperationException("Control cannot enter try");
+                        throw Error.ControlCannotEnterTry();
                     }
                 }
             }
@@ -161,7 +161,7 @@ namespace System.Linq.Expressions.Interpreter
             // Make sure that if this label was jumped to, it is also defined
             if (_references.Count > 0 && !HasDefinitions)
             {
-                throw new InvalidOperationException("label target undefined");
+                throw Error.LabelTargetUndefined(_node.Name);
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -713,7 +713,7 @@ namespace System.Linq.Expressions.Interpreter
                     break;
 
                 default:
-                    throw new InvalidOperationException("Invalid lvalue for assignment: " + node.Left.NodeType);
+                    throw Error.InvalidLvalue(node.Left.NodeType);
             }
         }
 
@@ -1900,7 +1900,7 @@ namespace System.Linq.Expressions.Interpreter
                     break;
                 }
             }
-            throw new InvalidOperationException("Rethrow requires catch");
+            throw Error.RethrowRequiresCatch();
         }
 
         private void CompileThrowUnaryExpression(Expression expr, bool asVoid)
@@ -2698,7 +2698,7 @@ namespace System.Linq.Expressions.Interpreter
                         Type type = GetMemberType(memberMember.Member);
                         if (memberMember.Member is PropertyInfo && type.GetTypeInfo().IsValueType)
                         {
-                            throw new InvalidOperationException("CannotAutoInitializeValueTypeMemberThroughProperty");
+                            throw Error.CannotAutoInitializeValueTypeMemberThroughProperty(memberMember.Bindings);
                         }
 
                         CompileMember(null, memberMember.Member);


### PR DESCRIPTION
Cases where the compiler already used a defined error in the equivalent
case. As well as better localisability, this gives more consistency
between compiler and interpreter.