### PR TITLE
Implement exception filters in interpreted expressions.

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -372,9 +372,6 @@
   <data name="UnsupportedExpressionType" xml:space="preserve">
     <value>The expression type '{0}' is not supported</value>
   </data>
-  <data name="FilterBlockNotSupported" xml:space="preserve">
-    <value>Filter blocks are not supported</value>
-  </data>
   <data name="FaultBlockNotSupported" xml:space="preserve">
     <value>Fault blocks are not supported</value>
   </data>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq.Expressions;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Threading;
 
 namespace System.Linq.Expressions.Interpreter
 {
@@ -385,6 +383,7 @@ namespace System.Linq.Expressions.Interpreter
 
             // Start to run the try/catch/finally blocks
             var instructions = frame.Interpreter.Instructions.Instructions;
+            ExceptionHandler exHandler;
             try
             {
                 // run the try block
@@ -399,7 +398,7 @@ namespace System.Linq.Expressions.Interpreter
                 if (index == _tryHandler.GotoEndTargetIndex)
                 {
                     // run the 'Goto' that jumps out of the try/catch/finally blocks
-                    Debug.Assert(instructions[index] is GotoInstruction, "should be the 'Goto' instruction that jumpes out the try/catch/finally");
+                    Debug.Assert(instructions[index] is GotoInstruction, "should be the 'Goto' instruction that jumps out the try/catch/finally");
                     frame.InstructionIndex += instructions[index].Run(frame);
                 }
             }
@@ -408,16 +407,9 @@ namespace System.Linq.Expressions.Interpreter
                 // a rethrow instruction in the try handler gets to run
                 throw;
             }
-            catch (Exception exception)
+            catch (Exception exception) when (_tryHandler.HasHandler(frame, ref exception, out exHandler))
             {
-                frame.SaveTraceToException(exception);
-                // rethrow if there is no catch blocks defined for this try block
-                if (!_tryHandler.IsCatchBlockExist) { throw; }
-
-                // Search for the best handler in the TryCatchFianlly block. If no suitable handler is found, rethrow
-                ExceptionHandler exHandler;
-                frame.InstructionIndex += _tryHandler.GotoHandler(frame, exception, out exHandler);
-                if (exHandler == null) { throw; }
+                frame.InstructionIndex += frame.Goto(exHandler.LabelIndex, exception, gotoExceptionHandler: true);
 
 #if FEATURE_THREAD_ABORT
                 // stay in the current catch so that ThreadAbortException is not rethrown by CLR:
@@ -444,7 +436,7 @@ namespace System.Linq.Expressions.Interpreter
                     if (index == _tryHandler.GotoEndTargetIndex)
                     {
                         // run the 'Goto' that jumps out of the try/catch/finally blocks
-                        Debug.Assert(instructions[index] is GotoInstruction, "should be the 'Goto' instruction that jumpes out the try/catch/finally");
+                        Debug.Assert(instructions[index] is GotoInstruction, "should be the 'Goto' instruction that jumps out the try/catch/finally");
                         frame.InstructionIndex += instructions[index].Run(frame);
                     }
                 }
@@ -568,6 +560,46 @@ namespace System.Linq.Expressions.Interpreter
         }
     }
 
+    // no-op: we need this just to balance the stack depth and aid debugging of the instruction list.
+    internal sealed class EnterExceptionFilterInstruction : Instruction
+    {
+        internal static readonly EnterExceptionFilterInstruction Instance = new EnterExceptionFilterInstruction();
+
+        private EnterExceptionFilterInstruction()
+        {
+        }
+
+        public override string InstructionName => "EnterExceptionFilter";
+
+        public override int ConsumedStack => 0;
+
+        // The exception is pushed onto the stack in the filter runner.
+        public override int ProducedStack => 1;
+
+        [ExcludeFromCodeCoverage] // Known to be a no-op, this instruction is skipped on execution.
+        public override int Run(InterpretedFrame frame) => 1;
+    }
+
+    // no-op: we need this just to balance the stack depth and aid debugging of the instruction list.
+    internal sealed class LeaveExceptionFilterInstruction : Instruction
+    {
+        internal static readonly LeaveExceptionFilterInstruction Instance = new LeaveExceptionFilterInstruction();
+
+        private LeaveExceptionFilterInstruction()
+        {
+        }
+
+        public override string InstructionName => "LeaveExceptionFilter";
+
+        // The boolean result is popped from the stack in the filter runner.
+        public override int ConsumedStack => 1;
+
+        public override int ProducedStack => 0;
+
+        [ExcludeFromCodeCoverage] // Known to be a no-op, this instruction is skipped on execution.
+        public override int Run(InterpretedFrame frame) => 1;
+    }
+
     // no-op: we need this just to balance the stack depth.
     internal sealed class EnterExceptionHandlerInstruction : Instruction
     {
@@ -597,6 +629,7 @@ namespace System.Linq.Expressions.Interpreter
         // Fault handlers: The value is kept on stack during fault handler evaluation.
         public override int ProducedStack { get { return 1; } }
 
+        [ExcludeFromCodeCoverage] // Known to be a no-op, this instruction is skipped on execution.
         public override int Run(InterpretedFrame frame)
         {
             // nop (the exception value is pushed by the interpreter in HandleCatch)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -1117,6 +1117,16 @@ namespace System.Linq.Expressions.Interpreter
             Emit(hasValue ? LeaveFaultInstruction.NonVoid : LeaveFaultInstruction.Void);
         }
 
+        public void EmitEnterExceptionFilter()
+        {
+            Emit(EnterExceptionFilterInstruction.Instance);
+        }
+
+        public void EmitLeaveExceptionFilter()
+        {
+            Emit(LeaveExceptionFilterInstruction.Instance);
+        }
+
         public void EmitEnterExceptionHandlerNonVoid()
         {
             Emit(EnterExceptionHandlerInstruction.NonVoid);

--- a/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -1,7 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Text;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -513,8 +514,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory]
-        [ClassData(typeof(CompilationTypes))]
-        [ActiveIssue(3838)]
+        [InlineData(true)]
         public void FilterOnCatch(bool useInterpreter)
         {
             TryExpression tryExp = Expression.TryCatch(
@@ -524,6 +524,315 @@ namespace System.Linq.Expressions.Tests
                 Expression.Catch(typeof(TestException), Expression.Constant(3))
                 );
             Assert.Equal(2, Expression.Lambda<Func<int>>(tryExp).Compile(useInterpreter)());
+        }
+
+        [Fact]
+        [ActiveIssue(3838)]
+        public void FilterOnCatchCompiled(bool useInterpreter)
+        {
+            FilterOnCatch(false);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        public void FilterCanAccessException(bool useInterpreter)
+        {
+            ParameterExpression exception = Expression.Variable(typeof(TestException));
+            TryExpression tryExp = Expression.TryCatch(
+                Expression.Throw(Expression.Constant(new TestException()), typeof(int)),
+                Expression.Catch(exception, Expression.Constant(1), Expression.Equal(Expression.Constant("This is not a drill."), Expression.Property(exception, "Message"))),
+                Expression.Catch(exception, Expression.Constant(2), Expression.Equal(Expression.Constant("This is a test exception"), Expression.Property(exception, "Message"))),
+                Expression.Catch(exception, Expression.Constant(3))
+                );
+            Assert.Equal(2, Expression.Lambda<Func<int>>(tryExp).Compile(useInterpreter)());
+        }
+
+        [Fact]
+        [ActiveIssue(3838)]
+        public void FilterCanAccessExceptionCompiled(bool useInterpreter)
+        {
+            FilterCanAccessException(false);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        public void FilterOverwiteExceptionVisibleToHandler(bool useInterpreter)
+        {
+            ParameterExpression exception = Expression.Variable(typeof(TestException));
+            TryExpression tryExp = Expression.TryCatch(
+                Expression.Throw(Expression.Constant(new TestException()), typeof(bool)),
+                Expression.Catch(
+                    exception,
+                    Expression.ReferenceEqual(Expression.Constant(null), exception),
+                    Expression.Block(
+                        Expression.Assign(exception, Expression.Constant(null, typeof(TestException))),
+                        Expression.Constant(true)
+                        )
+                    )
+                );
+            Assert.True(Expression.Lambda<Func<bool>>(tryExp).Compile(useInterpreter)());
+        }
+
+        [Fact]
+        [ActiveIssue(3838)]
+        public void FilterOverwiteExceptionVisibleToHandlerCompiler()
+        {
+            FilterOverwiteExceptionVisibleToHandler(false);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        public void FilterOverwriteExceptionNotVisibleToNextFilterOrHandler(bool useInterpreter)
+        {
+            ParameterExpression exception = Expression.Variable(typeof(TestException));
+            TryExpression tryExp = Expression.TryCatch(
+                Expression.Throw(Expression.Constant(new TestException()), typeof(int)),
+                Expression.Catch(
+                    exception,
+                    Expression.Constant(-1),
+                    Expression.Block(
+                        Expression.Assign(exception, Expression.Constant(null, typeof(TestException))),
+                        Expression.Constant(false)
+                        )
+                    ),
+                Expression.Catch(
+                    exception,
+                    Expression.Property(Expression.Property(exception, "Message"), "Length"),
+                    Expression.ReferenceNotEqual(exception, Expression.Constant(null))
+                )
+            );
+            Assert.Equal(24, Expression.Lambda<Func<int>>(tryExp).Compile(useInterpreter)());
+        }
+
+        [Fact]
+        [ActiveIssue(3838)]
+        public void FilterOverwriteExceptionNotVisibleToNextFilterOrHandlerCompiler()
+        {
+            FilterOverwriteExceptionNotVisibleToNextFilterOrHandler(false);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        public void FilterBeforeInnerFinally(bool useInterpreter)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            /*
+            Comparable to:
+
+            try
+            {
+                try
+                {
+                    sb.Append("A");
+                    throw new TestException();
+                }
+                finally
+                {
+                    sb.Append("B");
+                }
+            }
+            catch (TestException) when (sb.Append("C") != null)
+            {
+                sb.Append("D");
+            }
+
+            The filter should execute on the first pass, so the result should be "ACBD".
+            */
+
+            ConstantExpression builder = Expression.Constant(sb);
+            Type[] noTypes = Array.Empty<Type>();
+            TryExpression tryExp = Expression.TryCatch(
+                Expression.TryFinally(
+                    Expression.Block(
+                        Expression.Call(builder, "Append", noTypes, Expression.Constant('A')),
+                        Expression.Throw(Expression.Constant(new TestException()), typeof(StringBuilder))
+                        ),
+                    Expression.Call(builder, "Append", noTypes, Expression.Constant('B'))
+                ),
+                Expression.Catch(
+                    typeof(TestException),
+                    Expression.Call(builder, "Append", noTypes, Expression.Constant('D')),
+                    Expression.ReferenceNotEqual(Expression.Call(builder, "Append", noTypes, Expression.Constant('C')), Expression.Constant(null))
+                    )
+                );
+            Func<StringBuilder> func = Expression.Lambda<Func<StringBuilder>>(tryExp).Compile(useInterpreter);
+            Assert.Equal("ACBD", func().ToString());
+        }
+
+        [Fact]
+        [ActiveIssue(3838)]
+        public void FilterBeforeInnerFinallyCompiled()
+        {
+            FilterBeforeInnerFinally(false);
+        }
+
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        [ActiveIssue(3838)]
+        public void FilterBeforeInnerFault(bool useInterpreter)
+        {
+            StringBuilder sb = new StringBuilder();
+            ConstantExpression builder = Expression.Constant(sb);
+            Type[] noTypes = Array.Empty<Type>();
+            TryExpression tryExp = Expression.TryCatch(
+                Expression.TryFault(
+                    Expression.Block(
+                        Expression.Call(builder, "Append", noTypes, Expression.Constant('A')),
+                        Expression.Throw(Expression.Constant(new TestException()), typeof(StringBuilder))
+                        ),
+                    Expression.Call(builder, "Append", noTypes, Expression.Constant('B'))
+                ),
+                Expression.Catch(
+                    typeof(TestException),
+                    Expression.Call(builder, "Append", noTypes, Expression.Constant('D')),
+                    Expression.ReferenceNotEqual(Expression.Call(builder, "Append", noTypes, Expression.Constant('C')), Expression.Constant(null))
+                    )
+                );
+            Func<StringBuilder> func = Expression.Lambda<Func<StringBuilder>>(tryExp).Compile(useInterpreter);
+            Assert.Equal("ACBD", func().ToString());
+        }
+
+
+        [Theory]
+        [InlineData(true)]
+        public void ExceptionThrownInFilter(bool useInterpreter)
+        {
+            // An exception in a filter should be eaten and the filter fail.
+
+            TryExpression tryExp = Expression.TryCatch(
+                Expression.Throw(Expression.Constant(new TestException()), typeof(int)),
+                Expression.Catch(
+                    typeof(TestException),
+                    Expression.Constant(2),
+                    Expression.LessThan(
+                        Expression.Constant(3),
+                        Expression.Throw(Expression.Constant(new InvalidOperationException()), typeof(int))
+                        )
+                    ),
+                Expression.Catch(typeof(TestException), Expression.Constant(9))
+                );
+            Func<int> func = Expression.Lambda<Func<int>>(tryExp).Compile(useInterpreter);
+            Assert.Equal(9, func());
+        }
+
+        [Fact]
+        [ActiveIssue(3838)]
+        public void ExceptionThrownInFilterCompiled()
+        {
+            ExceptionThrownInFilter(false);
+        }
+
+        private bool MethodWithManyArguments(
+            int x, int y, int z,
+            int α, int β, int γ, int δ,
+            int klaatu, int barada, int nikto,
+            int anáil, int nathrach, int ortha, int bháis, int @is, int beatha, int @do, int chéal, int déanaimh,
+            bool returnBack)
+        {
+            return returnBack;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        public void DeepExceptionFilter(bool useInterpreter)
+        {
+            // An expression where the deepest use of the stack is within filters.
+            MethodCallExpression deepFalse = Expression.Call(
+                Expression.Constant(this),
+                "MethodWithManyArguments",
+                new Type[0],
+                Expression.Constant(1),
+                Expression.Constant(2),
+                Expression.Constant(3),
+                Expression.Constant(4),
+                Expression.Constant(5),
+                Expression.Constant(6),
+                Expression.Constant(7),
+                Expression.Constant(8),
+                Expression.Constant(9),
+                Expression.Constant(10),
+                Expression.Constant(11),
+                Expression.Constant(12),
+                Expression.Constant(13),
+                Expression.Constant(14),
+                Expression.Constant(15),
+                Expression.Constant(16),
+                Expression.Constant(17),
+                Expression.Constant(18),
+                Expression.Constant(19),
+                Expression.Constant(false)
+                );
+            MethodCallExpression deepTrue = Expression.Call(
+                Expression.Constant(this),
+                "MethodWithManyArguments",
+                new Type[0],
+                Expression.Constant(1),
+                Expression.Constant(2),
+                Expression.Constant(3),
+                Expression.Constant(4),
+                Expression.Constant(5),
+                Expression.Constant(6),
+                Expression.Constant(7),
+                Expression.Constant(8),
+                Expression.Constant(9),
+                Expression.Constant(10),
+                Expression.Constant(11),
+                Expression.Constant(12),
+                Expression.Constant(13),
+                Expression.Constant(14),
+                Expression.Constant(15),
+                Expression.Constant(16),
+                Expression.Constant(17),
+                Expression.Constant(18),
+                Expression.Constant(19),
+                Expression.Constant(true)
+                );
+            TryExpression tryExp = Expression.TryCatch(
+                Expression.Throw(Expression.Constant(new TestException()), typeof(int)),
+                Expression.Catch(typeof(TestException), Expression.Constant(1), deepFalse),
+                Expression.Catch(typeof(TestException), Expression.Constant(2), deepTrue)
+                );
+            Func<int> func = Expression.Lambda<Func<int>>(tryExp).Compile(useInterpreter);
+            Assert.Equal(2, func());
+        }
+
+        [Fact]
+        [ActiveIssue(3838)]
+        public void DeepExceptionFilterCompiled()
+        {
+            DeepExceptionFilter(false);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        public void JumpOutOfExceptionFilter(bool useInterpreter)
+        {
+            LabelTarget target = Expression.Label();
+            var tryExp = Expression.Lambda<Func<int>>(
+                Expression.TryCatch(
+                    Expression.Throw(Expression.Constant(new TestException()), typeof(int)),
+                    Expression.Catch(
+                        typeof(TestException),
+                        Expression.Block(
+                            Expression.Label(target),
+                            Expression.Constant(0)
+                            ),
+                        Expression.Block(
+                            Expression.Goto(target),
+                            Expression.Constant(true)
+                            )
+                        )
+                    )
+                );
+            Assert.Throws<InvalidOperationException>(() => tryExp.Compile(useInterpreter));
+        }
+
+        [Fact]
+        [ActiveIssue(3838)]
+        public void JumpOutOfExceptionFilterCompiled()
+        {
+            JumpOutOfExceptionFilter(false);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #3841.

Finding which catch block to run in a try-catch now happens entirely in a filter in the `EnterTryCatchFinallyInstruction`, where previously all exceptions would be caught and the matching occur within that catch-block.

As well as allowing for filter support, this also means that there is no catch if there was no corresponding catch block (all catch blocks caught different exception types), which makes the exception-handling of the interpreter better match the stack-walk of the CLR.