### PR TITLE
Update the PropertyInfo.GetAccessor test

### DIFF
--- a/src/System.Reflection.TypeExtensions/tests/PropertyInfo/PropertyInfoGetAccessors1.cs
+++ b/src/System.Reflection.TypeExtensions/tests/PropertyInfo/PropertyInfoGetAccessors1.cs
@@ -66,18 +66,6 @@ namespace System.Reflection.Tests
             Assert.Equal(2, methodinfo.Length);
         }
 
-        // Negative Test 1
-        [Fact]
-        public void NegTest1()
-        {
-            Type type = typeof(baseclass);
-            PropertyInfo properinfo = type.GetProperty("prop10");
-            Assert.Throws<ArgumentNullException>(() =>
-           {
-               MethodInfo[] methodinfo = properinfo.GetAccessors();
-           });
-        }
-
         public int pro1
         {
             set


### PR DESCRIPTION
Fixes Issue #6932

System.Reflection.TypeExtensions exposes GetAccessor(this PropertyInfo) extension method.
The test binary checked that in case PropertyInfo was null the extension method
threw ArgumentNullException. However since now System.Reflection exposes the actual method,
the call goes to PropertyInfo.GetAccessor method in System.Reflection and not the extension method in System.Reflection.TypeExtensions causing NullReferenceException instead of ArgumentNullException.

This issue won't be hit by any old code (pre System.Reflection.TypeExtensions time)
because the code would be relying on the behavior equivalent to the one in PropertyInfo.
However any new code that was written after System.Reflection.TypeExtensions was authored
could see a breaking change. This in unfortunate but I don't expect the impact to be high.

We could update System.Reflection.TypeExtensions to throw NullReferenceException just like System.Reflection but since System.Reflection.TypeExtensions is eventually to be phased out , the value seems pretty low. Thoughts?