### PR TITLE
Make native build conditional on script existing

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -35,11 +35,13 @@ if "%__buildSpec%"=="managed"  goto :BuildManaged
 :BuildNative
 :: Run the Native Windows build
 echo [%time%] Building Native Libraries...
-call %~dp0src\native\Windows\build-native.cmd %__args% >nativebuild.log
-IF ERRORLEVEL 1 (
-    echo Native component build failed see nativebuild.log for more details.
-) else (
-    echo [%time%] Successfully built Native Libraries.
+IF EXIST "%~dp0src\native\Windows\build-native.cmd" (
+    call %~dp0src\native\Windows\build-native.cmd %__args% >nativebuild.log
+    IF ERRORLEVEL 1 (
+        echo Native component build failed see nativebuild.log for more details.
+    ) else (
+        echo [%time%] Successfully built Native Libraries.
+    )
 )
 
 :: If we only wanted to build the native components, exit

--- a/build.sh
+++ b/build.sh
@@ -99,7 +99,7 @@ prepare_native_build()
     fi
 }
 
-build_managed_corefx()
+build_managed()
 {
     __buildproj=$__scriptpath/build.proj
     __buildlog=$__scriptpath/msbuild.log
@@ -116,7 +116,7 @@ build_managed_corefx()
     echo Build Exit Code = $BUILDERRORLEVEL
 }
 
-build_native_corefx()
+build_native()
 {
     # All set to commence the build
 
@@ -376,6 +376,10 @@ if [ "$__BuildOS" != "$__HostOS" ]; then
     __buildnative=false
 fi
 
+if [ ! -e "$__nativeroot" ]; then
+   __buildnative=false
+fi
+
 # Set the remaining variables based upon the determined build configuration
 __IntermediatesDir="$__rootbinpath/obj/$__BuildOS.$__BuildArch.$__BuildType/Native"
 __BinDir="$__rootbinpath/$__BuildOS.$__BuildArch.$__BuildType/Native"
@@ -404,7 +408,7 @@ if $__buildnative; then
 
     # Build the corefx native components.
 
-    build_native_corefx
+    build_native
 
     # Build complete
 fi
@@ -417,7 +421,7 @@ if $__buildmanaged; then
 
     # Build the corefx native components.
 
-    build_managed_corefx
+    build_managed
 
     # Build complete
 fi


### PR DESCRIPTION
dotnet/wcf tries to keep their build scripts in line with what we have
in coreclr, but they don't have any native components to build on
Windows. Gate our native build on the existence of the file we want to
call out to, which won't exist in dotnet/wcf.

Fixes #7001