### PR TITLE
Remove Title_set test method

### DIFF
--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -100,14 +100,6 @@ public class WindowAndCursorProps
         Assert.Throws<PlatformNotSupportedException>(() => Console.Title);
     }
 
-    [ActiveIssue(6223, PlatformID.Windows)]
-    [Fact]
-    [OuterLoop] // changes the title and we can't change it back automatically in the test
-    public static void Title_Set()
-    {
-        Console.Title = "Title set by unit test";
-    }
-
     [Fact]
     [PlatformSpecific(PlatformID.Windows)]
     public static void Title()


### PR DESCRIPTION
Fixes #6223 

This method is failing intermittently in the outerloop automated testing which can't be reproed locally. Interestingly we have only seen Console_setTitle call failing in Title_set test method and not in Title test method. For now, removing this method since we get the same coverage in both the test methods.