### PR TITLE
Add-ref 1:1 assemblies on Xamarin

### DIFF
--- a/src/Microsoft.CSharp/pkg/Microsoft.CSharp.pkgproj
+++ b/src/Microsoft.CSharp/pkg/Microsoft.CSharp.pkgproj
@@ -9,18 +9,30 @@
       <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\Microsoft.CSharp.builds" />
-    <InboxOnTargetFramework Include="MonoAndroid10" />
-    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="MonoAndroid10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="MonoTouch10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
     <InboxOnTargetFramework Include="net45">
       <AsFrameworkReference>true</AsFrameworkReference>
     </InboxOnTargetFramework>
     <InboxOnTargetFramework Include="win8" />
     <InboxOnTargetFramework Include="wp80" />
     <InboxOnTargetFramework Include="wpa81" />
-    <InboxOnTargetFramework Include="xamarinios10" />
-    <InboxOnTargetFramework Include="xamarinmac20" />
-    <InboxOnTargetFramework Include="xamarintvos10" />
-    <InboxOnTargetFramework Include="xamarinwatchos10" />
+    <InboxOnTargetFramework Include="xamarinios10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="xamarinmac20">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="xamarintvos10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="xamarinwatchos10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Compression/pkg/System.IO.Compression.pkgproj
+++ b/src/System.IO.Compression/pkg/System.IO.Compression.pkgproj
@@ -9,15 +9,29 @@
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.IO.Compression.builds" />
-    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="net45">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
     <InboxOnTargetFramework Include="win8" />
     <InboxOnTargetFramework Include="wpa81" />
-    <InboxOnTargetFramework Include="MonoAndroid10" />
-    <InboxOnTargetFramework Include="MonoTouch10" />
-    <InboxOnTargetFramework Include="xamarinios10" />
-    <InboxOnTargetFramework Include="xamarinmac20" />
-    <InboxOnTargetFramework Include="xamarintvos10" />
-    <InboxOnTargetFramework Include="xamarinwatchos10" />
+    <InboxOnTargetFramework Include="MonoAndroid10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="MonoTouch10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="xamarinios10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="xamarinmac20">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="xamarintvos10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="xamarinwatchos10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
 
     <ProjectReference Include="$(NativePackagePath)\runtime.native.System.IO.Compression\runtime.native.System.IO.Compression.pkgproj" />
   </ItemGroup>

--- a/src/System.Net.Http/pkg/System.Net.Http.pkgproj
+++ b/src/System.Net.Http/pkg/System.Net.Http.pkgproj
@@ -14,8 +14,12 @@
     <ProjectReference Include="$(NativePackagePath)\runtime.native.System.Security.Cryptography\runtime.native.System.Security.Cryptography.pkgproj" />
   </ItemGroup>
   <ItemGroup>
-    <InboxOnTargetFramework Include="monoandroid10" />
-    <InboxOnTargetFramework Include="monotouch10" />
+    <InboxOnTargetFramework Include="monoandroid10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="monotouch10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
     <InboxOnTargetFramework Include="net45">
       <AsFrameworkReference>true</AsFrameworkReference>
     </InboxOnTargetFramework>
@@ -24,10 +28,18 @@
     </InboxOnTargetFramework>
     <InboxOnTargetFramework Include="win8" />
     <InboxOnTargetFramework Include="wpa81" />
-    <InboxOnTargetFramework Include="xamarinios10" />
-    <InboxOnTargetFramework Include="Xamarinmac20" />
-    <InboxOnTargetFramework Include="xamarintvos10" />
-    <InboxOnTargetFramework Include="xamarinwatchos10" />
+    <InboxOnTargetFramework Include="xamarinios10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="Xamarinmac20">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="xamarintvos10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="xamarinwatchos10">
+      <AsFrameworkReference>true</AsFrameworkReference>
+    </InboxOnTargetFramework>
     <!-- TODO: Bring in Microsoft.Net.Http on older platforms -->
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
Microsoft.CSharp, System.IO.Compression, and System.Net.Http are all
reference assemblies in the desktop and mono/xamarin targeting packs.
As such these won't be referenced automatically.  Ensure we add a
reference when installing the package.

Fixes https://github.com/dotnet/corefx/issues/5955

/cc @onovotny