### PR TITLE
Clean up and expand PLINQ cancellation tests

### DIFF
--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -9,6 +9,20 @@ namespace System.Linq.Parallel.Tests
 {
     public partial class ParallelQueryCombinationTests
     {
+        private const int EventualCancellationSize = 128;
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Aggregate_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate((i, j) => j));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j, i => i));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j, (i, j) => i, i => i));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(() => 0, (i, j) => j, (i, j) => i, i => i));
+        }
+
         [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -14,859 +14,865 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Aggregate_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void Aggregate_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate((i, j) => j));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j, i => i));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j, (i, j) => i, i => i));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(() => 0, (i, j) => j, (i, j) => i, i => i));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Aggregate((i, j) => j));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Aggregate(0, (i, j) => j));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Aggregate(0, (i, j) => j, i => i));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Aggregate(0, (i, j) => j, (i, j) => i, i => i));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Aggregate(() => 0, (i, j) => j, (i, j) => i, i => i));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Aggregate_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void Aggregate_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate((i, j) => j));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j, i => i));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j, (i, j) => i, i => i));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(() => 0, (i, j) => j, (i, j) => i, i => i));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate((i, j) => j));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j, i => i));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j, (i, j) => i, i => i));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(() => 0, (i, j) => j, (i, j) => i, i => i));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void Aggregate_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Aggregate((x, y) => x));
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Aggregate(0, (x, y) => x + y));
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Aggregate(0, (x, y) => x + y, r => r));
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Aggregate(0, (a, x) => a + x, (l, r) => l + r, r => r));
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Aggregate(() => 0, (a, x) => a + x, (l, r) => l + r, r => r));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Aggregate((i, j) => j));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Aggregate(0, (i, j) => j));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Aggregate(0, (i, j) => j, i => i));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Aggregate(0, (i, j) => j, (i, j) => i, i => i));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Aggregate(() => 0, (i, j) => j, (i, j) => i, i => i));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Aggregate((i, j) => j));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Aggregate(0, (i, j) => j));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Aggregate(0, (i, j) => j, i => i));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Aggregate(0, (i, j) => j, (i, j) => i, i => i));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Aggregate(() => 0, (i, j) => j, (i, j) => i, i => i));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
-        public static void All_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void Aggregate_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).All(x => true));
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Aggregate((x, y) => x));
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Aggregate(0, (x, y) => x + y));
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Aggregate(0, (x, y) => x + y, r => r));
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Aggregate(0, (a, x) => a + x, (l, r) => l + r, r => r));
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Aggregate(() => 0, (a, x) => a + x, (l, r) => l + r, r => r));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
-        public static void All_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void All_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).All(x => true));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).All(x => true));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void All_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).All(x => true));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).All(x => true));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Any_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void All_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Any(x => false));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).All(x => true));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).All(x => true));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Any_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void All_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Any(x => false));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Any(x => false));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void Any_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Any());
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Any(x => true));
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).All(x => true));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Average_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void Any_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average());
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (int?)x));
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (long)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (long?)x));
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (float)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (float?)x));
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (double)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (double?)x));
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (decimal)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (decimal?)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Any(x => false));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Average_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void Any_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average());
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (int?)x));
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (long)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (long?)x));
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (float)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (float?)x));
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (double)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (double?)x));
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (decimal)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (decimal?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average());
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (int?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (long)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (long?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (float)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (float?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (double)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (double?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (decimal)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (decimal?)x));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void Average_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Average());
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Any(x => false));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Any(x => false));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Contains_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void Any_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Contains(-1));
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Any());
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Any(x => true));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Contains_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void Average_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Contains(-1));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Contains(-1));
-        }
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Average());
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (int?)x));
 
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void Contains_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Contains(DefaultStart));
-        }
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (long)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (long?)x));
 
-        [Theory]
-        [MemberData(nameof(UnaryCancelingOperators))]
-        [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Count_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
-        {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Count());
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).LongCount());
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Count(x => true));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).LongCount(x => true));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (float)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (float?)x));
+
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (double)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (double?)x));
+
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (decimal)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (decimal?)x));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Count_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void Average_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Count());
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).LongCount());
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Count(x => true));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).LongCount(x => true));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Count());
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).LongCount());
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Count(x => true));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).LongCount(x => true));
-        }
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Average());
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (int?)x));
 
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void Count_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Count());
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).LongCount());
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Count(x => true));
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).LongCount(x => true));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (long)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (long?)x));
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (float)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (float?)x));
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (double)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (double?)x));
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (decimal)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (decimal?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Average());
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (int?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (long)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (long?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (float)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (float?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (double)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (double?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (decimal)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Average(x => (decimal?)x));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
-        [MemberData(nameof(OrderCancelingOperators))]
-        public static void ElementAt_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void Average_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ElementAt(int.MaxValue));
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Average());
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Contains_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Contains(-1));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Contains_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Contains(-1));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Contains(-1));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Contains_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Contains(DefaultStart));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Count_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Count());
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).LongCount());
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Count(x => true));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).LongCount(x => true));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Count_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Count());
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).LongCount());
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Count(x => true));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).LongCount(x => true));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Count());
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).LongCount());
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Count(x => true));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).LongCount(x => true));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Count_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Count());
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).LongCount());
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Count(x => true));
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).LongCount(x => true));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void ElementAt_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void ElementAt_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ElementAt(int.MaxValue));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ElementAt(int.MaxValue));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void ElementAt_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ElementAt(0));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).ElementAt(int.MaxValue));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void ElementAtOrDefault_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void ElementAt_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ElementAt(int.MaxValue));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).ElementAt(int.MaxValue));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).ElementAt(int.MaxValue));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void ElementAtOrDefault_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void ElementAt_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ElementAtOrDefault(int.MaxValue));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ElementAtOrDefault(int.MaxValue));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void ElementAtOrDefault_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ElementAtOrDefault(0));
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ElementAtOrDefault(DefaultSize + 1));
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).ElementAt(0));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void First_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void ElementAtOrDefault_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).First(x => false));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).ElementAt(int.MaxValue));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void First_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void ElementAtOrDefault_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).First(x => false));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).First(x => false));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void First_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).First());
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).First(x => false));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).ElementAtOrDefault(int.MaxValue));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).ElementAtOrDefault(int.MaxValue));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void FirstOrDefault_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void ElementAtOrDefault_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).FirstOrDefault(x => false));
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).ElementAtOrDefault(0));
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).ElementAtOrDefault(DefaultSize + 1));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void FirstOrDefault_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void First_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).FirstOrDefault(x => false));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).FirstOrDefault(x => false));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void FirstOrDefault_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).FirstOrDefault());
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).FirstOrDefault(x => false));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryCancelingOperators))]
-        [MemberData(nameof(BinaryCancelingOperators))]
-        public static void ForAll_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
-        {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ForAll(x => { }));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryCancelingOperators))]
-        [MemberData(nameof(BinaryCancelingOperators))]
-        public static void ForAll_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
-        {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ForAll(x => { }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ForAll(x => { }));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void ForAll_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ForAll(x => { }));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).First(x => false));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void ForEach_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void First_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => { foreach (int i in Cancel(token, canceler, source, operation)) ; });
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).First(x => false));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).First(x => false));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void ForEach_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void First_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => { foreach (int i in Cancel(token, canceler, source, operation)) ; });
-            Functions.AssertAggregateNotCanceled((token, canceler) => { foreach (int i in Cancel(token, canceler, source, operation)) ; });
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void ForEach_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => { foreach (int i in Cancel(token, source, operation)) ; });
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).First());
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).First(x => false));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void Last_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void FirstOrDefault_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Last());
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Last(x => true));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).FirstOrDefault(x => false));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void Last_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void FirstOrDefault_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Last());
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Last(x => true));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Last());
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Last(x => true));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void Last_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Last());
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Last(x => true));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).FirstOrDefault(x => false));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).FirstOrDefault(x => false));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void LastOrDefault_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void FirstOrDefault_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).LastOrDefault());
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).LastOrDefault(x => true));
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).FirstOrDefault());
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).FirstOrDefault(x => false));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void ForAll_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).ForAll(x => { }));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void ForAll_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).ForAll(x => { }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).ForAll(x => { }));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void ForAll_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).ForAll(x => { }));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void LastOrDefault_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void ForEach_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).LastOrDefault());
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).LastOrDefault(x => true));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).LastOrDefault());
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).LastOrDefault(x => true));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void LastOrDefault_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).LastOrDefault());
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).LastOrDefault(x => true));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryCancelingOperators))]
-        [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Max_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
-        {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max());
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (int)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (int?)x));
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (long)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (long?)x));
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (float)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (float?)x));
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (double)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (double?)x));
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (decimal)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (decimal?)x));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryCancelingOperators))]
-        [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Max_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
-        {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max());
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (int)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (int?)x));
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (long)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (long?)x));
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (float)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (float?)x));
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (double)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (double?)x));
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (decimal)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (decimal?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max());
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (int)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (int?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (long)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (long?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (float)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (float?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (double)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (double?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (decimal)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (decimal?)x));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void Max_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Max());
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryCancelingOperators))]
-        [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Min_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
-        {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min());
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (int)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (int?)x));
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (long)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (long?)x));
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (float)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (float?)x));
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (double)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (double?)x));
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (decimal)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (decimal?)x));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryCancelingOperators))]
-        [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Min_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
-        {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min());
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (int)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (int?)x));
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (long)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (long?)x));
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (float)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (float?)x));
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (double)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (double?)x));
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (decimal)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (decimal?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min());
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (int)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (int?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (long)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (long?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (float)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (float?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (double)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (double?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (decimal)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (decimal?)x));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void Min_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Min());
+            AssertThrows.EventuallyCanceled((source, canceler) => { foreach (int i in operation.Item(source, canceler)) ; });
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void SequenceEqual_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void ForEach_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).SequenceEqual(ParallelEnumerable.Range(0, 128).AsOrdered()));
-            Functions.AssertEventuallyCanceled((token, canceler) => ParallelEnumerable.Range(0, 128).AsOrdered().SequenceEqual(Cancel(token, canceler, source, operation)));
+            AssertThrows.OtherTokenCanceled((source, canceler) => { foreach (int i in operation.Item(source, canceler)) ; });
+            AssertThrows.SameTokenNotCanceled((source, canceler) => { foreach (int i in operation.Item(source, canceler)) ; });
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void SequenceEqual_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void ForEach_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            SequenceEqual_AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).SequenceEqual(ParallelEnumerable.Range(0, 128).AsOrdered()));
-            SequenceEqual_AssertAggregateAlternateCanceled((token, canceler) => ParallelEnumerable.Range(0, 128).AsOrdered().SequenceEqual(Cancel(token, canceler, source, operation)));
-            SequenceEqual_AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).SequenceEqual(ParallelEnumerable.Range(0, 128).AsOrdered()));
-            SequenceEqual_AssertAggregateNotCanceled((token, canceler) => ParallelEnumerable.Range(0, 128).AsOrdered().SequenceEqual(Cancel(token, canceler, source, operation)));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void SequenceEqual_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).SequenceEqual(ParallelEnumerable.Range(0, 2)));
-            Functions.AssertAlreadyCanceled(token => ParallelEnumerable.Range(0, 2).SequenceEqual(Cancel(token, source, operation)));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryCancelingOperators))]
-        [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Single_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
-        {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Single(x => false));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryCancelingOperators))]
-        [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Single_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
-        {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Single(x => false));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Single(x => false));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void Single_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Single());
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Single(x => false));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryCancelingOperators))]
-        [MemberData(nameof(BinaryCancelingOperators))]
-        public static void SingleOrDefault_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
-        {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).SingleOrDefault(x => false));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryCancelingOperators))]
-        [MemberData(nameof(BinaryCancelingOperators))]
-        public static void SingleOrDefault_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
-        {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).SingleOrDefault(x => false));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).SingleOrDefault(x => false));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void SingleOrDefault_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).SingleOrDefault());
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).SingleOrDefault(x => false));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryCancelingOperators))]
-        [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Sum_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
-        {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum());
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (int?)x));
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (long)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (long?)x));
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (float)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (float?)x));
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (double)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (double?)x));
-
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (decimal)x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (decimal?)x));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryCancelingOperators))]
-        [MemberData(nameof(BinaryCancelingOperators))]
-        public static void Sum_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
-        {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum());
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (int?)x));
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (long)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (long?)x));
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (float)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (float?)x));
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (double)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (double?)x));
-
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (decimal)x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (decimal?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum());
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (int?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (long)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (long?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (float)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (float?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (double)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (double?)x));
-
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (decimal)x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (decimal?)x));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void Sum_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Sum());
+            AssertThrows.AlreadyCanceled(source => { foreach (int i in operation.Item(source, () => { })) ; });
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void ToArray_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void Last_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToArray());
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Last());
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Last(x => true));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void ToArray_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void Last_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToArray());
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToArray());
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void ToArray_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ToArray());
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryCancelingOperators))]
-        [MemberData(nameof(BinaryCancelingOperators))]
-        public static void ToDictionary_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
-        {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToDictionary(x => x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToDictionary(x => x, y => y));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryCancelingOperators))]
-        [MemberData(nameof(BinaryCancelingOperators))]
-        public static void ToDictionary_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
-        {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToDictionary(x => x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToDictionary(x => x, y => y));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToDictionary(x => x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToDictionary(x => x, y => y));
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void ToDictionary_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ToDictionary(x => x));
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ToDictionary(x => x, y => y));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Last());
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Last(x => true));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Last());
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Last(x => true));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void ToList_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void Last_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToList());
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Last());
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Last(x => true));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void ToList_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void LastOrDefault_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToList());
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToList());
-        }
-
-        [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void ToList_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
-        {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ToList());
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).LastOrDefault());
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).LastOrDefault(x => true));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void ToLookup_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void LastOrDefault_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToLookup(x => x));
-            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToLookup(x => x, y => y));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).LastOrDefault());
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).LastOrDefault(x => true));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).LastOrDefault());
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).LastOrDefault(x => true));
         }
 
         [Theory]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]
-        public static void ToLookup_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        public static void LastOrDefault_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToLookup(x => x));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToLookup(x => x, y => y));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToLookup(x => x));
-            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToLookup(x => x, y => y));
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).LastOrDefault());
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).LastOrDefault(x => true));
         }
 
         [Theory]
-        [MemberData(nameof(UnaryOperators))]
-        [MemberData(nameof(BinaryOperators))]
-        public static void ToLookup_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Max_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ToLookup(x => x));
-            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ToLookup(x => x, y => y));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Max());
+
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (int)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (int?)x));
+
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (long)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (long?)x));
+
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (float)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (float?)x));
+
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (double)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (double?)x));
+
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (decimal)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (decimal?)x));
         }
 
-        private static ParallelQuery<int> Cancel(CancellationToken token, Action canceler, Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Max_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            return operation.Item(canceler)(DefaultStart, EventualCancellationSize, source.Item(token));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Max());
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (int)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (int?)x));
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (long)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (long?)x));
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (float)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (float?)x));
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (double)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (double?)x));
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (decimal)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (decimal?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Max());
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (int)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (int?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (long)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (long?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (float)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (float?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (double)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (double?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (decimal)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Max(x => (decimal?)x));
         }
 
-        private static ParallelQuery<int> Cancel(CancellationToken token, LabeledOperation source, LabeledOperation operation)
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Max_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
         {
-            return operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item);
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Max());
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Min_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Min());
+
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (int)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (int?)x));
+
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (long)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (long?)x));
+
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (float)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (float?)x));
+
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (double)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (double?)x));
+
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (decimal)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (decimal?)x));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Min_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Min());
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (int)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (int?)x));
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (long)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (long?)x));
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (float)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (float?)x));
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (double)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (double?)x));
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (decimal)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (decimal?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Min());
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (int)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (int?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (long)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (long?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (float)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (float?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (double)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (double?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (decimal)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Min(x => (decimal?)x));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Min_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Min());
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void SequenceEqual_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).SequenceEqual(ParallelEnumerable.Range(0, EventualCancellationSize).AsOrdered()));
+            AssertThrows.EventuallyCanceled((source, canceler) => ParallelEnumerable.Range(0, EventualCancellationSize).AsOrdered().SequenceEqual(operation.Item(source, canceler)));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void SequenceEqual_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            SequenceEqual_AssertAggregateAlternateCanceled((token, canceler) => WithCancellation(token, canceler, operation).SequenceEqual(ParallelEnumerable.Range(0, 128).AsOrdered()));
+            SequenceEqual_AssertAggregateAlternateCanceled((token, canceler) => ParallelEnumerable.Range(0, 128).AsOrdered().SequenceEqual(WithCancellation(token, canceler, operation)));
+            SequenceEqual_AssertAggregateNotCanceled((token, canceler) => WithCancellation(token, canceler, operation).SequenceEqual(ParallelEnumerable.Range(0, 128).AsOrdered()));
+            SequenceEqual_AssertAggregateNotCanceled((token, canceler) => ParallelEnumerable.Range(0, 128).AsOrdered().SequenceEqual(WithCancellation(token, canceler, operation)));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void SequenceEqual_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).SequenceEqual(ParallelEnumerable.Range(0, 2)));
+            AssertThrows.AlreadyCanceled(source => ParallelEnumerable.Range(0, 2).SequenceEqual(operation.Item(source, () => { })));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Single_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Single(x => false));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Single_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Single(x => false));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Single(x => false));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Single_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Single());
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Single(x => false));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void SingleOrDefault_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).SingleOrDefault(x => false));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void SingleOrDefault_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).SingleOrDefault(x => false));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).SingleOrDefault(x => false));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void SingleOrDefault_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).SingleOrDefault());
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).SingleOrDefault(x => false));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Sum_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Sum());
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (int?)x));
+
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (long)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (long?)x));
+
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (float)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (float?)x));
+
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (double)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (double?)x));
+
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (decimal)x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (decimal?)x));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Sum_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Sum());
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (int?)x));
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (long)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (long?)x));
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (float)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (float?)x));
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (double)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (double?)x));
+
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (decimal)x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (decimal?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Sum());
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (int?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (long)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (long?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (float)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (float?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (double)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (double?)x));
+
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (decimal)x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).Sum(x => (decimal?)x));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Sum_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).Sum());
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ToArray_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).ToArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ToArray_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).ToArray());
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).ToArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ToArray_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).ToArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void ToDictionary_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).ToDictionary(x => x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).ToDictionary(x => x, y => y));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void ToDictionary_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).ToDictionary(x => x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).ToDictionary(x => x, y => y));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).ToDictionary(x => x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).ToDictionary(x => x, y => y));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void ToDictionary_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).ToDictionary(x => x));
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).ToDictionary(x => x, y => y));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ToList_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).ToList());
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ToList_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).ToList());
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).ToList());
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ToList_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).ToList());
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ToLookup_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).ToLookup(x => x));
+            AssertThrows.EventuallyCanceled((source, canceler) => operation.Item(source, canceler).ToLookup(x => x, y => y));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ToLookup_AggregateException_Wraps_OperationCanceledException(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).ToLookup(x => x));
+            AssertThrows.OtherTokenCanceled((source, canceler) => operation.Item(source, canceler).ToLookup(x => x, y => y));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).ToLookup(x => x));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => operation.Item(source, canceler).ToLookup(x => x, y => y));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ToLookup_OperationCanceledException_PreCanceled(Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).ToLookup(x => x));
+            AssertThrows.AlreadyCanceled(source => operation.Item(source, () => { }).ToLookup(x => x, y => y));
+        }
+
+        private static ParallelQuery<int> WithCancellation(CancellationToken token, Action canceler, Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>> operation)
+        {
+            return operation.Item(ParallelEnumerable.Range(DefaultStart, EventualCancellationSize).WithCancellation(token), canceler);
         }
 
         private static void SequenceEqual_AssertAggregateAlternateCanceled(Action<CancellationToken, Action> query)

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -207,6 +207,14 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void ForAll_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ForAll(x => { }));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void ForAll_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -24,6 +24,18 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Aggregate_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate((i, j) => j));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j, i => i));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j, (i, j) => i, i => i));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(() => 0, (i, j) => j, (i, j) => i, i => i));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void Aggregate_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
@@ -44,6 +56,14 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void All_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).All(x => true));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void All_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
@@ -57,6 +77,14 @@ namespace System.Linq.Parallel.Tests
         public static void Any_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Any(x => false));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Any_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Any(x => false));
         }
 
         [Theory]
@@ -90,6 +118,27 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Average_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average());
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (int?)x));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (long)x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (long?)x));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (float)x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (float?)x));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (double)x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (double?)x));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (decimal)x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (decimal?)x));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void Average_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
@@ -103,6 +152,14 @@ namespace System.Linq.Parallel.Tests
         public static void Contains_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Contains(-1));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Contains_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Contains(-1));
         }
 
         [Theory]
@@ -122,6 +179,17 @@ namespace System.Linq.Parallel.Tests
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).LongCount());
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Count(x => true));
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).LongCount(x => true));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Count_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Count());
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).LongCount());
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Count(x => true));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).LongCount(x => true));
         }
 
         [Theory]
@@ -145,6 +213,15 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ElementAt_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ElementAt(int.MaxValue));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void ElementAt_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
@@ -159,6 +236,15 @@ namespace System.Linq.Parallel.Tests
         public static void ElementAtOrDefault_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ElementAt(int.MaxValue));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ElementAtOrDefault_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ElementAtOrDefault(int.MaxValue));
         }
 
         [Theory]
@@ -180,6 +266,15 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void First_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).First(x => false));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void First_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
@@ -195,6 +290,15 @@ namespace System.Linq.Parallel.Tests
         public static void FirstOrDefault_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).FirstOrDefault(x => false));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void FirstOrDefault_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).FirstOrDefault(x => false));
         }
 
         [Theory]
@@ -215,6 +319,14 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void ForAll_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ForAll(x => { }));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void ForAll_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
@@ -229,6 +341,15 @@ namespace System.Linq.Parallel.Tests
         public static void ForEach_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertEventuallyCanceled((token, canceler) => { foreach (int i in Cancel(token, canceler, source, operation)) ; });
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ForEach_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => { foreach (int i in Cancel(token, canceler, source, operation)) ; });
         }
 
         [Theory]
@@ -250,6 +371,16 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void Last_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Last());
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Last(x => true));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void Last_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
@@ -266,6 +397,16 @@ namespace System.Linq.Parallel.Tests
         {
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).LastOrDefault());
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).LastOrDefault(x => true));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void LastOrDefault_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).LastOrDefault());
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).LastOrDefault(x => true));
         }
 
         [Theory]
@@ -299,6 +440,27 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Max_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max());
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (int?)x));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (long)x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (long?)x));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (float)x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (float?)x));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (double)x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (double?)x));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (decimal)x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (decimal?)x));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void Max_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
@@ -328,6 +490,27 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Min_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min());
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (int?)x));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (long)x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (long?)x));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (float)x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (float?)x));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (double)x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (double?)x));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (decimal)x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (decimal?)x));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void Min_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
@@ -343,6 +526,16 @@ namespace System.Linq.Parallel.Tests
         {
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).SequenceEqual(ParallelEnumerable.Range(0, 128).AsOrdered()));
             Functions.AssertEventuallyCanceled((token, canceler) => ParallelEnumerable.Range(0, 128).AsOrdered().SequenceEqual(Cancel(token, canceler, source, operation)));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void SequenceEqual_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            SequenceEqual_AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).SequenceEqual(ParallelEnumerable.Range(0, 128).AsOrdered()));
+            SequenceEqual_AssertAggregateAlternateCanceled((token, canceler) => ParallelEnumerable.Range(0, 128).AsOrdered().SequenceEqual(Cancel(token, canceler, source, operation)));
         }
 
         [Theory]
@@ -363,6 +556,14 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Single_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Single(x => false));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void Single_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
@@ -377,6 +578,14 @@ namespace System.Linq.Parallel.Tests
         public static void SingleOrDefault_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).SingleOrDefault(x => false));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void SingleOrDefault_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).SingleOrDefault(x => false));
         }
 
         [Theory]
@@ -410,6 +619,27 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Sum_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum());
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (int?)x));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (long)x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (long?)x));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (float)x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (float?)x));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (double)x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (double?)x));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (decimal)x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (decimal?)x));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void Sum_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
@@ -427,6 +657,15 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ToArray_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToArray());
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void ToArray_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
@@ -441,6 +680,15 @@ namespace System.Linq.Parallel.Tests
         {
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToDictionary(x => x));
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToDictionary(x => x, y => y));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void ToDictionary_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToDictionary(x => x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToDictionary(x => x, y => y));
         }
 
         [Theory]
@@ -462,6 +710,15 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ToList_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToList());
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void ToList_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
@@ -477,6 +734,16 @@ namespace System.Linq.Parallel.Tests
         {
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToLookup(x => x));
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToLookup(x => x, y => y));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ToLookup_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToLookup(x => x));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToLookup(x => x, y => y));
         }
 
         [Theory]
@@ -496,6 +763,17 @@ namespace System.Linq.Parallel.Tests
         private static ParallelQuery<int> Cancel(CancellationToken token, LabeledOperation source, LabeledOperation operation)
         {
             return operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item);
+        }
+
+        private static void SequenceEqual_AssertAggregateAlternateCanceled(Action<CancellationToken, Action> query)
+        {
+            CancellationTokenSource cs = new CancellationTokenSource();
+            cs.Cancel();
+            Action canceler = () => { throw new OperationCanceledException(cs.Token); };
+
+            AggregateException outer = Assert.Throws<AggregateException>(() => query(new CancellationTokenSource().Token, canceler));
+            AggregateException ae = Assert.Single<AggregateException>(outer.InnerExceptions.Cast<AggregateException>());
+            Assert.All(ae.InnerExceptions, e => Assert.IsType<OperationCanceledException>(e));
         }
     }
 }

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -223,6 +223,15 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ForEach_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => { foreach (int i in Cancel(token, canceler, source, operation)) ; });
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void ForEach_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -278,6 +278,27 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Max_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max());
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (int?)x));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (long)x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (long?)x));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (float)x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (float?)x));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (double)x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (double?)x));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (decimal)x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (decimal?)x));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void Max_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -36,6 +36,14 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void All_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).All(x => true));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void All_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -114,6 +114,17 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Count_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Count());
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).LongCount());
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Count(x => true));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).LongCount(x => true));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void Count_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -69,6 +69,27 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Average_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average());
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (int?)x));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (long)x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (long?)x));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (float)x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (float?)x));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (double)x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (double?)x));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (decimal)x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (decimal?)x));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void Average_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -307,6 +307,27 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Min_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min());
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (int?)x));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (long)x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (long?)x));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (float)x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (float?)x));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (double)x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (double?)x));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (decimal)x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (decimal?)x));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void Min_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -52,6 +52,14 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Any_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Any(x => false));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void Any_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -98,6 +98,14 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Contains_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Contains(-1));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void Contains_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -470,6 +470,16 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ToLookup_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToLookup(x => x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToLookup(x => x, y => y));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void ToLookup_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -33,6 +33,11 @@ namespace System.Linq.Parallel.Tests
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j, i => i));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j, (i, j) => i, i => i));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(() => 0, (i, j) => j, (i, j) => i, i => i));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate((i, j) => j));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j, i => i));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(0, (i, j) => j, (i, j) => i, i => i));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Aggregate(() => 0, (i, j) => j, (i, j) => i, i => i));
         }
 
         [Theory]
@@ -61,6 +66,7 @@ namespace System.Linq.Parallel.Tests
         public static void All_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).All(x => true));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).All(x => true));
         }
 
         [Theory]
@@ -85,6 +91,7 @@ namespace System.Linq.Parallel.Tests
         public static void Any_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Any(x => false));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Any(x => false));
         }
 
         [Theory]
@@ -136,6 +143,21 @@ namespace System.Linq.Parallel.Tests
 
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (decimal)x));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (decimal?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average());
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (int?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (long)x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (long?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (float)x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (float?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (double)x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (double?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (decimal)x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Average(x => (decimal?)x));
         }
 
         [Theory]
@@ -160,6 +182,7 @@ namespace System.Linq.Parallel.Tests
         public static void Contains_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Contains(-1));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Contains(-1));
         }
 
         [Theory]
@@ -190,6 +213,10 @@ namespace System.Linq.Parallel.Tests
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).LongCount());
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Count(x => true));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).LongCount(x => true));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Count());
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).LongCount());
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Count(x => true));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).LongCount(x => true));
         }
 
         [Theory]
@@ -219,6 +246,7 @@ namespace System.Linq.Parallel.Tests
         public static void ElementAt_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ElementAt(int.MaxValue));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ElementAt(int.MaxValue));
         }
 
         [Theory]
@@ -245,6 +273,7 @@ namespace System.Linq.Parallel.Tests
         public static void ElementAtOrDefault_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ElementAtOrDefault(int.MaxValue));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ElementAtOrDefault(int.MaxValue));
         }
 
         [Theory]
@@ -272,6 +301,7 @@ namespace System.Linq.Parallel.Tests
         public static void First_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).First(x => false));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).First(x => false));
         }
 
         [Theory]
@@ -299,6 +329,7 @@ namespace System.Linq.Parallel.Tests
         public static void FirstOrDefault_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).FirstOrDefault(x => false));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).FirstOrDefault(x => false));
         }
 
         [Theory]
@@ -324,6 +355,7 @@ namespace System.Linq.Parallel.Tests
         public static void ForAll_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ForAll(x => { }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ForAll(x => { }));
         }
 
         [Theory]
@@ -350,6 +382,7 @@ namespace System.Linq.Parallel.Tests
         public static void ForEach_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => { foreach (int i in Cancel(token, canceler, source, operation)) ; });
+            Functions.AssertAggregateNotCanceled((token, canceler) => { foreach (int i in Cancel(token, canceler, source, operation)) ; });
         }
 
         [Theory]
@@ -378,6 +411,8 @@ namespace System.Linq.Parallel.Tests
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Last());
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Last(x => true));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Last());
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Last(x => true));
         }
 
         [Theory]
@@ -407,6 +442,8 @@ namespace System.Linq.Parallel.Tests
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).LastOrDefault());
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).LastOrDefault(x => true));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).LastOrDefault());
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).LastOrDefault(x => true));
         }
 
         [Theory]
@@ -458,6 +495,21 @@ namespace System.Linq.Parallel.Tests
 
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (decimal)x));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (decimal?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max());
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (int?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (long)x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (long?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (float)x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (float?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (double)x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (double?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (decimal)x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (decimal?)x));
         }
 
         [Theory]
@@ -508,6 +560,21 @@ namespace System.Linq.Parallel.Tests
 
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (decimal)x));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (decimal?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min());
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (int?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (long)x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (long?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (float)x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (float?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (double)x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (double?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (decimal)x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (decimal?)x));
         }
 
         [Theory]
@@ -536,6 +603,8 @@ namespace System.Linq.Parallel.Tests
         {
             SequenceEqual_AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).SequenceEqual(ParallelEnumerable.Range(0, 128).AsOrdered()));
             SequenceEqual_AssertAggregateAlternateCanceled((token, canceler) => ParallelEnumerable.Range(0, 128).AsOrdered().SequenceEqual(Cancel(token, canceler, source, operation)));
+            SequenceEqual_AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).SequenceEqual(ParallelEnumerable.Range(0, 128).AsOrdered()));
+            SequenceEqual_AssertAggregateNotCanceled((token, canceler) => ParallelEnumerable.Range(0, 128).AsOrdered().SequenceEqual(Cancel(token, canceler, source, operation)));
         }
 
         [Theory]
@@ -561,6 +630,7 @@ namespace System.Linq.Parallel.Tests
         public static void Single_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Single(x => false));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Single(x => false));
         }
 
         [Theory]
@@ -586,6 +656,7 @@ namespace System.Linq.Parallel.Tests
         public static void SingleOrDefault_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).SingleOrDefault(x => false));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).SingleOrDefault(x => false));
         }
 
         [Theory]
@@ -637,6 +708,21 @@ namespace System.Linq.Parallel.Tests
 
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (decimal)x));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (decimal?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum());
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (int?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (long)x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (long?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (float)x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (float?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (double)x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (double?)x));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (decimal)x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (decimal?)x));
         }
 
         [Theory]
@@ -663,6 +749,7 @@ namespace System.Linq.Parallel.Tests
         public static void ToArray_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToArray());
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToArray());
         }
 
         [Theory]
@@ -689,6 +776,8 @@ namespace System.Linq.Parallel.Tests
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToDictionary(x => x));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToDictionary(x => x, y => y));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToDictionary(x => x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToDictionary(x => x, y => y));
         }
 
         [Theory]
@@ -716,6 +805,7 @@ namespace System.Linq.Parallel.Tests
         public static void ToList_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToList());
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToList());
         }
 
         [Theory]
@@ -744,6 +834,8 @@ namespace System.Linq.Parallel.Tests
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToLookup(x => x));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToLookup(x => x, y => y));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToLookup(x => x));
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToLookup(x => x, y => y));
         }
 
         [Theory]
@@ -772,6 +864,16 @@ namespace System.Linq.Parallel.Tests
             Action canceler = () => { throw new OperationCanceledException(cs.Token); };
 
             AggregateException outer = Assert.Throws<AggregateException>(() => query(new CancellationTokenSource().Token, canceler));
+            AggregateException ae = Assert.Single<AggregateException>(outer.InnerExceptions.Cast<AggregateException>());
+            Assert.All(ae.InnerExceptions, e => Assert.IsType<OperationCanceledException>(e));
+        }
+
+        private static void SequenceEqual_AssertAggregateNotCanceled(Action<CancellationToken, Action> query)
+        {
+            CancellationToken token = new CancellationTokenSource().Token;
+            Action canceler = () => { throw new OperationCanceledException(token); };
+
+            AggregateException outer = Assert.Throws<AggregateException>(() => query(token, canceler));
             AggregateException ae = Assert.Single<AggregateException>(outer.InnerExceptions.Cast<AggregateException>());
             Assert.All(ae.InnerExceptions, e => Assert.IsType<OperationCanceledException>(e));
         }

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -355,12 +355,28 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Single_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Single(x => false));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void Single_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
             Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Single());
             Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Single(x => false));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void SingleOrDefault_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).SingleOrDefault(x => false));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -136,11 +136,29 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ElementAt_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ElementAt(int.MaxValue));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void ElementAt_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
             Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ElementAt(0));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ElementAtOrDefault_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ElementAt(int.MaxValue));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -14,12 +14,11 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Aggregate_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Aggregate((x, y) => x));
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Aggregate(0, (x, y) => x + y));
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Aggregate(0, (x, y) => x + y, r => r));
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Aggregate(0, (a, x) => a + x, (l, r) => l + r, r => r));
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Aggregate(() => 0, (a, x) => a + x, (l, r) => l + r, r => r));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Aggregate((x, y) => x));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Aggregate(0, (x, y) => x + y));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Aggregate(0, (x, y) => x + y, r => r));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Aggregate(0, (a, x) => a + x, (l, r) => l + r, r => r));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Aggregate(() => 0, (a, x) => a + x, (l, r) => l + r, r => r));
         }
 
         [Theory]
@@ -27,7 +26,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void All_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).All(x => true));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).All(x => true));
         }
 
         [Theory]
@@ -35,8 +34,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Any_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Any());
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Any(x => true));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Any());
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Any(x => true));
         }
 
         [Theory]
@@ -44,7 +43,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Average_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Average());
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Average());
         }
 
         [Theory]
@@ -52,7 +51,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Contains_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Contains(DefaultStart));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Contains(DefaultStart));
         }
 
         [Theory]
@@ -60,10 +59,10 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Count_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Count());
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).LongCount());
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Count(x => true));
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).LongCount(x => true));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Count());
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).LongCount());
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Count(x => true));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).LongCount(x => true));
         }
 
         [Theory]
@@ -71,7 +70,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void ElementAt_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, (start, count, ignore) => source.Item(start, count).WithCancellation(token)).ElementAt(0));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ElementAt(0));
         }
 
         [Theory]
@@ -79,8 +78,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void ElementAtOrDefault_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, (start, count, ignore) => source.Item(start, count).WithCancellation(token)).ElementAtOrDefault(0));
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, (start, count, ignore) => source.Item(start, count).WithCancellation(token)).ElementAtOrDefault(DefaultSize + 1));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ElementAtOrDefault(0));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ElementAtOrDefault(DefaultSize + 1));
         }
 
         [Theory]
@@ -88,8 +87,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void First_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).First());
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).First(x => false));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).First());
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).First(x => false));
         }
 
         [Theory]
@@ -97,8 +96,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void FirstOrDefault_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).FirstOrDefault());
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).FirstOrDefault(x => false));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).FirstOrDefault());
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).FirstOrDefault(x => false));
         }
 
         [Theory]
@@ -106,7 +105,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void ForAll_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).ForAll(x => { }));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ForAll(x => { }));
         }
 
         [Theory]
@@ -114,7 +113,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void ForEach_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => { foreach (int i in operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item)) ; });
+            Functions.AssertAlreadyCanceled(token => { foreach (int i in Cancel(token, source, operation)) ; });
         }
 
         [Theory]
@@ -122,8 +121,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Last_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Last());
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Last(x => true));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Last());
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Last(x => true));
         }
 
         [Theory]
@@ -131,8 +130,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void LastOrDefault_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, (start, count, ignore) => source.Item(start, count).WithCancellation(token)).LastOrDefault());
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).LastOrDefault(x => true));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).LastOrDefault());
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).LastOrDefault(x => true));
         }
 
         [Theory]
@@ -140,7 +139,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Max_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, (start, count, ignore) => source.Item(start, count).WithCancellation(token)).Max());
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Max());
         }
 
         [Theory]
@@ -148,7 +147,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Min_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Min());
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Min());
         }
 
         [Theory]
@@ -156,8 +155,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void SequenceEqual_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).SequenceEqual(ParallelEnumerable.Range(0, 2)));
-            Functions.AssertAlreadyCanceled(token => ParallelEnumerable.Range(0, 2).SequenceEqual(operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item)));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).SequenceEqual(ParallelEnumerable.Range(0, 2)));
+            Functions.AssertAlreadyCanceled(token => ParallelEnumerable.Range(0, 2).SequenceEqual(Cancel(token, source, operation)));
         }
 
         [Theory]
@@ -165,8 +164,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Single_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Single());
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Single(x => false));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Single());
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Single(x => false));
         }
 
         [Theory]
@@ -174,8 +173,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void SingleOrDefault_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).SingleOrDefault());
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).SingleOrDefault(x => false));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).SingleOrDefault());
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).SingleOrDefault(x => false));
         }
 
         [Theory]
@@ -183,7 +182,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Sum_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Sum());
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Sum());
         }
 
         [Theory]
@@ -191,7 +190,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void ToArray_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).ToArray());
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ToArray());
         }
 
         [Theory]
@@ -199,8 +198,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void ToDictionary_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).ToDictionary(x => x));
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).ToDictionary(x => x, y => y));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ToDictionary(x => x));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ToDictionary(x => x, y => y));
         }
 
         [Theory]
@@ -208,7 +207,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void ToList_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).ToList());
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ToList());
         }
 
         [Theory]
@@ -216,8 +215,13 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void ToLookup_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).ToLookup(x => x));
-            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).ToLookup(x => x, y => y));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ToLookup(x => x));
+            Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ToLookup(x => x, y => y));
+        }
+
+        private static ParallelQuery<int> Cancel(CancellationToken token, LabeledOperation source, LabeledOperation operation)
+        {
+            return operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item);
         }
     }
 }

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -171,12 +171,30 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void First_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).First(x => false));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void First_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
             Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).First());
             Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).First(x => false));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void FirstOrDefault_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).FirstOrDefault(x => false));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -143,6 +143,17 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
+        public static void ForEach_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
+        {
+            CancellationTokenSource cs = new CancellationTokenSource();
+            cs.Cancel();
+
+            Functions.AssertIsCanceled(cs, () => { foreach (int i in operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item)) ; });
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryOperators))]
+        [MemberData(nameof(BinaryOperators))]
         public static void Last_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
             CancellationTokenSource cs = new CancellationTokenSource();

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -219,6 +219,11 @@ namespace System.Linq.Parallel.Tests
             Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).ToLookup(x => x, y => y));
         }
 
+        private static ParallelQuery<int> Cancel(CancellationToken token, Action canceler, Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            return operation.Item(canceler)(DefaultStart, EventualCancellationSize, source.Item(token));
+        }
+
         private static ParallelQuery<int> Cancel(CancellationToken token, LabeledOperation source, LabeledOperation operation)
         {
             return operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item);

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -418,6 +418,15 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ToArray_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToArray());
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void ToArray_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -14,14 +14,12 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Aggregate_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
 
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Aggregate((x, y) => x));
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Aggregate(0, (x, y) => x + y));
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Aggregate(0, (x, y) => x + y, r => r));
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Aggregate(0, (a, x) => a + x, (l, r) => l + r, r => r));
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Aggregate(() => 0, (a, x) => a + x, (l, r) => l + r, r => r));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Aggregate((x, y) => x));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Aggregate(0, (x, y) => x + y));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Aggregate(0, (x, y) => x + y, r => r));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Aggregate(0, (a, x) => a + x, (l, r) => l + r, r => r));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Aggregate(() => 0, (a, x) => a + x, (l, r) => l + r, r => r));
         }
 
         [Theory]
@@ -29,10 +27,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void All_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).All(x => true));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).All(x => true));
         }
 
         [Theory]
@@ -40,11 +35,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Any_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Any());
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Any(x => true));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Any());
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Any(x => true));
         }
 
         [Theory]
@@ -52,10 +44,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Average_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Average());
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Average());
         }
 
         [Theory]
@@ -63,10 +52,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Contains_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Contains(DefaultStart));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Contains(DefaultStart));
         }
 
         [Theory]
@@ -74,13 +60,10 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Count_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Count());
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).LongCount());
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Count(x => true));
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).LongCount(x => true));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Count());
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).LongCount());
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Count(x => true));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).LongCount(x => true));
         }
 
         [Theory]
@@ -88,10 +71,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void ElementAt_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, (start, count, ignore) => source.Item(start, count).WithCancellation(cs.Token)).ElementAt(0));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, (start, count, ignore) => source.Item(start, count).WithCancellation(token)).ElementAt(0));
         }
 
         [Theory]
@@ -99,11 +79,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void ElementAtOrDefault_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, (start, count, ignore) => source.Item(start, count).WithCancellation(cs.Token)).ElementAtOrDefault(0));
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, (start, count, ignore) => source.Item(start, count).WithCancellation(cs.Token)).ElementAtOrDefault(DefaultSize + 1));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, (start, count, ignore) => source.Item(start, count).WithCancellation(token)).ElementAtOrDefault(0));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, (start, count, ignore) => source.Item(start, count).WithCancellation(token)).ElementAtOrDefault(DefaultSize + 1));
         }
 
         [Theory]
@@ -111,11 +88,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void First_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).First());
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).First(x => false));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).First());
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).First(x => false));
         }
 
         [Theory]
@@ -123,11 +97,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void FirstOrDefault_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).FirstOrDefault());
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).FirstOrDefault(x => false));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).FirstOrDefault());
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).FirstOrDefault(x => false));
         }
 
         [Theory]
@@ -135,10 +106,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void ForAll_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).ForAll(x => { }));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).ForAll(x => { }));
         }
 
         [Theory]
@@ -146,10 +114,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void ForEach_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => { foreach (int i in operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item)) ; });
+            Functions.AssertAlreadyCanceled(token => { foreach (int i in operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item)) ; });
         }
 
         [Theory]
@@ -157,11 +122,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Last_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Last());
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Last(x => true));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Last());
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Last(x => true));
         }
 
         [Theory]
@@ -169,11 +131,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void LastOrDefault_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, (start, count, ignore) => source.Item(start, count).WithCancellation(cs.Token)).LastOrDefault());
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).LastOrDefault(x => true));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, (start, count, ignore) => source.Item(start, count).WithCancellation(token)).LastOrDefault());
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).LastOrDefault(x => true));
         }
 
         [Theory]
@@ -181,10 +140,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Max_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, (start, count, ignore) => source.Item(start, count).WithCancellation(cs.Token)).Max());
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, (start, count, ignore) => source.Item(start, count).WithCancellation(token)).Max());
         }
 
         [Theory]
@@ -192,10 +148,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Min_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Min());
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Min());
         }
 
         [Theory]
@@ -203,11 +156,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void SequenceEqual_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).SequenceEqual(ParallelEnumerable.Range(0, 2)));
-            Functions.AssertIsCanceled(cs, () => ParallelEnumerable.Range(0, 2).SequenceEqual(operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item)));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).SequenceEqual(ParallelEnumerable.Range(0, 2)));
+            Functions.AssertAlreadyCanceled(token => ParallelEnumerable.Range(0, 2).SequenceEqual(operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item)));
         }
 
         [Theory]
@@ -215,11 +165,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Single_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Single());
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Single(x => false));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Single());
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Single(x => false));
         }
 
         [Theory]
@@ -227,11 +174,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void SingleOrDefault_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).SingleOrDefault());
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).SingleOrDefault(x => false));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).SingleOrDefault());
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).SingleOrDefault(x => false));
         }
 
         [Theory]
@@ -239,10 +183,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Sum_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Sum());
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).Sum());
         }
 
         [Theory]
@@ -250,10 +191,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void ToArray_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).ToArray());
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).ToArray());
         }
 
         [Theory]
@@ -261,11 +199,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void ToDictionary_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).ToDictionary(x => x));
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).ToDictionary(x => x, y => y));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).ToDictionary(x => x));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).ToDictionary(x => x, y => y));
         }
 
         [Theory]
@@ -273,10 +208,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void ToList_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).ToList());
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).ToList());
         }
 
         [Theory]
@@ -284,11 +216,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void ToLookup_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).ToLookup(x => x));
-            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).ToLookup(x => x, y => y));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).ToLookup(x => x));
+            Functions.AssertAlreadyCanceled(token => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(token)).Item).ToLookup(x => x, y => y));
         }
     }
 }

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -453,6 +453,15 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void ToList_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToList());
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void ToList_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -336,6 +336,16 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void SequenceEqual_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).SequenceEqual(ParallelEnumerable.Range(0, 128).AsOrdered()));
+            Functions.AssertEventuallyCanceled((token, canceler) => ParallelEnumerable.Range(0, 128).AsOrdered().SequenceEqual(Cancel(token, canceler, source, operation)));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void SequenceEqual_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -240,12 +240,32 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void Last_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Last());
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Last(x => true));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void Last_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)
         {
             Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Last());
             Functions.AssertAlreadyCanceled(token => Cancel(token, source, operation).Last(x => true));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        [MemberData(nameof(OrderCancelingOperators))]
+        public static void LastOrDefault_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).LastOrDefault());
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).LastOrDefault(x => true));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -43,6 +43,7 @@ namespace System.Linq.Parallel.Tests
             CancellationTokenSource cs = new CancellationTokenSource();
             cs.Cancel();
 
+            Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Any());
             Functions.AssertIsCanceled(cs, () => operation.Item(DefaultStart, DefaultSize, source.Append(WithCancellation(cs.Token)).Item).Any(x => true));
         }
 

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -389,6 +389,27 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void Sum_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum());
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (int?)x));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (long)x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (long?)x));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (float)x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (float?)x));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (double)x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (double?)x));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (decimal)x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Sum(x => (decimal?)x));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void Sum_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -461,6 +461,8 @@ namespace System.Linq.Parallel.Tests
         public static void Max_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max());
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (int)x));
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (int?)x));
 
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (long)x));
@@ -482,6 +484,8 @@ namespace System.Linq.Parallel.Tests
         public static void Max_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max());
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (int)x));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (int?)x));
 
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (long)x));
@@ -497,6 +501,8 @@ namespace System.Linq.Parallel.Tests
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (decimal?)x));
 
             Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max());
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (int)x));
             Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (int?)x));
 
             Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Max(x => (long)x));
@@ -526,6 +532,8 @@ namespace System.Linq.Parallel.Tests
         public static void Min_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min());
+
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (int)x));
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (int?)x));
 
             Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (long)x));
@@ -547,6 +555,8 @@ namespace System.Linq.Parallel.Tests
         public static void Min_AggregateException_Wraps_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min());
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (int)x));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (int?)x));
 
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (long)x));
@@ -562,6 +572,8 @@ namespace System.Linq.Parallel.Tests
             Functions.AssertAggregateAlternateCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (decimal?)x));
 
             Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min());
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (int)x));
             Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (int?)x));
 
             Functions.AssertAggregateNotCanceled((token, canceler) => Cancel(token, canceler, source, operation).Min(x => (long)x));

--- a/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -435,6 +435,15 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnaryCancelingOperators))]
+        [MemberData(nameof(BinaryCancelingOperators))]
+        public static void ToDictionary_OperationCanceledException(Labeled<Func<CancellationToken, Operation>> source, Labeled<Func<Action, Operation>> operation)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToDictionary(x => x));
+            Functions.AssertEventuallyCanceled((token, canceler) => Cancel(token, canceler, source, operation).ToDictionary(x => x, y => y));
+        }
+
+        [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
         public static void ToDictionary_OperationCanceledException_PreCanceled(LabeledOperation source, LabeledOperation operation)

--- a/src/System.Linq.Parallel/tests/Combinatorial/SourcesAndOperators.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/SourcesAndOperators.cs
@@ -364,10 +364,15 @@ namespace System.Linq.Parallel.Tests
 
             foreach (var operation in new Labeled<Func<Action, Operation>>[] {
                 Labeled.Label<Func<Action, Operation>>("Except", cancel => (start, count, s) => s(start, count).Except(otherSource.Item(start, count), new CancelingEqualityComparer<int>(cancel))),
+                Labeled.Label<Func<Action, Operation>>("Except-Right", cancel => (start, count, s) => otherSource.Item(start, count).Except(s(start, count), new CancelingEqualityComparer<int>(cancel))),
                 Labeled.Label<Func<Action, Operation>>("GroupJoin", cancel => (start, count, s) => s(start, count).GroupJoin(otherSource.Item(start, count), x => x, y => y, (x, g) => x, new CancelingEqualityComparer<int>(cancel))),
+                Labeled.Label<Func<Action, Operation>>("GroupJoin-Right", cancel => (start, count, s) => otherSource.Item(start, count).GroupJoin(s(start, count), x => x, y => y, (x, g) => x, new CancelingEqualityComparer<int>(cancel))),
                 Labeled.Label<Func<Action, Operation>>("Intersect", cancel => (start, count, s) => s(start, count).Intersect(otherSource.Item(start, count), new CancelingEqualityComparer<int>(cancel))),
+                Labeled.Label<Func<Action, Operation>>("Intersect-Right", cancel => (start, count, s) => otherSource.Item(start, count).Intersect(s(start, count), new CancelingEqualityComparer<int>(cancel))),
                 Labeled.Label<Func<Action, Operation>>("Join", cancel => (start, count, s) => s(start, count).Join(otherSource.Item(start, count), x => x, y => y, (x, y) => x, new CancelingEqualityComparer<int>(cancel))),
+                Labeled.Label<Func<Action, Operation>>("Join-Right", cancel => (start, count, s) => otherSource.Item(start, count).Join(s(start, count), x => x, y => y, (x, y) => x, new CancelingEqualityComparer<int>(cancel))),
                 Labeled.Label<Func<Action, Operation>>("Union", cancel => (start, count, s) => s(start, count).Union(otherSource.Item(start, count), new CancelingEqualityComparer<int>(cancel))),
+                Labeled.Label<Func<Action, Operation>>("Union-Right", cancel => (start, count, s) => otherSource.Item(start, count).Union(s(start, count), new CancelingEqualityComparer<int>(cancel))),
                     })
             {
                 yield return new object[] { src, operation };

--- a/src/System.Linq.Parallel/tests/Combinatorial/SourcesAndOperators.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/SourcesAndOperators.cs
@@ -5,7 +5,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -76,19 +75,14 @@ namespace System.Linq.Parallel.Tests
 
         public static IEnumerable<object[]> OrderCancelingOperators()
         {
-            // Token sources are supplied via delegate so they can be re-created as necessary.
-            // This means the funcs taking tokens and actions must be labeled.
-            LabeledOperation source = UnorderedRangeSources().First();
-            var src = Labeled.Label<Func<CancellationToken, Operation>>(source.ToString(), token => source.Append(WithCancellation(token)).Item);
-
-            foreach (var operation in new Labeled<Func<Action, Operation>>[] {
-                Labeled.Label<Func<Action, Operation>>("OrderBy-Comparer", cancel => (start, count, s) => s(start, count).OrderBy(x => x, new CancelingComparer(cancel))),
-                Labeled.Label<Func<Action, Operation>>("OrderByDescending-Comparer", cancel => (start, count, s) => s(start, count).OrderByDescending(x => x, new CancelingComparer(cancel))),
-                Labeled.Label<Func<Action, Operation>>("ThenBy-Comparer", cancel => (start, count, s) => s(start, count).OrderBy(x => 0).ThenBy(x => x, new CancelingComparer(cancel))),
-                Labeled.Label<Func<Action, Operation>>("ThenByDescending-Comparer", cancel => (start, count, s) => s(start, count).OrderBy(x => 0).ThenByDescending(x => x, new CancelingComparer(cancel))),
+            foreach (var operation in new Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>[] {
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("OrderBy-Comparer", (source, cancel) => source.OrderBy(x => x, new CancelingComparer(cancel))),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("OrderByDescending-Comparer", (source, cancel) => source.OrderByDescending(x => x, new CancelingComparer(cancel))),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("ThenBy-Comparer", (source, cancel) => source.OrderBy(x => 0).ThenBy(x => x, new CancelingComparer(cancel))),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("ThenByDescending-Comparer", (source, cancel) => source.OrderBy(x => 0).ThenByDescending(x => x, new CancelingComparer(cancel))),
                 })
             {
-                yield return new object[] { src, operation };
+                yield return new object[] { operation };
             }
         }
 
@@ -216,27 +210,22 @@ namespace System.Linq.Parallel.Tests
 
         public static IEnumerable<object[]> UnaryCancelingOperators()
         {
-            // Token sources are supplied via delegate so they can be re-created as necessary.
-            // This means the funcs taking tokens and actions must be labeled.
-            LabeledOperation source = UnorderedRangeSources().First();
-            var src = Labeled.Label<Func<CancellationToken, Operation>>(source.ToString(), token => source.Append(WithCancellation(token)).Item);
-
-            foreach (var operation in new Labeled<Func<Action, Operation>>[] {
-                Labeled.Label<Func<Action, Operation>>("Distinct",cancel => (start, count, s) => s(start, count).Distinct(new CancelingEqualityComparer<int>(cancel))),
-                Labeled.Label<Func<Action, Operation>>("GroupBy-Comparer", cancel => (start, count, s) => s(start, count).GroupBy(x => x, new CancelingEqualityComparer<int>(cancel)).Select(g => g.Key)),
-                Labeled.Label<Func<Action, Operation>>("SelectMany", cancel => (start, count, s) => s(start, count).SelectMany(x => { cancel(); return new[] { x }; })),
-                Labeled.Label<Func<Action, Operation>>("SelectMany-Index", cancel => (start, count, s) => s(start, count).SelectMany((x, index) => { cancel(); return new[] { x }; })),
-                Labeled.Label<Func<Action, Operation>>("SelectMany-ResultSelector", cancel => (start, count, s) => s(start, count).SelectMany(x => new [] { x }, (group, elem) => { cancel(); return elem; })),
-                Labeled.Label<Func<Action, Operation>>("SelectMany-Index-ResultSelector", cancel => (start, count, s) => s(start, count).SelectMany((x, index) => new [] { x }, (group, elem) => { cancel(); return elem; })),
-                Labeled.Label<Func<Action, Operation>>("SkipWhile", cancel => (start, count, s) => s(start, count).SkipWhile(x => { cancel(); return true; })),
-                Labeled.Label<Func<Action, Operation>>("SkipWhile-Index", cancel => (start, count, s) => s(start, count).SkipWhile((x, index) => { cancel(); return true; })),
-                Labeled.Label<Func<Action, Operation>>("TakeWhile", cancel => (start, count, s) => s(start, count).TakeWhile(x => { cancel(); return true; })),
-                Labeled.Label<Func<Action, Operation>>("TakeWhile-Index", cancel => (start, count, s) => s(start, count).TakeWhile((x, index) => { cancel(); return true; })),
-                Labeled.Label<Func<Action, Operation>>("Where", cancel => (start, count, s) => s(start, count).Where(x => { cancel(); return true; })),
-                Labeled.Label<Func<Action, Operation>>("Where-Index", cancel => (start, count, s) => s(start, count).Where((x, index) => { cancel(); return true; })),
+            foreach (var operation in new Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>[] {
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("Distinct", (source,cancel) => source.Distinct(new CancelingEqualityComparer<int>(cancel))),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("GroupBy-Comparer", (source,cancel) => source.GroupBy(x => x, new CancelingEqualityComparer<int>(cancel)).Select(g => g.Key)),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("SelectMany", (source,cancel) => source.SelectMany(x => { cancel(); return new[] { x }; })),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("SelectMany-Index", (source,cancel) => source.SelectMany((x, index) => { cancel(); return new[] { x }; })),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("SelectMany-ResultSelector", (source,cancel) => source.SelectMany(x => new [] { x }, (group, elem) => { cancel(); return elem; })),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("SelectMany-Index-ResultSelector", (source,cancel) => source.SelectMany((x, index) => new [] { x }, (group, elem) => { cancel(); return elem; })),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("SkipWhile", (source,cancel) => source.SkipWhile(x => { cancel(); return true; })),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("SkipWhile-Index", (source,cancel) => source.SkipWhile((x, index) => { cancel(); return true; })),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("TakeWhile", (source,cancel) => source.TakeWhile(x => { cancel(); return true; })),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("TakeWhile-Index", (source,cancel) => source.TakeWhile((x, index) => { cancel(); return true; })),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("Where", (source,cancel) => source.Where(x => { cancel(); return true; })),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("Where-Index", (source,cancel) => source.Where((x, index) => { cancel(); return true; })),
                     })
             {
-                yield return new object[] { src, operation };
+                yield return new object[] { operation };
             }
         }
 
@@ -356,26 +345,20 @@ namespace System.Linq.Parallel.Tests
 
         public static IEnumerable<object[]> BinaryCancelingOperators()
         {
-            // Token sources are supplied via delegate so they can be re-created as necessary.
-            // This means the funcs taking tokens and actions must be labeled.
-            LabeledOperation source = UnorderedRangeSources().First();
-            var src = Labeled.Label<Func<CancellationToken, Operation>>(source.ToString(), token => source.Append(WithCancellation(token)).Item);
-            LabeledOperation otherSource = UnorderedRangeSources().First();
-
-            foreach (var operation in new Labeled<Func<Action, Operation>>[] {
-                Labeled.Label<Func<Action, Operation>>("Except", cancel => (start, count, s) => s(start, count).Except(otherSource.Item(start, count), new CancelingEqualityComparer<int>(cancel))),
-                Labeled.Label<Func<Action, Operation>>("Except-Right", cancel => (start, count, s) => otherSource.Item(start, count).Except(s(start, count), new CancelingEqualityComparer<int>(cancel))),
-                Labeled.Label<Func<Action, Operation>>("GroupJoin", cancel => (start, count, s) => s(start, count).GroupJoin(otherSource.Item(start, count), x => x, y => y, (x, g) => x, new CancelingEqualityComparer<int>(cancel))),
-                Labeled.Label<Func<Action, Operation>>("GroupJoin-Right", cancel => (start, count, s) => otherSource.Item(start, count).GroupJoin(s(start, count), x => x, y => y, (x, g) => x, new CancelingEqualityComparer<int>(cancel))),
-                Labeled.Label<Func<Action, Operation>>("Intersect", cancel => (start, count, s) => s(start, count).Intersect(otherSource.Item(start, count), new CancelingEqualityComparer<int>(cancel))),
-                Labeled.Label<Func<Action, Operation>>("Intersect-Right", cancel => (start, count, s) => otherSource.Item(start, count).Intersect(s(start, count), new CancelingEqualityComparer<int>(cancel))),
-                Labeled.Label<Func<Action, Operation>>("Join", cancel => (start, count, s) => s(start, count).Join(otherSource.Item(start, count), x => x, y => y, (x, y) => x, new CancelingEqualityComparer<int>(cancel))),
-                Labeled.Label<Func<Action, Operation>>("Join-Right", cancel => (start, count, s) => otherSource.Item(start, count).Join(s(start, count), x => x, y => y, (x, y) => x, new CancelingEqualityComparer<int>(cancel))),
-                Labeled.Label<Func<Action, Operation>>("Union", cancel => (start, count, s) => s(start, count).Union(otherSource.Item(start, count), new CancelingEqualityComparer<int>(cancel))),
-                Labeled.Label<Func<Action, Operation>>("Union-Right", cancel => (start, count, s) => otherSource.Item(start, count).Union(s(start, count), new CancelingEqualityComparer<int>(cancel))),
+            foreach (var operation in new Labeled<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>[] {
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("Except", (source, cancel) => source.Except(ParallelEnumerable.Range(DefaultStart, EventualCancellationSize), new CancelingEqualityComparer<int>(cancel))),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("Except-Right", (source, cancel) => ParallelEnumerable.Range(DefaultStart, EventualCancellationSize).Except(source, new CancelingEqualityComparer<int>(cancel))),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("GroupJoin", (source, cancel) => source.GroupJoin(ParallelEnumerable.Range(DefaultStart, EventualCancellationSize), x => x, y => y, (x, g) => x, new CancelingEqualityComparer<int>(cancel))),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("GroupJoin-Right", (source, cancel) => ParallelEnumerable.Range(DefaultStart, EventualCancellationSize).GroupJoin(source, x => x, y => y, (x, g) => x, new CancelingEqualityComparer<int>(cancel))),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("Intersect", (source, cancel) => source.Intersect(ParallelEnumerable.Range(DefaultStart, EventualCancellationSize), new CancelingEqualityComparer<int>(cancel))),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("Intersect-Right", (source, cancel) => ParallelEnumerable.Range(DefaultStart, EventualCancellationSize).Intersect(source, new CancelingEqualityComparer<int>(cancel))),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("Join", (source, cancel) => source.Join(ParallelEnumerable.Range(DefaultStart, EventualCancellationSize), x => x, y => y, (x, y) => x, new CancelingEqualityComparer<int>(cancel))),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("Join-Right", (source, cancel) => ParallelEnumerable.Range(DefaultStart, EventualCancellationSize).Join(source, x => x, y => y, (x, y) => x, new CancelingEqualityComparer<int>(cancel))),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("Union", (source, cancel) => source.Union(ParallelEnumerable.Range(DefaultStart, EventualCancellationSize), new CancelingEqualityComparer<int>(cancel))),
+                Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("Union-Right", (source, cancel) => ParallelEnumerable.Range(DefaultStart, EventualCancellationSize).Union(source, new CancelingEqualityComparer<int>(cancel))),
                     })
             {
-                yield return new object[] { src, operation };
+                yield return new object[] { operation };
             }
         }
 
@@ -384,8 +367,6 @@ namespace System.Linq.Parallel.Tests
         private static LabeledOperation Failing = Label("ThrowOnFirstEnumeration", (start, count, source) => Enumerables<int>.ThrowOnEnumeration().AsParallel());
 
         private static LabeledOperation AsOrdered = Label("AsOrdered", (start, count, source) => source(start, count).AsOrdered());
-
-        private static Func<CancellationToken, LabeledOperation> WithCancellation = token => Label("WithCancellation", (start, count, source) => source(start, count).WithCancellation(token));
 
         // There are two implementations here to help check that the 1st element is matched to the 1st element.
         private static Func<LabeledOperation, IEnumerable<LabeledOperation>> Zip_Ordered_Operation = sOther => new[] {

--- a/src/System.Linq.Parallel/tests/Combinatorial/SourcesAndOperators.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/SourcesAndOperators.cs
@@ -231,7 +231,7 @@ namespace System.Linq.Parallel.Tests
                 Labeled.Label<Func<Action, Operation>>("SkipWhile", cancel => (start, count, s) => s(start, count).SkipWhile(x => { cancel(); return true; })),
                 Labeled.Label<Func<Action, Operation>>("SkipWhile-Index", cancel => (start, count, s) => s(start, count).SkipWhile((x, index) => { cancel(); return true; })),
                 Labeled.Label<Func<Action, Operation>>("TakeWhile", cancel => (start, count, s) => s(start, count).TakeWhile(x => { cancel(); return true; })),
-                Labeled.Label<Func<Action, Operation>>("TakeWhile-Index", cancel => (start, count, s) => s(start, count).SkipWhile((x, index) => { cancel(); return true; })),
+                Labeled.Label<Func<Action, Operation>>("TakeWhile-Index", cancel => (start, count, s) => s(start, count).TakeWhile((x, index) => { cancel(); return true; })),
                 Labeled.Label<Func<Action, Operation>>("Where", cancel => (start, count, s) => s(start, count).Where(x => { cancel(); return true; })),
                 Labeled.Label<Func<Action, Operation>>("Where-Index", cancel => (start, count, s) => s(start, count).Where((x, index) => { cancel(); return true; })),
                     })

--- a/src/System.Linq.Parallel/tests/Helpers/AssertThrows.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/AssertThrows.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using Xunit;
+
+namespace System.Linq.Parallel.Tests
+{
+    internal static class AssertThrows
+    {
+        private const int EventualCancellationSize = 128;
+
+        public static void AlreadyCanceled(Action<ParallelQuery<int>> query)
+        {
+            ParallelQuery<int> s = Enumerables<int>.ThrowOnEnumeration(new ShouldNotBeInvokedException(), 2).AsParallel().WithCancellation(new CancellationToken(canceled: true));
+            OperationCanceledException oce = Assert.Throws<OperationCanceledException>(() => query(s));
+        }
+
+        public static void EventuallyCanceled(Action<ParallelQuery<int>, Action> query)
+        {
+            CancellationTokenSource source = new CancellationTokenSource();
+            int countdown = 4;
+            Action cancel = () =>
+            {
+                if (Interlocked.Decrement(ref countdown) == 0)
+                {
+                    source.Cancel();
+                }
+            };
+
+            ParallelQuery<int> s = ParallelEnumerable.Range(0, EventualCancellationSize).WithCancellation(source.Token);
+            OperationCanceledException oce = Assert.Throws<OperationCanceledException>(() => query(s, cancel));
+            Assert.Equal(source.Token, oce.CancellationToken);
+        }
+
+        public static void OtherTokenCanceled(Action<ParallelQuery<int>, Action> query)
+        {
+            CancellationTokenSource source = new CancellationTokenSource();
+            CancellationTokenSource alternate = new CancellationTokenSource();
+            int countdown = 4;
+            Action cancel = () =>
+            {
+                if (Interlocked.Decrement(ref countdown) == 0)
+                {
+                    // Only cancel/throw alternate.
+                    alternate.Cancel();
+                    alternate.Token.ThrowIfCancellationRequested();
+                }
+            };
+
+            ParallelQuery<int> s = ParallelEnumerable.Range(0, EventualCancellationSize).WithCancellation(source.Token);
+            OperationCanceledException oce = Wrapped<OperationCanceledException>(() => query(s, cancel));
+            Assert.NotEqual(source.Token, oce.CancellationToken);
+        }
+
+        public static void SameTokenNotCanceled(Action<ParallelQuery<int>, Action> query)
+        {
+            CancellationTokenSource source = new CancellationTokenSource();
+            int countdown = 4;
+            Action cancel = () =>
+            {
+                if (Interlocked.Decrement(ref countdown) == 0)
+                {
+                    throw new OperationCanceledException(source.Token);
+                }
+            };
+
+            ParallelQuery<int> s = ParallelEnumerable.Range(0, EventualCancellationSize).WithCancellation(source.Token);
+            OperationCanceledException oce = Wrapped<OperationCanceledException>(() => query(s, cancel));
+            Assert.Equal(source.Token, oce.CancellationToken);
+        }
+
+        public static T Wrapped<T>(Action action) where T : Exception
+        {
+            AggregateException ae = Assert.Throws<AggregateException>(action);
+            return Assert.IsType<T>(Assert.Single(ae.InnerExceptions));
+        }
+    }
+}

--- a/src/System.Linq.Parallel/tests/Helpers/Comparers.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/Comparers.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Threading;
 
 namespace System.Linq.Parallel.Tests
 {
@@ -54,6 +55,28 @@ namespace System.Linq.Parallel.Tests
         }
     }
 
+    internal class CancelingEqualityComparer<T> : IEqualityComparer<T>
+    {
+        private Action _canceler;
+
+        public CancelingEqualityComparer(Action canceler)
+        {
+            _canceler = canceler;
+        }
+
+        public bool Equals(T x, T y)
+        {
+            _canceler();
+            return EqualityComparer<T>.Default.Equals(x, y);
+        }
+
+        public int GetHashCode(T obj)
+        {
+            _canceler();
+            return obj.GetHashCode();
+        }
+    }
+
     internal class ReverseComparer : IComparer<int>
     {
         public static readonly ReverseComparer Instance = new ReverseComparer();
@@ -87,6 +110,22 @@ namespace System.Linq.Parallel.Tests
             return direction == 0 ? 0 :
                 direction > 0 ? int.MaxValue :
                 int.MinValue;
+        }
+    }
+
+    internal class CancelingComparer : IComparer<int>
+    {
+        private Action _canceler;
+
+        public CancelingComparer(Action canceler)
+        {
+            _canceler = canceler;
+        }
+
+        public int Compare(int x, int y)
+        {
+            _canceler();
+            return Comparer<int>.Default.Compare(x, y);
         }
     }
 

--- a/src/System.Linq.Parallel/tests/Helpers/Comparers.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/Comparers.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
 
 namespace System.Linq.Parallel.Tests
 {
@@ -55,9 +54,9 @@ namespace System.Linq.Parallel.Tests
         }
     }
 
-    internal class CancelingEqualityComparer<T> : IEqualityComparer<T>
+    internal sealed class CancelingEqualityComparer<T> : IEqualityComparer<T>
     {
-        private Action _canceler;
+        private readonly Action _canceler;
 
         public CancelingEqualityComparer(Action canceler)
         {
@@ -113,9 +112,9 @@ namespace System.Linq.Parallel.Tests
         }
     }
 
-    internal class CancelingComparer : IComparer<int>
+    internal sealed class CancelingComparer : IComparer<int>
     {
-        private Action _canceler;
+        private readonly Action _canceler;
 
         public CancelingComparer(Action canceler)
         {

--- a/src/System.Linq.Parallel/tests/Helpers/Enumerables.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/Enumerables.cs
@@ -24,9 +24,20 @@ namespace System.Linq.Parallel.Tests
         /// <returns>An enumerable that throws on the given enumeration.</returns>
         public static IEnumerable<T> ThrowOnEnumeration(int count)
         {
+            return ThrowOnEnumeration(new DeliberateTestException(), count);
+        }
+
+        /// <summary>
+        /// Get an enumerable that throws the given exception after the given number of enumerations.
+        /// </summary>
+        /// <param name="count">The number of enumerations until the error is thrown.</param>The
+        /// <param name="e">The exception to throw.</param>
+        /// <returns>An enumerable that throws on the given enumeration.</returns>
+        public static IEnumerable<T> ThrowOnEnumeration(Exception e, int count)
+        {
             return Enumerable.Range(0, count).Select(i =>
             {
-                if (i == count - 1) throw new DeliberateTestException();
+                if (i == count - 1) throw e;
                 return default(T);
             });
         }

--- a/src/System.Linq.Parallel/tests/Helpers/Functions.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/Functions.cs
@@ -66,6 +66,15 @@ namespace System.Linq.Parallel.Tests
             Assert.All(ae.InnerExceptions, e => Assert.IsType<OperationCanceledException>(e));
         }
 
+        public static void AssertAggregateNotCanceled(Action<CancellationToken, Action> query)
+        {
+            CancellationToken token = new CancellationTokenSource().Token;
+            Action canceler = () => { throw new OperationCanceledException(token); };
+
+            AggregateException ae = Assert.Throws<AggregateException>(() => query(token, canceler));
+            Assert.All(ae.InnerExceptions, e => Assert.IsType<OperationCanceledException>(e));
+        }
+
         public static void Enumerate<T>(this IEnumerable<T> e)
         {
             foreach (var x in e) { }

--- a/src/System.Linq.Parallel/tests/Helpers/Functions.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/Functions.cs
@@ -46,6 +46,16 @@ namespace System.Linq.Parallel.Tests
             Assert.Equal(cs.Token, oce.CancellationToken);
         }
 
+        public static void AssertEventuallyCanceled(Action<CancellationToken, Action> query)
+        {
+            CancellationTokenSource cs = new CancellationTokenSource();
+            int countDown = 4;
+            Action canceler = () => { if (Interlocked.Decrement(ref countDown) == 0) cs.Cancel(); };
+
+            OperationCanceledException oce = Assert.Throws<OperationCanceledException>(() => query(cs.Token, canceler));
+            Assert.Equal(cs.Token, oce.CancellationToken);
+        }
+
         public static void Enumerate<T>(this IEnumerable<T> e)
         {
             foreach (var x in e) { }

--- a/src/System.Linq.Parallel/tests/Helpers/Functions.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/Functions.cs
@@ -56,6 +56,16 @@ namespace System.Linq.Parallel.Tests
             Assert.Equal(cs.Token, oce.CancellationToken);
         }
 
+        public static void AssertAggregateAlternateCanceled(Action<CancellationToken, Action> query)
+        {
+            CancellationTokenSource cs = new CancellationTokenSource();
+            cs.Cancel();
+            Action canceler = () => { throw new OperationCanceledException(cs.Token); };
+
+            AggregateException ae = Assert.Throws<AggregateException>(() => query(new CancellationTokenSource().Token, canceler));
+            Assert.All(ae.InnerExceptions, e => Assert.IsType<OperationCanceledException>(e));
+        }
+
         public static void Enumerate<T>(this IEnumerable<T> e)
         {
             foreach (var x in e) { }

--- a/src/System.Linq.Parallel/tests/Helpers/Functions.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/Functions.cs
@@ -62,8 +62,7 @@ namespace System.Linq.Parallel.Tests
             cs.Cancel();
             Action canceler = () => { throw new OperationCanceledException(cs.Token); };
 
-            AggregateException ae = Assert.Throws<AggregateException>(() => query(new CancellationTokenSource().Token, canceler));
-            Assert.All(ae.InnerExceptions, e => Assert.IsType<OperationCanceledException>(e));
+            AssertThrowsWrapped<OperationCanceledException>(() => query(new CancellationTokenSource().Token, canceler));
         }
 
         public static void AssertAggregateNotCanceled(Action<CancellationToken, Action> query)
@@ -71,8 +70,7 @@ namespace System.Linq.Parallel.Tests
             CancellationToken token = new CancellationTokenSource().Token;
             Action canceler = () => { throw new OperationCanceledException(token); };
 
-            AggregateException ae = Assert.Throws<AggregateException>(() => query(token, canceler));
-            Assert.All(ae.InnerExceptions, e => Assert.IsType<OperationCanceledException>(e));
+            AssertThrowsWrapped<OperationCanceledException>(() => query(token, canceler));
         }
 
         public static void Enumerate<T>(this IEnumerable<T> e)

--- a/src/System.Linq.Parallel/tests/Helpers/Functions.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/Functions.cs
@@ -37,10 +37,13 @@ namespace System.Linq.Parallel.Tests
             Assert.All(ae.InnerExceptions, e => Assert.IsType<T>(e));
         }
 
-        public static void AssertIsCanceled(CancellationTokenSource source, Action query)
+        public static void AssertAlreadyCanceled(Action<CancellationToken> query)
         {
-            OperationCanceledException oce = Assert.Throws<OperationCanceledException>(query);
-            Assert.Equal(source.Token, oce.CancellationToken);
+            CancellationTokenSource cs = new CancellationTokenSource();
+            cs.Cancel();
+
+            OperationCanceledException oce = Assert.Throws<OperationCanceledException>(() => query(cs.Token));
+            Assert.Equal(cs.Token, oce.CancellationToken);
         }
 
         public static void Enumerate<T>(this IEnumerable<T> e)

--- a/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
@@ -312,6 +312,11 @@ namespace System.Linq.Parallel.Tests
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }, i => i));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }, (i, j) => i, i => i));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(() => 0, (i, j) => { canceler(); ; return j; }, (i, j) => i, i => i));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate((i, j) => { canceler(); return j; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }, i => i));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }, (i, j) => i, i => i));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(() => 0, (i, j) => { canceler(); ; return j; }, (i, j) => i, i => i));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
@@ -304,6 +304,17 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Aggregate_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate((i, j) => { canceler(); return j; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }, i => i));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }, (i, j) => i, i => i));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(() => 0, (i, j) => { canceler(); ; return j; }, (i, j) => i, i => i));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
@@ -292,41 +292,39 @@ namespace System.Linq.Parallel.Tests
             Assert.Equal(-1, ParallelEnumerable.Empty<int>().Aggregate(() => -1, (i, j) => i + j, (i, j) => i + j, i => i));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Aggregate_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Aggregate_OperationCanceledException()
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate((i, j) => { canceler(); return j; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }, i => i));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }, (i, j) => i, i => i));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(() => 0, (i, j) => { canceler(); ; return j; }, (i, j) => i, i => i));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Aggregate((i, j) => { canceler(); return j; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Aggregate(0, (i, j) => { canceler(); return j; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Aggregate(0, (i, j) => { canceler(); return j; }, i => i));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Aggregate(0, (i, j) => { canceler(); return j; }, (i, j) => i, i => i));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Aggregate(() => 0, (i, j) => { canceler(); ; return j; }, (i, j) => i, i => i));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Aggregate_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Aggregate_AggregateException_Wraps_OperationCanceledException()
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate((i, j) => { canceler(); return j; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }, i => i));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }, (i, j) => i, i => i));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(() => 0, (i, j) => { canceler(); ; return j; }, (i, j) => i, i => i));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate((i, j) => { canceler(); return j; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }, i => i));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }, (i, j) => i, i => i));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(() => 0, (i, j) => { canceler(); ; return j; }, (i, j) => i, i => i));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Aggregate((i, j) => { canceler(); return j; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Aggregate(0, (i, j) => { canceler(); return j; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Aggregate(0, (i, j) => { canceler(); return j; }, i => i));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Aggregate(0, (i, j) => { canceler(); return j; }, (i, j) => i, i => i));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Aggregate(() => 0, (i, j) => { canceler(); ; return j; }, (i, j) => i, i => i));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Aggregate((i, j) => { canceler(); return j; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Aggregate(0, (i, j) => { canceler(); return j; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Aggregate(0, (i, j) => { canceler(); return j; }, i => i));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Aggregate(0, (i, j) => { canceler(); return j; }, (i, j) => i, i => i));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Aggregate(() => 0, (i, j) => { canceler(); ; return j; }, (i, j) => i, i => i));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
-        public static void Aggregate_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Aggregate_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Aggregate((i, j) => i));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => i));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => i, i => i));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => i, (i, j) => i, i => i));
+            AssertThrows.AlreadyCanceled(source => source.Aggregate((i, j) => i));
+            AssertThrows.AlreadyCanceled(source => source.Aggregate(0, (i, j) => i));
+            AssertThrows.AlreadyCanceled(source => source.Aggregate(0, (i, j) => i, i => i));
+            AssertThrows.AlreadyCanceled(source => source.Aggregate(0, (i, j) => i, (i, j) => i, i => i));
+            AssertThrows.AlreadyCanceled(source => source.Aggregate(() => 0, (i, j) => i, (i, j) => i, i => i));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -291,6 +290,17 @@ namespace System.Linq.Parallel.Tests
             Assert.Equal(-1, ParallelEnumerable.Empty<int>().Aggregate(-1, (i, j) => i + j, i => i));
             Assert.Equal(-1, ParallelEnumerable.Empty<int>().Aggregate(-1, (i, j) => i + j, (i, j) => i + j, i => i));
             Assert.Equal(-1, ParallelEnumerable.Empty<int>().Aggregate(() => -1, (i, j) => i + j, (i, j) => i + j, i => i));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Aggregate_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate((i, j) => { canceler(); return j; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }, i => i));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => { canceler(); return j; }, (i, j) => i, i => i));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Aggregate(() => 0, (i, j) => { canceler(); ; return j; }, (i, j) => i, i => i));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
@@ -297,13 +297,10 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Aggregate((i, j) => i));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Aggregate(0, (i, j) => i));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Aggregate(0, (i, j) => i, i => i));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Aggregate(0, (i, j) => i, (i, j) => i, i => i));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Aggregate((i, j) => i));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => i));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => i, i => i));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Aggregate(0, (i, j) => i, (i, j) => i, i => i));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/AllTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AllTests.cs
@@ -89,10 +89,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void All_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).All(x => true));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).All(x => true));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/AllTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AllTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -83,6 +82,13 @@ namespace System.Linq.Parallel.Tests
         public static void All_OneTrue_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             All_OneTrue(labeled, count, position);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void All_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).All(x => { canceler(); return true; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/AllTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AllTests.cs
@@ -96,6 +96,7 @@ namespace System.Linq.Parallel.Tests
         public static void All_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).All(x => { canceler(); return true; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).All(x => { canceler(); return true; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/AllTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AllTests.cs
@@ -92,6 +92,13 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void All_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).All(x => { canceler(); return true; }));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void All_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/AllTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AllTests.cs
@@ -84,26 +84,23 @@ namespace System.Linq.Parallel.Tests
             All_OneTrue(labeled, count, position);
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void All_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void All_OperationCanceledException()
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).All(x => { canceler(); return true; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.All(x => { canceler(); return true; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void All_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void All_AggregateException_Wraps_OperationCanceledException()
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).All(x => { canceler(); return true; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).All(x => { canceler(); return true; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.All(x => { canceler(); return true; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.All(x => { canceler(); return true; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
-        public static void All_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void All_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).All(x => true));
+            AssertThrows.AlreadyCanceled(source => source.All(x => true));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/AnyTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AnyTests.cs
@@ -118,6 +118,13 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Any_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Any(x => { canceler(); return false; }));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Any_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/AnyTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AnyTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -109,6 +108,13 @@ namespace System.Linq.Parallel.Tests
         {
             Assert.True(InfiniteEnumerable().AsParallel().Any());
             Assert.True(InfiniteEnumerable().AsParallel().Any(x => true));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Any_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Any(x => { canceler(); return false; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/AnyTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AnyTests.cs
@@ -110,27 +110,24 @@ namespace System.Linq.Parallel.Tests
             Assert.True(InfiniteEnumerable().AsParallel().Any(x => true));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Any_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Any_OperationCanceledException()
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Any(x => { canceler(); return false; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Any(x => { canceler(); return false; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Any_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Any_AggregateException_Wraps_OperationCanceledException()
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Any(x => { canceler(); return false; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Any(x => { canceler(); return false; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Any(x => { canceler(); return false; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Any(x => { canceler(); return false; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
-        public static void Any_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Any_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Any());
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Any(x => true));
+            AssertThrows.AlreadyCanceled(source => source.Any());
+            AssertThrows.AlreadyCanceled(source => source.Any(x => true));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/AnyTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AnyTests.cs
@@ -122,6 +122,7 @@ namespace System.Linq.Parallel.Tests
         public static void Any_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Any(x => { canceler(); return false; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Any(x => { canceler(); return false; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/AnyTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AnyTests.cs
@@ -115,11 +115,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Any_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Any());
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Any(x => true));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Any());
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Any(x => true));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/AverageTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AverageTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -240,6 +239,26 @@ namespace System.Linq.Parallel.Tests
             Assert.Null(ParallelEnumerable.Empty<double?>().Average(x => x));
             Assert.Null(ParallelEnumerable.Empty<decimal?>().Average());
             Assert.Null(ParallelEnumerable.Empty<decimal?>().Average(x => x));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Average_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (int?)x; }));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (long)x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (long?)x; }));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (float)x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (float?)x; }));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (double)x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (double?)x; }));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (decimal)x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (decimal?)x; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/AverageTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AverageTests.cs
@@ -262,6 +262,26 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Average_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (int?)x; }));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (long)x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (long?)x; }));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (float)x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (float?)x; }));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (double)x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (double?)x; }));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (decimal)x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (decimal?)x; }));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Average_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/AverageTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AverageTests.cs
@@ -279,6 +279,21 @@ namespace System.Linq.Parallel.Tests
 
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (decimal)x; }));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (decimal?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (int?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (long)x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (long?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (float)x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (float?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (double)x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (double?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (decimal)x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (decimal?)x; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/AverageTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AverageTests.cs
@@ -241,79 +241,76 @@ namespace System.Linq.Parallel.Tests
             Assert.Null(ParallelEnumerable.Empty<decimal?>().Average(x => x));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Average_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Average_OperationCanceledException()
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (int?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Average(x => { canceler(); return x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Average(x => { canceler(); return (int?)x; }));
 
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (long)x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (long?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Average(x => { canceler(); return (long)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Average(x => { canceler(); return (long?)x; }));
 
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (float)x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (float?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Average(x => { canceler(); return (float)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Average(x => { canceler(); return (float?)x; }));
 
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (double)x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (double?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Average(x => { canceler(); return (double)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Average(x => { canceler(); return (double?)x; }));
 
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (decimal)x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (decimal?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Average(x => { canceler(); return (decimal)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Average(x => { canceler(); return (decimal?)x; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Average_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Average_AggregateException_Wraps_OperationCanceledException()
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (int?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Average(x => { canceler(); return x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Average(x => { canceler(); return (int?)x; }));
 
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (long)x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (long?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Average(x => { canceler(); return (long)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Average(x => { canceler(); return (long?)x; }));
 
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (float)x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (float?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Average(x => { canceler(); return (float)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Average(x => { canceler(); return (float?)x; }));
 
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (double)x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (double?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Average(x => { canceler(); return (double)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Average(x => { canceler(); return (double?)x; }));
 
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (decimal)x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (decimal?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Average(x => { canceler(); return (decimal)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Average(x => { canceler(); return (decimal?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (int?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Average(x => { canceler(); return x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Average(x => { canceler(); return (int?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (long)x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (long?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Average(x => { canceler(); return (long)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Average(x => { canceler(); return (long?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (float)x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (float?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Average(x => { canceler(); return (float)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Average(x => { canceler(); return (float?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (double)x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (double?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Average(x => { canceler(); return (double)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Average(x => { canceler(); return (double?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (decimal)x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Average(x => { canceler(); return (decimal?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Average(x => { canceler(); return (decimal)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Average(x => { canceler(); return (decimal?)x; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
-        public static void Average_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Average_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (int?)x));
+            AssertThrows.AlreadyCanceled(source => source.Average(x => x));
+            AssertThrows.AlreadyCanceled(source => source.Average(x => (int?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (long)x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (long?)x));
+            AssertThrows.AlreadyCanceled(source => source.Average(x => (long)x));
+            AssertThrows.AlreadyCanceled(source => source.Average(x => (long?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (float)x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (float?)x));
+            AssertThrows.AlreadyCanceled(source => source.Average(x => (float)x));
+            AssertThrows.AlreadyCanceled(source => source.Average(x => (float?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (double)x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (double?)x));
+            AssertThrows.AlreadyCanceled(source => source.Average(x => (double)x));
+            AssertThrows.AlreadyCanceled(source => source.Average(x => (double?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (decimal)x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (decimal?)x));
+            AssertThrows.AlreadyCanceled(source => source.Average(x => (decimal)x));
+            AssertThrows.AlreadyCanceled(source => source.Average(x => (decimal?)x));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/AverageTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AverageTests.cs
@@ -246,23 +246,20 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Average_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (int?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Average(x => x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Average(x => (int?)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (long)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (long?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Average(x => (long)x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Average(x => (long?)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (float)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (float?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Average(x => (float)x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Average(x => (float?)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (double)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (double?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Average(x => (double)x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Average(x => (double?)x));
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Average(x => (decimal)x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Average(x => (decimal?)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (decimal)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Average(x => (decimal?)x));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ContainsTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ContainsTests.cs
@@ -79,11 +79,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Contains_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Contains(0));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Contains(0, EqualityComparer<int>.Default));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Contains(0));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Contains(0, EqualityComparer<int>.Default));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ContainsTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ContainsTests.cs
@@ -86,6 +86,7 @@ namespace System.Linq.Parallel.Tests
         public static void Contains_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Contains(-1, new CancelingEqualityComparer<int>(canceler)));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Contains(-1, new CancelingEqualityComparer<int>(canceler)));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ContainsTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ContainsTests.cs
@@ -82,6 +82,13 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Contains_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Contains(-1, new CancelingEqualityComparer<int>(canceler)));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Contains_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/ContainsTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ContainsTests.cs
@@ -74,27 +74,24 @@ namespace System.Linq.Parallel.Tests
             Contains_OneMatching(labeled, count, position);
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Contains_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Contains_OperationCanceledException()
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Contains(-1, new CancelingEqualityComparer<int>(canceler)));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Contains(-1, new CancelingEqualityComparer<int>(canceler)));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Contains_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Contains_AggregateException_Wraps_OperationCanceledException()
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Contains(-1, new CancelingEqualityComparer<int>(canceler)));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Contains(-1, new CancelingEqualityComparer<int>(canceler)));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Contains(-1, new CancelingEqualityComparer<int>(canceler)));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Contains(-1, new CancelingEqualityComparer<int>(canceler)));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
-        public static void Contains_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Contains_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Contains(0));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Contains(0, EqualityComparer<int>.Default));
+            AssertThrows.AlreadyCanceled(source => source.Contains(0));
+            AssertThrows.AlreadyCanceled(source => source.Contains(0, EqualityComparer<int>.Default));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ContainsTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ContainsTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -73,6 +72,13 @@ namespace System.Linq.Parallel.Tests
         public static void Contains_OneMatching_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             Contains_OneMatching(labeled, count, position);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Contains_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Contains(-1, new CancelingEqualityComparer<int>(canceler)));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/CountLongCountTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/CountLongCountTests.cs
@@ -129,14 +129,11 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void CountLongCount_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Count());
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Count(x => true));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Count());
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Count(x => true));
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).LongCount());
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).LongCount(x => true));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).LongCount());
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).LongCount(x => true));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/CountLongCountTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/CountLongCountTests.cs
@@ -124,33 +124,30 @@ namespace System.Linq.Parallel.Tests
             LongCount_One(labeled, count, position);
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Count_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Count_OperationCanceledException()
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Count(x => { canceler(); return true; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).LongCount(x => { canceler(); return true; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Count(x => { canceler(); return true; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.LongCount(x => { canceler(); return true; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Count_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Count_AggregateException_Wraps_OperationCanceledException()
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Count(x => { canceler(); return true; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).LongCount(x => { canceler(); return true; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Count(x => { canceler(); return true; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).LongCount(x => { canceler(); return true; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Count(x => { canceler(); return true; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.LongCount(x => { canceler(); return true; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Count(x => { canceler(); return true; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.LongCount(x => { canceler(); return true; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
-        public static void CountLongCount_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void CountLongCount_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Count());
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Count(x => true));
+            AssertThrows.AlreadyCanceled(source => source.Count());
+            AssertThrows.AlreadyCanceled(source => source.Count(x => true));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).LongCount());
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).LongCount(x => true));
+            AssertThrows.AlreadyCanceled(source => source.LongCount());
+            AssertThrows.AlreadyCanceled(source => source.LongCount(x => true));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/CountLongCountTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/CountLongCountTests.cs
@@ -138,6 +138,8 @@ namespace System.Linq.Parallel.Tests
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Count(x => { canceler(); return true; }));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).LongCount(x => { canceler(); return true; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Count(x => { canceler(); return true; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).LongCount(x => { canceler(); return true; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/CountLongCountTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/CountLongCountTests.cs
@@ -133,6 +133,14 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Count_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Count(x => { canceler(); return true; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).LongCount(x => { canceler(); return true; }));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void CountLongCount_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/CountLongCountTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/CountLongCountTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -123,6 +122,14 @@ namespace System.Linq.Parallel.Tests
         public static void LongCount_One_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, long position)
         {
             LongCount_One(labeled, count, position);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Count_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Count(x => { canceler(); return true; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).LongCount(x => { canceler(); return true; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ElementAtElementAtOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ElementAtElementAtOrDefaultTests.cs
@@ -107,11 +107,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void ElementAt_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).ElementAt(0));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).ElementAtOrDefault(0));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ElementAt(0));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ElementAtOrDefault(0));
         }
 
         [Fact]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ElementAtElementAtOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ElementAtElementAtOrDefaultTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -103,12 +102,11 @@ namespace System.Linq.Parallel.Tests
             ElementAtOrDefault_OutOfRange(labeled, count, position);
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
-        public static void ElementAt_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void ElementAt_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ElementAt(0));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ElementAtOrDefault(0));
+            AssertThrows.AlreadyCanceled(source => source.ElementAt(0));
+            AssertThrows.AlreadyCanceled(source => source.ElementAtOrDefault(0));
         }
 
         [Fact]

--- a/src/System.Linq.Parallel/tests/QueryOperators/FirstFirstOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/FirstFirstOrDefaultTests.cs
@@ -133,6 +133,14 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void First_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).First(x => { canceler(); return false; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).FirstOrDefault(x => { canceler(); return false; }));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void First_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/FirstFirstOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/FirstFirstOrDefaultTests.cs
@@ -138,6 +138,8 @@ namespace System.Linq.Parallel.Tests
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).First(x => { canceler(); return false; }));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).FirstOrDefault(x => { canceler(); return false; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).First(x => { canceler(); return false; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).FirstOrDefault(x => { canceler(); return false; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/FirstFirstOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/FirstFirstOrDefaultTests.cs
@@ -129,14 +129,11 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void First_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).First());
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).First(x => true));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).First());
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).First(x => true));
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).FirstOrDefault());
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).FirstOrDefault(x => true));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).FirstOrDefault());
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).FirstOrDefault(x => true));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/FirstFirstOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/FirstFirstOrDefaultTests.cs
@@ -124,33 +124,30 @@ namespace System.Linq.Parallel.Tests
             FirstOrDefault_NoMatch(labeled, count, position);
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void First_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void First_OperationCanceledException()
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).First(x => { canceler(); return false; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).FirstOrDefault(x => { canceler(); return false; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.First(x => { canceler(); return false; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.FirstOrDefault(x => { canceler(); return false; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void First_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void First_AggregateException_Wraps_OperationCanceledException()
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).First(x => { canceler(); return false; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).FirstOrDefault(x => { canceler(); return false; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).First(x => { canceler(); return false; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).FirstOrDefault(x => { canceler(); return false; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.First(x => { canceler(); return false; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.FirstOrDefault(x => { canceler(); return false; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.First(x => { canceler(); return false; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.FirstOrDefault(x => { canceler(); return false; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
-        public static void First_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void First_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).First());
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).First(x => true));
+            AssertThrows.AlreadyCanceled(source => source.First());
+            AssertThrows.AlreadyCanceled(source => source.First(x => true));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).FirstOrDefault());
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).FirstOrDefault(x => true));
+            AssertThrows.AlreadyCanceled(source => source.FirstOrDefault());
+            AssertThrows.AlreadyCanceled(source => source.FirstOrDefault(x => true));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/FirstFirstOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/FirstFirstOrDefaultTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -123,6 +122,14 @@ namespace System.Linq.Parallel.Tests
         public static void FirstOrDefault_NoMatch_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             FirstOrDefault_NoMatch(labeled, count, position);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void First_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).First(x => { canceler(); return false; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).FirstOrDefault(x => { canceler(); return false; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ForAllTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ForAllTests.cs
@@ -28,26 +28,23 @@ namespace System.Linq.Parallel.Tests
             ForAll(labeled, count);
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void ForAll_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void ForAll_OperationCanceledException()
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).ForAll(x => canceler()));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.ForAll(x => canceler()));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void ForAll_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void ForAll_AggregateException_Wraps_OperationCanceledException()
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).ForAll(x => canceler()));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).ForAll(x => canceler()));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.ForAll(x => canceler()));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.ForAll(x => canceler()));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
-        public static void ForAll_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void ForAll_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ForAll(x => { }));
+            AssertThrows.AlreadyCanceled(source => source.ForAll(x => { }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ForAllTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ForAllTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -27,6 +26,13 @@ namespace System.Linq.Parallel.Tests
         public static void ForAll_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ForAll(labeled, count);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void ForAll_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).ForAll(x => canceler()));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ForAllTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ForAllTests.cs
@@ -40,6 +40,7 @@ namespace System.Linq.Parallel.Tests
         public static void ForAll_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).ForAll(x => canceler()));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).ForAll(x => canceler()));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ForAllTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ForAllTests.cs
@@ -33,10 +33,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void ForAll_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).ForAll(x => { }));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ForAll(x => { }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ForAllTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ForAllTests.cs
@@ -36,6 +36,13 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void ForAll_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).ForAll(x => canceler()));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void ForAll_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/GetEnumeratorTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/GetEnumeratorTests.cs
@@ -130,5 +130,17 @@ namespace System.Linq.Parallel.Tests
             Assert.Equal(0, count);
             Assert.False(enumerator.MoveNext());
         }
+
+        [Theory]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        public static void ImmediateDispose(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            // Regression test for an issue causing ODE if a queryEnumerator is disposed before moveNext is called.
+            ParallelQuery<int> query = labeled.Item;
+            IEnumerator<int> enumerator = query.GetEnumerator();
+            Assert.NotNull(enumerator);
+            enumerator.Dispose();
+        }
     }
 }

--- a/src/System.Linq.Parallel/tests/QueryOperators/GetEnumeratorTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/GetEnumeratorTests.cs
@@ -86,6 +86,22 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 128 }, MemberType = typeof(Sources))]
+        public static void GetEnumerator_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => { foreach (var i in labeled.Item.WithCancellation(token)) { canceler(); }; });
+        }
+
+        [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1 }, MemberType = typeof(Sources))]
+        public static void GetEnumerator_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertAlreadyCanceled(token => { foreach (var i in labeled.Item.WithCancellation(token)) { throw new ShouldNotBeInvokedException(); }; });
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void GetEnumerator_MoveNextAfterQueryOpeningFailsIsIllegal(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/LastLastOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/LastLastOrDefaultTests.cs
@@ -138,6 +138,8 @@ namespace System.Linq.Parallel.Tests
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Last(x => { canceler(); return true; }));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).LastOrDefault(x => { canceler(); return false; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Last(x => { canceler(); return true; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).LastOrDefault(x => { canceler(); return false; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/LastLastOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/LastLastOrDefaultTests.cs
@@ -133,6 +133,14 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Last_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Last(x => { canceler(); return true; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).LastOrDefault(x => { canceler(); return false; }));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Last_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/LastLastOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/LastLastOrDefaultTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -123,6 +122,14 @@ namespace System.Linq.Parallel.Tests
         public static void LastOrDefault_NoMatch_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             LastOrDefault_NoMatch(labeled, count, position);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Last_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Last(x => { canceler(); return true; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).LastOrDefault(x => { canceler(); return true; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/LastLastOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/LastLastOrDefaultTests.cs
@@ -129,14 +129,11 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Last_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Last());
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Last(x => true));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Last());
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Last(x => true));
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).LastOrDefault());
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).LastOrDefault(x => true));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).LastOrDefault());
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).LastOrDefault(x => true));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/LastLastOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/LastLastOrDefaultTests.cs
@@ -124,33 +124,30 @@ namespace System.Linq.Parallel.Tests
             LastOrDefault_NoMatch(labeled, count, position);
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Last_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Last_OperationCanceledException()
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Last(x => { canceler(); return true; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).LastOrDefault(x => { canceler(); return true; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Last(x => { canceler(); return true; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.LastOrDefault(x => { canceler(); return true; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Last_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Last_AggregateException_Wraps_OperationCanceledException()
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Last(x => { canceler(); return true; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).LastOrDefault(x => { canceler(); return false; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Last(x => { canceler(); return true; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).LastOrDefault(x => { canceler(); return false; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Last(x => { canceler(); return true; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.LastOrDefault(x => { canceler(); return false; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Last(x => { canceler(); return true; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.LastOrDefault(x => { canceler(); return false; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
-        public static void Last_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Last_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Last());
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Last(x => true));
+            AssertThrows.AlreadyCanceled(source => source.Last());
+            AssertThrows.AlreadyCanceled(source => source.Last(x => true));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).LastOrDefault());
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).LastOrDefault(x => true));
+            AssertThrows.AlreadyCanceled(source => source.LastOrDefault());
+            AssertThrows.AlreadyCanceled(source => source.LastOrDefault(x => true));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/MaxTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/MaxTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -284,25 +283,22 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Max_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (int?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Max(x => x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Max(x => (int?)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (long)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (long?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Max(x => (long)x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Max(x => (long?)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (float)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (float?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Max(x => (float)x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Max(x => (float?)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (double)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (double?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Max(x => (double)x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Max(x => (double?)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (decimal)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (decimal?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Max(x => (decimal)x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Max(x => (decimal?)x));
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Max(x => new NotComparable(x)));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => new NotComparable(x)));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/MaxTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/MaxTests.cs
@@ -279,81 +279,78 @@ namespace System.Linq.Parallel.Tests
             Assert.Throws<InvalidOperationException>(() => labeled.Item.Max(x => new NotComparable(x)));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Max_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Max_OperationCanceledException()
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (int?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Max(x => { canceler(); return x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Max(x => { canceler(); return (int?)x; }));
 
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (long)x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (long?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Max(x => { canceler(); return (long)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Max(x => { canceler(); return (long?)x; }));
 
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (float)x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (float?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Max(x => { canceler(); return (float)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Max(x => { canceler(); return (float?)x; }));
 
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (double)x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (double?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Max(x => { canceler(); return (double)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Max(x => { canceler(); return (double?)x; }));
 
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (decimal)x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (decimal?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Max(x => { canceler(); return (decimal)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Max(x => { canceler(); return (decimal?)x; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Max_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Max_AggregateException_Wraps_OperationCanceledException()
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (int?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Max(x => { canceler(); return x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Max(x => { canceler(); return (int?)x; }));
 
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (long)x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (long?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Max(x => { canceler(); return (long)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Max(x => { canceler(); return (long?)x; }));
 
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (float)x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (float?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Max(x => { canceler(); return (float)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Max(x => { canceler(); return (float?)x; }));
 
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (double)x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (double?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Max(x => { canceler(); return (double)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Max(x => { canceler(); return (double?)x; }));
 
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (decimal)x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (decimal?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Max(x => { canceler(); return (decimal)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Max(x => { canceler(); return (decimal?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (int?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Max(x => { canceler(); return x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Max(x => { canceler(); return (int?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (long)x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (long?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Max(x => { canceler(); return (long)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Max(x => { canceler(); return (long?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (float)x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (float?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Max(x => { canceler(); return (float)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Max(x => { canceler(); return (float?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (double)x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (double?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Max(x => { canceler(); return (double)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Max(x => { canceler(); return (double?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (decimal)x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (decimal?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Max(x => { canceler(); return (decimal)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Max(x => { canceler(); return (decimal?)x; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
-        public static void Max_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Max_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (int?)x));
+            AssertThrows.AlreadyCanceled(source => source.Max(x => x));
+            AssertThrows.AlreadyCanceled(source => source.Max(x => (int?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (long)x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (long?)x));
+            AssertThrows.AlreadyCanceled(source => source.Max(x => (long)x));
+            AssertThrows.AlreadyCanceled(source => source.Max(x => (long?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (float)x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (float?)x));
+            AssertThrows.AlreadyCanceled(source => source.Max(x => (float)x));
+            AssertThrows.AlreadyCanceled(source => source.Max(x => (float?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (double)x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (double?)x));
+            AssertThrows.AlreadyCanceled(source => source.Max(x => (double)x));
+            AssertThrows.AlreadyCanceled(source => source.Max(x => (double?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (decimal)x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => (decimal?)x));
+            AssertThrows.AlreadyCanceled(source => source.Max(x => (decimal)x));
+            AssertThrows.AlreadyCanceled(source => source.Max(x => (decimal?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Max(x => new NotComparable(x)));
+            AssertThrows.AlreadyCanceled(source => source.Max(x => new NotComparable(x)));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/MaxTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/MaxTests.cs
@@ -300,6 +300,26 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Max_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (int?)x; }));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (long)x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (long?)x; }));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (float)x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (float?)x; }));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (double)x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (double?)x; }));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (decimal)x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (decimal?)x; }));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Max_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/MaxTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/MaxTests.cs
@@ -317,6 +317,21 @@ namespace System.Linq.Parallel.Tests
 
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (decimal)x; }));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (decimal?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (int?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (long)x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (long?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (float)x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (float?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (double)x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (double?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (decimal)x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (decimal?)x; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/MaxTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/MaxTests.cs
@@ -280,6 +280,26 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Max_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (int?)x; }));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (long)x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (long?)x; }));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (float)x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (float?)x; }));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (double)x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (double?)x; }));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (decimal)x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Max(x => { canceler(); return (decimal?)x; }));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Max_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/MinTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/MinTests.cs
@@ -350,6 +350,21 @@ namespace System.Linq.Parallel.Tests
 
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (decimal)x; }));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (decimal?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (int?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (long)x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (long?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (float)x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (float?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (double)x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (double?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (decimal)x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (decimal?)x; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/MinTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/MinTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -317,25 +316,22 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Min_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (int?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Min(x => x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Min(x => (int?)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (long)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (long?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Min(x => (long)x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Min(x => (long?)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (float)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (float?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Min(x => (float)x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Min(x => (float?)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (double)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (double?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Min(x => (double)x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Min(x => (double?)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (decimal)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (decimal?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Min(x => (decimal)x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Min(x => (decimal?)x));
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Min(x => new NotComparable(x)));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => new NotComparable(x)));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/MinTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/MinTests.cs
@@ -313,6 +313,26 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Min_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (int?)x; }));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (long)x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (long?)x; }));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (float)x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (float?)x; }));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (double)x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (double?)x; }));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (decimal)x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (decimal?)x; }));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Min_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/MinTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/MinTests.cs
@@ -333,6 +333,26 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Min_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (int?)x; }));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (long)x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (long?)x; }));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (float)x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (float?)x; }));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (double)x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (double?)x; }));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (decimal)x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (decimal?)x; }));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Min_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/MinTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/MinTests.cs
@@ -312,81 +312,78 @@ namespace System.Linq.Parallel.Tests
             Assert.Throws<InvalidOperationException>(() => labeled.Item.Min(x => new NotComparable(x)));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Min_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Min_OperationCanceledException()
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (int?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Min(x => { canceler(); return x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Min(x => { canceler(); return (int?)x; }));
 
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (long)x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (long?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Min(x => { canceler(); return (long)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Min(x => { canceler(); return (long?)x; }));
 
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (float)x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (float?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Min(x => { canceler(); return (float)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Min(x => { canceler(); return (float?)x; }));
 
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (double)x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (double?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Min(x => { canceler(); return (double)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Min(x => { canceler(); return (double?)x; }));
 
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (decimal)x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (decimal?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Min(x => { canceler(); return (decimal)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Min(x => { canceler(); return (decimal?)x; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Min_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Min_AggregateException_Wraps_OperationCanceledException()
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (int?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Min(x => { canceler(); return x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Min(x => { canceler(); return (int?)x; }));
 
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (long)x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (long?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Min(x => { canceler(); return (long)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Min(x => { canceler(); return (long?)x; }));
 
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (float)x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (float?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Min(x => { canceler(); return (float)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Min(x => { canceler(); return (float?)x; }));
 
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (double)x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (double?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Min(x => { canceler(); return (double)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Min(x => { canceler(); return (double?)x; }));
 
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (decimal)x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (decimal?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Min(x => { canceler(); return (decimal)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Min(x => { canceler(); return (decimal?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (int?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Min(x => { canceler(); return x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Min(x => { canceler(); return (int?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (long)x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (long?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Min(x => { canceler(); return (long)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Min(x => { canceler(); return (long?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (float)x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (float?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Min(x => { canceler(); return (float)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Min(x => { canceler(); return (float?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (double)x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (double?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Min(x => { canceler(); return (double)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Min(x => { canceler(); return (double?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (decimal)x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Min(x => { canceler(); return (decimal?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Min(x => { canceler(); return (decimal)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Min(x => { canceler(); return (decimal?)x; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
-        public static void Min_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Min_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (int?)x));
+            AssertThrows.AlreadyCanceled(source => source.Min(x => x));
+            AssertThrows.AlreadyCanceled(source => source.Min(x => (int?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (long)x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (long?)x));
+            AssertThrows.AlreadyCanceled(source => source.Min(x => (long)x));
+            AssertThrows.AlreadyCanceled(source => source.Min(x => (long?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (float)x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (float?)x));
+            AssertThrows.AlreadyCanceled(source => source.Min(x => (float)x));
+            AssertThrows.AlreadyCanceled(source => source.Min(x => (float?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (double)x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (double?)x));
+            AssertThrows.AlreadyCanceled(source => source.Min(x => (double)x));
+            AssertThrows.AlreadyCanceled(source => source.Min(x => (double?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (decimal)x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => (decimal?)x));
+            AssertThrows.AlreadyCanceled(source => source.Min(x => (decimal)x));
+            AssertThrows.AlreadyCanceled(source => source.Min(x => (decimal?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Min(x => new NotComparable(x)));
+            AssertThrows.AlreadyCanceled(source => source.Min(x => new NotComparable(x)));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/SelectSelectManyTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SelectSelectManyTests.cs
@@ -205,6 +205,14 @@ namespace System.Linq.Parallel.Tests
         //
         // SelectMany
         //
+        // [Regression Test]
+        //   An issue occurred because the QuerySettings structure was not being deep-cloned during
+        //   query-opening.  As a result, the concurrent inner-enumerators (for the RHS operators)
+        //   that occur in SelectMany were sharing CancellationState that they should not have.
+        //   The result was that enumerators could falsely believe they had been canceled when
+        //   another inner-enumerator was disposed.
+        //
+        //   Note: the failure was intermittent.  this test would fail about 1 in 2 times on mikelid1 (4-core).
 
         public static IEnumerable<object[]> SelectManyUnorderedData(int[] counts)
         {
@@ -238,7 +246,7 @@ namespace System.Linq.Parallel.Tests
         {
             yield return Labeled.Label("Array", (Func<int, int, IEnumerable<int>>)((start, count) => Enumerable.Range(start * count, count).ToArray()));
             yield return Labeled.Label("Enumerable.Range", (Func<int, int, IEnumerable<int>>)((start, count) => Enumerable.Range(start * count, count)));
-            yield return Labeled.Label("ParallelEnumerable.Range", (Func<int, int, IEnumerable<int>>)((start, count) => ParallelEnumerable.Range(start * count, count)));
+            yield return Labeled.Label("ParallelEnumerable.Range", (Func<int, int, IEnumerable<int>>)((start, count) => ParallelEnumerable.Range(start * count, count).AsOrdered().Select(x => x)));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/SequenceEqualTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SequenceEqualTests.cs
@@ -146,14 +146,11 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(SequenceEqualUnequalData), new[] { 4 })]
         public static void SequenceEqual_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count, int item)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
+            Functions.AssertAlreadyCanceled(token => left.Item.WithCancellation(token).SequenceEqual(right.Item));
+            Functions.AssertAlreadyCanceled(token => left.Item.WithCancellation(token).SequenceEqual(right.Item, new ModularCongruenceComparer(1)));
 
-            Functions.AssertIsCanceled(cs, () => left.Item.WithCancellation(cs.Token).SequenceEqual(right.Item));
-            Functions.AssertIsCanceled(cs, () => left.Item.WithCancellation(cs.Token).SequenceEqual(right.Item, new ModularCongruenceComparer(1)));
-
-            Functions.AssertIsCanceled(cs, () => left.Item.SequenceEqual(right.Item.WithCancellation(cs.Token)));
-            Functions.AssertIsCanceled(cs, () => left.Item.SequenceEqual(right.Item.WithCancellation(cs.Token), new ModularCongruenceComparer(1)));
+            Functions.AssertAlreadyCanceled(token => left.Item.SequenceEqual(right.Item.WithCancellation(token)));
+            Functions.AssertAlreadyCanceled(token => left.Item.SequenceEqual(right.Item.WithCancellation(token), new ModularCongruenceComparer(1)));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/SequenceEqualTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SequenceEqualTests.cs
@@ -143,6 +143,14 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(SequenceEqualUnequalData), new[] { 128 })]
+        public static void SequenceEqual_OperationCanceledException(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => left.Item.WithCancellation(token).SequenceEqual(right.Item, new CancelingEqualityComparer<int>(canceler)));
+            Functions.AssertEventuallyCanceled((token, canceler) => left.Item.SequenceEqual(right.Item.WithCancellation(token), new CancelingEqualityComparer<int>(canceler)));
+        }
+
+        [Theory]
         [MemberData(nameof(SequenceEqualUnequalData), new[] { 4 })]
         public static void SequenceEqual_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count, int item)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/SingleSingleOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SingleSingleOrDefaultTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -164,6 +163,14 @@ namespace System.Linq.Parallel.Tests
         public static void SingleOrDefault_OneMatch_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int element)
         {
             SingleOrDefault_OneMatch(labeled, count, element);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Single_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Single(x => { canceler(); return false; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).SingleOrDefault(x => { canceler(); return false; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/SingleSingleOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SingleSingleOrDefaultTests.cs
@@ -169,6 +169,11 @@ namespace System.Linq.Parallel.Tests
         public static void Single_OperationCanceledException()
         {
             AssertThrows.EventuallyCanceled((source, canceler) => source.Single(x => { canceler(); return false; }));
+        }
+
+        [Fact]
+        public static void SingleOrDefault_OperationCanceledException()
+        {
             AssertThrows.EventuallyCanceled((source, canceler) => source.SingleOrDefault(x => { canceler(); return false; }));
         }
 
@@ -176,9 +181,13 @@ namespace System.Linq.Parallel.Tests
         public static void Single_AggregateException_Wraps_OperationCanceledException()
         {
             AssertThrows.OtherTokenCanceled((source, canceler) => source.Single(x => { canceler(); return false; }));
-            AssertThrows.OtherTokenCanceled((source, canceler) => source.SingleOrDefault(x => { canceler(); return false; }));
-
             AssertThrows.SameTokenNotCanceled((source, canceler) => source.Single(x => { canceler(); return false; }));
+        }
+
+        [Fact]
+        public static void SingleOrDefault_AggregateException_Wraps_OperationCanceledException()
+        {
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.SingleOrDefault(x => { canceler(); return false; }));
             AssertThrows.SameTokenNotCanceled((source, canceler) => source.SingleOrDefault(x => { canceler(); return false; }));
         }
 
@@ -187,7 +196,11 @@ namespace System.Linq.Parallel.Tests
         {
             AssertThrows.AlreadyCanceled(source => source.Single());
             AssertThrows.AlreadyCanceled(source => source.Single(x => true));
+        }
 
+        [Fact]
+        public static void SingleOrDefault_OperationCanceledException_PreCanceled()
+        {
             AssertThrows.AlreadyCanceled(source => source.SingleOrDefault());
             AssertThrows.AlreadyCanceled(source => source.SingleOrDefault(x => true));
         }

--- a/src/System.Linq.Parallel/tests/QueryOperators/SingleSingleOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SingleSingleOrDefaultTests.cs
@@ -170,14 +170,11 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Single_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Single());
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Single(x => true));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Single());
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Single(x => true));
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).SingleOrDefault());
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).SingleOrDefault(x => true));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).SingleOrDefault());
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).SingleOrDefault(x => true));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/SingleSingleOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SingleSingleOrDefaultTests.cs
@@ -179,6 +179,9 @@ namespace System.Linq.Parallel.Tests
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Single(x => { canceler(); return false; }));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).SingleOrDefault(x => { canceler(); return false; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Single(x => { canceler(); return false; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).SingleOrDefault(x => { canceler(); return false; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/SingleSingleOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SingleSingleOrDefaultTests.cs
@@ -174,6 +174,14 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Single_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Single(x => { canceler(); return false; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).SingleOrDefault(x => { canceler(); return false; }));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Single_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/SingleSingleOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SingleSingleOrDefaultTests.cs
@@ -165,34 +165,31 @@ namespace System.Linq.Parallel.Tests
             SingleOrDefault_OneMatch(labeled, count, element);
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Single_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Single_OperationCanceledException()
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Single(x => { canceler(); return false; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).SingleOrDefault(x => { canceler(); return false; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Single(x => { canceler(); return false; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.SingleOrDefault(x => { canceler(); return false; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Single_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Single_AggregateException_Wraps_OperationCanceledException()
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Single(x => { canceler(); return false; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).SingleOrDefault(x => { canceler(); return false; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Single(x => { canceler(); return false; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.SingleOrDefault(x => { canceler(); return false; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Single(x => { canceler(); return false; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).SingleOrDefault(x => { canceler(); return false; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Single(x => { canceler(); return false; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.SingleOrDefault(x => { canceler(); return false; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
-        public static void Single_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Single_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Single());
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Single(x => true));
+            AssertThrows.AlreadyCanceled(source => source.Single());
+            AssertThrows.AlreadyCanceled(source => source.Single(x => true));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).SingleOrDefault());
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).SingleOrDefault(x => true));
+            AssertThrows.AlreadyCanceled(source => source.SingleOrDefault());
+            AssertThrows.AlreadyCanceled(source => source.SingleOrDefault(x => true));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/SumTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SumTests.cs
@@ -371,6 +371,21 @@ namespace System.Linq.Parallel.Tests
 
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (decimal)x; }));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (decimal?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (int?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (long)x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (long?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (float)x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (float?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (double)x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (double?)x; }));
+
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (decimal)x; }));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (decimal?)x; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/SumTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SumTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -332,6 +331,26 @@ namespace System.Linq.Parallel.Tests
             ParallelQuery<int> query = labeled.Item;
             Assert.Equal(0, query.Select(x => (decimal?)null).Sum());
             Assert.Equal(0, query.Sum(x => (decimal?)null));
+        }
+
+        [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Sum_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (int?)x; }));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (long)x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (long?)x; }));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (float)x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (float?)x; }));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (double)x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (double?)x; }));
+
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (decimal)x; }));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (decimal?)x; }));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/SumTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SumTests.cs
@@ -354,6 +354,26 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void Sum_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (int?)x; }));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (long)x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (long?)x; }));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (float)x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (float?)x; }));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (double)x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (double?)x; }));
+
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (decimal)x; }));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (decimal?)x; }));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Sum_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/SumTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SumTests.cs
@@ -333,79 +333,76 @@ namespace System.Linq.Parallel.Tests
             Assert.Equal(0, query.Sum(x => (decimal?)null));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Sum_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Sum_OperationCanceledException()
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (int?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Sum(x => { canceler(); return x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Sum(x => { canceler(); return (int?)x; }));
 
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (long)x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (long?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Sum(x => { canceler(); return (long)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Sum(x => { canceler(); return (long?)x; }));
 
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (float)x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (float?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Sum(x => { canceler(); return (float)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Sum(x => { canceler(); return (float?)x; }));
 
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (double)x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (double?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Sum(x => { canceler(); return (double)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Sum(x => { canceler(); return (double?)x; }));
 
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (decimal)x; }));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (decimal?)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Sum(x => { canceler(); return (decimal)x; }));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.Sum(x => { canceler(); return (decimal?)x; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void Sum_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Sum_AggregateException_Wraps_OperationCanceledException()
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (int?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Sum(x => { canceler(); return x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Sum(x => { canceler(); return (int?)x; }));
 
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (long)x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (long?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Sum(x => { canceler(); return (long)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Sum(x => { canceler(); return (long?)x; }));
 
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (float)x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (float?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Sum(x => { canceler(); return (float)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Sum(x => { canceler(); return (float?)x; }));
 
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (double)x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (double?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Sum(x => { canceler(); return (double)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Sum(x => { canceler(); return (double?)x; }));
 
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (decimal)x; }));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (decimal?)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Sum(x => { canceler(); return (decimal)x; }));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.Sum(x => { canceler(); return (decimal?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (int?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Sum(x => { canceler(); return x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Sum(x => { canceler(); return (int?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (long)x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (long?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Sum(x => { canceler(); return (long)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Sum(x => { canceler(); return (long?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (float)x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (float?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Sum(x => { canceler(); return (float)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Sum(x => { canceler(); return (float?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (double)x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (double?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Sum(x => { canceler(); return (double)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Sum(x => { canceler(); return (double?)x; }));
 
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (decimal)x; }));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).Sum(x => { canceler(); return (decimal?)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Sum(x => { canceler(); return (decimal)x; }));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.Sum(x => { canceler(); return (decimal?)x; }));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
-        public static void Sum_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void Sum_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (int?)x));
+            AssertThrows.AlreadyCanceled(source => source.Sum(x => x));
+            AssertThrows.AlreadyCanceled(source => source.Sum(x => (int?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (long)x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (long?)x));
+            AssertThrows.AlreadyCanceled(source => source.Sum(x => (long)x));
+            AssertThrows.AlreadyCanceled(source => source.Sum(x => (long?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (float)x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (float?)x));
+            AssertThrows.AlreadyCanceled(source => source.Sum(x => (float)x));
+            AssertThrows.AlreadyCanceled(source => source.Sum(x => (float?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (double)x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (double?)x));
+            AssertThrows.AlreadyCanceled(source => source.Sum(x => (double)x));
+            AssertThrows.AlreadyCanceled(source => source.Sum(x => (double?)x));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (decimal)x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (decimal?)x));
+            AssertThrows.AlreadyCanceled(source => source.Sum(x => (decimal)x));
+            AssertThrows.AlreadyCanceled(source => source.Sum(x => (decimal?)x));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/SumTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SumTests.cs
@@ -338,23 +338,20 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Sum_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (int?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Sum(x => x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Sum(x => (int?)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (long)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (long?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Sum(x => (long)x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Sum(x => (long?)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (float)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (float?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Sum(x => (float)x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Sum(x => (float?)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (double)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (double?)x));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Sum(x => (double)x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Sum(x => (double?)x));
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Sum(x => (decimal)x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).Sum(x => (decimal?)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (decimal)x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).Sum(x => (decimal?)x));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToArrayTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToArrayTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -45,12 +44,10 @@ namespace System.Linq.Parallel.Tests
             ToArray(labeled, count);
         }
 
-        [Theory]
-        [MemberData(nameof(Sources.Ranges), new[] { 1 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.ThrowOnFirstEnumeration), MemberType = typeof(UnorderedSources))]
-        public static void ToArray_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void ToArray_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToArray());
+            AssertThrows.AlreadyCanceled(source => source.ToArray());
         }
 
         [Fact]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToArrayTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToArrayTests.cs
@@ -50,10 +50,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.ThrowOnFirstEnumeration), MemberType = typeof(UnorderedSources))]
         public static void ToArray_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).ToArray());
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToArray());
         }
 
         [Fact]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToDictionaryTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToDictionaryTests.cs
@@ -201,32 +201,29 @@ namespace System.Linq.Parallel.Tests
             ToDictionary_DuplicateKeys_ElementSelector_CustomComparator(labeled, count);
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void ToDictionary_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void ToDictionary_OperationCanceledException()
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToDictionary(x => x, new CancelingEqualityComparer<int>(canceler)));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToDictionary(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.ToDictionary(x => x, new CancelingEqualityComparer<int>(canceler)));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.ToDictionary(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void ToDictionary_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void ToDictionary_AggregateException_Wraps_OperationCanceledException()
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToDictionary(x => x, new CancelingEqualityComparer<int>(canceler)));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToDictionary(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToDictionary(x => x, new CancelingEqualityComparer<int>(canceler)));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToDictionary(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.ToDictionary(x => x, new CancelingEqualityComparer<int>(canceler)));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.ToDictionary(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.ToDictionary(x => x, new CancelingEqualityComparer<int>(canceler)));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.ToDictionary(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
-        public static void ToDictionary_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void ToDictionary_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToDictionary(x => x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToDictionary(x => x, EqualityComparer<int>.Default));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToDictionary(x => x, y => y));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToDictionary(x => x, y => y, EqualityComparer<int>.Default));
+            AssertThrows.AlreadyCanceled(source => source.ToDictionary(x => x));
+            AssertThrows.AlreadyCanceled(source => source.ToDictionary(x => x, EqualityComparer<int>.Default));
+            AssertThrows.AlreadyCanceled(source => source.ToDictionary(x => x, y => y));
+            AssertThrows.AlreadyCanceled(source => source.ToDictionary(x => x, y => y, EqualityComparer<int>.Default));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToDictionaryTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToDictionaryTests.cs
@@ -206,13 +206,10 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).ToDictionary(x => x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).ToDictionary(x => x, EqualityComparer<int>.Default));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).ToDictionary(x => x, y => y));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).ToDictionary(x => x, y => y, EqualityComparer<int>.Default));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToDictionary(x => x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToDictionary(x => x, EqualityComparer<int>.Default));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToDictionary(x => x, y => y));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToDictionary(x => x, y => y, EqualityComparer<int>.Default));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToDictionaryTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToDictionaryTests.cs
@@ -210,6 +210,14 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void ToDictionary_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToDictionary(x => x, new CancelingEqualityComparer<int>(canceler)));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToDictionary(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToDictionaryTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToDictionaryTests.cs
@@ -215,6 +215,8 @@ namespace System.Linq.Parallel.Tests
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToDictionary(x => x, new CancelingEqualityComparer<int>(canceler)));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToDictionary(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToDictionary(x => x, new CancelingEqualityComparer<int>(canceler)));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToDictionary(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToDictionaryTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToDictionaryTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -200,6 +199,14 @@ namespace System.Linq.Parallel.Tests
         public static void ToDictionary_DuplicateKeys_ElementSelector_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary_DuplicateKeys_ElementSelector_CustomComparator(labeled, count);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void ToDictionary_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToDictionary(x => x, new CancelingEqualityComparer<int>(canceler)));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToDictionary(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToListTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToListTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -45,11 +44,10 @@ namespace System.Linq.Parallel.Tests
             ToList(labeled, count);
         }
 
-        [Theory]
-        [MemberData(nameof(Sources.Ranges), new[] { 1 }, MemberType = typeof(Sources))]
-        public static void ToList_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void ToList_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToList());
+            AssertThrows.AlreadyCanceled(source => source.ToList());
         }
 
         [Fact]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToListTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToListTests.cs
@@ -49,10 +49,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(Sources.Ranges), new[] { 1 }, MemberType = typeof(Sources))]
         public static void ToList_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).ToList());
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToList());
         }
 
         [Fact]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToLookupTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToLookupTests.cs
@@ -219,6 +219,14 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void ToLookup_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToLookup(x => x, new CancelingEqualityComparer<int>(canceler)));
+            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToLookup(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
+        }
+
+        [Theory]
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToLookupTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToLookupTests.cs
@@ -224,6 +224,8 @@ namespace System.Linq.Parallel.Tests
         {
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToLookup(x => x, new CancelingEqualityComparer<int>(canceler)));
             Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToLookup(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToLookup(x => x, new CancelingEqualityComparer<int>(canceler)));
+            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToLookup(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToLookupTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToLookupTests.cs
@@ -215,14 +215,11 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            CancellationTokenSource cs = new CancellationTokenSource();
-            cs.Cancel();
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToLookup(x => x));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToLookup(x => x, EqualityComparer<int>.Default));
 
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).ToLookup(x => x));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).ToLookup(x => x, EqualityComparer<int>.Default));
-
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).ToLookup(x => x, y => y));
-            Functions.AssertIsCanceled(cs, () => labeled.Item.WithCancellation(cs.Token).ToLookup(x => x, y => y, EqualityComparer<int>.Default));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToLookup(x => x, y => y));
+            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToLookup(x => x, y => y, EqualityComparer<int>.Default));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToLookupTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToLookupTests.cs
@@ -210,33 +210,30 @@ namespace System.Linq.Parallel.Tests
             ToLookup_DuplicateKeys_ElementSelector_CustomComparator(labeled, count);
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void ToDictionary_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void ToDictionary_OperationCanceledException()
         {
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToLookup(x => x, new CancelingEqualityComparer<int>(canceler)));
-            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToLookup(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.ToLookup(x => x, new CancelingEqualityComparer<int>(canceler)));
+            AssertThrows.EventuallyCanceled((source, canceler) => source.ToLookup(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
-        public static void ToLookup_AggregateException_Wraps_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void ToLookup_AggregateException_Wraps_OperationCanceledException()
         {
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToLookup(x => x, new CancelingEqualityComparer<int>(canceler)));
-            Functions.AssertAggregateAlternateCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToLookup(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToLookup(x => x, new CancelingEqualityComparer<int>(canceler)));
-            Functions.AssertAggregateNotCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToLookup(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.ToLookup(x => x, new CancelingEqualityComparer<int>(canceler)));
+            AssertThrows.OtherTokenCanceled((source, canceler) => source.ToLookup(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.ToLookup(x => x, new CancelingEqualityComparer<int>(canceler)));
+            AssertThrows.SameTokenNotCanceled((source, canceler) => source.ToLookup(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
         }
 
-        [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
-        public static void ToLookup_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void ToLookup_OperationCanceledException_PreCanceled()
         {
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToLookup(x => x));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToLookup(x => x, EqualityComparer<int>.Default));
+            AssertThrows.AlreadyCanceled(source => source.ToLookup(x => x));
+            AssertThrows.AlreadyCanceled(source => source.ToLookup(x => x, EqualityComparer<int>.Default));
 
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToLookup(x => x, y => y));
-            Functions.AssertAlreadyCanceled(token => labeled.Item.WithCancellation(token).ToLookup(x => x, y => y, EqualityComparer<int>.Default));
+            AssertThrows.AlreadyCanceled(source => source.ToLookup(x => x, y => y));
+            AssertThrows.AlreadyCanceled(source => source.ToLookup(x => x, y => y, EqualityComparer<int>.Default));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToLookupTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToLookupTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
@@ -209,6 +208,14 @@ namespace System.Linq.Parallel.Tests
         public static void ToLookup_DuplicateKeys_ElementSelector_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup_DuplicateKeys_ElementSelector_CustomComparator(labeled, count);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 128 }, MemberType = typeof(UnorderedSources))]
+        public static void ToDictionary_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToLookup(x => x, new CancelingEqualityComparer<int>(canceler)));
+            Functions.AssertEventuallyCanceled((token, canceler) => labeled.Item.WithCancellation(token).ToLookup(x => x, y => y, new CancelingEqualityComparer<int>(canceler)));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -31,6 +31,7 @@
     <Compile Include="Combinatorial\ParallelQueryCombinationTests.cs" />
     <Compile Include="Combinatorial\SourcesAndOperators.cs" />
     <Compile Include="Combinatorial\UnorderedParallelQueryCombinationTests.cs" />
+    <Compile Include="Helpers\AssertThrows.cs" />
     <Compile Include="Helpers\Comparers.cs" />
     <Compile Include="Helpers\DeliberateTestException.cs" />
     <Compile Include="Helpers\Enumerables.cs" />

--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -22,6 +22,9 @@
     <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
+      <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
+    </Compile>
     <Compile Include="Combinatorial\CancellationParallelQueryCombinationTests.cs" />
     <Compile Include="Combinatorial\FailingParallelQueryCombinationTests.cs" />
     <Compile Include="Combinatorial\LabeledOperation.cs" />

--- a/src/System.Linq.Parallel/tests/WithCancellationTests.cs
+++ b/src/System.Linq.Parallel/tests/WithCancellationTests.cs
@@ -51,42 +51,6 @@ namespace System.Linq.Parallel.Tests
             labeled.Item.WithCancellation(new CancellationToken(false));
         }
 
-        /// <summary>
-        ///
-        /// [Regression Test]
-        ///   This issue occurred because the QuerySettings structure was not being deep-cloned during
-        ///   query-opening.  As a result, the concurrent inner-enumerators (for the RHS operators)
-        ///   that occur in SelectMany were sharing CancellationState that they should not have.
-        ///   The result was that enumerators could falsely believe they had been canceled when
-        ///   another inner-enumerator was disposed.
-        ///
-        ///   Note: the failure was intermittent.  this test would fail about 1 in 2 times on mikelid1 (4-core).
-        /// </summary>
-        /// <returns></returns>
-        [Fact]
-        public static void CloningQuerySettingsForSelectMany()
-        {
-            var plinq_src = ParallelEnumerable.Range(0, 1999).AsParallel();
-            Exception caughtException = null;
-
-            try
-            {
-                var inner = ParallelEnumerable.Range(0, 20).AsParallel().Select(_item => _item);
-                var output = plinq_src
-                    .SelectMany(
-                        _x => inner,
-                        (_x, _y) => _x
-                    )
-                    .ToArray();
-            }
-            catch (Exception ex)
-            {
-                caughtException = ex;
-            }
-
-            Assert.Null(caughtException);
-        }
-
         // [Regression Test]
         // Use of the async channel can block both the consumer and producer threads.. before the cancellation work
         // these had no means of being awoken.

--- a/src/System.Linq.Parallel/tests/WithCancellationTests.cs
+++ b/src/System.Linq.Parallel/tests/WithCancellationTests.cs
@@ -13,41 +13,37 @@ namespace System.Linq.Parallel.Tests
     // the tests here are only regarding basic API correctness and sanity checking.
     public static class WithCancellationTests
     {
-        [Theory]
-        [MemberData(nameof(Sources.Ranges), new[] { 16 }, MemberType = typeof(Sources))]
-        public static void WithCancellation_Multiple_NotCancelable(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void WithCancellation_Multiple_NotCancelable()
         {
             // Multiple not-cancel-able tokens is not an error.
-            labeled.Item.WithCancellation(new CancellationToken()).WithCancellation(new CancellationToken());
+            ParallelEnumerable.Range(0, 1).WithCancellation(new CancellationToken()).WithCancellation(new CancellationToken());
             CancellationToken token = new CancellationToken();
-            labeled.Item.WithCancellation(token).WithCancellation(token);
+            ParallelEnumerable.Range(0, 1).WithCancellation(token).WithCancellation(token);
         }
 
-        [Theory]
-        [MemberData(nameof(Sources.Ranges), new[] { 16 }, MemberType = typeof(Sources))]
-        public static void WithCancellation_Multiple_CancelableToken(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void WithCancellation_Multiple_CancelableToken()
         {
             CancellationToken token = new CancellationTokenSource().Token;
-            Assert.Throws<InvalidOperationException>(() => labeled.Item.WithCancellation(token).WithCancellation(token));
-            Assert.Throws<InvalidOperationException>(() => labeled.Item.WithCancellation(token).WithCancellation(new CancellationTokenSource().Token));
+            Assert.Throws<InvalidOperationException>(() => ParallelEnumerable.Range(0, 1).WithCancellation(token).WithCancellation(token));
+            Assert.Throws<InvalidOperationException>(() => ParallelEnumerable.Range(0, 1).WithCancellation(token).WithCancellation(new CancellationTokenSource().Token));
         }
 
-        [Theory]
-        [MemberData(nameof(Sources.Ranges), new[] { 16 }, MemberType = typeof(Sources))]
-        public static void WithCancellation_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void WithCancellation_PreCanceled()
         {
             // Anticipation is the query will cancel soon after starting.
             CancellationTokenSource source = new CancellationTokenSource();
             source.Cancel();
-            labeled.Item.WithCancellation(source.Token);
+            ParallelEnumerable.Range(0, 1).WithCancellation(source.Token);
         }
 
-        [Theory]
-        [MemberData(nameof(Sources.Ranges), new[] { 16 }, MemberType = typeof(Sources))]
-        public static void WithCancellation_NotCancelable(Labeled<ParallelQuery<int>> labeled, int count)
+        [Fact]
+        public static void WithCancellation_NotCancelable()
         {
-            labeled.Item.WithCancellation(new CancellationToken(true));
-            labeled.Item.WithCancellation(new CancellationToken(false));
+            ParallelEnumerable.Range(0, 1).WithCancellation(new CancellationToken(true));
+            ParallelEnumerable.Range(0, 1).WithCancellation(new CancellationToken(false));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/WithCancellationTests.cs
+++ b/src/System.Linq.Parallel/tests/WithCancellationTests.cs
@@ -155,14 +155,6 @@ namespace System.Linq.Parallel.Tests
                                               "Cancellation_ODEIssue:  We expect an aggregate exception with OCEs in it.");
         }
 
-        // Regression test for an issue causing ODE if a queryEnumerator is disposed before moveNext is called.
-        [Fact]
-        public static void ImmediateDispose()
-        {
-            var queryEnumerator = Enumerable.Range(1, 10).AsParallel().Select(x => x).GetEnumerator();
-            queryEnumerator.Dispose();
-        }
-
         // throwing a fake OCE(ct) when the ct isn't canceled should produce an AggregateException.
         [Fact]
         public static void SetOperationsThrowAggregateOnCancelOrDispose_2()

--- a/src/System.Linq.Parallel/tests/WithCancellationTests.cs
+++ b/src/System.Linq.Parallel/tests/WithCancellationTests.cs
@@ -118,38 +118,6 @@ namespace System.Linq.Parallel.Tests
             enumerator.Dispose();
         }
 
-        [Fact]
-        public static void DontDoWorkIfTokenAlreadyCanceled()
-        {
-            OperationCanceledException oce = null;
-
-            CancellationTokenSource cs = new CancellationTokenSource();
-            var query = Enumerable.Range(0, 100000000)
-            .Select(x =>
-            {
-                if (x > 0) // to avoid the "Error:unreachable code detected"
-                    throw new ArgumentException("User-delegate exception.");
-                return x;
-            })
-            .AsParallel()
-            .WithCancellation(cs.Token)
-            .Select(x => x);
-
-            cs.Cancel();
-            try
-            {
-                foreach (var item in query) //We expect an OperationCancelledException during the MoveNext
-                {
-                }
-            }
-            catch (OperationCanceledException ex)
-            {
-                oce = ex;
-            }
-
-            Assert.NotNull(oce);
-        }
-
         private static void DisposedEnumerator(ParallelQuery<int> query, bool delay = false)
         {
             query = query.WithCancellation(new CancellationTokenSource().Token).Select(x => x);

--- a/src/System.Linq.Parallel/tests/WithCancellationTests.cs
+++ b/src/System.Linq.Parallel/tests/WithCancellationTests.cs
@@ -157,7 +157,7 @@ namespace System.Linq.Parallel.Tests
             IEnumerator<int> enumerator = query.GetEnumerator();
 
             enumerator.MoveNext();
-            if (delay) Task.Delay(1000).Wait();
+            if (delay) Task.Delay(10).Wait();
             enumerator.MoveNext();
             enumerator.Dispose();
 

--- a/src/System.Linq.Parallel/tests/WithCancellationTests.cs
+++ b/src/System.Linq.Parallel/tests/WithCancellationTests.cs
@@ -33,6 +33,24 @@ namespace System.Linq.Parallel.Tests
             Assert.Throws<InvalidOperationException>(() => labeled.Item.WithCancellation(token).WithCancellation(new CancellationTokenSource().Token));
         }
 
+        [Theory]
+        [MemberData(nameof(Sources.Ranges), new[] { 16 }, MemberType = typeof(Sources))]
+        public static void WithCancellation_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            // Anticipation is the query will cancel soon after starting.
+            CancellationTokenSource source = new CancellationTokenSource();
+            source.Cancel();
+            labeled.Item.WithCancellation(source.Token);
+        }
+
+        [Theory]
+        [MemberData(nameof(Sources.Ranges), new[] { 16 }, MemberType = typeof(Sources))]
+        public static void WithCancellation_NotCancelable(Labeled<ParallelQuery<int>> labeled, int count)
+        {
+            labeled.Item.WithCancellation(new CancellationToken(true));
+            labeled.Item.WithCancellation(new CancellationToken(false));
+        }
+
         /// <summary>
         ///
         /// [Regression Test]

--- a/src/System.Linq.Parallel/tests/WithCancellationTests.cs
+++ b/src/System.Linq.Parallel/tests/WithCancellationTests.cs
@@ -71,13 +71,13 @@ namespace System.Linq.Parallel.Tests
         // However, only the producers need to wake up on cancellation as the consumer
         // will wake up once all the producers have gone away (via AsynchronousOneToOneChannel.SetDone())
         //
-        // To specifically verify this test, check that the Async channels were blocked in TryEnqueChunk before Dispose() is called
+        // To specifically verify this test, it was checked that the Async channels were blocked in TryEnqueChunk before Dispose() was called
         //  -> this was verified manually, but is not simple to automate
         [Theory]
         [OuterLoop] // explicit timeouts / delays
         // Provide enough elements to ensure all the cores get >64K ints. Good up to 1000 cores
-        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 16 }, MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 64 * 1024 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 64 * 1024 }, MemberType = typeof(UnorderedSources))]
         public static void WithCancellation_DisposedEnumerator_ChannelCancellation_ProducerBlocked(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;

--- a/src/System.Linq.Parallel/tests/WithCancellationTests.cs
+++ b/src/System.Linq.Parallel/tests/WithCancellationTests.cs
@@ -106,23 +106,16 @@ namespace System.Linq.Parallel.Tests
 
         // If a query is canceled and immediately disposed, the dispose should not throw an OCE.
         [Theory]
-        [MemberData("Ranges", (object)(new int[] { 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 16 }, MemberType = typeof(UnorderedSources))]
         public static void WithCancellation_CancelThenDispose(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            try
-            {
-                CancellationTokenSource cancel = new CancellationTokenSource();
-                var q = ParallelEnumerable.Range(0, 1000).WithCancellation(cancel.Token).Select(x => x);
-                IEnumerator<int> e = q.GetEnumerator();
-                e.MoveNext();
+            CancellationTokenSource cancel = new CancellationTokenSource();
+            IEnumerator<int> enumerator = labeled.Item.WithCancellation(cancel.Token).GetEnumerator();
+            enumerator.MoveNext();
 
-                cancel.Cancel();
-                e.Dispose();
-            }
-            catch (Exception e)
-            {
-                Assert.True(false, string.Format("PlinqCancellationTests.CancelThenDispose:  > Failed. Expected no exception, got " + e.GetType()));
-            }
+            cancel.Cancel();
+            enumerator.Dispose();
         }
 
         [Fact]


### PR DESCRIPTION
This cleans up and expands tests relating to cancellation in PLINQ.

Many of these are new tests relating to in-flight cancellation.  Several are tweaks to the existing pre-canceled tests.

Line coverage is up ~.5% to 93.3%, and branch coverage is up ~1%, to 92%