### PR TITLE
Update out of date comment in List<T>

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/List.cs
+++ b/src/System.Collections/src/System/Collections/Generic/List.cs
@@ -33,7 +33,8 @@ namespace System.Collections.Generic
 
         // Constructs a List. The list is initially empty and has a capacity
         // of zero. Upon adding the first element to the list the capacity is
-        // increased to 16, and then increased in multiples of two as required.
+        // increased to _defaultCapacity, and then increased in multiples of two
+        // as required.
         public List()
         {
             _items = _emptyArray;


### PR DESCRIPTION
Comment for parameterless constructor of `List<T>` claimed that the default non-zero capacity was 16, even though `_defaultCapacity` is actually 4.

Updated the comment to refer to `_defaultCapacity`, to make sure it doesn't need to be updated again if `_defaultCapacity` changes in the future.