### PR TITLE
Fix Pipes test failure due to inheritable handles

### DIFF
--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="PipeTestBase.cs" />
     <Compile Include="PipeTest.Read.cs" />
     <Compile Include="PipeTest.Write.cs" />
+    <Compile Include="XunitAssemblyAttributes.cs" />
     <Compile Include="Performance\Perf.AnonymousPipeStream.cs" />
     <Compile Include="Performance\Perf.NamedPipeStream.cs" />
     <Compile Include="Performance\Perf.PipeTest.cs" />

--- a/src/System.IO.Pipes/tests/XunitAssemblyAttributes.cs
+++ b/src/System.IO.Pipes/tests/XunitAssemblyAttributes.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+// Some tests launch processes.  If other tests that run concurrently create inheritable pipes and the launched
+// process inherits it, then the lifetime of those pipes will be extended beyond when the test expects, leading
+// to failures due to naming conflicts and the like.  On Unix this can happen even for non-inheritable pipes, as they're
+// made non-inheritable via CLOEXEC, but there's still a small window between the process being forked and that
+// forked process calling exec where the handle remains open in the other process.
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]


### PR DESCRIPTION
Same issue as in https://github.com/dotnet/corefx/pull/6984, but for pipes.

Fixes #7021 
cc: @ianhays