### PR TITLE
Make UriBuilder.Fragment setter idempotent

### DIFF
--- a/src/System.Private.Uri/src/System/UriBuilder.cs
+++ b/src/System.Private.Uri/src/System/UriBuilder.cs
@@ -179,7 +179,7 @@ namespace System
                 {
                     value = string.Empty;
                 }
-                if (value.Length > 0)
+                if (value.Length > 0 && value[0] != '#')
                 {
                     value = '#' + value;
                 }

--- a/src/System.Private.Uri/tests/FunctionalTests/UriBuilderTests.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriBuilderTests.cs
@@ -290,7 +290,8 @@ namespace System.PrivateUri.Tests
 
         [Theory]
         [InlineData("fragment", "#fragment")]
-        [InlineData("#fragment", "##fragment")]
+        [InlineData("#fragment", "#fragment")]
+        [InlineData("#", "#")]
         [InlineData("", "")]
         [InlineData(null, "")]
         public void Fragment_Get_Set(string value, string expected)


### PR DESCRIPTION
Similar to #6926, but for UriBuilder.Fragment.

This is a breaking change, but I noticed that if the PR above was merged, this made sense

/cc @stephentoub