### PR TITLE
Added support to map particular DiagnosticSource Events to particular…

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -121,7 +121,7 @@ namespace System.Diagnostics
     /// disambiguate).   However if they nest you need to use another EventSource event because the rules of EventSource 
     /// activities state that a start of the same event terminates any existing activity of the same name.   
     /// 
-    /// As its name suggests RecursiveActivit1Start, is marked as recursive and thus can be used when the activity can nest with 
+    /// As its name suggests RecursiveActivity1Start, is marked as recursive and thus can be used when the activity can nest with 
     /// itself.   This should not be a 'top most' activity because it is not 'self healing' (if you miss a stop, then the
     /// activity NEVER ends).   
     /// 

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -83,26 +83,26 @@ namespace System.Diagnostics
     /// discover what is available.
     /// 
     /// 
-    /// * How data is loged in the EventSource 
+    /// * How data is logged in the EventSource 
     /// 
     /// By default all data from Diagnostic sources is logged to the the DiagnosticEventSouce event called 'Event' 
     /// which has three fields  
     /// 
     ///     string SourceName, 
     ///     string EventName, 
-    ///     IEnumerable<KeyValuePair<string, string>> Argument
+    ///     IEnumerable[KeyValuePair[string, string]] Argument
     /// 
-    /// However to spport start-stop activity tacking, there are six other events that can be used 
+    /// However to support start-stop activity tracking, there are six other events that can be used 
     /// 
     ///     Activity1Start         
     ///     Activity1Stop
     ///     Activity2Start
     ///     Activity2Stop
-    ///     RecActivity1Start
-    ///     RecActivity1Stop
+    ///     RecursiveActivity1Start
+    ///     RecursiveActivity1Stop
     ///     
     /// By using the SourceName/EventName@EventSourceName syntax, you can force particular DiagnosticSource events to
-    /// be logged with one of these EventSource events.   This is useful because the events above have start-stop sematics
+    /// be logged with one of these EventSource events.   This is useful because the events above have start-stop semantics
     /// which means that they create activity IDs that are attached to all logging messages between the start and
     /// the stop (see https://blogs.msdn.microsoft.com/vancem/2015/09/14/exploring-eventsource-activity-correlation-and-causation-features/)
     /// 
@@ -118,11 +118,11 @@ namespace System.Diagnostics
     /// Simmilarly SecurityStart is mapped to Activity2Start.    
     /// 
     /// Note you can map many DiangosticSource events to the same EventSource Event (e.g. Activity1Start).  As long as the
-    /// activityies don't nest, you can reuse the same event name (since the payloads have the DiagnosticSource name which can
+    /// activities don't nest, you can reuse the same event name (since the payloads have the DiagnosticSource name which can
     /// disambiguate).   However if they nest you need to use another EventSource event because the rules of EventSource 
     /// activities state that a start of the same event terminates any existing activity of the same name.   
     /// 
-    /// As its name suggests RecActivit1Start, is marked as recursive and thus can be used when the activity can nest with 
+    /// As its name suggests RecursiveActivit1Start, is marked as recursive and thus can be used when the activity can nest with 
     /// itself.   This should not be a 'top most' activity because it is not 'self healing' (if you miss a stop, then the
     /// activity NEVER ends).   
     /// 
@@ -183,6 +183,7 @@ namespace System.Diagnostics
         {
             WriteEvent(4, SourceName, EventName, Arguments);
         }
+
         /// <summary>
         /// Used to mark the end of an activity 
         /// </summary>
@@ -191,6 +192,7 @@ namespace System.Diagnostics
         {
             WriteEvent(5, SourceName, EventName, Arguments);
         }
+
         /// <summary>
         /// Used to mark the beginning of an activity 
         /// </summary>
@@ -199,6 +201,7 @@ namespace System.Diagnostics
         {
             WriteEvent(6, SourceName, EventName, Arguments);
         }
+
         /// <summary>
         /// Used to mark the end of an activity that can be recursive.  
         /// </summary>
@@ -207,19 +210,21 @@ namespace System.Diagnostics
         {
             WriteEvent(7, SourceName, EventName, Arguments);
         }
+
         /// <summary>
         /// Used to mark the beginning of an activity 
         /// </summary>
         [Event(8, Keywords = Keywords.Events, ActivityOptions = EventActivityOptions.Recursive)]
-        private void RecActivity1Start(string SourceName, string EventName, IEnumerable<KeyValuePair<string, string>> Arguments)
+        private void RecursiveActivity1Start(string SourceName, string EventName, IEnumerable<KeyValuePair<string, string>> Arguments)
         {
             WriteEvent(8, SourceName, EventName, Arguments);
         }
+
         /// <summary>
         /// Used to mark the end of an activity that can be recursive.  
         /// </summary>
         [Event(9, Keywords = Keywords.Events, ActivityOptions = EventActivityOptions.Recursive)]
-        private void RecActivity1Stop(string SourceName, string EventName, IEnumerable<KeyValuePair<string, string>> Arguments)
+        private void RecursiveActivity1Stop(string SourceName, string EventName, IEnumerable<KeyValuePair<string, string>> Arguments)
         {
             WriteEvent(9, SourceName, EventName, Arguments);
         }
@@ -430,7 +435,7 @@ namespace System.Diagnostics
                 {
                     listenerNameFilter = filterAndPayloadSpec.Substring(startIdx, slashIdx - startIdx);
 
-                    var atIdx = filterAndPayloadSpec.IndexOf('@', slashIdx+1, endEventNameIdx - slashIdx-1);
+                    var atIdx = filterAndPayloadSpec.IndexOf('@', slashIdx+1, endEventNameIdx - slashIdx - 1);
                     if (0 <= atIdx)
                     {
                         activityName = filterAndPayloadSpec.Substring(atIdx + 1, endEventNameIdx - atIdx - 1);

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -688,6 +688,9 @@ namespace System.Diagnostics.Tests
                     wroteEvent = true;
                 }
             }
+           
+            if (eventData.EventName == "EventSourceMessage" && 0 < eventData.Payload.Count) 
+                System.Diagnostics.Debug.WriteLine("EventSourceMessage: " + eventData.Payload[0].ToString());
 
             var otherEventWritten = OtherEventWritten;
             if (otherEventWritten != null && !wroteEvent)

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -108,7 +108,7 @@ namespace System.Diagnostics.Tests
                 // Turn on events with both implicit and explicit types You can have whitespace 
                 // before and after each spec.   Use \n rather than \r\n 
                 eventSourceListener.Enable(
-                    "  LinuxNewLineConventionsSource/TestEvent1:-cls_Point_X=cls.Point.X\n" + 
+                    "  LinuxNewLineConventionsSource/TestEvent1:-cls_Point_X=cls.Point.X\n" +
                     "  LinuxNewLineConventionsSource/TestEvent2:-cls_Url=cls.Url\n"
                     );
 
@@ -412,7 +412,7 @@ namespace System.Diagnostics.Tests
                 // This is just to make debugging easier.  
                 var messages = new List<string>();
 
-                eventSourceListener.OtherEventWritten += delegate(EventWrittenEventArgs evnt)
+                eventSourceListener.OtherEventWritten += delegate (EventWrittenEventArgs evnt)
                 {
                     if (evnt.EventName == "Message")
                     {
@@ -425,6 +425,76 @@ namespace System.Diagnostics.Tests
                 eventSourceListener.Enable("TestMessagesSource/TestEvent1:-cls.Url");
                 Assert.Equal(0, eventSourceListener.EventCount);
                 Assert.True(3 <= messages.Count);
+            }
+        }
+
+        /// <summary>
+        /// Tests the feature to send the messsages as EventSource Activities.  
+        /// </summary>
+        [Fact]
+        public void TestActivities()
+        {
+            using (var eventSourceListener = new TestDiagnosticSourceEventListener())
+            using (var diagnosticSourceListener = new DiagnosticListener("TestActivitiesSource"))
+            {
+                Assert.Equal(0, eventSourceListener.EventCount);
+                eventSourceListener.Enable(
+                    "TestActivitiesSource/TestActivity1Start@Activity1Start\r\n" +
+                    "TestActivitiesSource/TestActivity1Stop@Activity1Stop\r\n" + 
+                    "TestActivitiesSource/TestActivity2Start@Activity2Start\r\n" +
+                    "TestActivitiesSource/TestActivity2Stop@Activity2Stop\r\n" + 
+                    "TestActivitiesSource/TestEvent\r\n"
+                    );
+
+                // Start activity 1
+                diagnosticSourceListener.Write("TestActivity1Start", new { propStr = "start" });
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("Activity1Start", eventSourceListener.LastEvent.EventSourceEventName);
+                Assert.Equal("TestActivitiesSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestActivity1Start", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(1, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("start", eventSourceListener.LastEvent.Arguments["propStr"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+
+                // Start nested activity 2
+                diagnosticSourceListener.Write("TestActivity2Start", new { propStr = "start" });
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("Activity2Start", eventSourceListener.LastEvent.EventSourceEventName);
+                Assert.Equal("TestActivitiesSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestActivity2Start", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(1, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("start", eventSourceListener.LastEvent.Arguments["propStr"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+
+                // Send a normal event 
+                diagnosticSourceListener.Write("TestEvent", new { propStr = "event" });
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("Event", eventSourceListener.LastEvent.EventSourceEventName);
+                Assert.Equal("TestActivitiesSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestEvent", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(1, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("event", eventSourceListener.LastEvent.Arguments["propStr"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+
+                // Stop nested activity 2
+                diagnosticSourceListener.Write("TestActivity2Stop", new { propStr = "stop" });
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("Activity2Stop", eventSourceListener.LastEvent.EventSourceEventName);
+                Assert.Equal("TestActivitiesSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestActivity2Stop", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(1, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("stop", eventSourceListener.LastEvent.Arguments["propStr"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
+
+                // Stop activity 1
+                diagnosticSourceListener.Write("TestActivity1Stop", new { propStr = "stop" });
+                Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
+                Assert.Equal("Activity1Stop", eventSourceListener.LastEvent.EventSourceEventName);
+                Assert.Equal("TestActivitiesSource", eventSourceListener.LastEvent.SourceName);
+                Assert.Equal("TestActivity1Stop", eventSourceListener.LastEvent.EventName);
+                Assert.Equal(1, eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("stop", eventSourceListener.LastEvent.Arguments["propStr"]);
+                eventSourceListener.ResetEventCountAndLastEvent();
             }
         }
     }
@@ -464,8 +534,11 @@ namespace System.Diagnostics.Tests
 
         public int EventCount;
         public DiagnosticSourceEvent LastEvent;
-        public DiagnosticSourceEvent SecondLast;
+#if DEBUG 
+        // Here just for debugging.  Lets you see the last 3 events that were sent.  
+        public DiagnosticSourceEvent SecondLast;  
         public DiagnosticSourceEvent ThirdLast;
+#endif 
 
         /// <summary>
         /// Sets the EventCount to 0 and LastEvent to null
@@ -474,8 +547,10 @@ namespace System.Diagnostics.Tests
         {
             EventCount = 0;
             LastEvent = null;
+#if DEBUG
             SecondLast = null;
             ThirdLast = null;
+#endif
         }
 
         /// <summary>
@@ -489,8 +564,10 @@ namespace System.Diagnostics.Tests
             if (Filter != null && !Filter(anEvent))
                 return;
 
+#if DEBUG 
             ThirdLast = SecondLast;
             SecondLast = LastEvent;
+#endif
 
             EventCount++;
             LastEvent = anEvent;
@@ -506,6 +583,9 @@ namespace System.Diagnostics.Tests
         public string SourceName;
         public string EventName;
         public Dictionary<string, string> Arguments;
+
+        // Not typically important. 
+        public string EventSourceEventName;    // This is the name of the EventSourceEvent that carried the data.   Only important for activities.  
 
         public override string ToString()
         {
@@ -579,13 +659,14 @@ namespace System.Diagnostics.Tests
             var eventWritten = EventWritten;
             if (eventWritten != null)
             {
-                if (eventData.EventName == "Event" && eventData.Payload.Count == 3)
+                if (eventData.Payload.Count == 3 && (eventData.EventName == "Event" || eventData.EventName.Contains("Activity")))
                 {
                     Debug.Assert(eventData.PayloadNames[0] == "SourceName");
                     Debug.Assert(eventData.PayloadNames[1] == "EventName");
                     Debug.Assert(eventData.PayloadNames[2] == "Arguments");
 
                     var anEvent = new DiagnosticSourceEvent();
+                    anEvent.EventSourceEventName = eventData.EventName;
                     anEvent.SourceName = eventData.Payload[0].ToString();
                     anEvent.EventName = eventData.Payload[1].ToString();
                     anEvent.Arguments = new Dictionary<string, string>();


### PR DESCRIPTION
… EventSource Events.

This is to support activities in Diagnostic Source.

By default, all DiagnosticSource Events are forwarded to the EventSource by a EventSource event
called 'Event'.    However in order for DiangosticSources to participate in EventSource 'start-stop'
activities, you need the EventSourceEvents to be marked as being starts and stops.

This change adds a 6 EventSource Events that are so marked (e.g. Activity1Start, Activity2Stop ...)
and adds a new  @EventSourceEventName syntax when specifying a FilterAndTransformSpec.

    DiagnosticSourceName/EventName@EventSourceEventName

This allows you to specify that paritcular DiagnosticSource Events map to particular EventSource
event and thus participate in start-stop activity tracking.