### PR TITLE
Split packaging for Clrcompression by appx/non-appx

### DIFF
--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
@@ -23,15 +23,15 @@
       <OSGroup>OSX</OSGroup>
       <Platform>amd64</Platform>
     </Project>
-    <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
+    <Project Include="win7\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
       <Platform>x86</Platform>
     </Project>
-    <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
+    <Project Include="win7\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
       <Platform>amd64</Platform>
     </Project>
-    <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
+    <Project Include="win7\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
       <Platform>arm</Platform>
     </Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
@@ -35,6 +35,18 @@
       <OSGroup>Windows_NT</OSGroup>
       <Platform>arm</Platform>
     </Project>
+    <Project Include="win10\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <Platform>x86</Platform>
+    </Project>
+    <Project Include="win10\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="win10\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <Platform>arm</Platform>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
@@ -21,13 +21,22 @@
     <ProjectReference Include="ubuntu\runtime.native.System.IO.Compression.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
-    <ProjectReference Include="win\runtime.native.System.IO.Compression.pkgproj">
+    <ProjectReference Include="win7\runtime.native.System.IO.Compression.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
-    <ProjectReference Include="win\runtime.native.System.IO.Compression.pkgproj">
+    <ProjectReference Include="win7\runtime.native.System.IO.Compression.pkgproj">
       <Platform>arm</Platform>
     </ProjectReference>
-    <ProjectReference Include="win\runtime.native.System.IO.Compression.pkgproj">
+    <ProjectReference Include="win7\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>x86</Platform>
+    </ProjectReference>
+    <ProjectReference Include="win10\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="win10\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>arm</Platform>
+    </ProjectReference>
+    <ProjectReference Include="win10\runtime.native.System.IO.Compression.pkgproj">
       <Platform>x86</Platform>
     </ProjectReference>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/win10/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/win10/runtime.native.System.IO.Compression.pkgproj
@@ -4,14 +4,10 @@
   
   <PropertyGroup>
     <Version>4.0.1</Version>
-    <PackageTargetRuntime>win7-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageTargetRuntime>win10-$(PackagePlatform)</PackageTargetRuntime>
   </PropertyGroup>
 
-  <!-- These paths are not built in CoreFx, enable when fixing https://github.com/dotnet/corefx/issues/826 -->
   <ItemGroup>
-    <File Include="$(WinNativePath)clrcompression.dll">
-      <TargetPath>runtimes/win7-$(PackagePlatform)/native</TargetPath>
-    </File>
     <!-- use Win10 temporarily as the distinguishing factor, in reality the distinction is app-container vs not. -->
     <File Include="$(WinNativePath)..\..\NetCoreForCoreCLR\native\clrcompression.dll">
       <TargetPath>runtimes/win10-$(PackagePlatform)/native</TargetPath>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/win7/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/win7/runtime.native.System.IO.Compression.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+    <PropertyGroup>
+        <Version>4.0.1</Version>
+        <PackageTargetRuntime>win7-$(PackagePlatform)</PackageTargetRuntime>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <File Include="$(WinNativePath)\clrcompression.dll">
+            <TargetPath>runtimes/win7-$(PackagePlatform)/native</TargetPath>
+        </File>
+    </ItemGroup>
+
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
Rebased @ianhays  pull request from here: #7009 . @weshaggard, @ericstj could you double-check that the paths look correct after my rebase?