### PR TITLE
Expose MemberDescriptor in ComponentModel

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
+++ b/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
@@ -51,12 +51,12 @@
     <Compile Include="System\ComponentModel\Int16Converter.cs" />
     <Compile Include="System\ComponentModel\Int32Converter.cs" />
     <Compile Include="System\ComponentModel\Int64Converter.cs" />
-    <!--<Compile Include="System\ComponentModel\ICustomTypeDescriptor.cs" />-->
+    <Compile Include="System\ComponentModel\ICustomTypeDescriptor.cs" />
     <!--<Compile Include="System\ComponentModel\IExtenderProvider.cs" />-->
     <!--<Compile Include="System\ComponentModel\IListSource.cs" />-->
     <Compile Include="System\ComponentModel\ITypeDescriptorContext.cs" />
     <!--<Compile Include="System\ComponentModel\ITypedList.cs" />-->
-    <!--<Compile Include="System\ComponentModel\MemberDescriptor.cs" />-->
+    <Compile Include="System\ComponentModel\MemberDescriptor.cs" />
     <Compile Include="System\ComponentModel\MultilineStringConverter.cs" />
     <Compile Include="System\ComponentModel\NullableConverter.cs" />
     <Compile Include="System\ComponentModel\PropertyDescriptor.cs" />

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EventDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EventDescriptor.cs
@@ -6,32 +6,17 @@ namespace System.ComponentModel
 {
     /// <devdoc>
     ///    <para>
-    ///       Provides a description
-    ///       of an event.
+    ///       Provides a description of an event.
     ///    </para>
     /// </devdoc>
-#if FEATURE_MEMBERDESCRIPTOR
     public abstract class EventDescriptor : MemberDescriptor
-#else
-    public abstract class EventDescriptor
-#endif
     {
         /// <devdoc>
         ///    <para>
         ///       Initializes a new instance of the <see cref='System.ComponentModel.EventDescriptor'/> class with the
-        ///       specified name and attribute
-        ///       array.
+        ///       specified name and attribute array.
         ///    </para>
         /// </devdoc>
-#if !FEATURE_MEMBERDESCRIPTOR
-        // TODO: This is a placeholder until MemberDescriptor is implemented
-        protected EventDescriptor(string name, Attribute[] attrs)
-        {
-            Name = name;
-        }
-
-        public string Name { get; }
-#else
         protected EventDescriptor(string name, Attribute[] attrs)
             : base(name, attrs)
         {
@@ -40,8 +25,7 @@ namespace System.ComponentModel
         /// <devdoc>
         ///    <para>
         ///       Initializes a new instance of the <see cref='System.ComponentModel.EventDescriptor'/> class with the name and attributes in
-        ///       the specified <see cref='System.ComponentModel.MemberDescriptor'/>
-        ///       .
+        ///       the specified <see cref='System.ComponentModel.MemberDescriptor'/>.
         ///    </para>
         /// </devdoc>
         protected EventDescriptor(MemberDescriptor descr)
@@ -53,29 +37,24 @@ namespace System.ComponentModel
         ///    <para>
         ///       Initializes a new instance of the <see cref='System.ComponentModel.EventDescriptor'/> class with
         ///       the name in the specified <see cref='System.ComponentModel.MemberDescriptor'/> and the
-        ///       attributes in both the <see cref='System.ComponentModel.MemberDescriptor'/> and the <see cref='System.Attribute'/>
-        ///       array.
+        ///       attributes in both the <see cref='System.ComponentModel.MemberDescriptor'/> and the <see cref='System.Attribute'/> array.
         ///    </para>
         /// </devdoc>
         protected EventDescriptor(MemberDescriptor descr, Attribute[] attrs)
             : base(descr, attrs)
         {
         }
-#endif
 
         /// <devdoc>
         ///    <para>
-        ///       When overridden in a derived
-        ///       class,
-        ///       gets the type of the component this event is bound to.
+        ///       When overridden in a derived class, gets the type of the component this event is bound to.
         ///    </para>
         /// </devdoc>
         public abstract Type ComponentType { get; }
 
         /// <devdoc>
         ///    <para>
-        ///       When overridden in a derived
-        ///       class, gets the type of delegate for the event.
+        ///       When overridden in a derived class, gets the type of delegate for the event.
         ///    </para>
         /// </devdoc>
         public abstract Type EventType { get; }
@@ -91,21 +70,15 @@ namespace System.ComponentModel
 
         /// <devdoc>
         ///    <para>
-        ///       When overridden in
-        ///       a derived class,
-        ///       binds the event to the component.
+        ///       When overridden in a derived class, binds the event to the component.
         ///    </para>
         /// </devdoc>
         public abstract void AddEventHandler(object component, Delegate value);
 
         /// <devdoc>
         ///    <para>
-        ///       When
-        ///       overridden
-        ///       in a derived class, unbinds the delegate from the
-        ///       component
-        ///       so that the delegate will no
-        ///       longer receive events from the component.
+        ///       When overridden in a derived class, unbinds the delegate from the component
+        ///       so that the delegate will no longer receive events from the component.
         ///    </para>
         /// </devdoc>
         public abstract void RemoveEventHandler(object component, Delegate value);

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ICustomTypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ICustomTypeDescriptor.cs
@@ -2,17 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.Serialization.Formatters;
-using System.Runtime.InteropServices;
-using System.Diagnostics;
-using System;
-using Microsoft.Win32;
-
 namespace System.ComponentModel
 {
     /// <devdoc>
-    ///    <para>Provides an interface that provides custom type information for an 
-    ///       object.</para>
+    ///    <para>Provides an interface that provides custom type information for an object.</para>
     /// </devdoc>
     public interface ICustomTypeDescriptor
     {
@@ -41,7 +34,6 @@ namespace System.ComponentModel
         ///    <para>Gets the default event for this object.</para>
         /// </devdoc>
         EventDescriptor GetDefaultEvent();
-
 
         /// <devdoc>
         ///    <para>Gets the default property for this object.</para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
@@ -2,24 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+using System.Reflection;
+
 namespace System.ComponentModel
 {
     /// <devdoc>
     ///    <para>Provides a description of a property.</para>
     /// </devdoc>
-#if PLACEHOLDER
     public abstract class PropertyDescriptor : MemberDescriptor
-#else
-    public abstract class PropertyDescriptor
-#endif
     {
-#if PLACEHOLDER
         private TypeConverter _converter = null;
         private Hashtable _valueChangedHandlers;
         private object[] _editors;
         private Type[] _editorTypes;
         private int _editorCount;
-#endif
 
         /// <devdoc>
         ///    <para>
@@ -27,14 +24,6 @@ namespace System.ComponentModel
         ///       attributes.
         ///    </para>
         /// </devdoc>
-#if !PLACEHOLDER
-        // TODO: This is a temp constructor to unblock PropertyDescriptorCollection
-        protected PropertyDescriptor(string name, Attribute[] attrs)
-        {
-            Name = name;
-        }
-        public string Name { get; }
-#else
         protected PropertyDescriptor(string name, Attribute[] attrs)
         : base(name, attrs)
         {
@@ -92,7 +81,7 @@ namespace System.ComponentModel
                     if (attr.ConverterTypeName != null && attr.ConverterTypeName.Length > 0)
                     {
                         Type converterType = GetTypeFromName(attr.ConverterTypeName);
-                        if (converterType != null && typeof(TypeConverter).IsAssignableFrom(converterType))
+                        if (converterType != null && typeof(TypeConverter).GetTypeInfo().IsAssignableFrom(converterType))
                         {
                             _converter = (TypeConverter)CreateInstance(converterType);
                         }
@@ -107,6 +96,7 @@ namespace System.ComponentModel
             }
         }
 
+#if PLACEHOLDER
         /// <devdoc>
         ///    <para>
         ///       Gets a value
@@ -145,6 +135,7 @@ namespace System.ComponentModel
                 return attr.Visibility;
             }
         }
+#endif
 
         /// <devdoc>
         ///    <para>
@@ -227,7 +218,7 @@ namespace System.ComponentModel
         protected object CreateInstance(Type type)
         {
             Type[] typeArgs = new Type[] { typeof(Type) };
-            ConstructorInfo ctor = type.GetConstructor(typeArgs);
+            ConstructorInfo ctor = type.GetTypeInfo().GetConstructor(typeArgs);
             if (ctor != null)
             {
                 return TypeDescriptor.CreateInstance(null, type, typeArgs, new object[] { PropertyType });
@@ -324,6 +315,7 @@ namespace System.ComponentModel
             //
             if (editor == null)
             {
+#if FEATURE_EDITORATTRIBUTE
                 for (int i = 0; i < attrs.Count; i++)
                 {
                     EditorAttribute attr = attrs[i] as EditorAttribute;
@@ -344,6 +336,7 @@ namespace System.ComponentModel
                         }
                     }
                 }
+#endif
 
                 // Now, if we failed to find it in our own attributes, go to the
                 // component descriptor.
@@ -426,14 +419,14 @@ namespace System.ComponentModel
             if (ComponentType != null)
             {
                 if ((typeFromGetType == null) ||
-                    (ComponentType.Assembly.FullName.Equals(typeFromGetType.Assembly.FullName)))
+                    (ComponentType.GetTypeInfo().Assembly.FullName.Equals(typeFromGetType.GetTypeInfo().Assembly.FullName)))
                 {
                     int comma = typeName.IndexOf(',');
 
                     if (comma != -1)
                         typeName = typeName.Substring(0, comma);
 
-                    typeFromComponent = ComponentType.Assembly.GetType(typeName);
+                    typeFromComponent = ComponentType.GetTypeInfo().Assembly.GetType(typeName);
                 }
             }
 
@@ -442,10 +435,7 @@ namespace System.ComponentModel
 
         /// <devdoc>
         ///    <para>
-        ///       When overridden in a derived class, gets the current
-        ///       value
-        ///       of the
-        ///       property on a component.
+        ///       When overridden in a derived class, gets the current value of the property on a component.
         ///    </para>
         /// </devdoc>
         public abstract object GetValue(object component);
@@ -459,11 +449,7 @@ namespace System.ComponentModel
         {
             if (component != null && _valueChangedHandlers != null)
             {
-                EventHandler handler = (EventHandler)_valueChangedHandlers[component];
-                if (handler != null)
-                {
-                    handler(component, e);
-                }
+                ((EventHandler)_valueChangedHandlers[component])?.Invoke(component, e);
             }
         }
 
@@ -509,10 +495,7 @@ namespace System.ComponentModel
 
         /// <devdoc>
         ///    <para>
-        ///       When overridden in a derived class, resets the
-        ///       value
-        ///       for this property
-        ///       of the component.
+        ///       When overridden in a derived class, resets the value for this property of the component.
         ///    </para>
         /// </devdoc>
         public abstract void ResetValue(object component);
@@ -528,8 +511,7 @@ namespace System.ComponentModel
         /// <devdoc>
         ///    <para>
         ///       When overridden in a derived class, indicates whether the
-        ///       value of
-        ///       this property needs to be persisted.
+        ///       value of this property needs to be persisted.
         ///    </para>
         /// </devdoc>
         public abstract bool ShouldSerializeValue(object component);
@@ -547,6 +529,5 @@ namespace System.ComponentModel
                 return false;
             }
         }
-#endif
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -21,8 +21,10 @@ namespace System.ComponentModel
         private static Hashtable s_providerTypeTable = new Hashtable();      // A direct mapping from type to provider.
         private static volatile Hashtable s_defaultProviders = new Hashtable();      // A table of type -> default provider to track DefaultTypeDescriptionProviderAttributes.
         private static volatile WeakHashtable s_associationTable;
-        private static int s_metadataVersion;                          // a version stamp for our metadata.  Used by property descriptors to know when to rebuild
-                                                                      // attributes.
+#endif
+        // A version stamp for our metadata used by property descriptors to know when to rebuild attributes.
+        private static int s_metadataVersion = 0;
+#if PLACEHOLDER
 
 
         // This is an index that we use to create a unique name for a property in the
@@ -155,6 +157,7 @@ namespace System.ComponentModel
                 return typeof(TypeDescriptorInterface);
             }
         }
+#endif
 
         /// <devdoc>
         ///     This value increments each time someone refreshes or changes metadata.
@@ -167,6 +170,7 @@ namespace System.ComponentModel
             }
         }
 
+#if PLACEHOLDER
         /// <include file='doc\TypeDescriptor.uex' path='docs/doc[@for="TypeDescriptor.Refreshed"]/*' />
         /// <devdoc>
         ///    Occurs when Refreshed is raised for a component.
@@ -631,6 +635,7 @@ namespace System.ComponentModel
         {
             return new ReflectEventDescriptor(componentType, oldEventDescriptor, attributes);
         }
+#endif
 
         /// <devdoc>
         ///     This method will search internal tables within TypeDescriptor for 
@@ -639,6 +644,9 @@ namespace System.ComponentModel
         /// </devdoc>
         public static object CreateInstance(IServiceProvider provider, Type objectType, Type[] argTypes, object[] args)
         {
+            throw new NotImplementedException();
+        }
+#if PLACEHOLDER
             if (objectType == null)
             {
                 throw new ArgumentNullException("objectType");
@@ -1268,14 +1276,17 @@ namespace System.ComponentModel
 
             return newMembers;
         }
+#endif
 
         /// <devdoc>
         ///     The GetAssociation method returns the correct object to invoke 
         ///     for the requested type.  It never returns null.  
         /// </devdoc>
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
         public static object GetAssociation(Type type, object primary)
         {
+            throw new NotImplementedException();
+        }
+#if PLACEHOLDER
             if (type == null)
             {
                 throw new ArgumentNullException("type");
@@ -1683,6 +1694,7 @@ namespace System.ComponentModel
 
             return NodeFor(component).GetExtendedTypeDescriptor(component);
         }
+        #endif
 
         /// <devdoc>
         ///     Gets an editor with the specified base type for the
@@ -1690,6 +1702,9 @@ namespace System.ComponentModel
         /// </devdoc>
         public static object GetEditor(object component, Type editorBaseType)
         {
+            throw new NotImplementedException();
+        }
+#if PLACEHOLDER
             return GetEditor(component, editorBaseType, false);
         }
 
@@ -1958,6 +1973,7 @@ namespace System.ComponentModel
 
             return GetDescriptor(componentType, "componentType").GetProperties();
         }
+#endif
 
         /// <devdoc>
         ///    Gets a collection of properties for a specified type of 
@@ -1965,6 +1981,9 @@ namespace System.ComponentModel
         /// </devdoc>
         public static PropertyDescriptorCollection GetProperties(Type componentType, Attribute[] attributes)
         {
+            throw new NotImplementedException();
+        }
+#if PLACEHOLDER
             if (componentType == null)
             {
                 Debug.Fail("COMPAT:  Returning an empty collection, but you should not pass null here");
@@ -2002,6 +2021,7 @@ namespace System.ComponentModel
         {
             return GetPropertiesImpl(component, null, noCustomTypeDesc, true);
         }
+#endif
 
         /// <devdoc>
         ///    Gets a collection of properties for a specified 
@@ -2010,6 +2030,9 @@ namespace System.ComponentModel
         /// </devdoc>
         public static PropertyDescriptorCollection GetProperties(object component, Attribute[] attributes)
         {
+            throw new NotImplementedException();
+        }
+#if PLACEHOLDER
             return GetProperties(component, attributes, false);
         }
 

--- a/src/System.ComponentModel.TypeConverter/tests/PropertyDescriptorCollectionTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/PropertyDescriptorCollectionTests.cs
@@ -214,6 +214,47 @@ namespace System.ComponentModel.Tests
                 : base(name, new Attribute[] { })
             {
             }
+
+            public override Type ComponentType
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public override Type PropertyType
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public override bool CanResetValue(object component)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override object GetValue(object component)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void ResetValue(object component)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void SetValue(object component, object value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool ShouldSerializeValue(object component)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }


### PR DESCRIPTION
This exposes all the members in MemberDescriptor and updates PropertyDescriptor and EventDescriptor to derive from it. This also exposes a few methods in TypeDescriptor that are necessary for these types, but leaves the implementation empty (or throw NotImplementedException).

@chlowell