### PR TITLE
Cleanup and add extensive WebUtility tests

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
@@ -60,7 +60,6 @@ namespace System.Net.Tests
             yield return Tuple.Create("%F0%90%8F%BF", "\uD800\uDFFF"); // Surrogate pair
         }
 
-        [ActiveIssue(7166)]
         public static IEnumerable<Tuple<string, string>> UrlEncode_SharedTestData()
         {
             // Recent change brings function inline with RFC 3986 to return hex-encoded chars in uppercase
@@ -88,7 +87,6 @@ namespace System.Net.Tests
             */
         }
 
-        [ActiveIssue(7166)]
         public static IEnumerable<object[]> UrlEncodeDecode_Roundtrip_SharedTestData()
         {
             yield return new object[] { "'" };
@@ -143,6 +141,7 @@ namespace System.Net.Tests
 
         [Theory]
         [MemberData(nameof(UrlEncode_TestData))]
+        // [ActiveIssue(7166)]
         public static void UrlEncode(string value, string expected)
         {
             Assert.Equal(expected, WebUtility.UrlEncode(value));
@@ -150,6 +149,7 @@ namespace System.Net.Tests
 
         [Theory]
         [MemberData(nameof(UrlEncodeDecode_Roundtrip_SharedTestData))]
+        // [ActiveIssue(7166)]
         public static void UrlEncodeDecode_Roundtrip(string value)
         {
             string encoded = WebUtility.UrlEncode(value);
@@ -224,6 +224,7 @@ namespace System.Net.Tests
 
         [Theory]
         [MemberData(nameof(UrlEncodeToBytes_TestData))]
+        // [ActiveIssue(7166)]
         public static void UrlEncodeToBytes(byte[] value, int offset, int count, byte[] expected)
         {
             byte[] actual = WebUtility.UrlEncodeToBytes(value, offset, count);
@@ -244,6 +245,7 @@ namespace System.Net.Tests
 
         [Theory]
         [MemberData(nameof(UrlEncodeDecode_Roundtrip_SharedTestData))]
+        // [ActiveIssue(7166)]
         public static void UrlEncodeDecodeToBytes_Roundtrip(string url)
         {
             byte[] input = Encoding.UTF8.GetBytes(url);

--- a/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
@@ -141,7 +141,6 @@ namespace System.Net.Tests
 
         [Theory]
         [MemberData(nameof(UrlEncode_TestData))]
-        // [ActiveIssue(7166)]
         public static void UrlEncode(string value, string expected)
         {
             Assert.Equal(expected, WebUtility.UrlEncode(value));
@@ -149,7 +148,6 @@ namespace System.Net.Tests
 
         [Theory]
         [MemberData(nameof(UrlEncodeDecode_Roundtrip_SharedTestData))]
-        // [ActiveIssue(7166)]
         public static void UrlEncodeDecode_Roundtrip(string value)
         {
             string encoded = WebUtility.UrlEncode(value);
@@ -224,7 +222,6 @@ namespace System.Net.Tests
 
         [Theory]
         [MemberData(nameof(UrlEncodeToBytes_TestData))]
-        // [ActiveIssue(7166)]
         public static void UrlEncodeToBytes(byte[] value, int offset, int count, byte[] expected)
         {
             byte[] actual = WebUtility.UrlEncodeToBytes(value, offset, count);
@@ -245,7 +242,6 @@ namespace System.Net.Tests
 
         [Theory]
         [MemberData(nameof(UrlEncodeDecode_Roundtrip_SharedTestData))]
-        // [ActiveIssue(7166)]
         public static void UrlEncodeDecodeToBytes_Roundtrip(string url)
         {
             byte[] input = Encoding.UTF8.GetBytes(url);

--- a/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using Xunit;
 
@@ -10,6 +12,8 @@ namespace System.Net.Tests
 {
     public class WebUtilityTests
     {
+        // HtmlEncode + HtmlDecode
+
         public static IEnumerable<object[]> HtmlDecode_TestData()
         {
             yield return new object[] { "Hello! &apos;&quot;&lt;&amp;&gt;\u2665&hearts;\u00E7&#xe7;&#231;", "Hello! '\"<&>\u2665\u2665\u00E7\u00E7\u00E7" };
@@ -46,11 +50,79 @@ namespace System.Net.Tests
             Assert.Equal(expected, WebUtility.HtmlEncode(value));
         }
 
-        public static IEnumerable<object[]> UrlDecode_TestData()
+        // Shared test data for UrlEncode + Decode and their ToBytes counterparts
+
+        public static IEnumerable<Tuple<string, string>> UrlDecode_SharedTestData()
         {
             // Recent change brings function inline with RFC 3986 to return hex-encoded chars in uppercase
-            yield return new object[] { "%2F%5C%22%09Hello!+%E2%99%A5%3F%2F%5C%22%09World!+%E2%99%A5%3F%E2%99%A5", "/\\\"\tHello! \u2665?/\\\"\tWorld! \u2665?\u2665" };
-            yield return new object[] { "Hello, world", "Hello, world" }; // No special chars
+            yield return Tuple.Create("%2F%5C%22%09Hello!+%E2%99%A5%3F%2F%5C%22%09World!+%E2%99%A5%3F%E2%99%A5", "/\\\"\tHello! \u2665?/\\\"\tWorld! \u2665?\u2665");
+            yield return Tuple.Create("Hello, world", "Hello, world"); // No special chars
+            yield return Tuple.Create("%F0%90%8F%BF", "\uD800\uDFFF"); // Surrogate pair
+        }
+
+        public static IEnumerable<Tuple<string, string>> UrlEncode_SharedTestData()
+        {
+            // Recent change brings function inline with RFC 3986 to return hex-encoded chars in uppercase
+            yield return Tuple.Create("/\\\"\tHello! \u2665?/\\\"\tWorld! \u2665?\u2665", "%2F%5C%22%09Hello!+%E2%99%A5%3F%2F%5C%22%09World!+%E2%99%A5%3F%E2%99%A5");
+            yield return Tuple.Create("'", "%27");
+            yield return Tuple.Create("\uD800\uDFFF", "%F0%90%8F%BF"); // Surrogate pairs should be encoded as 4 bytes together
+
+            // Tests for stray surrogate chars (all should be encoded as U+FFFD)
+            // Relevant GitHub issue: dotnet/corefx#7036
+
+            // Commented out since xUnit is throwing an exception
+            // when trying to serialize the invalid chars to an XML file.
+            // Feel free to uncomment once that is fixed.
+
+            /*
+            yield return Tuple.Create("\uD800", "%EF%BF%BD"); // High surrogate
+            yield return Tuple.Create("\uDC00", "%EF%BF%BD"); // Low surrogate
+
+            yield return Tuple.Create("\uDC00\uD800", "%EF%BF%BD%EF%BF%BD"); // Low + high
+            yield return Tuple.Create("\uD900\uDA00", "%EF%BF%BD%EF%BF%BD"); // High + high
+            yield return Tuple.Create("\uDE00\uDF00", "%EF%BF%BD%EF%BF%BD"); // Low + low
+
+            yield return Tuple.Create("!\uDB00@", "!%EF%BF%BD%40"); // Non-surrogate + high + non-surrogate
+            yield return Tuple.Create("#\uDD00$", "%23%EF%BF%BD%24"); // Non-surrogate + low + non-surrogate
+            */
+        }
+
+        public static IEnumerable<object[]> UrlEncodeDecode_Roundtrip_SharedTestData()
+        {
+            yield return new object[] { "'" };
+            yield return new object[] { "http://www.microsoft.com" };
+            yield return new object[] { "/\\\"\tHello! \u2665?/\\\"\tWorld! \u2665?\u2665" };
+            yield return new object[] { "\uD800\uDFFF" }; // Surrogate pairs
+
+            yield return new object[] { CharRange('\uE000', '\uF8FF') }; // BMP private use chars
+            yield return new object[] { CharRange('\uFDD0', '\uFDEF') }; // Low BMP non-chars
+            // xUnit also seems to be having problems with 0xFFFE as well,
+            // so let's comment this out for now.
+            // yield return new object[] { "\uFFFE\uFFFF" }; // High BMP non-chars
+
+            yield return new object[] { CharRange('\0', '\u001F') }; // C0 controls
+            yield return new object[] { CharRange('\u0080', '\u009F') }; // C1 controls
+
+            yield return new object[] { CharRange('\u202A', '\u202E') }; // BIDI embedding and override
+            yield return new object[] { CharRange('\u2066', '\u2069') }; // BIDI isolate
+
+            yield return new object[] { "\uFEFF" }; // BOM
+
+            // Astral plane private use chars
+            yield return new object[] { CharRange(0xF0000, 0xFFFFD) };
+            yield return new object[] { CharRange(0x100000, 0x10FFFD) };
+            // Astral plane non-chars
+            yield return new object[] { "\U0001FFFE" };
+            yield return new object[] { "\U0001FFFF" };
+            yield return new object[] { CharRange(0x2FFFE, 0x10FFFF) };
+        }
+
+        // UrlEncode + UrlDecode
+
+        public static IEnumerable<object[]> UrlDecode_TestData()
+        {
+            foreach (var tuple in UrlDecode_SharedTestData())
+                yield return new object[] { tuple.Item1, tuple.Item2 };
             yield return new object[] { null, null };
         }
 
@@ -63,9 +135,8 @@ namespace System.Net.Tests
 
         public static IEnumerable<object[]> UrlEncode_TestData()
         {
-            // Recent change brings function inline with RFC 3986 to return hex-encoded chars in uppercase
-            yield return new object[] { "/\\\"\tHello! \u2665?/\\\"\tWorld! \u2665?\u2665", "%2F%5C%22%09Hello!+%E2%99%A5%3F%2F%5C%22%09World!+%E2%99%A5%3F%E2%99%A5" };
-            yield return new object[] { "'", "%27" };
+            foreach (var tuple in UrlEncode_SharedTestData())
+                yield return new object[] { tuple.Item1, tuple.Item2 };
             yield return new object[] { null, null };
         }
 
@@ -77,19 +148,32 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [InlineData("'")]
-        [InlineData("http://www.microsoft.com")]
-        [InlineData("/\\\"\tHello! \u2665?/\\\"\tWorld! \u2665?\u2665")]
+        [MemberData(nameof(UrlEncodeDecode_Roundtrip_SharedTestData))]
         public static void UrlEncodeDecode_Roundtrip(string value)
         {
             string encoded = WebUtility.UrlEncode(value);
             Assert.Equal(value, WebUtility.UrlDecode(encoded));
         }
+        
+        // UrlEncode + DecodeToBytes
 
-        [Fact]
-        public static void UrlDecodeToBytes_NullEncodedValue_ReturnsNull()
+        public static IEnumerable<object[]> UrlDecodeToBytes_TestData()
         {
-            Assert.Null(WebUtility.UrlDecodeToBytes(null, 0, 0));
+            foreach (var tuple in UrlDecode_SharedTestData())
+            {
+                byte[] input = Encoding.UTF8.GetBytes(tuple.Item1);
+                byte[] output = Encoding.UTF8.GetBytes(tuple.Item2);
+                yield return new object[] { input, 0, input.Length, output };
+            }
+            yield return new object[] { null, 0, 0, null };
+        }
+
+        [Theory]
+        [MemberData(nameof(UrlDecodeToBytes_TestData))]
+        public static void UrlDecodeToBytes(byte[] value, int offset, int count, byte[] expected)
+        {
+            byte[] actual = WebUtility.UrlDecodeToBytes(value, offset, count);
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
@@ -125,11 +209,24 @@ namespace System.Net.Tests
             Assert.Equal(count, outputBytes.Length);
             Assert.Equal(subInputBytes, outputBytes);
         }
+        
+        public static IEnumerable<object[]> UrlEncodeToBytes_TestData()
+        {
+            foreach (var tuple in UrlEncode_SharedTestData())
+            {
+                byte[] input = Encoding.UTF8.GetBytes(tuple.Item1);
+                byte[] output = Encoding.UTF8.GetBytes(tuple.Item2);
+                yield return new object[] { input, 0, input.Length, output };
+            }
+            yield return new object[] { null, 0, 0, null };
+        }
 
         [Theory]
-        public static void UrlEncodeToBytes_NullValue_ReturnsNull()
+        [MemberData(nameof(UrlEncodeToBytes_TestData))]
+        public static void UrlEncodeToBytes(byte[] value, int offset, int count, byte[] expected)
         {
-            Assert.Null(WebUtility.UrlEncodeToBytes(null, 0, 0));
+            byte[] actual = WebUtility.UrlEncodeToBytes(value, offset, count);
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
@@ -145,14 +242,71 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [InlineData("'")]
-        [InlineData("http://www.microsoft.com")]
-        [InlineData("/\\\"\tHello! \u2665?/\\\"\tWorld! \u2665?\u2665")]
+        [MemberData(nameof(UrlEncodeDecode_Roundtrip_SharedTestData))]
         public static void UrlEncodeDecodeToBytes_Roundtrip(string url)
         {
-            byte[] input = System.Text.Encoding.UTF8.GetBytes(url);
+            byte[] input = Encoding.UTF8.GetBytes(url);
             byte[] encoded = WebUtility.UrlEncodeToBytes(input, 0, input.Length);
             Assert.Equal(input, WebUtility.UrlDecodeToBytes(encoded, 0, encoded.Length));
+        }
+        
+        // [Theory]
+        // [InlineData("FooBarQuux", 3, 7, "BarQuux")]
+        [ActiveIssue(6947)]
+        public static void UrlEncodeToBytes_ExcludeIrrelevantData(string value, int offset, int count, string expected)
+        {
+            byte[] input = Encoding.UTF8.GetBytes(value);
+            byte[] encoded = WebUtility.UrlEncodeToBytes(input, offset, count);
+            string actual = Encoding.UTF8.GetString(encoded);
+            Assert.Equal(expected, actual);
+        }
+
+        // [Theory]
+        // [InlineData("FooBarQuux", 3, 7, "BarQuux")]
+        [ActiveIssue(6947)]
+        public static void UrlDecodeToBytes_ExcludeIrrelevantData(string value, int offset, int count, string expected)
+        {
+            byte[] input = Encoding.UTF8.GetBytes(value);
+            byte[] decoded = WebUtility.UrlDecodeToBytes(input, offset, count);
+            string actual = Encoding.UTF8.GetString(decoded);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void UrlEncodeToBytes_NewArray()
+        {
+            // If no encoding is needed, the current implementation simply
+            // returns the input array to a method which then clones it.
+
+            // We have to make sure it always returns a new array, to
+            // prevent problems where the input array is changed if
+            // the output one is modified.
+
+            byte[] input = Encoding.UTF8.GetBytes("Dont.Need.Encoding");
+            byte[] output = WebUtility.UrlEncodeToBytes(input, 0, input.Length);
+            Assert.NotSame(input, output);
+        }
+
+        [Fact]
+        public static void UrlDecodeToBytes_NewArray()
+        {
+            byte[] input = Encoding.UTF8.GetBytes("Dont.Need.Decoding");
+            byte[] output = WebUtility.UrlDecodeToBytes(input, 0, input.Length);
+            Assert.NotSame(input, output);
+        }
+
+        public static string CharRange(int start, int end)
+        {
+            Debug.Assert(start <= end);
+
+            int capacity = end - start + 1;
+            var builder = new StringBuilder(capacity);
+            for (int i = start; i <= end; i++)
+            {
+                // 0 -> \0, 65 -> A, 0x10FFFF -> \U0010FFFF
+                builder.Append(char.ConvertFromUtf32(i));
+            }
+            return builder.ToString();
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
@@ -60,21 +60,21 @@ namespace System.Net.Tests
             yield return Tuple.Create("%F0%90%8F%BF", "\uD800\uDFFF"); // Surrogate pair
         }
 
+        [ActiveIssue(7166)]
         public static IEnumerable<Tuple<string, string>> UrlEncode_SharedTestData()
         {
             // Recent change brings function inline with RFC 3986 to return hex-encoded chars in uppercase
             yield return Tuple.Create("/\\\"\tHello! \u2665?/\\\"\tWorld! \u2665?\u2665", "%2F%5C%22%09Hello!+%E2%99%A5%3F%2F%5C%22%09World!+%E2%99%A5%3F%E2%99%A5");
             yield return Tuple.Create("'", "%27");
             yield return Tuple.Create("\uD800\uDFFF", "%F0%90%8F%BF"); // Surrogate pairs should be encoded as 4 bytes together
-
-            // Tests for stray surrogate chars (all should be encoded as U+FFFD)
-            // Relevant GitHub issue: dotnet/corefx#7036
-
-            // Commented out since xUnit is throwing an exception
-            // when trying to serialize the invalid chars to an XML file.
-            // Feel free to uncomment once that is fixed.
+            
+            // TODO: Uncomment this block out when dotnet/corefx#7166 is fixed.
 
             /*
+            
+            // Tests for stray surrogate chars (all should be encoded as U+FFFD)
+            // Relevant GitHub issue: dotnet/corefx#7036
+            
             yield return Tuple.Create("\uD800", "%EF%BF%BD"); // High surrogate
             yield return Tuple.Create("\uDC00", "%EF%BF%BD"); // Low surrogate
 
@@ -84,9 +84,11 @@ namespace System.Net.Tests
 
             yield return Tuple.Create("!\uDB00@", "!%EF%BF%BD%40"); // Non-surrogate + high + non-surrogate
             yield return Tuple.Create("#\uDD00$", "%23%EF%BF%BD%24"); // Non-surrogate + low + non-surrogate
+            
             */
         }
 
+        [ActiveIssue(7166)]
         public static IEnumerable<object[]> UrlEncodeDecode_Roundtrip_SharedTestData()
         {
             yield return new object[] { "'" };
@@ -96,8 +98,7 @@ namespace System.Net.Tests
 
             yield return new object[] { CharRange('\uE000', '\uF8FF') }; // BMP private use chars
             yield return new object[] { CharRange('\uFDD0', '\uFDEF') }; // Low BMP non-chars
-            // xUnit also seems to be having problems with 0xFFFE as well,
-            // so let's comment this out for now.
+            // TODO: Uncomment when dotnet/corefx#7166 is fixed.
             // yield return new object[] { "\uFFFE\uFFFF" }; // High BMP non-chars
 
             yield return new object[] { CharRange('\0', '\u001F') }; // C0 controls

--- a/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
@@ -250,9 +250,8 @@ namespace System.Net.Tests
             Assert.Equal(input, WebUtility.UrlDecodeToBytes(encoded, 0, encoded.Length));
         }
         
-        // [Theory]
-        // [InlineData("FooBarQuux", 3, 7, "BarQuux")]
-        [ActiveIssue(6947)]
+        [Theory]
+        [InlineData("FooBarQuux", 3, 7, "BarQuux")]
         public static void UrlEncodeToBytes_ExcludeIrrelevantData(string value, int offset, int count, string expected)
         {
             byte[] input = Encoding.UTF8.GetBytes(value);
@@ -261,9 +260,8 @@ namespace System.Net.Tests
             Assert.Equal(expected, actual);
         }
 
-        // [Theory]
-        // [InlineData("FooBarQuux", 3, 7, "BarQuux")]
-        [ActiveIssue(6947)]
+        [Theory]
+        [InlineData("FooBarQuux", 3, 7, "BarQuux")]
         public static void UrlDecodeToBytes_ExcludeIrrelevantData(string value, int offset, int count, string expected)
         {
             byte[] input = Encoding.UTF8.GetBytes(value);


### PR DESCRIPTION
This follows up on #6698 by adding extensive testing based on the failures encountered in that PR. Primarily, it adds tests for surrogate characters, and makes sure spaces are properly en/decoded in the `ToBytes` methods.

Additional changes:

- Test data sharing between regular `UrlEncode`/`Decode` and the `byte[]`-based methods
- Replace magic string usage in `MemberData` with `nameof`
- Added comments to the code to separate it into different regions
- Added tests to make sure the `ToBytes` methods always return a new array
- Added, but commented out regression tests for #6947 (uncomment once that issue is resolved)

cc @davidsh @stephentoub @JonHanna