### PR TITLE
Remove ApiCompat baseline file for net46 X509

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/ApiCompatBaseline.net46.txt
+++ b/src/System.Security.Cryptography.X509Certificates/src/ApiCompatBaseline.net46.txt
@@ -1,3 +1,0 @@
-MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509ChainStatusFlags System.Security.Cryptography.X509Certificates.X509ChainStatusFlags.ExplicitDistrust' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509ChainStatusFlags System.Security.Cryptography.X509Certificates.X509ChainStatusFlags.HasNotSupportedCriticalExtension' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Cryptography.X509Certificates.X509ChainStatusFlags System.Security.Cryptography.X509Certificates.X509ChainStatusFlags.HasWeakSignature' does not exist in the implementation but it does exist in the contract.


### PR DESCRIPTION
Adding the ApiCompat file and removing the errors happened on parallel
pull requests.  Verified using latest buildtools drop that ApiCompat passes
without the baseline file.

Fixes # #6935
cc: @venkat-raman251