### PR TITLE
Speed up SortedSet AddAllElements

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -167,8 +167,7 @@ namespace System.Collections.Generic
         {
             foreach (T item in collection)
             {
-                if (!this.Contains(item))
-                    Add(item);
+                AddIfNotPresent(item);
             }
         }
 


### PR DESCRIPTION
Contains searches the tree till if finds the nearest node and then Add does the same thing. This change will halve the number operations needed to add each element.