### PR TITLE
Implement UpdateDependencies script to automatically take new versions of dependencies

### DIFF
--- a/UpdateDependencies.ps1
+++ b/UpdateDependencies.ps1
@@ -1,0 +1,113 @@
+﻿#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+# This script updates all the project.json files with the latest CoreFX build version,
+# and then creates a Pull Request for the change.
+
+param(
+    [Parameter(Mandatory=$true)][string]$GitHubUser,
+    [Parameter(Mandatory=$true)][string]$GitHubEmail,
+    [Parameter(Mandatory=$true)][string]$GitHubPassword,
+    [Parameter(Mandatory=$true)][string]$CoreFxVersionUrl, 
+    [string]$GitHubUpstreamOwner='dotnet', 
+    [string]$GitHubOriginOwner=$GitHubUser,
+    [string]$GitHubProject='corefx',
+    [string]$GitHubUpstreamBranch='master')
+
+$CoreFxLatestVersion = Invoke-WebRequest $CoreFxVersionUrl -UseBasicParsing
+$CoreFxLatestVersion = $CoreFxLatestVersion.ToString().Trim()
+
+# Updates the dir.props file with the latest CoreFX build number
+function UpdateValidDependencyVersionsFile
+{
+    if (!$CoreFxLatestVersion)
+    {
+        Write-Error "Unable to find latest CoreFX version at $CoreFxVersionUrl"
+        return $false
+    }
+
+    $DirPropsPath = "$PSScriptRoot\dir.props"
+    
+    $DirPropsContent = Get-Content $DirPropsPath | % { 
+        $_ -replace "<CoreFxExpectedPrerelease>.*</CoreFxExpectedPrerelease>","<CoreFxExpectedPrerelease>$CoreFxLatestVersion</CoreFxExpectedPrerelease>"
+    }
+    Set-Content $DirPropsPath $DirPropsContent
+
+    return $true
+}
+
+# Updates all the project.json files with out of date version numbers
+function RunUpdatePackageDependencyVersions
+{
+    cmd /c $PSScriptRoot\build.cmd /t:UpdateInvalidPackageVersions | Out-Host
+
+    return $LASTEXITCODE -eq 0
+}
+
+# Creates a Pull Request for the updated version numbers
+function CreatePullRequest
+{
+    $GitStatus = git status --porcelain
+    if ([string]::IsNullOrWhiteSpace($GitStatus))
+    {
+        Write-Warning "Dependencies are currently up to date"
+        return $true
+    }
+    
+    $CommitMessage = "Updating CoreFX dependencies to $CoreFxLatestVersion"
+
+    $env:GIT_COMMITTER_NAME = $GitHubUser
+    $env:GIT_COMMITTER_EMAIL = $GitHubEmail
+    git commit -a -m "$CommitMessage" --author "$GitHubUser <$GitHubEmail>" | Out-Host
+
+    $RemoteUrl = "github.com/$GitHubOriginOwner/$GitHubProject.git"
+    $RemoteBranchName = "UpdateDependencies$([DateTime]::UtcNow.ToString('yyyyMMddhhmmss'))"
+    $RefSpec = "HEAD:refs/heads/$RemoteBranchName"
+
+    Write-Host "git push https://$RemoteUrl $RefSpec"
+    # pipe this to null so the password secret isn't in the logs
+    git push "https://$($GitHubUser):$GitHubPassword@$RemoteUrl" $RefSpec 2>&1 | Out-Null
+
+    $CreatePRBody = @"
+    {
+        "title": "$CommitMessage", 
+        "head": "$($GitHubOriginOwner):$RemoteBranchName", 
+        "base": "$GitHubUpstreamBranch" 
+    }
+"@
+
+    $CreatePRHeaders = @{'Accept'='application/vnd.github.v3+json'; 'Authorization'="token $GitHubPassword"}
+
+    try
+    {
+        Invoke-WebRequest https://api.github.com/repos/$GitHubUpstreamOwner/$GitHubProject/pulls -UseBasicParsing -Method Post -Body $CreatePRBody -Headers $CreatePRHeaders
+    }
+    catch
+    {
+        Write-Error $_.ToString()
+        return $false
+    }
+
+    return $true
+}
+
+if (!(UpdateValidDependencyVersionsFile))
+{
+    Exit -1
+}
+
+if (!(RunUpdatePackageDependencyVersions))
+{
+    Exit -1
+}
+
+if (!(CreatePullRequest))
+{
+    Exit -1
+}
+
+Write-Host -ForegroundColor Green "Successfully updated dependencies from the latest build numbers"
+
+exit $LastExitCode

--- a/dir.props
+++ b/dir.props
@@ -62,7 +62,7 @@
 
   <!-- Import packaging props -->
   <Import Project="$(MSBuildThisFileDirectory)Packaging.props"/>
-  
+
   <!-- Import Build tools common props file where repo-independent properties are found -->
   <Import Project="$(ToolsDir)Build.Common.props" />
 
@@ -76,20 +76,25 @@
   <PropertyGroup>
     <ValidatePackageVersions>true</ValidatePackageVersions>
     <ProhibitFloatingDependencies>true</ProhibitFloatingDependencies>
+    <CoreFxExpectedPrerelease>rc3-23925-00</CoreFxExpectedPrerelease>
   </PropertyGroup>
 
   <ItemGroup>
-    <ValidationPattern Include="^(?i)((System\..%2A)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore.%2A)|(Microsoft\.TargetingPack\.Private\.(CoreCLR|NETNative))|(Microsoft\.Win32\..%2A)|(Microsoft\.VisualBasic))(?&lt;!TestData)$">
-      <ExpectedPrerelease>rc3-23925-00</ExpectedPrerelease>
+    <ValidationPattern Include="CoreFxVersions">
+      <IdentityRegex>^(?i)((System\..*)|(NETStandard\.Library)|(Microsoft\.CSharp)|(Microsoft\.NETCore.*)|(Microsoft\.TargetingPack\.Private\.(CoreCLR|NETNative))|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)$</IdentityRegex>
+      <ExpectedPrerelease>$(CoreFxExpectedPrerelease)</ExpectedPrerelease>
     </ValidationPattern>
-    <ValidationPattern Include="^(?i)Microsoft\.TargetingPack\.(NetFramework.%2A|Private\.WinRT)$">
+    <ValidationPattern Include="TargetingPackVersions">
+      <IdentityRegex>^(?i)Microsoft\.TargetingPack\.(NetFramework.*|Private\.WinRT)$</IdentityRegex>
       <ExpectedVersion>1.0.1</ExpectedVersion>
     </ValidationPattern>
-    <ValidationPattern Include="^(?i)xunit$">
+    <ValidationPattern Include="xUnitStableVersions">
+      <IdentityRegex>^(?i)xunit$</IdentityRegex>
       <ExpectedVersion>2.1.0</ExpectedVersion>
     </ValidationPattern>
-    <ValidationPattern Include="^(?i)xunit\.netcore\.extensions$">
-      <ExpectedVersion>1.0.0-prerelease-00123</ExpectedVersion>
+    <ValidationPattern Include="xUnitExtensionsVersions">
+      <IdentityRegex>^(?i)xunit\.netcore\.extensions$</IdentityRegex>
+      <ExpectedVersion>1.0.0-prerelease-00187</ExpectedVersion>
     </ValidationPattern>
   </ItemGroup>
 
@@ -381,14 +386,14 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-  
+
   <PropertyGroup>
     <IsRedistAssembly Condition="'$(IsRedistAssembly)'=='' AND ($(MSBuildProjectFullPath.Contains('\redist\')) OR $(MSBuildProjectFullPath.Contains('/redist/')))">true</IsRedistAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsRedistAssembly)'=='true'">
     <NuGetRuntimeIdentifier Condition="'$(TargetGroup)' == 'netcore50'">win8</NuGetRuntimeIdentifier>
     <NuGetRuntimeIdentifier Condition="'$(TargetGroup)' == 'netcore50aot'">win8-aot</NuGetRuntimeIdentifier>
-    
+
     <!-- workaround Dev14 issue with nuget targets -->
     <RuntimeIndentifier>$(NuGetRuntimeIdentifier)</RuntimeIndentifier>
   </PropertyGroup>


### PR DESCRIPTION
There are 2 changes here:

1. Move dependency validation patterns to Item metadata and add programmatic names.
 - This allows automated tools to update the version numbers easier by referencing the names.
Another advantage is we can write regular expressions easier. Putting regular expressions in the Include attribute can cause a lot of issues.
2. Initial implementation of the UpdateDependencies.ps1 script. This script will be used to automate taking new versions of dependencies when new builds are available.
 - The first (and probably only) dependency to be automated is the CoreFX build numbers in the project.json files.

@dagood @weshaggard