### PR TITLE
Fix restore on Unix

### DIFF
--- a/src/System.Collections/src/project.json
+++ b/src/System.Collections/src/project.json
@@ -22,7 +22,7 @@
         "System.Diagnostics.Tools": "4.0.0",
         "System.Resources.ResourceManager": "4.0.0",
         "System.Runtime": "4.0.20",
-        "System.Runtime.Extensions": "4.0.0",
+        "System.Runtime.Extensions": "4.0.10",
         "System.Threading": "4.0.10"
       }
     }

--- a/src/System.IO.Pipes/tests/NativeOverlapped.unix.cs
+++ b/src/System.IO.Pipes/tests/NativeOverlapped.unix.cs
@@ -1,0 +1,3 @@
+
+// stub implementation of NativeOverlapped to compile windows only tests in Unix build
+internal struct NativeOverlapped {}

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -16,6 +16,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetsWindows)' == 'true'">
+    <ProjectJson>win/project.json</ProjectJson>
+    <ProjectLockJson>win/project.lock.json</ProjectLockJson>
+  </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>
@@ -31,6 +35,7 @@
     <Compile Include="AnonymousPipeTests\AnonymousPipeTest.Specific.cs" />
     <Compile Include="AnonymousPipeTests\AnonymousPipeTest.Write.cs" />
     <Compile Include="Interop.cs" />
+    <Compile Condition="'$(TargetsUnix)' == 'true'" Include="NativeOverlapped.unix.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.CreateServer.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.CreateClient.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.CrossProcess.cs" />

--- a/src/System.IO.Pipes/tests/win/project.json
+++ b/src/System.IO.Pipes/tests/win/project.json
@@ -16,6 +16,7 @@
     "System.Security.Principal": "4.0.1-rc3-23918",
     "System.Text.RegularExpressions": "4.0.12-rc3-23918",
     "System.Threading.Tasks": "4.0.11-rc3-23918",
+    "System.Threading.Overlapped": "4.0.1-rc3-23918",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
@@ -23,5 +24,9 @@
     "dnxcore50": {
       "imports": "portable-net45+win8"
     }
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {}
   }
 }

--- a/src/System.Threading.Overlapped/src/project.json
+++ b/src/System.Threading.Overlapped/src/project.json
@@ -1,3 +1,4 @@
+
 {
   "frameworks": {
     "netstandard1.3": {
@@ -12,13 +13,13 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23918",
-        "System.Diagnostics.Debug": "4.0.0.0",
-        "System.Resources.ResourceManager": "4.0.0.0",
-        "System.Runtime": "4.0.20.0",
-        "System.Runtime.Extensions": "4.0.0.0",
-        "System.Runtime.Handles": "4.0.00.0",
-        "System.Runtime.InteropServices": "4.0.20.0",
-        "System.Threading": "4.0.10.0"
+        "System.Diagnostics.Debug": "4.0.0",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Extensions": "4.0.10",
+        "System.Runtime.Handles": "4.0.0",
+        "System.Runtime.InteropServices": "4.0.20",
+        "System.Threading": "4.0.10"
       }
     },
     "net46": {


### PR DESCRIPTION
The pipe tests were using NativeOverlapped which still doesn't have a
not-supported impl.  Add a dummy implementation and don't try to
restore it for Unix.

Two other NetCore50 projects were restoring a lower version of S.R.E
that didn't contain an impl for NetCore50.

Fixes #7062