### PR TITLE
Distinguish raw IPv4 from IPv6 in unix Ping implementation

### DIFF
--- a/src/Common/src/System/Net/RawSocketPermissions.cs
+++ b/src/Common/src/System/Net/RawSocketPermissions.cs
@@ -8,22 +8,22 @@ namespace System.Net
 {
     internal static partial class RawSocketPermissions
     {
-        private static readonly Lazy<bool> s_canUseRawSockets = new Lazy<bool>(CheckRawSocketPermissions);
+        private static readonly Lazy<bool> s_canUseRawIPv4Sockets = new Lazy<bool>(() => CheckRawSocketPermissions(AddressFamily.InterNetwork));
+        private static readonly Lazy<bool> s_canUseRawIPv6Sockets = new Lazy<bool>(() => CheckRawSocketPermissions(AddressFamily.InterNetworkV6));
 
         /// <summary>
         /// Returns whether or not the current user has the necessary permission to open raw sockets.
         /// </summary>
-        public static bool CanUseRawSockets()
-        {
-            return s_canUseRawSockets.Value;
-        }
+        public static bool CanUseRawSockets(AddressFamily addressFamily) =>
+            addressFamily == AddressFamily.InterNetworkV6 ?
+                s_canUseRawIPv6Sockets.Value :
+                s_canUseRawIPv4Sockets.Value;
 
-        private static bool CheckRawSocketPermissions()
+        private static bool CheckRawSocketPermissions(AddressFamily addressFamily)
         {
             try
             {
-                Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Raw, ProtocolType.Icmp);
-                s.Dispose();
+                new Socket(addressFamily, SocketType.Raw, ProtocolType.Icmp).Dispose();
                 return true;
             }
             catch

--- a/src/Common/tests/System/Net/Capability.RawSocketPermissions.cs
+++ b/src/Common/tests/System/Net/Capability.RawSocketPermissions.cs
@@ -2,13 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Net.Sockets;
+
 namespace System.Net.Test.Common
 {
     public static partial class Capability
     {
-        public static bool CanUseRawSockets()
+        public static bool CanUseRawSockets(AddressFamily addressFamily)
         {
-            return RawSocketPermissions.CanUseRawSockets();
+            return RawSocketPermissions.CanUseRawSockets(addressFamily);
         }
     }
 }

--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
@@ -22,7 +22,7 @@ namespace System.Net.NetworkInformation
         {
             try
             {
-                Task<PingReply> t = RawSocketPermissions.CanUseRawSockets() ?
+                Task<PingReply> t = RawSocketPermissions.CanUseRawSockets(address.AddressFamily) ?
                     SendIcmpEchoRequestOverRawSocket(address, buffer, timeout, options) :
                     SendWithPingUtility(address, buffer, timeout, options);
                 return await t.ConfigureAwait(false);

--- a/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -134,7 +134,7 @@ namespace System.Net.NetworkInformation.Tests
                     Assert.True(pingReply.Address.Equals(localIpAddress));
 
                     // Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-                    if (Capability.CanUseRawSockets())
+                    if (Capability.CanUseRawSockets(localIpAddress.AddressFamily))
                     {
                         Assert.Equal(buffer, pingReply.Buffer);
                     }
@@ -179,7 +179,7 @@ namespace System.Net.NetworkInformation.Tests
                     Assert.True(pingReply.Address.Equals(localIpAddress));
 
                     // Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-                    if (Capability.CanUseRawSockets())
+                    if (Capability.CanUseRawSockets(localIpAddress.AddressFamily))
                     {
                         Assert.Equal(buffer, pingReply.Buffer);
                     }
@@ -251,7 +251,7 @@ namespace System.Net.NetworkInformation.Tests
                     Assert.True(pingReply.Address.Equals(localIpAddress));
 
                     // Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-                    if (Capability.CanUseRawSockets())
+                    if (Capability.CanUseRawSockets(localIpAddress.AddressFamily))
                     {
                         Assert.Equal(buffer, pingReply.Buffer);
                     }
@@ -295,7 +295,7 @@ namespace System.Net.NetworkInformation.Tests
                     Assert.True(pingReply.Address.Equals(localIpAddress));
 
                     // Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-                    if (Capability.CanUseRawSockets())
+                    if (Capability.CanUseRawSockets(localIpAddress.AddressFamily))
                     {
                         Assert.Equal(buffer, pingReply.Buffer);
                     }


### PR DESCRIPTION
Some systems enable raw sockets to be opened for ICMP but not ICMPv6, but our current test in Ping for whether to open a raw socket directly is based only on ICMP, which then causes run-time failures when an IPv6 address is used.  This commit augments the current check to distinguish between the two.

cc: @mellinoe, @ericeil 
Fixes #7064