### PR TITLE
Fix Issue 7090 (regain compatibility for 32bit systems)

### DIFF
--- a/src/Native/System.Net.Security.Native/pal_gssapi.cpp
+++ b/src/Native/System.Net.Security.Native/pal_gssapi.cpp
@@ -232,7 +232,7 @@ extern "C" void NetSecurityNative_ReleaseGssBuffer(void* buffer, uint64_t length
     assert(buffer != nullptr);
 
     uint32_t minorStatus;
-    GssBuffer gssBuffer{.length = length, .value = buffer};
+    GssBuffer gssBuffer{.length = static_cast<size_t>(length), .value = buffer};
     gss_release_buffer(&minorStatus, &gssBuffer);
 }
 


### PR DESCRIPTION
Recently added System.Net.Security.Native has broken the compatibility with 32bit systems by using uint64_t to pass size of a buffer. Use size_t instead to make it compatible for both 64 and 32 bit systems.

This fixes the issue #7090