### PR TITLE
Make MoveFile on unix fall back to CopyFile in more cases

### DIFF
--- a/src/Common/src/Interop/Unix/Interop.IOErrors.cs
+++ b/src/Common/src/Interop/Unix/Interop.IOErrors.cs
@@ -111,6 +111,8 @@ internal static partial class Interop
     /// <returns></returns>
     internal static Exception GetExceptionForIoErrno(ErrorInfo errorInfo, string path = null, bool isDirectory = false)
     {
+        // Translate the errno into a known set of exception types.  For cases where multiple errnos map
+        // to the same exception type, include an inner exception with the details.
         switch (errorInfo.Error)
         {
             case Error.ENOENT:
@@ -130,9 +132,10 @@ internal static partial class Interop
             case Error.EACCES:
             case Error.EBADF:
             case Error.EPERM:
+                Exception inner = GetIOException(errorInfo);
                 return !string.IsNullOrEmpty(path) ?
-                    new UnauthorizedAccessException(SR.Format(SR.UnauthorizedAccess_IODenied_Path, path)) :
-                    new UnauthorizedAccessException(SR.UnauthorizedAccess_IODenied_NoPathName);
+                    new UnauthorizedAccessException(SR.Format(SR.UnauthorizedAccess_IODenied_Path, path), inner) :
+                    new UnauthorizedAccessException(SR.UnauthorizedAccess_IODenied_NoPathName, inner);
 
             case Error.ENAMETOOLONG:
                 return new PathTooLongException(SR.IO_PathTooLong);

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -47,25 +47,53 @@ namespace System.IO
             // as a Creation and Deletion instead of a Rename and thus differ from Windows.
             if (Interop.Sys.Link(sourceFullPath, destFullPath) < 0)
             {
+                // If link fails, we can fall back to doing a full copy, but we'll only do so for
+                // cases where we expect link could fail but such a copy could succeed.  We don't
+                // want to do so for all errors, because the copy could incur a lot of cost
+                // even if we know it'll eventually fail, e.g. EROFS means that the source file
+                // system is read-only and couldn't support the link being added, but if it's
+                // read-only, then the move should fail any way due to an inability to delete
+                // the source file.
                 Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
-                if (errorInfo.Error == Interop.Error.EXDEV) // rename fails across devices / mount points
+                if (errorInfo.Error == Interop.Error.EXDEV ||      // rename fails across devices / mount points
+                    errorInfo.Error == Interop.Error.EPERM ||      // permissions might not allow creating hard links even if a copy would work
+                    errorInfo.Error == Interop.Error.EOPNOTSUPP || // links aren't supported by the source file system
+                    errorInfo.Error == Interop.Error.EMLINK)       // too many hard links to the source file
                 {
                     CopyFile(sourceFullPath, destFullPath, overwrite: false);
                 }
-                else if (errorInfo.Error == Interop.Error.ENOENT && !Directory.Exists(Path.GetDirectoryName(destFullPath))) // The parent directory of destFile can't be found
-                {
-                    // Windows distinguishes between whether the directory or the file isn't found,
-                    // and throws a different exception in these cases.  We attempt to approximate that
-                    // here; there is a race condition here, where something could change between
-                    // when the error occurs and our checks, but it's the best we can do, and the
-                    // worst case in such a race condition (which could occur if the file system is
-                    // being manipulated concurrently with these checks) is that we throw a
-                    // FileNotFoundException instead of DirectoryNotFoundexception.
-                    throw Interop.GetExceptionForIoErrno(errorInfo, destFullPath, isDirectory: true);
-                }
                 else
                 {
-                    throw Interop.GetExceptionForIoErrno(errorInfo);
+                    // The operation failed.  Within reason, ty to determine which path caused the problem 
+                    // so we can throw a detailed exception.
+                    string path = null;
+                    bool isDirectory = false;
+                    if (errorInfo.Error == Interop.Error.ENOENT)
+                    {
+                        if (!Directory.Exists(Path.GetDirectoryName(destFullPath)))
+                        {
+                            // The parent directory of destFile can't be found.
+                            // Windows distinguishes between whether the directory or the file isn't found,
+                            // and throws a different exception in these cases.  We attempt to approximate that
+                            // here; there is a race condition here, where something could change between
+                            // when the error occurs and our checks, but it's the best we can do, and the
+                            // worst case in such a race condition (which could occur if the file system is
+                            // being manipulated concurrently with these checks) is that we throw a
+                            // FileNotFoundException instead of DirectoryNotFoundexception.
+                            path = destFullPath;
+                            isDirectory = true;
+                        }
+                        else
+                        {
+                            path = sourceFullPath;
+                        }
+                    }
+                    else if (errorInfo.Error == Interop.Error.EEXIST)
+                    {
+                        path = destFullPath;
+                    }
+
+                    throw Interop.GetExceptionForIoErrno(errorInfo, path, isDirectory);
                 }
             }
             DeleteFile(sourceFullPath);


### PR DESCRIPTION
There are a variety of situations in which a link-and-delete could fail but a copy-and-delete could succeed.  This commit adds some more cases where we fall back.  It also improves the exception thrown in a few cases to include more details about the cause.

Hopefully fixes https://github.com/dotnet/corefx/issues/7091, but good to do regardless.
cc: @ianhays, @ctaggart, @Priya91, @JeremyKuhne 