### PR TITLE
Dispose of X509Certificate used in WinHttpHandler server callback

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -289,6 +289,8 @@ namespace System.Net.Http
                     {
                         chain.Dispose();
                     }
+
+                    serverCertificate.Dispose();
                 }
             }
         }

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
@@ -119,7 +119,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
         {
                 Assert.Equal(SslPolicyErrors.None, _validationCallbackHistory.SslPolicyErrors);
                 Assert.True(_validationCallbackHistory.CertificateChain.Count > 0);
-                _output.WriteLine("Certificate.Subject: {0}", _validationCallbackHistory.Certificate.Subject);
+                _output.WriteLine("Certificate.Subject: {0}", _validationCallbackHistory.CertificateSubject);
                 _output.WriteLine("Expected HostName: {0}", expectedHostName);
         }
         
@@ -130,7 +130,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             SslPolicyErrors sslPolicyErrors)
         {
             _validationCallbackHistory.WasCalled = true;
-            _validationCallbackHistory.Certificate = certificate;
+            _validationCallbackHistory.CertificateSubject = certificate.Subject;
             foreach (var element in chain.ChainElements)
             {
                 _validationCallbackHistory.CertificateChain.Add(element.Certificate);
@@ -164,7 +164,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             public bool ReturnFailure;
             public bool WasCalled;
             public SslPolicyErrors SslPolicyErrors;
-            public X509Certificate2 Certificate;
+            public string CertificateSubject;
             public X509CertificateCollection CertificateChain;
             public X509ChainStatus[] ChainStatus;
 
@@ -174,7 +174,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                 ReturnFailure = false;
                 WasCalled = false;
                 SslPolicyErrors = SslPolicyErrors.None;
-                Certificate = null;
+                CertificateSubject = null;
                 CertificateChain = new X509CertificateCollection();
                 ChainStatus = null;
             }


### PR DESCRIPTION
cc: @davidsh, @bartonjs