### PR TITLE
[TestBug] Fix Issue#7083

### DIFF
--- a/src/System.Diagnostics.Process/tests/Interop.cs
+++ b/src/System.Diagnostics.Process/tests/Interop.cs
@@ -64,7 +64,7 @@ namespace System.Diagnostics.Tests
         [DllImport("libc")]
         internal static extern int getsid(int pid);
 
-        [DllImport("api-ms-win-core-processthreads-l1-1-2.dll")]
+        [DllImport("api-ms-win-core-processthreads-l1-1-0.dll")]
         internal static extern bool ProcessIdToSessionId(uint dwProcessId, out uint pSessionId);
 
         [DllImport("api-ms-win-core-processthreads-l1-1-0.dll")]


### PR DESCRIPTION
Fixes #7083 

System.Diagnotics.Process test TestSessionId used incorrect api-set version in pinvoke
which made it fail on win7. Updated the pinvoke signature.