### PR TITLE
Improve UDP test reliability

### DIFF
--- a/src/Common/tests/System/Net/Sockets/Configuration.cs
+++ b/src/Common/tests/System/Net/Sockets/Configuration.cs
@@ -9,7 +9,10 @@ namespace System.Net.Sockets.Tests
     public static class Configuration
     {
         // Timeout values in milliseconds.
-        public static readonly int PassingTestTimeout = 5000;
-        public static readonly int FailingTestTimeout = 100;  
+        public const int PassingTestTimeout = 5000;
+        public const int FailingTestTimeout = 100;
+
+        // Number of redundant UDP packets to send to increase test reliability
+        public const int UDPRedundancy = 10;
     }
 }

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/ReceiveMessageFrom.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/ReceiveMessageFrom.cs
@@ -20,7 +20,11 @@ namespace System.Net.Sockets.Tests
 
                     Socket sender = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
                     sender.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                    sender.SendTo(new byte[1024], new IPEndPoint(IPAddress.Loopback, port));
+
+                    for (int i = 0; i < Configuration.UDPRedundancy; i++)
+                    {
+                        sender.SendTo(new byte[1024], new IPEndPoint(IPAddress.Loopback, port));
+                    }
 
                     IPPacketInformation packetInformation;
                     SocketFlags flags = SocketFlags.None;

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/ReceiveMessageFromAsync.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/ReceiveMessageFromAsync.cs
@@ -31,7 +31,11 @@ namespace System.Net.Sockets.Tests
 
                     Socket sender = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
                     sender.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                    sender.SendTo(new byte[1024], new IPEndPoint(IPAddress.Loopback, port));
+
+                    for (int i = 0; i < Configuration.UDPRedundancy; i++)
+                    {
+                        sender.SendTo(new byte[1024], new IPEndPoint(IPAddress.Loopback, port));
+                    }
 
                     SocketAsyncEventArgs args = new SocketAsyncEventArgs();
                     args.RemoteEndPoint = new IPEndPoint(IPAddress.Any, 0);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SelectAndPollTests.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SelectAndPollTests.cs
@@ -41,7 +41,10 @@ namespace System.Net.Sockets.Tests
                 int receiverPort = receiver.BindToAnonymousPort(IPAddress.Loopback);
                 var receiverEndpoint = new IPEndPoint(IPAddress.Loopback, receiverPort);
 
-                sender.SendTo(new byte[1], SocketFlags.None, receiverEndpoint);
+                for (int i = 0; i < Configuration.UDPRedundancy; i++)
+                {
+                    sender.SendTo(new byte[1], SocketFlags.None, receiverEndpoint);
+                }
 
                 var list = new List<Socket> { receiver };
                 Socket.Select(list, null, null, SelectSuccessTimeoutMicroseconds);
@@ -78,8 +81,11 @@ namespace System.Net.Sockets.Tests
                 int secondReceiverPort = secondReceiver.BindToAnonymousPort(IPAddress.Loopback);
                 var secondReceiverEndpoint = new IPEndPoint(IPAddress.Loopback, secondReceiverPort);
 
-                sender.SendTo(new byte[1], SocketFlags.None, firstReceiverEndpoint);
-                sender.SendTo(new byte[1], SocketFlags.None, secondReceiverEndpoint);
+                for (int i = 0; i < Configuration.UDPRedundancy; i++)
+                {
+                    sender.SendTo(new byte[1], SocketFlags.None, firstReceiverEndpoint);
+                    sender.SendTo(new byte[1], SocketFlags.None, secondReceiverEndpoint);
+                }
 
                 var sw = Stopwatch.StartNew();
                 Assert.True(SpinWait.SpinUntil(() =>
@@ -126,7 +132,10 @@ namespace System.Net.Sockets.Tests
                 int secondReceiverPort = secondReceiver.BindToAnonymousPort(IPAddress.Loopback);
                 var secondReceiverEndpoint = new IPEndPoint(IPAddress.Loopback, secondReceiverPort);
 
-                sender.SendTo(new byte[1], SocketFlags.None, secondReceiverEndpoint);
+                for (int i = 0; i < Configuration.UDPRedundancy; i++)
+                {
+                    sender.SendTo(new byte[1], SocketFlags.None, secondReceiverEndpoint);
+                }
 
                 var list = new List<Socket> { firstReceiver, secondReceiver };
                 Socket.Select(list, null, null, SelectSuccessTimeoutMicroseconds);
@@ -272,7 +281,10 @@ namespace System.Net.Sockets.Tests
                 int receiverPort = receiver.BindToAnonymousPort(IPAddress.Loopback);
                 var receiverEndpoint = new IPEndPoint(IPAddress.Loopback, receiverPort);
 
-                sender.SendTo(new byte[1], SocketFlags.None, receiverEndpoint);
+                for (int i = 0; i < Configuration.UDPRedundancy; i++)
+                {
+                    sender.SendTo(new byte[1], SocketFlags.None, receiverEndpoint);
+                }
 
                 Assert.True(receiver.Poll(SelectSuccessTimeoutMicroseconds, SelectMode.SelectRead));
             }

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendReceive.cs
@@ -22,6 +22,7 @@ namespace System.Net.Sockets.Tests
 
         private static void SendToRecvFrom_Datagram_UDP(IPAddress leftAddress, IPAddress rightAddress)
         {
+            // TODO #5185: Harden against packet loss
             const int DatagramSize = 256;
             const int DatagramsToSend = 256;
             const int AckTimeout = 1000;
@@ -96,6 +97,7 @@ namespace System.Net.Sockets.Tests
 
         private static void SendToRecvFromAPM_Datagram_UDP(IPAddress leftAddress, IPAddress rightAddress)
         {
+            // TODO #5185: Harden against packet loss
             const int DatagramSize = 256;
             const int DatagramsToSend = 256;
             const int AckTimeout = 1000;

--- a/src/System.Net.Sockets/tests/FunctionalTests/IPPacketInformationTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/IPPacketInformationTest.cs
@@ -72,7 +72,11 @@ namespace System.Net.Sockets.Tests
 
                 Assert.True(receiver.ReceiveMessageFromAsync(receiveArgs));
 
-                sender.SendTo(new byte[1], new IPEndPoint(IPAddress.Loopback, port));
+                // Send a few packets, in case they aren't delivered reliably.
+                for (int i = 0; i < Configuration.UDPRedundancy; i++)
+                {
+                    sender.SendTo(new byte[1], new IPEndPoint(IPAddress.Loopback, port));
+                }
 
                 Assert.True(waitHandle.WaitOne(ReceiveTimeout));
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -30,6 +30,7 @@ namespace System.Net.Sockets.Tests
         [MemberData(nameof(SendToRecvFromAsync_Datagram_UDP_MemberData))]
         public void SendToRecvFromAsync_Datagram_UDP(IPAddress leftAddress, IPAddress rightAddress)
         {
+            // TODO #5185: harden against packet loss
             const int DatagramSize = 256;
             const int DatagramsToSend = 256;
             const int AckTimeout = 1000;


### PR DESCRIPTION
Harden the UDP Sockets tests against packet loss.  Whenever we expect to receive a UDP packet, we'll send 10 packets; hopefully this will reduce the failure rate in these tests.  There are three remaining tests that are a little trickier to harden; I've marked these with TODOs, and will address them separately.

Fixes most of #5185 

@stephentoub @cipop @davidsh