### PR TITLE
Use CngUIProtectedLevels.None to prevent tests from popping UI

### DIFF
--- a/src/System.Security.Cryptography.Cng/tests/CreateTests.cs
+++ b/src/System.Security.Cryptography.Cng/tests/CreateTests.cs
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography.Cng.Tests
             CngKeyCreationParameters p = new CngKeyCreationParameters();
             p.ExportPolicy = CngExportPolicies.AllowExport;
             p.KeyUsage = CngKeyUsages.KeyAgreement;
-            p.UIPolicy = new CngUIPolicy(CngUIProtectionLevels.ForceHighProtection, "MyFriendlyName", "MyDescription", "MyUseContext", "MyCreationTitle");
+            p.UIPolicy = new CngUIPolicy(CngUIProtectionLevels.None, "MyFriendlyName", "MyDescription", "MyUseContext", "MyCreationTitle");
             byte[] myPropValue1 = "23afbc".HexToByteArray();
             p.Parameters.Add(new CngProperty("MyProp1", myPropValue1, CngPropertyOptions.CustomProperty));
             byte[] myPropValue2 = "8765".HexToByteArray();
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography.Cng.Tests
                 Assert.Equal(CngExportPolicies.AllowExport, key.ExportPolicy);
                 Assert.Equal(CngKeyUsages.KeyAgreement, key.KeyUsage);
                 CngUIPolicy uiPolicy = key.UIPolicy;
-                Assert.Equal(CngUIProtectionLevels.ForceHighProtection, uiPolicy.ProtectionLevel);
+                Assert.Equal(CngUIProtectionLevels.None, uiPolicy.ProtectionLevel);
                 Assert.Equal("MyFriendlyName", uiPolicy.FriendlyName);
                 Assert.Equal("MyDescription", uiPolicy.Description);
                 Assert.Equal("MyUseContext", uiPolicy.UseContext);


### PR DESCRIPTION
This is a temporary mitigation for the hang witnessed in #7086.

It's unclear at this time why ForceHighProtection isn't doing what is expected on Win8.1, and while that's "an issue", the bigger issue at hand is the test hang.  So this changes the test to a non-hanging value.  (Which, incidentally, passes on Windows 7 :smile:).

cc: @AtsushiKan @stephentoub