### PR TITLE
Create all emitted types at once after emit phase finishes

### DIFF
--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -238,7 +238,7 @@ namespace System.Xml.Serialization
             }
         }
 
-        internal void GenerateEnd(string[] methods, XmlMapping[] xmlMappings, Type[] types)
+        internal TypeBuilder GenerateEnd(out ConstructorBuilder defaultCtor)
         {
             GenerateReferencedMethods();
             GenerateInitCallbacksMethod();
@@ -274,13 +274,13 @@ namespace System.Xml.Serialization
             }
             ilg.EndMethod();
 
-            this.typeBuilder.DefineDefaultConstructor(
+            defaultCtor = this.typeBuilder.DefineDefaultConstructor(
                 CodeGenerator.PublicMethodAttributes);
-            Type readerType = this.typeBuilder.CreateTypeInfo().AsType();
-            CreatedTypes.Add(readerType.Name, readerType);
+
+            return typeBuilder;
         }
 
-        internal string GenerateElement(XmlMapping xmlMapping)
+        internal MethodBuilder GenerateElement(XmlMapping xmlMapping)
         {
             if (!xmlMapping.IsReadable)
                 return null;
@@ -388,7 +388,7 @@ namespace System.Xml.Serialization
         }
 
 
-        private string GenerateMembersElement(XmlMembersMapping xmlMembersMapping)
+        private MethodBuilder GenerateMembersElement(XmlMembersMapping xmlMembersMapping)
         {
             return GenerateLiteralMembersElement(xmlMembersMapping);
         }
@@ -422,7 +422,7 @@ namespace System.Xml.Serialization
             return RaCodeGen.GetStringForMember(parent, mapping.ChoiceIdentifier.MemberName, parentTypeDesc);
         }
 
-        private string GenerateLiteralMembersElement(XmlMembersMapping xmlMembersMapping)
+        private MethodBuilder GenerateLiteralMembersElement(XmlMembersMapping xmlMembersMapping)
         {
             ElementAccessor element = xmlMembersMapping.Accessor;
             MemberMapping[] mappings = ((MembersMapping)element.Mapping).Members;
@@ -647,9 +647,7 @@ namespace System.Xml.Serialization
             }
 
             ilg.Ldloc(ilg.GetLocal("p"));
-            ilg.EndMethod();
-
-            return methodName;
+            return ilg.EndMethod();
         }
 
         private void InitializeValueTypes(string arrayName, MemberMapping[] mappings)
@@ -667,7 +665,7 @@ namespace System.Xml.Serialization
             }
         }
 
-        private string GenerateTypeElement(XmlTypeMapping xmlTypeMapping)
+        private MethodBuilder GenerateTypeElement(XmlTypeMapping xmlTypeMapping)
         {
             ElementAccessor element = xmlTypeMapping.Accessor;
             TypeMapping mapping = element.Mapping;
@@ -708,8 +706,7 @@ namespace System.Xml.Serialization
             // for code compat as compiler does
             ilg.Stloc(ilg.ReturnLocal);
             ilg.Ldloc(ilg.ReturnLocal);
-            ilg.EndMethod();
-            return methodName;
+            return ilg.EndMethod();
         }
 
         private string NextMethodName(string name)

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
@@ -61,16 +61,15 @@ namespace System.Xml.Serialization
                 WriteEnumMethod((EnumMapping)mapping);
             }
         }
-        internal Type GenerateEnd()
+        internal TypeBuilder GenerateEnd(out ConstructorBuilder defaultCtor)
         {
             GenerateReferencedMethods();
             GenerateInitCallbacksMethod();
-            this.typeBuilder.DefineDefaultConstructor(
-                CodeGenerator.PublicMethodAttributes);
-            return this.typeBuilder.CreateTypeInfo().AsType();
+            defaultCtor = this.typeBuilder.DefineDefaultConstructor(CodeGenerator.PublicMethodAttributes);
+            return this.typeBuilder;
         }
 
-        internal string GenerateElement(XmlMapping xmlMapping)
+        internal MethodBuilder GenerateElement(XmlMapping xmlMapping)
         {
             if (!xmlMapping.IsWriteable)
                 return null;
@@ -347,7 +346,7 @@ namespace System.Xml.Serialization
             WriteTag("WriteEmptyTag", name, ns);
         }
 
-        private string GenerateMembersElement(XmlMembersMapping xmlMembersMapping)
+        private MethodBuilder GenerateMembersElement(XmlMembersMapping xmlMembersMapping)
         {
             ElementAccessor element = xmlMembersMapping.Accessor;
             MembersMapping mapping = (MembersMapping)element.Mapping;
@@ -538,11 +537,11 @@ namespace System.Xml.Serialization
             {
                 WriteEndElement();
             }
-            ilg.EndMethod();
-            return methodName;
+
+            return ilg.EndMethod();
         }
 
-        private string GenerateTypeElement(XmlTypeMapping xmlTypeMapping)
+        private MethodBuilder GenerateTypeElement(XmlTypeMapping xmlTypeMapping)
         {
             ElementAccessor element = xmlTypeMapping.Accessor;
             TypeMapping mapping = element.Mapping;
@@ -587,8 +586,7 @@ namespace System.Xml.Serialization
 
             WriteMember(new SourceInfo("o", "o", null, typeof(object), ilg), null, new ElementAccessor[] { element }, null, null, mapping.TypeDesc, true);
 
-            ilg.EndMethod();
-            return methodName;
+            return ilg.EndMethod();
         }
 
         private string NextMethodName(string name)


### PR DESCRIPTION
This change is a prerequisite to moving Xml serialization over to metadata/pe writer from System.Reflection.Metadata. Types being emitted can't be loaded until the entire assembly is emitted.