### PR TITLE
Fix UrlEncodeToBytes returning entire rather than partial array

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -316,7 +316,18 @@ namespace System.Net
 
             // nothing to expand?
             if (cSpaces == 0 && cUnsafe == 0)
-                return bytes;
+            {
+                if (0 == offset && bytes.Length == count)
+                {
+                    return bytes;
+                }
+                else
+                {
+                    var subarray = new byte[count];
+                    Buffer.BlockCopy(bytes, offset, subarray, 0, count);
+                    return subarray;
+                }
+            }
 
             // expand not 'safe' characters into %XX, spaces to +s
             byte[] expandedBytes = new byte[count + cUnsafe * 2];

--- a/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Text;
 using Xunit;
 
 namespace System.Net.Tests
@@ -84,7 +85,7 @@ namespace System.Net.Tests
             string encoded = WebUtility.UrlEncode(value);
             Assert.Equal(value, WebUtility.UrlDecode(encoded));
         }
-        
+
         [Fact]
         public static void UrlDecodeToBytes_NullEncodedValue_ReturnsNull()
         {
@@ -103,9 +104,26 @@ namespace System.Net.Tests
             Assert.Throws<ArgumentOutOfRangeException>("count", () => WebUtility.UrlDecodeToBytes(new byte[1], 0, 3)); // Count > bytes.Length
         }
 
-        public static IEnumerable<object[]> Url_EncodeToBytes_TestData()
+        [Theory]
+        [InlineData("a", 0, 1)]
+        [InlineData("a", 1, 0)]
+        [InlineData("abc", 0, 3)]
+        [InlineData("abc", 1, 2)]
+        [InlineData("abc", 1, 1)]
+        [InlineData("abcd", 1, 2)]
+        [InlineData("abcd", 2, 2)]
+        public static void UrlEncodeToBytes_NothingToExpand_OutputMatchesSubInput(string inputString, int offset, int count)
         {
-            yield return new object[] { null, 0, 0, null };
+            byte[] inputBytes = Encoding.UTF8.GetBytes(inputString);
+            byte[] subInputBytes = new byte[count];
+            Buffer.BlockCopy(inputBytes, offset, subInputBytes, 0, count);
+            Assert.Equal(inputString.Length, inputBytes.Length);
+
+            byte[] outputBytes = WebUtility.UrlEncodeToBytes(inputBytes, offset, count);
+
+            Assert.NotSame(inputBytes, outputBytes);
+            Assert.Equal(count, outputBytes.Length);
+            Assert.Equal(subInputBytes, outputBytes);
         }
 
         [Theory]


### PR DESCRIPTION
Port fix from .NET Framework.

Fixes #6947 
cc: @davidsh, @jamesqo