### PR TITLE
Remove workaround P2P refs from System.IO.Pipes.Tests

### DIFF
--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -87,17 +87,6 @@
       <Project>{16ee5522-f387-4c9e-9ef2-b5134b043f37}</Project>
       <Name>System.IO.Pipes</Name>
     </ProjectReference>
-
-    <!-- TODO: Remove these once packages are updated to include recent changes to SocketErrorPal -->
-    <ProjectReference Include="..\..\System.Net.Sockets\src\System.Net.Sockets.csproj">
-      <Project>{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}</Project>
-      <Name>System.Net.Sockets</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\System.Net.Primitives\src\System.Net.Primitives.csproj">
-      <Project>{8772BC91-7B55-49B9-94FA-4B1BE5BEAB55}</Project>
-      <Name>System.Net.Primitives</Name>
-    </ProjectReference>
-
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
These P2P references had been added temporarily as a workaround when adding some functionality to one of the native shims.  Now that everything is in the packages, I'm removing the workaround.

cc: @ericstj