### PR TITLE
Fix Issue#7082

### DIFF
--- a/src/Common/src/Interop/Windows/mincore/Interop.GetConsoleTitle.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetConsoleTitle.cs
@@ -20,13 +20,22 @@ internal partial class Interop
         // throw.
         private const int MaxAllowedBufferSizeInChars = 24500;
 
+        // GetConsoleTitle sometimes interprets the second parameter (nSize) as number of bytes and sometimes as the number of chars.
+        // Instead of doing complicated and dangerous logic to determine if this may or may not occur,
+        // we simply assume the worst and reserve a bigger buffer. This way we may use a bit more memory,
+        // but we will always be safe.
+        private static int AdjustNumberOfChars(int numChars)
+        {
+            return numChars * 2;
+        }
+
         // 1. We first try to call the GetConsoleTitle with an InitialBufferSizeInChars of 256.
         // 2. Then based on the return value either increase the capacity or return failure.
         internal static int GetConsoleTitle(out string title, out int titleLength)
         {
             int lastError = 0;
-            StringBuilder sb = new StringBuilder(InitialBufferSizeInChars);
-            int len = GetConsoleTitle(sb, InitialBufferSizeInChars);
+            StringBuilder sb = new StringBuilder(AdjustNumberOfChars(InitialBufferSizeInChars + 1));
+            int len = GetConsoleTitle(sb, sb.Capacity);
 
             if (len <= 0)
             {
@@ -44,7 +53,7 @@ internal partial class Interop
                 if (len > InitialBufferSizeInChars)
                 {
                     // We need to increase the sb capacity and retry.
-                    sb.Capacity = len + 1;
+                    sb.Capacity = AdjustNumberOfChars(len + 1);
                     len = GetConsoleTitle(sb, sb.Capacity);
                     if (len <= 0)
                     {

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetConsoleTitle.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetConsoleTitle.cs
@@ -24,7 +24,7 @@ internal partial class Interop
         // Instead of doing complicated and dangerous logic to determine if this may or may not occur,
         // we simply assume the worst and reserve a bigger buffer. This way we may use a bit more memory,
         // but we will always be safe.
-        private static int AdjustNumberOfChars(int numChars)
+        private static int CharCountToByteCount(int numChars)
         {
             return numChars * 2;
         }
@@ -34,7 +34,7 @@ internal partial class Interop
         internal static int GetConsoleTitle(out string title, out int titleLength)
         {
             int lastError = 0;
-            StringBuilder sb = new StringBuilder(AdjustNumberOfChars(InitialBufferSizeInChars + 1));
+            StringBuilder sb = new StringBuilder(CharCountToByteCount(InitialBufferSizeInChars + 1));
             int len = GetConsoleTitle(sb, sb.Capacity);
 
             if (len <= 0)
@@ -53,7 +53,7 @@ internal partial class Interop
                 if (len > InitialBufferSizeInChars)
                 {
                     // We need to increase the sb capacity and retry.
-                    sb.Capacity = AdjustNumberOfChars(len + 1);
+                    sb.Capacity = CharCountToByteCount(len + 1);
                     len = GetConsoleTitle(sb, sb.Capacity);
                     if (len <= 0)
                     {

--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -115,12 +115,17 @@ public class WindowAndCursorProps
 
             Assert.Equal(newTitle, Console.Title);
 
-            //// Try setting a Title greater than 256 chars.
+            // Try setting a Title equal to 256 chars.
+            newTitle = new string('a', 256);
+            Console.Title = newTitle;
+            Assert.Equal(newTitle, Console.Title);
+
+            // Try setting a Title greater than 256 chars.
             newTitle = new string('a', 1024);
             Console.Title = newTitle;
             Assert.Equal(newTitle, Console.Title);
 
-            //// Try setting a title greater than 24500 chars and check that it fails.
+            // Try setting a title greater than 24500 chars and check that it fails.
             newTitle = new string('a', 24501);
             Assert.Throws<ArgumentOutOfRangeException>(() => { Console.Title = newTitle; });
         }


### PR DESCRIPTION
Fixes #7082 

GetConsoleTitle(LPTSTR lpConsoleTitle, DWORD nSize) behaves differently on different OSes. nSize at times represents the size of the buffer in bytes and at times in chars. To work-around the issue I have always assumed that the size is in bytes which has the side-effect of allocating extra buffer in case it represents chars, however this is the easiest implementation.