### PR TITLE
Fix unprotected access to non-thread-safe IntrinsicTypeConverters dictionary

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/project.json
+++ b/src/System.ComponentModel.TypeConverter/src/project.json
@@ -6,6 +6,7 @@
         "System.ComponentModel": "4.0.0",
         "System.ComponentModel.Primitives": "4.0.0",
         "System.Diagnostics.Contracts": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.0",
         "System.Diagnostics.Tools": "4.0.0",
         "System.Globalization": "4.0.0",
         "System.Reflection": "4.0.0",


### PR DESCRIPTION
Lack of synchronization here can cause corruption of the dictionary, as well as causing concurrent searches to fail with exceptions due to the collection being modified concurrently.

Fixes #7151 
cc: @krwq, @ianhays