### PR TITLE
Remove unnecessary .gitignore for SqlClient tests

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/DataCommon/.gitignore
+++ b/src/System.Data.SqlClient/tests/ManualTests/DataCommon/.gitignore
@@ -1,1 +1,0 @@
-ConnectionString.xml


### PR DESCRIPTION
Mistakenly read that .gitignore could ignore changes to currently tracked files. Reverts https://github.com/dotnet/corefx/commit/8758e6a185b22ffd8332110880892e61bc9f570b