### PR TITLE
Fix net46 ref asset in System.Runtime.TypeExtensions

### DIFF
--- a/src/System.Reflection.TypeExtensions/src/redist/System.Reflection.TypeExtensions.depproj
+++ b/src/System.Reflection.TypeExtensions/src/redist/System.Reflection.TypeExtensions.depproj
@@ -7,6 +7,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
+    <PackageAsRefAndLib Condition="'$(TargetGroup)'=='net46'">true</PackageAsRefAndLib>
   </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />


### PR DESCRIPTION
After some recent work in System.Runtime.TypeExtensions library
we were no longer putting the facade into the ref\net46 folder
which caused the netstandard1.3 reference assembly to be selected
for net46 and there are type conflicts (i.e. BindingFlags).