### PR TITLE
Remove CommandBehavior.CloseConnection from DDAsyncTest, since it causes a close connection race condition when executing multiple async readers on the same connection.

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/DDBasics/AsyncTest/AsyncTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DDBasics/AsyncTest/AsyncTest.cs
@@ -52,8 +52,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             await conn.OpenAsync();
             var cmd = new SqlCommand(cmdText, conn);
 
-
-            using (SqlDataReader reader = await cmd.ExecuteReaderAsync(CommandBehavior.CloseConnection))
+            using (SqlDataReader reader = await cmd.ExecuteReaderAsync())
             {
                 while (await reader.ReadAsync())
                 {
@@ -87,7 +86,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         {
             var cmd = new SqlCommand(cmdText, conn);
 
-            using (SqlDataReader reader = await cmd.ExecuteReaderAsync(CommandBehavior.CloseConnection))
+            using (SqlDataReader reader = await cmd.ExecuteReaderAsync())
             {
                 while (await reader.ReadAsync())
                 {


### PR DESCRIPTION
When using CommandBehavior.CloseConnection, the underlying connection is closed when the reader is closed. Since some of these tests execute multiple readers on the same connection, the connection may be incorrectly closed before all tasks finish.