### PR TITLE
Improve DataContractJsonSerializer performance for dictionary

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
@@ -341,7 +341,7 @@ namespace System.Runtime.Serialization.Json
                 oldItemContract.UnderlyingType.GetTypeInfo().IsGenericType &&
                 (oldItemContract.UnderlyingType.GetGenericTypeDefinition() == Globals.TypeOfKeyValue))
             {
-                return ClassDataContract.CreateClassDataContractForKeyValue(oldItemContract.UnderlyingType, oldItemContract.Namespace, new string[] { JsonGlobals.KeyString, JsonGlobals.ValueString });
+                return DataContract.GetDataContract(oldItemContract.UnderlyingType);
             }
             return oldItemContract;
         }


### PR DESCRIPTION
In DCJS code path to serialize/de-serialize dictionary, there is one place where we always create new data contract for key-value type, while we can leverage on the data contract cache instead. This results in significant performance differences between CoreClr and Desktop.

This change resolves that issue by getting data contract for key-value type with a method which utilizes the cache. With this change we'll see 10-20x perf improvement for dictionary scenarios.

I'm confirming with NetNative to ensure no regression and will update.

cc: @SGuyGe @zhenlan @shmao