### PR TITLE
Interpreted cast exception

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -822,6 +822,11 @@ namespace System.Linq.Expressions.Interpreter
             Emit(new CastToEnumInstruction(toType));
         }
 
+        public void EmitCastReferenceToEnum(Type toType)
+        {
+            Emit(new CastReferenceToEnumInstruction(toType));
+        }
+
         #endregion
 
         #region Boolean Operators

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -1140,7 +1140,7 @@ namespace System.Linq.Expressions.Interpreter
             if (typeTo.GetTypeInfo().IsEnum)
             {
                 _instructions.Emit(NullCheckInstruction.Instance);
-                _instructions.EmitCastToEnum(typeTo);
+                _instructions.EmitCastReferenceToEnum(typeTo);
                 return;
             }
 

--- a/src/System.Linq.Expressions/tests/Cast/AsNullable.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsNullable.cs
@@ -12,131 +12,131 @@ namespace System.Linq.Expressions.Tests
     {
         #region Test methods
 
-        [Fact]
-        public static void CheckNullableEnumAsEnumTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableEnumAsEnumTypeTest(bool useInterpreter)
         {
             E?[] array = new E?[] { null, (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableEnumAsEnumType(array[i]);
+                VerifyNullableEnumAsEnumType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableEnumAsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableEnumAsObjectTest(bool useInterpreter)
         {
             E?[] array = new E?[] { null, (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableEnumAsObject(array[i]);
+                VerifyNullableEnumAsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableIntAsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableIntAsObjectTest(bool useInterpreter)
         {
             int?[] array = new int?[] { null, 0, 1, -1, int.MinValue, int.MaxValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableIntAsObject(array[i]);
+                VerifyNullableIntAsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableIntAsValueTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableIntAsValueTypeTest(bool useInterpreter)
         {
             int?[] array = new int?[] { null, 0, 1, -1, int.MinValue, int.MaxValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableIntAsValueType(array[i]);
+                VerifyNullableIntAsValueType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableStructAsIEquatableOfStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableStructAsIEquatableOfStructTest(bool useInterpreter)
         {
             S?[] array = new S?[] { null, default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableStructAsIEquatableOfStruct(array[i]);
+                VerifyNullableStructAsIEquatableOfStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableStructAsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableStructAsObjectTest(bool useInterpreter)
         {
             S?[] array = new S?[] { null, default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableStructAsObject(array[i]);
+                VerifyNullableStructAsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableStructAsValueTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableStructAsValueTypeTest(bool useInterpreter)
         {
             S?[] array = new S?[] { null, default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableStructAsValueType(array[i]);
+                VerifyNullableStructAsValueType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastObjectAsEnum()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastObjectAsEnum(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionAsObjectHelper<E>();
+            CheckGenericWithStructRestrictionAsObjectHelper<E>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastObjectAsStruct()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastObjectAsStruct(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionAsObjectHelper<S>();
+            CheckGenericWithStructRestrictionAsObjectHelper<S>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastObjectAsStructWithStringAndField()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastObjectAsStructWithStringAndField(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionAsObjectHelper<Scs>();
+            CheckGenericWithStructRestrictionAsObjectHelper<Scs>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastValueTypeAsEnum()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastValueTypeAsEnum(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionAsValueTypeHelper<E>();
+            CheckGenericWithStructRestrictionAsValueTypeHelper<E>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStruct()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStruct(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionAsValueTypeHelper<S>();
+            CheckGenericWithStructRestrictionAsValueTypeHelper<S>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStructWithStringAndField()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStructWithStringAndField(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionAsValueTypeHelper<Scs>();
+            CheckGenericWithStructRestrictionAsValueTypeHelper<Scs>(useInterpreter);
         }
 
         #endregion
 
         #region Generic helpers
 
-        private static void CheckGenericWithStructRestrictionAsObjectHelper<Ts>() where Ts : struct
+        private static void CheckGenericWithStructRestrictionAsObjectHelper<Ts>(bool useInterpreter) where Ts : struct
         {
             Ts[] array = new Ts[] { default(Ts), new Ts() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericWithStructRestrictionAsObject<Ts>(array[i]);
+                VerifyGenericWithStructRestrictionAsObject<Ts>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckGenericWithStructRestrictionAsValueTypeHelper<Ts>() where Ts : struct
+        private static void CheckGenericWithStructRestrictionAsValueTypeHelper<Ts>(bool useInterpreter) where Ts : struct
         {
             Ts[] array = new Ts[] { default(Ts), new Ts() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericWithStructRestrictionAsValueType<Ts>(array[i]);
+                VerifyGenericWithStructRestrictionAsValueType<Ts>(array[i], useInterpreter);
             }
         }
 
@@ -144,409 +144,103 @@ namespace System.Linq.Expressions.Tests
 
         #region Test verifiers
 
-        private static void VerifyNullableEnumAsEnumType(E? value)
+        private static void VerifyNullableEnumAsEnumType(E? value, bool useInterpreter)
         {
             Expression<Func<Enum>> e =
                 Expression.Lambda<Func<Enum>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(E?)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Enum> f = e.Compile();
+            Func<Enum> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            Enum etResult = default(Enum);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            Enum csResult = default(Enum);
-            Exception csException = null;
-            try
-            {
-                csResult = value as Enum;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as ValueType, f());
         }
 
-        private static void VerifyNullableEnumAsObject(E? value)
+        private static void VerifyNullableEnumAsObject(E? value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(E?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyNullableIntAsObject(int? value)
+        private static void VerifyNullableIntAsObject(int? value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(int?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyNullableIntAsValueType(int? value)
+        private static void VerifyNullableIntAsValueType(int? value, bool useInterpreter)
         {
             Expression<Func<ValueType>> e =
                 Expression.Lambda<Func<ValueType>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(int?)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            ValueType etResult = default(ValueType);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            ValueType csResult = default(ValueType);
-            Exception csException = null;
-            try
-            {
-                csResult = value as ValueType;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as ValueType, f());
         }
 
-        private static void VerifyNullableStructAsIEquatableOfStruct(S? value)
+        private static void VerifyNullableStructAsIEquatableOfStruct(S? value, bool useInterpreter)
         {
             Expression<Func<IEquatable<S>>> e =
                 Expression.Lambda<Func<IEquatable<S>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(S?)), typeof(IEquatable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<S>> f = e.Compile();
+            Func<IEquatable<S>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEquatable<S> etResult = default(IEquatable<S>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEquatable<S> csResult = default(IEquatable<S>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IEquatable<S>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IEquatable<S>, f());
         }
 
-        private static void VerifyNullableStructAsObject(S? value)
+        private static void VerifyNullableStructAsObject(S? value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(S?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyNullableStructAsValueType(S? value)
+        private static void VerifyNullableStructAsValueType(S? value, bool useInterpreter)
         {
             Expression<Func<ValueType>> e =
                 Expression.Lambda<Func<ValueType>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(S?)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            ValueType etResult = default(ValueType);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            ValueType csResult = default(ValueType);
-            Exception csException = null;
-            try
-            {
-                csResult = value as ValueType;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as ValueType, f());
         }
 
-        private static void VerifyGenericWithStructRestrictionAsObject<Ts>(Ts value) where Ts : struct
+        private static void VerifyGenericWithStructRestrictionAsObject<Ts>(Ts value, bool useInterpreter) where Ts : struct
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Ts)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyGenericWithStructRestrictionAsValueType<Ts>(Ts value) where Ts : struct
+        private static void VerifyGenericWithStructRestrictionAsValueType<Ts>(Ts value, bool useInterpreter) where Ts : struct
         {
             Expression<Func<ValueType>> e =
                 Expression.Lambda<Func<ValueType>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Ts)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            ValueType etResult = default(ValueType);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            ValueType csResult = default(ValueType);
-            Exception csException = null;
-            try
-            {
-                csResult = value as ValueType;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as ValueType, f());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Cast/AsTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsTests.cs
@@ -12,871 +12,871 @@ namespace System.Linq.Expressions.Tests
     {
         #region Test methods
 
-        [Fact]
-        public static void CheckCustomAsCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomAsCustom2Test(bool useInterpreter)
         {
             C[] array = new C[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomAsCustom2(array[i]);
+                VerifyCustomAsCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomAsInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomAsInterfaceTest(bool useInterpreter)
         {
             C[] array = new C[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomAsInterface(array[i]);
+                VerifyCustomAsInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomAsIEquatableOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomAsIEquatableOfCustomTest(bool useInterpreter)
         {
             C[] array = new C[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomAsIEquatableOfCustom(array[i]);
+                VerifyCustomAsIEquatableOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomAsIEquatableOfCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomAsIEquatableOfCustom2Test(bool useInterpreter)
         {
             C[] array = new C[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomAsIEquatableOfCustom2(array[i]);
+                VerifyCustomAsIEquatableOfCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomAsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomAsObjectTest(bool useInterpreter)
         {
             C[] array = new C[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomAsObject(array[i]);
+                VerifyCustomAsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayAsCustom2ArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayAsCustom2ArrayTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayAsCustom2Array(array[i]);
+                VerifyCustomArrayAsCustom2Array(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayAsIEnumerableOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayAsIEnumerableOfCustomTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayAsIEnumerableOfCustom(array[i]);
+                VerifyCustomArrayAsIEnumerableOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayAsIEnumerableOfCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayAsIEnumerableOfCustom2Test(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayAsIEnumerableOfCustom2(array[i]);
+                VerifyCustomArrayAsIEnumerableOfCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayAsIEnumerableOfInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayAsIEnumerableOfInterfaceTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayAsIEnumerableOfInterface(array[i]);
+                VerifyCustomArrayAsIEnumerableOfInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayAsIEnumerableOfObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayAsIEnumerableOfObjectTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayAsIEnumerableOfObject(array[i]);
+                VerifyCustomArrayAsIEnumerableOfObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayAsIListOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayAsIListOfCustomTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayAsIListOfCustom(array[i]);
+                VerifyCustomArrayAsIListOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayAsIListOfCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayAsIListOfCustom2Test(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayAsIListOfCustom2(array[i]);
+                VerifyCustomArrayAsIListOfCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayAsIListOfInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayAsIListOfInterfaceTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayAsIListOfInterface(array[i]);
+                VerifyCustomArrayAsIListOfInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayAsIListOfObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayAsIListOfObjectTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayAsIListOfObject(array[i]);
+                VerifyCustomArrayAsIListOfObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayAsObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayAsObjectArrayTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayAsObjectArray(array[i]);
+                VerifyCustomArrayAsObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2AsCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2AsCustomTest(bool useInterpreter)
         {
             D[] array = new D[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2AsCustom(array[i]);
+                VerifyCustom2AsCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2AsInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2AsInterfaceTest(bool useInterpreter)
         {
             D[] array = new D[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2AsInterface(array[i]);
+                VerifyCustom2AsInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2AsIEquatableOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2AsIEquatableOfCustomTest(bool useInterpreter)
         {
             D[] array = new D[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2AsIEquatableOfCustom(array[i]);
+                VerifyCustom2AsIEquatableOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2AsIEquatableOfCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2AsIEquatableOfCustom2Test(bool useInterpreter)
         {
             D[] array = new D[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2AsIEquatableOfCustom2(array[i]);
+                VerifyCustom2AsIEquatableOfCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2AsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2AsObjectTest(bool useInterpreter)
         {
             D[] array = new D[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2AsObject(array[i]);
+                VerifyCustom2AsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2ArrayAsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2ArrayAsCustomArrayTest(bool useInterpreter)
         {
             D[][] array = new D[][] { null, new D[] { null, new D(), new D(0), new D(5) }, new D[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2ArrayAsCustomArray(array[i]);
+                VerifyCustom2ArrayAsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckDelegateAsFuncOfObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckDelegateAsFuncOfObjectTest(bool useInterpreter)
         {
             Delegate[] array = new Delegate[] { null, (Func<object>)delegate () { return null; }, (Func<int, int>)delegate (int i) { return i + 1; }, (Action<object>)delegate { } };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyDelegateAsFuncOfObject(array[i]);
+                VerifyDelegateAsFuncOfObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckDelegateAsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckDelegateAsObjectTest(bool useInterpreter)
         {
             Delegate[] array = new Delegate[] { null, (Func<object>)delegate () { return null; }, (Func<int, int>)delegate (int i) { return i + 1; }, (Action<object>)delegate { } };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyDelegateAsObject(array[i]);
+                VerifyDelegateAsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckEnumAsEnumTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckEnumAsEnumTypeTest(bool useInterpreter)
         {
             E[] array = new E[] { (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyEnumAsEnumType(array[i]);
+                VerifyEnumAsEnumType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckEnumAsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckEnumAsObjectTest(bool useInterpreter)
         {
             E[] array = new E[] { (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyEnumAsObject(array[i]);
+                VerifyEnumAsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckEnumTypeAsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckEnumTypeAsObjectTest(bool useInterpreter)
         {
             Enum[] array = new Enum[] { null, (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue, (El)0, El.A, El.B, (El)long.MaxValue, (El)long.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyEnumTypeAsObject(array[i]);
+                VerifyEnumTypeAsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckFuncOfObjectAsDelegateTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckFuncOfObjectAsDelegateTest(bool useInterpreter)
         {
             Func<object>[] array = new Func<object>[] { null, (Func<object>)delegate () { return null; } };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyFuncOfObjectAsDelegate(array[i]);
+                VerifyFuncOfObjectAsDelegate(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckInterfaceAsCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckInterfaceAsCustomTest(bool useInterpreter)
         {
             I[] array = new I[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyInterfaceAsCustom(array[i]);
+                VerifyInterfaceAsCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckInterfaceAsCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckInterfaceAsCustom2Test(bool useInterpreter)
         {
             I[] array = new I[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyInterfaceAsCustom2(array[i]);
+                VerifyInterfaceAsCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckInterfaceAsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckInterfaceAsObjectTest(bool useInterpreter)
         {
             I[] array = new I[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyInterfaceAsObject(array[i]);
+                VerifyInterfaceAsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfCustomAsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfCustomAsCustomArrayTest(bool useInterpreter)
         {
             IEnumerable<C>[] array = new IEnumerable<C>[] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10], new List<C>(), new List<C>(new C[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfCustomAsCustomArray(array[i]);
+                VerifyIEnumerableOfCustomAsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfCustomAsObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfCustomAsObjectArrayTest(bool useInterpreter)
         {
             IEnumerable<C>[] array = new IEnumerable<C>[] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10], new List<C>(), new List<C>(new C[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfCustomAsObjectArray(array[i]);
+                VerifyIEnumerableOfCustomAsObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfCustomAsCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfCustomAsCustomTest(bool useInterpreter)
         {
             IEnumerable<C>[] array = new IEnumerable<C>[] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10], new List<C>(), new List<C>(new C[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfCustomAsCustom(array[i]);
+                VerifyIEnumerableOfCustomAsCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfCustomAsCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfCustomAsCustom2Test(bool useInterpreter)
         {
             IEnumerable<C>[] array = new IEnumerable<C>[] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10], new List<C>(), new List<C>(new C[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfCustomAsCustom2(array[i]);
+                VerifyIEnumerableOfCustomAsCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfCustomAsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfCustomAsObjectTest(bool useInterpreter)
         {
             IEnumerable<C>[] array = new IEnumerable<C>[] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10], new List<C>(), new List<C>(new C[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfCustomAsObject(array[i]);
+                VerifyIEnumerableOfCustomAsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfCustom2AsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfCustom2AsCustomArrayTest(bool useInterpreter)
         {
             IEnumerable<D>[] array = new IEnumerable<D>[] { null, new D[] { null, new D(), new D(0), new D(5) }, new D[10], new List<D>(), new List<D>(new D[] { null, new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfCustom2AsCustomArray(array[i]);
+                VerifyIEnumerableOfCustom2AsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfCustom2AsCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfCustom2AsCustomTest(bool useInterpreter)
         {
             IEnumerable<D>[] array = new IEnumerable<D>[] { null, new D[] { null, new D(), new D(0), new D(5) }, new D[10], new List<D>(), new List<D>(new D[] { null, new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfCustom2AsCustom(array[i]);
+                VerifyIEnumerableOfCustom2AsCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfCustom2AsCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfCustom2AsCustom2Test(bool useInterpreter)
         {
             IEnumerable<D>[] array = new IEnumerable<D>[] { null, new D[] { null, new D(), new D(0), new D(5) }, new D[10], new List<D>(), new List<D>(new D[] { null, new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfCustom2AsCustom2(array[i]);
+                VerifyIEnumerableOfCustom2AsCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfCustom2AsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfCustom2AsObjectTest(bool useInterpreter)
         {
             IEnumerable<D>[] array = new IEnumerable<D>[] { null, new D[] { null, new D(), new D(0), new D(5) }, new D[10], new List<D>(), new List<D>(new D[] { null, new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfCustom2AsObject(array[i]);
+                VerifyIEnumerableOfCustom2AsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfInterfaceAsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfInterfaceAsCustomArrayTest(bool useInterpreter)
         {
             IEnumerable<I>[] array = new IEnumerable<I>[] { null, new I[] { null, new C(), new D(), new D(0), new D(5) }, new I[10], new List<I>(), new List<I>(new I[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfInterfaceAsCustomArray(array[i]);
+                VerifyIEnumerableOfInterfaceAsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfInterfaceAsObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfInterfaceAsObjectArrayTest(bool useInterpreter)
         {
             IEnumerable<I>[] array = new IEnumerable<I>[] { null, new I[] { null, new C(), new D(), new D(0), new D(5) }, new I[10], new List<I>(), new List<I>(new I[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfInterfaceAsObjectArray(array[i]);
+                VerifyIEnumerableOfInterfaceAsObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfObjectAsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfObjectAsCustomArrayTest(bool useInterpreter)
         {
             IEnumerable<object>[] array = new IEnumerable<object>[] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10], new List<object>(), new List<object>(new object[] { null, new object(), new C(), new D(3) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfObjectAsCustomArray(array[i]);
+                VerifyIEnumerableOfObjectAsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfObjectAsObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfObjectAsObjectArrayTest(bool useInterpreter)
         {
             IEnumerable<object>[] array = new IEnumerable<object>[] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10], new List<object>(), new List<object>(new object[] { null, new object(), new C(), new D(3) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfObjectAsObjectArray(array[i]);
+                VerifyIEnumerableOfObjectAsObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfStructAsStructArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfStructAsStructArrayTest(bool useInterpreter)
         {
             IEnumerable<S>[] array = new IEnumerable<S>[] { null, new S[] { default(S), new S() }, new S[10], new List<S>(), new List<S>(new S[] { default(S), new S() }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfStructAsStructArray(array[i]);
+                VerifyIEnumerableOfStructAsStructArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfCustomAsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfCustomAsCustomArrayTest(bool useInterpreter)
         {
             IList<C>[] array = new IList<C>[] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10], new List<C>(), new List<C>(new C[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfCustomAsCustomArray(array[i]);
+                VerifyIListOfCustomAsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfCustomAsObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfCustomAsObjectArrayTest(bool useInterpreter)
         {
             IList<C>[] array = new IList<C>[] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10], new List<C>(), new List<C>(new C[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfCustomAsObjectArray(array[i]);
+                VerifyIListOfCustomAsObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfCustom2AsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfCustom2AsCustomArrayTest(bool useInterpreter)
         {
             IList<D>[] array = new IList<D>[] { null, new D[] { null, new D(), new D(0), new D(5) }, new D[10], new List<D>(), new List<D>(new D[] { null, new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfCustom2AsCustomArray(array[i]);
+                VerifyIListOfCustom2AsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfInterfaceAsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfInterfaceAsCustomArrayTest(bool useInterpreter)
         {
             IList<I>[] array = new IList<I>[] { null, new I[] { null, new C(), new D(), new D(0), new D(5) }, new I[10], new List<I>(), new List<I>(new I[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfInterfaceAsCustomArray(array[i]);
+                VerifyIListOfInterfaceAsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfInterfaceAsObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfInterfaceAsObjectArrayTest(bool useInterpreter)
         {
             IList<I>[] array = new IList<I>[] { null, new I[] { null, new C(), new D(), new D(0), new D(5) }, new I[10], new List<I>(), new List<I>(new I[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfInterfaceAsObjectArray(array[i]);
+                VerifyIListOfInterfaceAsObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfObjectAsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfObjectAsCustomArrayTest(bool useInterpreter)
         {
             IList<object>[] array = new IList<object>[] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10], new List<object>(), new List<object>(new object[] { null, new object(), new C(), new D(3) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfObjectAsCustomArray(array[i]);
+                VerifyIListOfObjectAsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfObjectAsObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfObjectAsObjectArrayTest(bool useInterpreter)
         {
             IList<object>[] array = new IList<object>[] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10], new List<object>(), new List<object>(new object[] { null, new object(), new C(), new D(3) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfObjectAsObjectArray(array[i]);
+                VerifyIListOfObjectAsObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfStructAsStructArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfStructAsStructArrayTest(bool useInterpreter)
         {
             IList<S>[] array = new IList<S>[] { null, new S[] { default(S), new S() }, new S[10], new List<S>(), new List<S>(new S[] { default(S), new S() }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfStructAsStructArray(array[i]);
+                VerifyIListOfStructAsStructArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIntAsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIntAsObjectTest(bool useInterpreter)
         {
             int[] array = new int[] { 0, 1, -1, int.MinValue, int.MaxValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIntAsObject(array[i]);
+                VerifyIntAsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIntAsValueTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIntAsValueTypeTest(bool useInterpreter)
         {
             int[] array = new int[] { 0, 1, -1, int.MinValue, int.MaxValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIntAsValueType(array[i]);
+                VerifyIntAsValueType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectAsCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectAsCustomTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectAsCustom(array[i]);
+                VerifyObjectAsCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectAsCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectAsCustom2Test(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectAsCustom2(array[i]);
+                VerifyObjectAsCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectAsDelegateTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectAsDelegateTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectAsDelegate(array[i]);
+                VerifyObjectAsDelegate(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectAsEnumTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectAsEnumTypeTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectAsEnumType(array[i]);
+                VerifyObjectAsEnumType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectAsInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectAsInterfaceTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectAsInterface(array[i]);
+                VerifyObjectAsInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectAsIEquatableOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectAsIEquatableOfCustomTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectAsIEquatableOfCustom(array[i]);
+                VerifyObjectAsIEquatableOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectAsIEquatableOfCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectAsIEquatableOfCustom2Test(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectAsIEquatableOfCustom2(array[i]);
+                VerifyObjectAsIEquatableOfCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectAsValueTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectAsValueTypeTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectAsValueType(array[i]);
+                VerifyObjectAsValueType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayAsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayAsCustomArrayTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayAsCustomArray(array[i]);
+                VerifyObjectArrayAsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayAsIEnumerableOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayAsIEnumerableOfCustomTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayAsIEnumerableOfCustom(array[i]);
+                VerifyObjectArrayAsIEnumerableOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayAsIEnumerableOfInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayAsIEnumerableOfInterfaceTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayAsIEnumerableOfInterface(array[i]);
+                VerifyObjectArrayAsIEnumerableOfInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayAsIEnumerableOfObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayAsIEnumerableOfObjectTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayAsIEnumerableOfObject(array[i]);
+                VerifyObjectArrayAsIEnumerableOfObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayAsIListOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayAsIListOfCustomTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayAsIListOfCustom(array[i]);
+                VerifyObjectArrayAsIListOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayAsIListOfInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayAsIListOfInterfaceTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayAsIListOfInterface(array[i]);
+                VerifyObjectArrayAsIListOfInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayAsIListOfObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayAsIListOfObjectTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayAsIListOfObject(array[i]);
+                VerifyObjectArrayAsIListOfObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckStructAsIEquatableOfStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckStructAsIEquatableOfStructTest(bool useInterpreter)
         {
             S[] array = new S[] { default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyStructAsIEquatableOfStruct(array[i]);
+                VerifyStructAsIEquatableOfStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckStructAsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckStructAsObjectTest(bool useInterpreter)
         {
             S[] array = new S[] { default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyStructAsObject(array[i]);
+                VerifyStructAsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckStructAsValueTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckStructAsValueTypeTest(bool useInterpreter)
         {
             S[] array = new S[] { default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyStructAsValueType(array[i]);
+                VerifyStructAsValueType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckStructArrayAsIEnumerableOfStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckStructArrayAsIEnumerableOfStructTest(bool useInterpreter)
         {
             S[][] array = new S[][] { null, new S[] { default(S), new S() }, new S[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyStructArrayAsIEnumerableOfStruct(array[i]);
+                VerifyStructArrayAsIEnumerableOfStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckStructArrayAsIListOfStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckStructArrayAsIListOfStructTest(bool useInterpreter)
         {
             S[][] array = new S[][] { null, new S[] { default(S), new S() }, new S[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyStructArrayAsIListOfStruct(array[i]);
+                VerifyStructArrayAsIListOfStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckValueTypeAsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckValueTypeAsObjectTest(bool useInterpreter)
         {
             ValueType[] array = new ValueType[] { null, default(S), new Scs(null, new S()), E.A, El.B };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyValueTypeAsObject(array[i]);
+                VerifyValueTypeAsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckGenericAsObjectCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckGenericAsObjectCustomTest(bool useInterpreter)
         {
-            CheckGenericAsObjectHelper<C>();
+            CheckGenericAsObjectHelper<C>(useInterpreter);
         }
 
-        [Fact]
-        public static void CheckGenericAsObjectEnumTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckGenericAsObjectEnumTest(bool useInterpreter)
         {
-            CheckGenericAsObjectHelper<E>();
+            CheckGenericAsObjectHelper<E>(useInterpreter);
         }
 
-        [Fact]
-        public static void CheckGenericAsObjectObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckGenericAsObjectObjectTest(bool useInterpreter)
         {
-            CheckGenericAsObjectHelper<object>();
+            CheckGenericAsObjectHelper<object>(useInterpreter);
         }
 
-        [Fact]
-        public static void CheckGenericAsObjectStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckGenericAsObjectStructTest(bool useInterpreter)
         {
-            CheckGenericAsObjectHelper<S>();
+            CheckGenericAsObjectHelper<S>(useInterpreter);
         }
 
-        [Fact]
-        public static void CheckGenericAsObjectStructWithStringAndValueTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckGenericAsObjectStructWithStringAndValueTest(bool useInterpreter)
         {
-            CheckGenericAsObjectHelper<Scs>();
+            CheckGenericAsObjectHelper<Scs>(useInterpreter);
         }
 
-        [Fact]
-        public static void CheckGenericWithClassRestrictionAsCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckGenericWithClassRestrictionAsCustomTest(bool useInterpreter)
         {
-            CheckGenericWithClassRestrictionAsObjectHelper<C>();
+            CheckGenericWithClassRestrictionAsObjectHelper<C>(useInterpreter);
         }
 
-        [Fact]
-        public static void CheckGenericWithClassRestrictionAsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckGenericWithClassRestrictionAsObjectTest(bool useInterpreter)
         {
-            CheckGenericWithClassRestrictionAsObjectHelper<object>();
+            CheckGenericWithClassRestrictionAsObjectHelper<object>(useInterpreter);
         }
 
-        [Fact]
-        public static void CheckGenericWithStructRestrictionAsEnumTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckGenericWithStructRestrictionAsEnumTest(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionAsObjectHelper<E>();
+            CheckGenericWithStructRestrictionAsObjectHelper<E>(useInterpreter);
         }
 
-        [Fact]
-        public static void CheckGenericWithStructRestrictionAsStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckGenericWithStructRestrictionAsStructTest(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionAsObjectHelper<S>();
+            CheckGenericWithStructRestrictionAsObjectHelper<S>(useInterpreter);
         }
 
-        [Fact]
-        public static void CheckGenericWithStructRestrictionAsStructWithStringAndValueTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckGenericWithStructRestrictionAsStructWithStringAndValueTest(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionAsObjectHelper<Scs>();
+            CheckGenericWithStructRestrictionAsObjectHelper<Scs>(useInterpreter);
         }
 
-        [Fact]
-        public static void CheckGenericWithStructRestrictionAsValueTypeAsEnumTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckGenericWithStructRestrictionAsValueTypeAsEnumTest(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionAsValueTypeHelper<E>();
+            CheckGenericWithStructRestrictionAsValueTypeHelper<E>(useInterpreter);
         }
 
-        [Fact]
-        public static void CheckGenericWithStructRestrictionAsValueTypeAsStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckGenericWithStructRestrictionAsValueTypeAsStructTest(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionAsValueTypeHelper<S>();
+            CheckGenericWithStructRestrictionAsValueTypeHelper<S>(useInterpreter);
         }
 
-        [Fact]
-        public static void CheckGenericWithStructRestrictionAsValueTypeAsStructWithStringAndValueTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckGenericWithStructRestrictionAsValueTypeAsStructWithStringAndValueTest(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionAsValueTypeHelper<Scs>();
+            CheckGenericWithStructRestrictionAsValueTypeHelper<Scs>(useInterpreter);
         }
 
         #endregion
 
         #region Generic helpers
 
-        private static void CheckGenericAsObjectHelper<T>()
+        private static void CheckGenericAsObjectHelper<T>(bool useInterpreter)
         {
             T[] array = new T[] { default(T) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericAsObject<T>(array[i]);
+                VerifyGenericAsObject<T>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckGenericWithClassRestrictionAsObjectHelper<Tc>() where Tc : class
+        private static void CheckGenericWithClassRestrictionAsObjectHelper<Tc>(bool useInterpreter) where Tc : class
         {
             Tc[] array = new Tc[] { null, default(Tc) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericWithClassRestrictionAsObject<Tc>(array[i]);
+                VerifyGenericWithClassRestrictionAsObject<Tc>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckGenericWithStructRestrictionAsObjectHelper<Ts>() where Ts : struct
+        private static void CheckGenericWithStructRestrictionAsObjectHelper<Ts>(bool useInterpreter) where Ts : struct
         {
             Ts[] array = new Ts[] { default(Ts), new Ts() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericWithStructRestrictionAsObject<Ts>(array[i]);
+                VerifyGenericWithStructRestrictionAsObject<Ts>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckGenericWithStructRestrictionAsValueTypeHelper<Ts>() where Ts : struct
+        private static void CheckGenericWithStructRestrictionAsValueTypeHelper<Ts>(bool useInterpreter) where Ts : struct
         {
             Ts[] array = new Ts[] { default(Ts), new Ts() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericWithStructRestrictionAsValueType<Ts>(array[i]);
+                VerifyGenericWithStructRestrictionAsValueType<Ts>(array[i], useInterpreter);
             }
         }
 
@@ -884,3559 +884,875 @@ namespace System.Linq.Expressions.Tests
 
         #region Test verifiers
 
-        private static void VerifyCustomAsCustom2(C value)
+        private static void VerifyCustomAsCustom2(C value, bool useInterpreter)
         {
             Expression<Func<D>> e =
                 Expression.Lambda<Func<D>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            D etResult = default(D);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            D csResult = default(D);
-            Exception csException = null;
-            try
-            {
-                csResult = value as D;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as D, f());
         }
 
-        private static void VerifyCustomAsInterface(C value)
+        private static void VerifyCustomAsInterface(C value, bool useInterpreter)
         {
             Expression<Func<I>> e =
                 Expression.Lambda<Func<I>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f = e.Compile();
+            Func<I> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            I etResult = default(I);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            I csResult = default(I);
-            Exception csException = null;
-            try
-            {
-                csResult = value as I;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as I, f());
         }
 
-        private static void VerifyCustomAsIEquatableOfCustom(C value)
+        private static void VerifyCustomAsIEquatableOfCustom(C value, bool useInterpreter)
         {
             Expression<Func<IEquatable<C>>> e =
                 Expression.Lambda<Func<IEquatable<C>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f = e.Compile();
+            Func<IEquatable<C>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEquatable<C> etResult = default(IEquatable<C>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEquatable<C> csResult = default(IEquatable<C>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IEquatable<C>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IEquatable<C>, f());
         }
 
-        private static void VerifyCustomAsIEquatableOfCustom2(C value)
+        private static void VerifyCustomAsIEquatableOfCustom2(C value, bool useInterpreter)
         {
             Expression<Func<IEquatable<D>>> e =
                 Expression.Lambda<Func<IEquatable<D>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f = e.Compile();
+            Func<IEquatable<D>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEquatable<D> etResult = default(IEquatable<D>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEquatable<D> csResult = default(IEquatable<D>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IEquatable<D>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IEquatable<D>, f());
         }
 
-        private static void VerifyCustomAsObject(C value)
+        private static void VerifyCustomAsObject(C value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyCustomArrayAsCustom2Array(C[] value)
+        private static void VerifyCustomArrayAsCustom2Array(C[] value, bool useInterpreter)
         {
             Expression<Func<D[]>> e =
                 Expression.Lambda<Func<D[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(D[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            D[] etResult = default(D[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            D[] csResult = default(D[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as D[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as D[], f());
         }
 
-        private static void VerifyCustomArrayAsIEnumerableOfCustom(C[] value)
+        private static void VerifyCustomArrayAsIEnumerableOfCustom(C[] value, bool useInterpreter)
         {
             Expression<Func<IEnumerable<C>>> e =
                 Expression.Lambda<Func<IEnumerable<C>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<C>> f = e.Compile();
+            Func<IEnumerable<C>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEnumerable<C> etResult = default(IEnumerable<C>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEnumerable<C> csResult = default(IEnumerable<C>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IEnumerable<C>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IEnumerable<C>, f());
         }
 
-        private static void VerifyCustomArrayAsIEnumerableOfCustom2(C[] value)
+        private static void VerifyCustomArrayAsIEnumerableOfCustom2(C[] value, bool useInterpreter)
         {
             Expression<Func<IEnumerable<D>>> e =
                 Expression.Lambda<Func<IEnumerable<D>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<D>> f = e.Compile();
+            Func<IEnumerable<D>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEnumerable<D> etResult = default(IEnumerable<D>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEnumerable<D> csResult = default(IEnumerable<D>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IEnumerable<D>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IEnumerable<D>, f());
         }
 
-        private static void VerifyCustomArrayAsIEnumerableOfInterface(C[] value)
+        private static void VerifyCustomArrayAsIEnumerableOfInterface(C[] value, bool useInterpreter)
         {
             Expression<Func<IEnumerable<I>>> e =
                 Expression.Lambda<Func<IEnumerable<I>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<I>> f = e.Compile();
+            Func<IEnumerable<I>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEnumerable<I> etResult = default(IEnumerable<I>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEnumerable<I> csResult = default(IEnumerable<I>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IEnumerable<I>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IEnumerable<I>, f());
         }
 
-        private static void VerifyCustomArrayAsIEnumerableOfObject(C[] value)
+        private static void VerifyCustomArrayAsIEnumerableOfObject(C[] value, bool useInterpreter)
         {
             Expression<Func<IEnumerable<object>>> e =
                 Expression.Lambda<Func<IEnumerable<object>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<object>> f = e.Compile();
+            Func<IEnumerable<object>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEnumerable<object> etResult = default(IEnumerable<object>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEnumerable<object> csResult = default(IEnumerable<object>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IEnumerable<object>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IEnumerable<object>, f());
         }
 
-        private static void VerifyCustomArrayAsIListOfCustom(C[] value)
+        private static void VerifyCustomArrayAsIListOfCustom(C[] value, bool useInterpreter)
         {
             Expression<Func<IList<C>>> e =
                 Expression.Lambda<Func<IList<C>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(IList<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<C>> f = e.Compile();
+            Func<IList<C>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IList<C> etResult = default(IList<C>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IList<C> csResult = default(IList<C>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IList<C>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IList<C>, f());
         }
 
-        private static void VerifyCustomArrayAsIListOfCustom2(C[] value)
+        private static void VerifyCustomArrayAsIListOfCustom2(C[] value, bool useInterpreter)
         {
             Expression<Func<IList<D>>> e =
                 Expression.Lambda<Func<IList<D>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(IList<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<D>> f = e.Compile();
+            Func<IList<D>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IList<D> etResult = default(IList<D>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
+            Assert.Equal(value as IList<D>, f());
 
-            // compute the value with regular IL
-            IList<D> csResult = default(IList<D>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IList<D>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
         }
 
-        private static void VerifyCustomArrayAsIListOfInterface(C[] value)
+        private static void VerifyCustomArrayAsIListOfInterface(C[] value, bool useInterpreter)
         {
             Expression<Func<IList<I>>> e =
                 Expression.Lambda<Func<IList<I>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(IList<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<I>> f = e.Compile();
+            Func<IList<I>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IList<I> etResult = default(IList<I>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IList<I> csResult = default(IList<I>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IList<I>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IList<I>, f());
         }
 
-        private static void VerifyCustomArrayAsIListOfObject(C[] value)
+        private static void VerifyCustomArrayAsIListOfObject(C[] value, bool useInterpreter)
         {
             Expression<Func<IList<object>>> e =
                 Expression.Lambda<Func<IList<object>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(IList<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<object>> f = e.Compile();
+            Func<IList<object>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IList<object> etResult = default(IList<object>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IList<object> csResult = default(IList<object>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IList<object>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IList<object>, f());
         }
 
-        private static void VerifyCustomArrayAsObjectArray(C[] value)
+        private static void VerifyCustomArrayAsObjectArray(C[] value, bool useInterpreter)
         {
             Expression<Func<object[]>> e =
                 Expression.Lambda<Func<object[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(C[])), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object[] etResult = default(object[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object[] csResult = default(object[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object[], f());
         }
 
-        private static void VerifyCustom2AsCustom(D value)
+        private static void VerifyCustom2AsCustom(D value, bool useInterpreter)
         {
             Expression<Func<C>> e =
                 Expression.Lambda<Func<C>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(D)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C etResult = default(C);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
+            Assert.Equal(value as C, f());
 
-            // compute the value with regular IL
-            C csResult = default(C);
-            Exception csException = null;
-            try
-            {
-                csResult = value as C;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
         }
 
-        private static void VerifyCustom2AsInterface(D value)
+        private static void VerifyCustom2AsInterface(D value, bool useInterpreter)
         {
             Expression<Func<I>> e =
                 Expression.Lambda<Func<I>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(D)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f = e.Compile();
+            Func<I> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            I etResult = default(I);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            I csResult = default(I);
-            Exception csException = null;
-            try
-            {
-                csResult = value as I;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as I, f());
         }
 
-        private static void VerifyCustom2AsIEquatableOfCustom(D value)
+        private static void VerifyCustom2AsIEquatableOfCustom(D value, bool useInterpreter)
         {
             Expression<Func<IEquatable<C>>> e =
                 Expression.Lambda<Func<IEquatable<C>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(D)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f = e.Compile();
+            Func<IEquatable<C>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEquatable<C> etResult = default(IEquatable<C>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEquatable<C> csResult = default(IEquatable<C>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IEquatable<C>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IEquatable<C>, f());
         }
 
-        private static void VerifyCustom2AsIEquatableOfCustom2(D value)
+        private static void VerifyCustom2AsIEquatableOfCustom2(D value, bool useInterpreter)
         {
             Expression<Func<IEquatable<D>>> e =
                 Expression.Lambda<Func<IEquatable<D>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(D)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f = e.Compile();
+            Func<IEquatable<D>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEquatable<D> etResult = default(IEquatable<D>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEquatable<D> csResult = default(IEquatable<D>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IEquatable<D>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IEquatable<D>, f());
         }
 
-        private static void VerifyCustom2AsObject(D value)
+        private static void VerifyCustom2AsObject(D value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(D)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyCustom2ArrayAsCustomArray(D[] value)
+        private static void VerifyCustom2ArrayAsCustomArray(D[] value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(D[])), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as C[], f());
         }
 
-        private static void VerifyDelegateAsFuncOfObject(Delegate value)
+        private static void VerifyDelegateAsFuncOfObject(Delegate value, bool useInterpreter)
         {
             Expression<Func<Func<object>>> e =
                 Expression.Lambda<Func<Func<object>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Delegate)), typeof(Func<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>> f = e.Compile();
+            Func<Func<object>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            Func<object> etResult = default(Func<object>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            Func<object> csResult = default(Func<object>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as Func<object>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as Func<object>, f());
         }
 
-        private static void VerifyDelegateAsObject(Delegate value)
+        private static void VerifyDelegateAsObject(Delegate value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Delegate)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyEnumAsEnumType(E value)
+        private static void VerifyEnumAsEnumType(E value, bool useInterpreter)
         {
             Expression<Func<Enum>> e =
                 Expression.Lambda<Func<Enum>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(E)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Enum> f = e.Compile();
+            Func<Enum> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            Enum etResult = default(Enum);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            Enum csResult = default(Enum);
-            Exception csException = null;
-            try
-            {
-                csResult = value as Enum;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as Enum, f());
         }
 
-        private static void VerifyEnumAsObject(E value)
+        private static void VerifyEnumAsObject(E value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(E)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyEnumTypeAsObject(Enum value)
+        private static void VerifyEnumTypeAsObject(Enum value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Enum)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyFuncOfObjectAsDelegate(Func<object> value)
+        private static void VerifyFuncOfObjectAsDelegate(Func<object> value, bool useInterpreter)
         {
             Expression<Func<Delegate>> e =
                 Expression.Lambda<Func<Delegate>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Func<object>)), typeof(Delegate)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate> f = e.Compile();
+            Func<Delegate> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            Delegate etResult = default(Delegate);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            Delegate csResult = default(Delegate);
-            Exception csException = null;
-            try
-            {
-                csResult = value as Delegate;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as Delegate, f());
         }
 
-        private static void VerifyInterfaceAsCustom(I value)
+        private static void VerifyInterfaceAsCustom(I value, bool useInterpreter)
         {
             Expression<Func<C>> e =
                 Expression.Lambda<Func<C>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(I)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C etResult = default(C);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C csResult = default(C);
-            Exception csException = null;
-            try
-            {
-                csResult = value as C;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as C, f());
         }
 
-        private static void VerifyInterfaceAsCustom2(I value)
+        private static void VerifyInterfaceAsCustom2(I value, bool useInterpreter)
         {
             Expression<Func<D>> e =
                 Expression.Lambda<Func<D>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(I)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            D etResult = default(D);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            D csResult = default(D);
-            Exception csException = null;
-            try
-            {
-                csResult = value as D;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as D, f());
         }
 
-        private static void VerifyInterfaceAsObject(I value)
+        private static void VerifyInterfaceAsObject(I value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(I)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyIEnumerableOfCustomAsCustomArray(IEnumerable<C> value)
+        private static void VerifyIEnumerableOfCustomAsCustomArray(IEnumerable<C> value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as C[], f());
         }
 
-        private static void VerifyIEnumerableOfCustomAsObjectArray(IEnumerable<C> value)
+        private static void VerifyIEnumerableOfCustomAsObjectArray(IEnumerable<C> value, bool useInterpreter)
         {
             Expression<Func<object[]>> e =
                 Expression.Lambda<Func<object[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object[] etResult = default(object[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object[] csResult = default(object[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object[], f());
         }
 
-        private static void VerifyIEnumerableOfCustomAsCustom(IEnumerable<C> value)
+        private static void VerifyIEnumerableOfCustomAsCustom(IEnumerable<C> value, bool useInterpreter)
         {
             Expression<Func<C>> e =
                 Expression.Lambda<Func<C>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C etResult = default(C);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C csResult = default(C);
-            Exception csException = null;
-            try
-            {
-                csResult = value as C;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as C, f());
         }
 
-        private static void VerifyIEnumerableOfCustomAsCustom2(IEnumerable<C> value)
+        private static void VerifyIEnumerableOfCustomAsCustom2(IEnumerable<C> value, bool useInterpreter)
         {
             Expression<Func<D>> e =
                 Expression.Lambda<Func<D>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            D etResult = default(D);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            D csResult = default(D);
-            Exception csException = null;
-            try
-            {
-                csResult = value as D;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as D, f());
         }
 
-        private static void VerifyIEnumerableOfCustomAsObject(IEnumerable<C> value)
+        private static void VerifyIEnumerableOfCustomAsObject(IEnumerable<C> value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyIEnumerableOfCustom2AsCustomArray(IEnumerable<D> value)
+        private static void VerifyIEnumerableOfCustom2AsCustomArray(IEnumerable<D> value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<D>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as C[], f());
         }
 
-        private static void VerifyIEnumerableOfCustom2AsCustom(IEnumerable<D> value)
+        private static void VerifyIEnumerableOfCustom2AsCustom(IEnumerable<D> value, bool useInterpreter)
         {
             Expression<Func<C>> e =
                 Expression.Lambda<Func<C>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<D>)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C etResult = default(C);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C csResult = default(C);
-            Exception csException = null;
-            try
-            {
-                csResult = value as C;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as C, f());
         }
 
-        private static void VerifyIEnumerableOfCustom2AsCustom2(IEnumerable<D> value)
+        private static void VerifyIEnumerableOfCustom2AsCustom2(IEnumerable<D> value, bool useInterpreter)
         {
             Expression<Func<D>> e =
                 Expression.Lambda<Func<D>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<D>)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            D etResult = default(D);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            D csResult = default(D);
-            Exception csException = null;
-            try
-            {
-                csResult = value as D;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as D, f());
         }
 
-        private static void VerifyIEnumerableOfCustom2AsObject(IEnumerable<D> value)
+        private static void VerifyIEnumerableOfCustom2AsObject(IEnumerable<D> value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<D>)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyIEnumerableOfInterfaceAsCustomArray(IEnumerable<I> value)
+        private static void VerifyIEnumerableOfInterfaceAsCustomArray(IEnumerable<I> value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<I>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as C[], f());
         }
 
-        private static void VerifyIEnumerableOfInterfaceAsObjectArray(IEnumerable<I> value)
+        private static void VerifyIEnumerableOfInterfaceAsObjectArray(IEnumerable<I> value, bool useInterpreter)
         {
             Expression<Func<object[]>> e =
                 Expression.Lambda<Func<object[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<I>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object[] etResult = default(object[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object[] csResult = default(object[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object[], f());
         }
 
-        private static void VerifyIEnumerableOfObjectAsCustomArray(IEnumerable<object> value)
+        private static void VerifyIEnumerableOfObjectAsCustomArray(IEnumerable<object> value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<object>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as C[], f());
         }
 
-        private static void VerifyIEnumerableOfObjectAsObjectArray(IEnumerable<object> value)
+        private static void VerifyIEnumerableOfObjectAsObjectArray(IEnumerable<object> value, bool useInterpreter)
         {
             Expression<Func<object[]>> e =
                 Expression.Lambda<Func<object[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<object>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object[] etResult = default(object[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object[] csResult = default(object[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object[], f());
         }
 
-        private static void VerifyIEnumerableOfStructAsStructArray(IEnumerable<S> value)
+        private static void VerifyIEnumerableOfStructAsStructArray(IEnumerable<S> value, bool useInterpreter)
         {
             Expression<Func<S[]>> e =
                 Expression.Lambda<Func<S[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IEnumerable<S>)), typeof(S[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            S[] etResult = default(S[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            S[] csResult = default(S[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as S[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as S[], f());
         }
 
-        private static void VerifyIListOfCustomAsCustomArray(IList<C> value)
+        private static void VerifyIListOfCustomAsCustomArray(IList<C> value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IList<C>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as C[], f());
         }
 
-        private static void VerifyIListOfCustomAsObjectArray(IList<C> value)
+        private static void VerifyIListOfCustomAsObjectArray(IList<C> value, bool useInterpreter)
         {
             Expression<Func<object[]>> e =
                 Expression.Lambda<Func<object[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IList<C>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object[] etResult = default(object[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object[] csResult = default(object[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object[], f());
         }
 
-        private static void VerifyIListOfCustom2AsCustomArray(IList<D> value)
+        private static void VerifyIListOfCustom2AsCustomArray(IList<D> value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IList<D>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as C[], f());
         }
 
-        private static void VerifyIListOfInterfaceAsCustomArray(IList<I> value)
+        private static void VerifyIListOfInterfaceAsCustomArray(IList<I> value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IList<I>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as C[], f());
         }
 
-        private static void VerifyIListOfInterfaceAsObjectArray(IList<I> value)
+        private static void VerifyIListOfInterfaceAsObjectArray(IList<I> value, bool useInterpreter)
         {
             Expression<Func<object[]>> e =
                 Expression.Lambda<Func<object[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IList<I>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object[] etResult = default(object[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object[] csResult = default(object[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object[], f());
         }
 
-        private static void VerifyIListOfObjectAsCustomArray(IList<object> value)
+        private static void VerifyIListOfObjectAsCustomArray(IList<object> value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IList<object>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as C[], f());
         }
 
-        private static void VerifyIListOfObjectAsObjectArray(IList<object> value)
+        private static void VerifyIListOfObjectAsObjectArray(IList<object> value, bool useInterpreter)
         {
             Expression<Func<object[]>> e =
                 Expression.Lambda<Func<object[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IList<object>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object[] etResult = default(object[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object[] csResult = default(object[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object[], f());
         }
 
-        private static void VerifyIListOfStructAsStructArray(IList<S> value)
+        private static void VerifyIListOfStructAsStructArray(IList<S> value, bool useInterpreter)
         {
             Expression<Func<S[]>> e =
                 Expression.Lambda<Func<S[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(IList<S>)), typeof(S[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            S[] etResult = default(S[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            S[] csResult = default(S[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as S[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as S[], f());
         }
 
-        private static void VerifyIntAsObject(int value)
+        private static void VerifyIntAsObject(int value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(int)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyIntAsValueType(int value)
+        private static void VerifyIntAsValueType(int value, bool useInterpreter)
         {
             Expression<Func<ValueType>> e =
                 Expression.Lambda<Func<ValueType>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(int)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            ValueType etResult = default(ValueType);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            ValueType csResult = default(ValueType);
-            Exception csException = null;
-            try
-            {
-                csResult = value as ValueType;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as ValueType, f());
         }
 
-        private static void VerifyObjectAsCustom(object value)
+        private static void VerifyObjectAsCustom(object value, bool useInterpreter)
         {
             Expression<Func<C>> e =
                 Expression.Lambda<Func<C>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C etResult = default(C);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C csResult = default(C);
-            Exception csException = null;
-            try
-            {
-                csResult = value as C;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as C, f());
         }
 
-        private static void VerifyObjectAsCustom2(object value)
+        private static void VerifyObjectAsCustom2(object value, bool useInterpreter)
         {
             Expression<Func<D>> e =
                 Expression.Lambda<Func<D>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            D etResult = default(D);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            D csResult = default(D);
-            Exception csException = null;
-            try
-            {
-                csResult = value as D;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as D, f());
         }
 
-        private static void VerifyObjectAsDelegate(object value)
+        private static void VerifyObjectAsDelegate(object value, bool useInterpreter)
         {
             Expression<Func<Delegate>> e =
                 Expression.Lambda<Func<Delegate>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object)), typeof(Delegate)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate> f = e.Compile();
+            Func<Delegate> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            Delegate etResult = default(Delegate);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            Delegate csResult = default(Delegate);
-            Exception csException = null;
-            try
-            {
-                csResult = value as Delegate;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as Delegate, f());
         }
 
-        private static void VerifyObjectAsEnumType(object value)
+        private static void VerifyObjectAsEnumType(object value, bool useInterpreter)
         {
             Expression<Func<Enum>> e =
                 Expression.Lambda<Func<Enum>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Enum> f = e.Compile();
+            Func<Enum> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            Enum etResult = default(Enum);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            Enum csResult = default(Enum);
-            Exception csException = null;
-            try
-            {
-                csResult = value as Enum;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as Enum, f());
         }
 
-        private static void VerifyObjectAsInterface(object value)
+        private static void VerifyObjectAsInterface(object value, bool useInterpreter)
         {
             Expression<Func<I>> e =
                 Expression.Lambda<Func<I>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f = e.Compile();
+            Func<I> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            I etResult = default(I);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            I csResult = default(I);
-            Exception csException = null;
-            try
-            {
-                csResult = value as I;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as I, f());
         }
 
-        private static void VerifyObjectAsIEquatableOfCustom(object value)
+        private static void VerifyObjectAsIEquatableOfCustom(object value, bool useInterpreter)
         {
             Expression<Func<IEquatable<C>>> e =
                 Expression.Lambda<Func<IEquatable<C>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f = e.Compile();
+            Func<IEquatable<C>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEquatable<C> etResult = default(IEquatable<C>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEquatable<C> csResult = default(IEquatable<C>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IEquatable<C>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IEquatable<C>, f());
         }
 
-        private static void VerifyObjectAsIEquatableOfCustom2(object value)
+        private static void VerifyObjectAsIEquatableOfCustom2(object value, bool useInterpreter)
         {
             Expression<Func<IEquatable<D>>> e =
                 Expression.Lambda<Func<IEquatable<D>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f = e.Compile();
+            Func<IEquatable<D>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEquatable<D> etResult = default(IEquatable<D>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEquatable<D> csResult = default(IEquatable<D>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IEquatable<D>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IEquatable<D>, f());
         }
 
-        private static void VerifyObjectAsValueType(object value)
+        private static void VerifyObjectAsValueType(object value, bool useInterpreter)
         {
             Expression<Func<ValueType>> e =
                 Expression.Lambda<Func<ValueType>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            ValueType etResult = default(ValueType);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            ValueType csResult = default(ValueType);
-            Exception csException = null;
-            try
-            {
-                csResult = value as ValueType;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as ValueType, f());
         }
 
-        private static void VerifyObjectArrayAsCustomArray(object[] value)
+        private static void VerifyObjectArrayAsCustomArray(object[] value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object[])), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = value as C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as C[], f());
         }
 
-        private static void VerifyObjectArrayAsIEnumerableOfCustom(object[] value)
+        private static void VerifyObjectArrayAsIEnumerableOfCustom(object[] value, bool useInterpreter)
         {
             Expression<Func<IEnumerable<C>>> e =
                 Expression.Lambda<Func<IEnumerable<C>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<C>> f = e.Compile();
+            Func<IEnumerable<C>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEnumerable<C> etResult = default(IEnumerable<C>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEnumerable<C> csResult = default(IEnumerable<C>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IEnumerable<C>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IEnumerable<C>, f());
         }
 
-        private static void VerifyObjectArrayAsIEnumerableOfInterface(object[] value)
+        private static void VerifyObjectArrayAsIEnumerableOfInterface(object[] value, bool useInterpreter)
         {
             Expression<Func<IEnumerable<I>>> e =
                 Expression.Lambda<Func<IEnumerable<I>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<I>> f = e.Compile();
+            Func<IEnumerable<I>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEnumerable<I> etResult = default(IEnumerable<I>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEnumerable<I> csResult = default(IEnumerable<I>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IEnumerable<I>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IEnumerable<I>, f());
         }
 
-        private static void VerifyObjectArrayAsIEnumerableOfObject(object[] value)
+        private static void VerifyObjectArrayAsIEnumerableOfObject(object[] value, bool useInterpreter)
         {
             Expression<Func<IEnumerable<object>>> e =
                 Expression.Lambda<Func<IEnumerable<object>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<object>> f = e.Compile();
+            Func<IEnumerable<object>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEnumerable<object> etResult = default(IEnumerable<object>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEnumerable<object> csResult = default(IEnumerable<object>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IEnumerable<object>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IEnumerable<object>, f());
         }
 
-        private static void VerifyObjectArrayAsIListOfCustom(object[] value)
+        private static void VerifyObjectArrayAsIListOfCustom(object[] value, bool useInterpreter)
         {
             Expression<Func<IList<C>>> e =
                 Expression.Lambda<Func<IList<C>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object[])), typeof(IList<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<C>> f = e.Compile();
+            Func<IList<C>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IList<C> etResult = default(IList<C>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IList<C> csResult = default(IList<C>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IList<C>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IList<C>, f());
         }
 
-        private static void VerifyObjectArrayAsIListOfInterface(object[] value)
+        private static void VerifyObjectArrayAsIListOfInterface(object[] value, bool useInterpreter)
         {
             Expression<Func<IList<I>>> e =
                 Expression.Lambda<Func<IList<I>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object[])), typeof(IList<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<I>> f = e.Compile();
+            Func<IList<I>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IList<I> etResult = default(IList<I>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IList<I> csResult = default(IList<I>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IList<I>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IList<I>, f());
         }
 
-        private static void VerifyObjectArrayAsIListOfObject(object[] value)
+        private static void VerifyObjectArrayAsIListOfObject(object[] value, bool useInterpreter)
         {
             Expression<Func<IList<object>>> e =
                 Expression.Lambda<Func<IList<object>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(object[])), typeof(IList<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<object>> f = e.Compile();
+            Func<IList<object>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IList<object> etResult = default(IList<object>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IList<object> csResult = default(IList<object>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IList<object>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IList<object>, f());
         }
 
-        private static void VerifyStructAsIEquatableOfStruct(S value)
+        private static void VerifyStructAsIEquatableOfStruct(S value, bool useInterpreter)
         {
             Expression<Func<IEquatable<S>>> e =
                 Expression.Lambda<Func<IEquatable<S>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(S)), typeof(IEquatable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<S>> f = e.Compile();
+            Func<IEquatable<S>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEquatable<S> etResult = default(IEquatable<S>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEquatable<S> csResult = default(IEquatable<S>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IEquatable<S>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IEquatable<S>, f());
         }
 
-        private static void VerifyStructAsObject(S value)
+        private static void VerifyStructAsObject(S value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(S)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyStructAsValueType(S value)
+        private static void VerifyStructAsValueType(S value, bool useInterpreter)
         {
             Expression<Func<ValueType>> e =
                 Expression.Lambda<Func<ValueType>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(S)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            ValueType etResult = default(ValueType);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            ValueType csResult = default(ValueType);
-            Exception csException = null;
-            try
-            {
-                csResult = value as ValueType;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as ValueType, f());
         }
 
-        private static void VerifyStructArrayAsIEnumerableOfStruct(S[] value)
+        private static void VerifyStructArrayAsIEnumerableOfStruct(S[] value, bool useInterpreter)
         {
             Expression<Func<IEnumerable<S>>> e =
                 Expression.Lambda<Func<IEnumerable<S>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(S[])), typeof(IEnumerable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<S>> f = e.Compile();
+            Func<IEnumerable<S>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEnumerable<S> etResult = default(IEnumerable<S>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEnumerable<S> csResult = default(IEnumerable<S>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IEnumerable<S>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IEnumerable<S>, f());
         }
 
-        private static void VerifyStructArrayAsIListOfStruct(S[] value)
+        private static void VerifyStructArrayAsIListOfStruct(S[] value, bool useInterpreter)
         {
             Expression<Func<IList<S>>> e =
                 Expression.Lambda<Func<IList<S>>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(S[])), typeof(IList<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<S>> f = e.Compile();
+            Func<IList<S>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IList<S> etResult = default(IList<S>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IList<S> csResult = default(IList<S>);
-            Exception csException = null;
-            try
-            {
-                csResult = value as IList<S>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as IList<S>, f());
         }
 
-        private static void VerifyValueTypeAsObject(ValueType value)
+        private static void VerifyValueTypeAsObject(ValueType value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(ValueType)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyGenericAsObject<T>(T value)
+        private static void VerifyGenericAsObject<T>(T value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(T)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyGenericWithClassRestrictionAsObject<Tc>(Tc value) where Tc : class
+        private static void VerifyGenericWithClassRestrictionAsObject<Tc>(Tc value, bool useInterpreter) where Tc : class
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Tc)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyGenericWithStructRestrictionAsObject<Ts>(Ts value) where Ts : struct
+        private static void VerifyGenericWithStructRestrictionAsObject<Ts>(Ts value, bool useInterpreter) where Ts : struct
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Ts)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = value as object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as object, f());
         }
 
-        private static void VerifyGenericWithStructRestrictionAsValueType<Ts>(Ts value) where Ts : struct
+        private static void VerifyGenericWithStructRestrictionAsValueType<Ts>(Ts value, bool useInterpreter) where Ts : struct
         {
             Expression<Func<ValueType>> e =
                 Expression.Lambda<Func<ValueType>>(
                     Expression.TypeAs(Expression.Constant(value, typeof(Ts)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            ValueType etResult = default(ValueType);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            ValueType csResult = default(ValueType);
-            Exception csException = null;
-            try
-            {
-                csResult = value as ValueType;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value as ValueType, f());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Cast/CastNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastNullableTests.cs
@@ -12,131 +12,131 @@ namespace System.Linq.Expressions.Tests
     {
         #region Test methods
 
-        [Fact]
-        public static void CheckNullableEnumCastEnumTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableEnumCastEnumTypeTest(bool useInterpreter)
         {
             E?[] array = new E?[] { null, (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableEnumCastEnumType(array[i]);
+                VerifyNullableEnumCastEnumType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableEnumCastObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableEnumCastObjectTest(bool useInterpreter)
         {
             E?[] array = new E?[] { null, (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableEnumCastObject(array[i]);
+                VerifyNullableEnumCastObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableIntCastObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableIntCastObjectTest(bool useInterpreter)
         {
             int?[] array = new int?[] { null, 0, 1, -1, int.MinValue, int.MaxValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableIntCastObject(array[i]);
+                VerifyNullableIntCastObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableIntCastValueTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableIntCastValueTypeTest(bool useInterpreter)
         {
             int?[] array = new int?[] { null, 0, 1, -1, int.MinValue, int.MaxValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableIntCastValueType(array[i]);
+                VerifyNullableIntCastValueType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableStructCastIEquatableOfStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableStructCastIEquatableOfStructTest(bool useInterpreter)
         {
             S?[] array = new S?[] { null, default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableStructCastIEquatableOfStruct(array[i]);
+                VerifyNullableStructCastIEquatableOfStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableStructCastObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableStructCastObjectTest(bool useInterpreter)
         {
             S?[] array = new S?[] { null, default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableStructCastObject(array[i]);
+                VerifyNullableStructCastObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableStructCastValueTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableStructCastValueTypeTest(bool useInterpreter)
         {
             S?[] array = new S?[] { null, default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableStructCastValueType(array[i]);
+                VerifyNullableStructCastValueType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastObjectAsEnum()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastObjectAsEnum(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionCastObjectHelper<E>();
+            CheckGenericWithStructRestrictionCastObjectHelper<E>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastObjectAsStruct()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastObjectAsStruct(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionCastObjectHelper<S>();
+            CheckGenericWithStructRestrictionCastObjectHelper<S>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastObjectAsStructWithStringAndField()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastObjectAsStructWithStringAndField(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionCastObjectHelper<Scs>();
+            CheckGenericWithStructRestrictionCastObjectHelper<Scs>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastValueTypeAsEnum()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastValueTypeAsEnum(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionCastValueTypeHelper<E>();
+            CheckGenericWithStructRestrictionCastValueTypeHelper<E>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStruct()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStruct(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionCastValueTypeHelper<S>();
+            CheckGenericWithStructRestrictionCastValueTypeHelper<S>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStructWithStringAndField()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStructWithStringAndField(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionCastValueTypeHelper<Scs>();
+            CheckGenericWithStructRestrictionCastValueTypeHelper<Scs>(useInterpreter);
         }
 
         #endregion
 
         #region Generic helpers
 
-        private static void CheckGenericWithStructRestrictionCastObjectHelper<Ts>() where Ts : struct
+        private static void CheckGenericWithStructRestrictionCastObjectHelper<Ts>(bool useInterpreter) where Ts : struct
         {
             Ts[] array = new Ts[] { default(Ts), new Ts() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericWithStructRestrictionCastObject<Ts>(array[i]);
+                VerifyGenericWithStructRestrictionCastObject<Ts>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckGenericWithStructRestrictionCastValueTypeHelper<Ts>() where Ts : struct
+        private static void CheckGenericWithStructRestrictionCastValueTypeHelper<Ts>(bool useInterpreter) where Ts : struct
         {
             Ts[] array = new Ts[] { default(Ts), new Ts() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericWithStructRestrictionCastValueType<Ts>(array[i]);
+                VerifyGenericWithStructRestrictionCastValueType<Ts>(array[i], useInterpreter);
             }
         }
 
@@ -144,409 +144,103 @@ namespace System.Linq.Expressions.Tests
 
         #region Test verifiers
 
-        private static void VerifyNullableEnumCastEnumType(E? value)
+        private static void VerifyNullableEnumCastEnumType(E? value, bool useInterpreter)
         {
             Expression<Func<Enum>> e =
                 Expression.Lambda<Func<Enum>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Enum> f = e.Compile();
+            Func<Enum> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            Enum etResult = default(Enum);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            Enum csResult = default(Enum);
-            Exception csException = null;
-            try
-            {
-                csResult = (Enum)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyNullableEnumCastObject(E? value)
+        private static void VerifyNullableEnumCastObject(E? value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(E?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyNullableIntCastObject(int? value)
+        private static void VerifyNullableIntCastObject(int? value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyNullableIntCastValueType(int? value)
+        private static void VerifyNullableIntCastValueType(int? value, bool useInterpreter)
         {
             Expression<Func<ValueType>> e =
                 Expression.Lambda<Func<ValueType>>(
                     Expression.Convert(Expression.Constant(value, typeof(int?)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            ValueType etResult = default(ValueType);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            ValueType csResult = default(ValueType);
-            Exception csException = null;
-            try
-            {
-                csResult = (ValueType)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyNullableStructCastIEquatableOfStruct(S? value)
+        private static void VerifyNullableStructCastIEquatableOfStruct(S? value, bool useInterpreter)
         {
             Expression<Func<IEquatable<S>>> e =
                 Expression.Lambda<Func<IEquatable<S>>>(
                     Expression.Convert(Expression.Constant(value, typeof(S?)), typeof(IEquatable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<S>> f = e.Compile();
+            Func<IEquatable<S>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEquatable<S> etResult = default(IEquatable<S>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEquatable<S> csResult = default(IEquatable<S>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IEquatable<S>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyNullableStructCastObject(S? value)
+        private static void VerifyNullableStructCastObject(S? value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(S?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyNullableStructCastValueType(S? value)
+        private static void VerifyNullableStructCastValueType(S? value, bool useInterpreter)
         {
             Expression<Func<ValueType>> e =
                 Expression.Lambda<Func<ValueType>>(
                     Expression.Convert(Expression.Constant(value, typeof(S?)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            ValueType etResult = default(ValueType);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            ValueType csResult = default(ValueType);
-            Exception csException = null;
-            try
-            {
-                csResult = (ValueType)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyGenericWithStructRestrictionCastObject<Ts>(Ts value) where Ts : struct
+        private static void VerifyGenericWithStructRestrictionCastObject<Ts>(Ts value, bool useInterpreter) where Ts : struct
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(Ts)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyGenericWithStructRestrictionCastValueType<Ts>(Ts value) where Ts : struct
+        private static void VerifyGenericWithStructRestrictionCastValueType<Ts>(Ts value, bool useInterpreter) where Ts : struct
         {
             Expression<Func<ValueType>> e =
                 Expression.Lambda<Func<ValueType>>(
                     Expression.Convert(Expression.Constant(value, typeof(Ts)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            ValueType etResult = default(ValueType);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            ValueType csResult = default(ValueType);
-            Exception csException = null;
-            try
-            {
-                csResult = (ValueType)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -263,7 +263,7 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckEnumTypeCastEnumTest(bool useInterpreter)
         {
             Enum[] array = new Enum[] { null, (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue, (El)0, El.A, El.B, (El)long.MaxValue, (El)long.MinValue };
@@ -273,25 +273,11 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
-        [Fact]
-        [ActiveIssue(7169)]
-        public static void CheckEnumTypeCastEnumTestInterpreted()
-        {
-            CheckEnumTypeCastEnumTest(true);
-        }
-
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckUnsignedEnumInObjectCastEnum(bool useInterpreter)
         {
             foreach (Eu value in new[] { Eu.Bagahi, Eu.Laca, Eu.Bachahé, (Eu)uint.MaxValue })
                 VerifyUnsignedEnumInObjectCastEnum(value, useInterpreter);
-        }
-
-        [Fact]
-        [ActiveIssue(7169)]
-        public static void CheckUnsignedEnumInObjectCastEnumInterpreted()
-        {
-            CheckUnsignedEnumInObjectCastEnum(true);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
@@ -645,7 +631,7 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckObjectCastEnumTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
@@ -653,13 +639,6 @@ namespace System.Linq.Expressions.Tests
             {
                 VerifyObjectCastEnum(array[i], useInterpreter);
             }
-        }
-
-        [Fact]
-        [ActiveIssue(7169)]
-        public static void CheckObjectCastEnumTestInterpreted()
-        {
-            CheckObjectCastEnumTest(true);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
@@ -888,17 +867,10 @@ namespace System.Linq.Expressions.Tests
             CheckObjectCastGenericHelper<C>(useInterpreter);
         }
 
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void ConvertObjectCastGenericAsEnum(bool useInterpreter)
         {
             CheckObjectCastGenericHelper<E>(useInterpreter);
-        }
-
-        [Fact]
-        [ActiveIssue(7169)]
-        public static void ConvertObjectCastGenericAsEnumInterpreted()
-        {
-            ConvertObjectCastGenericAsEnum(true);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
@@ -931,17 +903,10 @@ namespace System.Linq.Expressions.Tests
             CheckObjectCastGenericWithClassRestrictionHelper<object>(useInterpreter);
         }
 
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void ConvertObjectCastGenericWithStructRestrictionAsEnum(bool useInterpreter)
         {
             CheckObjectCastGenericWithStructRestrictionHelper<E>(useInterpreter);
-        }
-
-        [Fact]
-        [ActiveIssue(7169)]
-        public static void ConvertObjectCastGenericWithStructRestrictionAsEnumInterpreted()
-        {
-            ConvertObjectCastGenericWithStructRestrictionAsEnum(true);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
@@ -1034,17 +999,10 @@ namespace System.Linq.Expressions.Tests
             CheckGenericWithStructRestrictionCastValueTypeHelper<Scs>(useInterpreter);
         }
 
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void ConvertValueTypeCastGenericWithStructRestrictionAsEnum(bool useInterpreter)
         {
             CheckValueTypeCastGenericWithStructRestrictionHelper<E>(useInterpreter);
-        }
-
-        [Fact]
-        [ActiveIssue(7169)]
-        public static void ConvertValueTypeCastGenericWithStructRestrictionAsEnumInterpreted()
-        {
-            ConvertValueTypeCastGenericWithStructRestrictionAsEnum(true);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]

--- a/src/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -12,1055 +13,1125 @@ namespace System.Linq.Expressions.Tests
     {
         #region Test methods
 
-        [Fact]
-        public static void CheckCustomCastCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomCastCustom2Test(bool useInterpreter)
         {
             C[] array = new C[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomCastCustom2(array[i]);
+                VerifyCustomCastCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomCastInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomCastInterfaceTest(bool useInterpreter)
         {
             C[] array = new C[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomCastInterface(array[i]);
+                VerifyCustomCastInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomCastIEquatableOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomCastIEquatableOfCustomTest(bool useInterpreter)
         {
             C[] array = new C[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomCastIEquatableOfCustom(array[i]);
+                VerifyCustomCastIEquatableOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomCastIEquatableOfCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomCastIEquatableOfCustom2Test(bool useInterpreter)
         {
             C[] array = new C[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomCastIEquatableOfCustom2(array[i]);
+                VerifyCustomCastIEquatableOfCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomCastObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomCastObjectTest(bool useInterpreter)
         {
             C[] array = new C[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomCastObject(array[i]);
+                VerifyCustomCastObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayCastCustom2ArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayCastCustom2ArrayTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayCastCustom2Array(array[i]);
+                VerifyCustomArrayCastCustom2Array(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayCastIEnumerableOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayCastIEnumerableOfCustomTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayCastIEnumerableOfCustom(array[i]);
+                VerifyCustomArrayCastIEnumerableOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayCastIEnumerableOfCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayCastIEnumerableOfCustom2Test(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayCastIEnumerableOfCustom2(array[i]);
+                VerifyCustomArrayCastIEnumerableOfCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayCastIEnumerableOfInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayCastIEnumerableOfInterfaceTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayCastIEnumerableOfInterface(array[i]);
+                VerifyCustomArrayCastIEnumerableOfInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayCastIEnumerableOfObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayCastIEnumerableOfObjectTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayCastIEnumerableOfObject(array[i]);
+                VerifyCustomArrayCastIEnumerableOfObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayCastIListOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayCastIListOfCustomTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayCastIListOfCustom(array[i]);
+                VerifyCustomArrayCastIListOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayCastIListOfCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayCastIListOfCustom2Test(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayCastIListOfCustom2(array[i]);
+                VerifyCustomArrayCastIListOfCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayCastIListOfInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayCastIListOfInterfaceTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayCastIListOfInterface(array[i]);
+                VerifyCustomArrayCastIListOfInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayCastIListOfObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayCastIListOfObjectTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayCastIListOfObject(array[i]);
+                VerifyCustomArrayCastIListOfObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayCastObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayCastObjectArrayTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayCastObjectArray(array[i]);
+                VerifyCustomArrayCastObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2CastCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2CastCustomTest(bool useInterpreter)
         {
             D[] array = new D[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2CastCustom(array[i]);
+                VerifyCustom2CastCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2CastInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2CastInterfaceTest(bool useInterpreter)
         {
             D[] array = new D[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2CastInterface(array[i]);
+                VerifyCustom2CastInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2CastIEquatableOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2CastIEquatableOfCustomTest(bool useInterpreter)
         {
             D[] array = new D[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2CastIEquatableOfCustom(array[i]);
+                VerifyCustom2CastIEquatableOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2CastIEquatableOfCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2CastIEquatableOfCustom2Test(bool useInterpreter)
         {
             D[] array = new D[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2CastIEquatableOfCustom2(array[i]);
+                VerifyCustom2CastIEquatableOfCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2CastObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2CastObjectTest(bool useInterpreter)
         {
             D[] array = new D[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2CastObject(array[i]);
+                VerifyCustom2CastObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2ArrayCastCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2ArrayCastCustomArrayTest(bool useInterpreter)
         {
             D[][] array = new D[][] { null, new D[] { null, new D(), new D(0), new D(5) }, new D[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2ArrayCastCustomArray(array[i]);
+                VerifyCustom2ArrayCastCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckDelegateCastFuncOfObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckDelegateCastFuncOfObjectTest(bool useInterpreter)
         {
             Delegate[] array = new Delegate[] { null, (Func<object>)delegate () { return null; }, (Func<int, int>)delegate (int i) { return i + 1; }, (Action<object>)delegate { } };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyDelegateCastFuncOfObject(array[i]);
+                VerifyDelegateCastFuncOfObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckDelegateCastObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckDelegateCastObjectTest(bool useInterpreter)
         {
             Delegate[] array = new Delegate[] { null, (Func<object>)delegate () { return null; }, (Func<int, int>)delegate (int i) { return i + 1; }, (Action<object>)delegate { } };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyDelegateCastObject(array[i]);
+                VerifyDelegateCastObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckEnumCastEnumTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckEnumCastEnumTypeTest(bool useInterpreter)
         {
             E[] array = new E[] { (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyEnumCastEnumType(array[i]);
+                VerifyEnumCastEnumType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckEnumCastObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckEnumCastObjectTest(bool useInterpreter)
         {
             E[] array = new E[] { (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyEnumCastObject(array[i]);
+                VerifyEnumCastObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckEnumTypeCastEnumTest()
+        [Theory, InlineData(false)]
+        public static void CheckEnumTypeCastEnumTest(bool useInterpreter)
         {
             Enum[] array = new Enum[] { null, (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue, (El)0, El.A, El.B, (El)long.MaxValue, (El)long.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyEnumTypeCastEnum(array[i]);
+                VerifyEnumTypeCastEnum(array[i], useInterpreter);
             }
         }
 
         [Fact]
-        public static void CheckEnumTypeCastObjectTest()
+        [ActiveIssue(7169)]
+        public static void CheckEnumTypeCastEnumTestInterpreted()
+        {
+            CheckEnumTypeCastEnumTest(true);
+        }
+
+        [Theory, InlineData(false)]
+        public static void CheckUnsignedEnumInObjectCastEnum(bool useInterpreter)
+        {
+            foreach (Eu value in new[] { Eu.Bagahi, Eu.Laca, Eu.Bachahé, (Eu)uint.MaxValue })
+                VerifyUnsignedEnumInObjectCastEnum(value, useInterpreter);
+        }
+
+        [Fact]
+        [ActiveIssue(7169)]
+        public static void CheckUnsignedEnumInObjectCastEnumInterpreted()
+        {
+            CheckUnsignedEnumInObjectCastEnum(true);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckUnsignedEnumCastEnum(bool useInterpreter)
+        {
+            foreach (Eu value in new[] { Eu.Bagahi, Eu.Laca, Eu.Bachahé, (Eu)uint.MaxValue })
+                VerifyUnsignedEnumCastEnum(value, useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckEnumCastLongEnum(bool useInterpreter)
+        {
+            foreach (E value in new[] { E.A, E.B, (E)int.MinValue, (E)int.MaxValue })
+                VerifyEnumCastLongEnum(value, useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckLongEnumCastEnum(bool useInterpreter)
+        {
+            foreach (El value in new[] { El.A, El.B, (El)int.MaxValue, (El)long.MaxValue, (El)long.MinValue })
+                VerifyLongEnumCastEnum(value, useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckEnumTypeCastObjectTest(bool useInterpreter)
         {
             Enum[] array = new Enum[] { null, (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue, (El)0, El.A, El.B, (El)long.MaxValue, (El)long.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyEnumTypeCastObject(array[i]);
+                VerifyEnumTypeCastObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckFuncOfObjectCastDelegateTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckFuncOfObjectCastDelegateTest(bool useInterpreter)
         {
             Func<object>[] array = new Func<object>[] { null, (Func<object>)delegate () { return null; } };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyFuncOfObjectCastDelegate(array[i]);
+                VerifyFuncOfObjectCastDelegate(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckInterfaceCastCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckInterfaceCastCustomTest(bool useInterpreter)
         {
             I[] array = new I[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyInterfaceCastCustom(array[i]);
+                VerifyInterfaceCastCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckInterfaceCastCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckInterfaceCastCustom2Test(bool useInterpreter)
         {
             I[] array = new I[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyInterfaceCastCustom2(array[i]);
+                VerifyInterfaceCastCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckInterfaceCastObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckInterfaceCastObjectTest(bool useInterpreter)
         {
             I[] array = new I[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyInterfaceCastObject(array[i]);
+                VerifyInterfaceCastObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfCustomCastCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfCustomCastCustomArrayTest(bool useInterpreter)
         {
             IEnumerable<C>[] array = new IEnumerable<C>[] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10], new List<C>(), new List<C>(new C[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfCustomCastCustomArray(array[i]);
+                VerifyIEnumerableOfCustomCastCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfCustomCastObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfCustomCastObjectArrayTest(bool useInterpreter)
         {
             IEnumerable<C>[] array = new IEnumerable<C>[] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10], new List<C>(), new List<C>(new C[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfCustomCastObjectArray(array[i]);
+                VerifyIEnumerableOfCustomCastObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfCustom2CastCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfCustom2CastCustomArrayTest(bool useInterpreter)
         {
             IEnumerable<D>[] array = new IEnumerable<D>[] { null, new D[] { null, new D(), new D(0), new D(5) }, new D[10], new List<D>(), new List<D>(new D[] { null, new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfCustom2CastCustomArray(array[i]);
+                VerifyIEnumerableOfCustom2CastCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfInterfaceCastCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfInterfaceCastCustomArrayTest(bool useInterpreter)
         {
             IEnumerable<I>[] array = new IEnumerable<I>[] { null, new I[] { null, new C(), new D(), new D(0), new D(5) }, new I[10], new List<I>(), new List<I>(new I[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfInterfaceCastCustomArray(array[i]);
+                VerifyIEnumerableOfInterfaceCastCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfInterfaceCastObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfInterfaceCastObjectArrayTest(bool useInterpreter)
         {
             IEnumerable<I>[] array = new IEnumerable<I>[] { null, new I[] { null, new C(), new D(), new D(0), new D(5) }, new I[10], new List<I>(), new List<I>(new I[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfInterfaceCastObjectArray(array[i]);
+                VerifyIEnumerableOfInterfaceCastObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfObjectCastCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfObjectCastCustomArrayTest(bool useInterpreter)
         {
             IEnumerable<object>[] array = new IEnumerable<object>[] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10], new List<object>(), new List<object>(new object[] { null, new object(), new C(), new D(3) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfObjectCastCustomArray(array[i]);
+                VerifyIEnumerableOfObjectCastCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfObjectCastObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfObjectCastObjectArrayTest(bool useInterpreter)
         {
             IEnumerable<object>[] array = new IEnumerable<object>[] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10], new List<object>(), new List<object>(new object[] { null, new object(), new C(), new D(3) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfObjectCastObjectArray(array[i]);
+                VerifyIEnumerableOfObjectCastObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfStructCastStructArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfStructCastStructArrayTest(bool useInterpreter)
         {
             IEnumerable<S>[] array = new IEnumerable<S>[] { null, new S[] { default(S), new S() }, new S[10], new List<S>(), new List<S>(new S[] { default(S), new S() }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfStructCastStructArray(array[i]);
+                VerifyIEnumerableOfStructCastStructArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEquatableOfCustomCastCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEquatableOfCustomCastCustomTest(bool useInterpreter)
         {
             IEquatable<C>[] array = new IEquatable<C>[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEquatableOfCustomCastCustom(array[i]);
+                VerifyIEquatableOfCustomCastCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEquatableOfCustomCastCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEquatableOfCustomCastCustom2Test(bool useInterpreter)
         {
             IEquatable<C>[] array = new IEquatable<C>[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEquatableOfCustomCastCustom2(array[i]);
+                VerifyIEquatableOfCustomCastCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEquatableOfCustomCastObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEquatableOfCustomCastObjectTest(bool useInterpreter)
         {
             IEquatable<C>[] array = new IEquatable<C>[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEquatableOfCustomCastObject(array[i]);
+                VerifyIEquatableOfCustomCastObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEquatableOfCustom2CastCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEquatableOfCustom2CastCustomTest(bool useInterpreter)
         {
             IEquatable<D>[] array = new IEquatable<D>[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEquatableOfCustom2CastCustom(array[i]);
+                VerifyIEquatableOfCustom2CastCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEquatableOfCustom2CastCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEquatableOfCustom2CastCustom2Test(bool useInterpreter)
         {
             IEquatable<D>[] array = new IEquatable<D>[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEquatableOfCustom2CastCustom2(array[i]);
+                VerifyIEquatableOfCustom2CastCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEquatableOfCustom2CastObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEquatableOfCustom2CastObjectTest(bool useInterpreter)
         {
             IEquatable<D>[] array = new IEquatable<D>[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEquatableOfCustom2CastObject(array[i]);
+                VerifyIEquatableOfCustom2CastObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEquatableOfStructCastStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEquatableOfStructCastStructTest(bool useInterpreter)
         {
             IEquatable<S>[] array = new IEquatable<S>[] { null };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEquatableOfStructCastStruct(array[i]);
+                VerifyIEquatableOfStructCastStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfCustomCastCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfCustomCastCustomArrayTest(bool useInterpreter)
         {
             IList<C>[] array = new IList<C>[] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10], new List<C>(), new List<C>(new C[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfCustomCastCustomArray(array[i]);
+                VerifyIListOfCustomCastCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfCustomCastObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfCustomCastObjectArrayTest(bool useInterpreter)
         {
             IList<C>[] array = new IList<C>[] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10], new List<C>(), new List<C>(new C[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfCustomCastObjectArray(array[i]);
+                VerifyIListOfCustomCastObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfCustom2CastCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfCustom2CastCustomArrayTest(bool useInterpreter)
         {
             IList<D>[] array = new IList<D>[] { null, new D[] { null, new D(), new D(0), new D(5) }, new D[10], new List<D>(), new List<D>(new D[] { null, new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfCustom2CastCustomArray(array[i]);
+                VerifyIListOfCustom2CastCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfInterfaceCastCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfInterfaceCastCustomArrayTest(bool useInterpreter)
         {
             IList<I>[] array = new IList<I>[] { null, new I[] { null, new C(), new D(), new D(0), new D(5) }, new I[10], new List<I>(), new List<I>(new I[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfInterfaceCastCustomArray(array[i]);
+                VerifyIListOfInterfaceCastCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfInterfaceCastObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfInterfaceCastObjectArrayTest(bool useInterpreter)
         {
             IList<I>[] array = new IList<I>[] { null, new I[] { null, new C(), new D(), new D(0), new D(5) }, new I[10], new List<I>(), new List<I>(new I[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfInterfaceCastObjectArray(array[i]);
+                VerifyIListOfInterfaceCastObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfObjectCastCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfObjectCastCustomArrayTest(bool useInterpreter)
         {
             IList<object>[] array = new IList<object>[] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10], new List<object>(), new List<object>(new object[] { null, new object(), new C(), new D(3) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfObjectCastCustomArray(array[i]);
+                VerifyIListOfObjectCastCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfObjectCastObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfObjectCastObjectArrayTest(bool useInterpreter)
         {
             IList<object>[] array = new IList<object>[] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10], new List<object>(), new List<object>(new object[] { null, new object(), new C(), new D(3) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfObjectCastObjectArray(array[i]);
+                VerifyIListOfObjectCastObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfStructCastStructArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfStructCastStructArrayTest(bool useInterpreter)
         {
             IList<S>[] array = new IList<S>[] { null, new S[] { default(S), new S() }, new S[10], new List<S>(), new List<S>(new S[] { default(S), new S() }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfStructCastStructArray(array[i]);
+                VerifyIListOfStructCastStructArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIntCastObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIntCastObjectTest(bool useInterpreter)
         {
             int[] array = new int[] { 0, 1, -1, int.MinValue, int.MaxValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIntCastObject(array[i]);
+                VerifyIntCastObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIntCastValueTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIntCastValueTypeTest(bool useInterpreter)
         {
             int[] array = new int[] { 0, 1, -1, int.MinValue, int.MaxValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIntCastValueType(array[i]);
+                VerifyIntCastValueType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectCastCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectCastCustomTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectCastCustom(array[i]);
+                VerifyObjectCastCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectCastCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectCastCustom2Test(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectCastCustom2(array[i]);
+                VerifyObjectCastCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectCastDelegateTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectCastDelegateTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectCastDelegate(array[i]);
+                VerifyObjectCastDelegate(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectCastEnumTest()
+        [Theory, InlineData(false)]
+        public static void CheckObjectCastEnumTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectCastEnum(array[i]);
+                VerifyObjectCastEnum(array[i], useInterpreter);
             }
         }
 
         [Fact]
-        public static void CheckObjectCastEnumTypeTest()
+        [ActiveIssue(7169)]
+        public static void CheckObjectCastEnumTestInterpreted()
+        {
+            CheckObjectCastEnumTest(true);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectCastEnumTypeTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectCastEnumType(array[i]);
+                VerifyObjectCastEnumType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectCastInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectCastInterfaceTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectCastInterface(array[i]);
+                VerifyObjectCastInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectCastIEquatableOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectCastIEquatableOfCustomTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectCastIEquatableOfCustom(array[i]);
+                VerifyObjectCastIEquatableOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectCastIEquatableOfCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectCastIEquatableOfCustom2Test(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectCastIEquatableOfCustom2(array[i]);
+                VerifyObjectCastIEquatableOfCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectCastIntTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectCastIntTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectCastInt(array[i]);
+                VerifyObjectCastInt(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectCastStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectCastStructTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectCastStruct(array[i]);
+                VerifyObjectCastStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectCastValueTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectCastValueTypeTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectCastValueType(array[i]);
+                VerifyObjectCastValueType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayCastCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayCastCustomArrayTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayCastCustomArray(array[i]);
+                VerifyObjectArrayCastCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayCastIEnumerableOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayCastIEnumerableOfCustomTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayCastIEnumerableOfCustom(array[i]);
+                VerifyObjectArrayCastIEnumerableOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayCastIEnumerableOfInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayCastIEnumerableOfInterfaceTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayCastIEnumerableOfInterface(array[i]);
+                VerifyObjectArrayCastIEnumerableOfInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayCastIEnumerableOfObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayCastIEnumerableOfObjectTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayCastIEnumerableOfObject(array[i]);
+                VerifyObjectArrayCastIEnumerableOfObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayCastIListOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayCastIListOfCustomTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayCastIListOfCustom(array[i]);
+                VerifyObjectArrayCastIListOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayCastIListOfInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayCastIListOfInterfaceTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayCastIListOfInterface(array[i]);
+                VerifyObjectArrayCastIListOfInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayCastIListOfObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayCastIListOfObjectTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayCastIListOfObject(array[i]);
+                VerifyObjectArrayCastIListOfObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckStructCastIEquatableOfStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckStructCastIEquatableOfStructTest(bool useInterpreter)
         {
             S[] array = new S[] { default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyStructCastIEquatableOfStruct(array[i]);
+                VerifyStructCastIEquatableOfStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckStructCastObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckStructCastObjectTest(bool useInterpreter)
         {
             S[] array = new S[] { default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyStructCastObject(array[i]);
+                VerifyStructCastObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckStructCastValueTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckStructCastValueTypeTest(bool useInterpreter)
         {
             S[] array = new S[] { default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyStructCastValueType(array[i]);
+                VerifyStructCastValueType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckStructArrayCastIEnumerableOfStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckStructArrayCastIEnumerableOfStructTest(bool useInterpreter)
         {
             S[][] array = new S[][] { null, new S[] { default(S), new S() }, new S[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyStructArrayCastIEnumerableOfStruct(array[i]);
+                VerifyStructArrayCastIEnumerableOfStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckStructArrayCastIListOfStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckStructArrayCastIListOfStructTest(bool useInterpreter)
         {
             S[][] array = new S[][] { null, new S[] { default(S), new S() }, new S[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyStructArrayCastIListOfStruct(array[i]);
+                VerifyStructArrayCastIListOfStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckValueTypeCastIntTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckValueTypeCastIntTest(bool useInterpreter)
         {
             ValueType[] array = new ValueType[] { null, default(S), new Scs(null, new S()), E.A, El.B };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyValueTypeCastInt(array[i]);
+                VerifyValueTypeCastInt(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckValueTypeCastObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckValueTypeCastObjectTest(bool useInterpreter)
         {
             ValueType[] array = new ValueType[] { null, default(S), new Scs(null, new S()), E.A, El.B };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyValueTypeCastObject(array[i]);
+                VerifyValueTypeCastObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckValueTypeCastStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckValueTypeCastStructTest(bool useInterpreter)
         {
             ValueType[] array = new ValueType[] { null, default(S), new Scs(null, new S()), E.A, El.B };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyValueTypeCastStruct(array[i]);
+                VerifyValueTypeCastStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void ConvertObjectCastGenericAsCustom()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericAsCustom(bool useInterpreter)
         {
-            CheckObjectCastGenericHelper<C>();
+            CheckObjectCastGenericHelper<C>(useInterpreter);
+        }
+
+        [Theory, InlineData(false)]
+        public static void ConvertObjectCastGenericAsEnum(bool useInterpreter)
+        {
+            CheckObjectCastGenericHelper<E>(useInterpreter);
         }
 
         [Fact]
-        public static void ConvertObjectCastGenericAsEnum()
+        [ActiveIssue(7169)]
+        public static void ConvertObjectCastGenericAsEnumInterpreted()
         {
-            CheckObjectCastGenericHelper<E>();
+            ConvertObjectCastGenericAsEnum(true);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericAsObject(bool useInterpreter)
+        {
+            CheckObjectCastGenericHelper<object>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericAsStruct(bool useInterpreter)
+        {
+            CheckObjectCastGenericHelper<S>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericAsStructWithStringAndField(bool useInterpreter)
+        {
+            CheckObjectCastGenericHelper<Scs>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericWithClassRestrictionAsCustom(bool useInterpreter)
+        {
+            CheckObjectCastGenericWithClassRestrictionHelper<C>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericWithClassRestrictionAsObject(bool useInterpreter)
+        {
+            CheckObjectCastGenericWithClassRestrictionHelper<object>(useInterpreter);
+        }
+
+        [Theory, InlineData(false)]
+        public static void ConvertObjectCastGenericWithStructRestrictionAsEnum(bool useInterpreter)
+        {
+            CheckObjectCastGenericWithStructRestrictionHelper<E>(useInterpreter);
         }
 
         [Fact]
-        public static void ConvertObjectCastGenericAsObject()
+        [ActiveIssue(7169)]
+        public static void ConvertObjectCastGenericWithStructRestrictionAsEnumInterpreted()
         {
-            CheckObjectCastGenericHelper<object>();
+            ConvertObjectCastGenericWithStructRestrictionAsEnum(true);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericWithStructRestrictionAsStruct(bool useInterpreter)
+        {
+            CheckObjectCastGenericWithStructRestrictionHelper<S>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericWithStructRestrictionAsStructWithStringAndField(bool useInterpreter)
+        {
+            CheckObjectCastGenericWithStructRestrictionHelper<Scs>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericCastObjectAsCustom(bool useInterpreter)
+        {
+            CheckGenericCastObjectHelper<C>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericCastObjectAsEnum(bool useInterpreter)
+        {
+            CheckGenericCastObjectHelper<E>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericCastObjectAsObject(bool useInterpreter)
+        {
+            CheckGenericCastObjectHelper<object>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericCastObjectAsStruct(bool useInterpreter)
+        {
+            CheckGenericCastObjectHelper<S>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericCastObjectAsStructWithStringAndField(bool useInterpreter)
+        {
+            CheckGenericCastObjectHelper<Scs>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithClassRestrictionCastObjectAsCustom(bool useInterpreter)
+        {
+            CheckGenericWithClassRestrictionCastObjectHelper<C>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithClassRestrictionCastObjectAsObject(bool useInterpreter)
+        {
+            CheckGenericWithClassRestrictionCastObjectHelper<object>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastObjectAsEnum(bool useInterpreter)
+        {
+            CheckGenericWithStructRestrictionCastObjectHelper<E>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastObjectAsStruct(bool useInterpreter)
+        {
+            CheckGenericWithStructRestrictionCastObjectHelper<S>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastObjectAsStructWithStringAndField(bool useInterpreter)
+        {
+            CheckGenericWithStructRestrictionCastObjectHelper<Scs>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastValueTypeAsEnum(bool useInterpreter)
+        {
+            CheckGenericWithStructRestrictionCastValueTypeHelper<E>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStruct(bool useInterpreter)
+        {
+            CheckGenericWithStructRestrictionCastValueTypeHelper<S>(useInterpreter);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStructWithStringAndField(bool useInterpreter)
+        {
+            CheckGenericWithStructRestrictionCastValueTypeHelper<Scs>(useInterpreter);
+        }
+
+        [Theory, InlineData(false)]
+        public static void ConvertValueTypeCastGenericWithStructRestrictionAsEnum(bool useInterpreter)
+        {
+            CheckValueTypeCastGenericWithStructRestrictionHelper<E>(useInterpreter);
         }
 
         [Fact]
-        public static void ConvertObjectCastGenericAsStruct()
+        [ActiveIssue(7169)]
+        public static void ConvertValueTypeCastGenericWithStructRestrictionAsEnumInterpreted()
         {
-            CheckObjectCastGenericHelper<S>();
+            ConvertValueTypeCastGenericWithStructRestrictionAsEnum(true);
         }
 
-        [Fact]
-        public static void ConvertObjectCastGenericAsStructWithStringAndField()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertValueTypeCastGenericWithStructRestrictionAsStruct(bool useInterpreter)
         {
-            CheckObjectCastGenericHelper<Scs>();
+            CheckValueTypeCastGenericWithStructRestrictionHelper<S>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertObjectCastGenericWithClassRestrictionAsCustom()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertValueTypeCastGenericWithStructRestrictionAsStructWithStringAndField(bool useInterpreter)
         {
-            CheckObjectCastGenericWithClassRestrictionHelper<C>();
-        }
-
-        [Fact]
-        public static void ConvertObjectCastGenericWithClassRestrictionAsObject()
-        {
-            CheckObjectCastGenericWithClassRestrictionHelper<object>();
-        }
-
-        [Fact]
-        public static void ConvertObjectCastGenericWithStructRestrictionAsEnum()
-        {
-            CheckObjectCastGenericWithStructRestrictionHelper<E>();
-        }
-
-        [Fact]
-        public static void ConvertObjectCastGenericWithStructRestrictionAsStruct()
-        {
-            CheckObjectCastGenericWithStructRestrictionHelper<S>();
-        }
-
-        [Fact]
-        public static void ConvertObjectCastGenericWithStructRestrictionAsStructWithStringAndField()
-        {
-            CheckObjectCastGenericWithStructRestrictionHelper<Scs>();
-        }
-
-        [Fact]
-        public static void ConvertGenericCastObjectAsCustom()
-        {
-            CheckGenericCastObjectHelper<C>();
-        }
-
-        [Fact]
-        public static void ConvertGenericCastObjectAsEnum()
-        {
-            CheckGenericCastObjectHelper<E>();
-        }
-
-        [Fact]
-        public static void ConvertGenericCastObjectAsObject()
-        {
-            CheckGenericCastObjectHelper<object>();
-        }
-
-        [Fact]
-        public static void ConvertGenericCastObjectAsStruct()
-        {
-            CheckGenericCastObjectHelper<S>();
-        }
-
-        [Fact]
-        public static void ConvertGenericCastObjectAsStructWithStringAndField()
-        {
-            CheckGenericCastObjectHelper<Scs>();
-        }
-
-        [Fact]
-        public static void ConvertGenericWithClassRestrictionCastObjectAsCustom()
-        {
-            CheckGenericWithClassRestrictionCastObjectHelper<C>();
-        }
-
-        [Fact]
-        public static void ConvertGenericWithClassRestrictionCastObjectAsObject()
-        {
-            CheckGenericWithClassRestrictionCastObjectHelper<object>();
-        }
-
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastObjectAsEnum()
-        {
-            CheckGenericWithStructRestrictionCastObjectHelper<E>();
-        }
-
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastObjectAsStruct()
-        {
-            CheckGenericWithStructRestrictionCastObjectHelper<S>();
-        }
-
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastObjectAsStructWithStringAndField()
-        {
-            CheckGenericWithStructRestrictionCastObjectHelper<Scs>();
-        }
-
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastValueTypeAsEnum()
-        {
-            CheckGenericWithStructRestrictionCastValueTypeHelper<E>();
-        }
-
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStruct()
-        {
-            CheckGenericWithStructRestrictionCastValueTypeHelper<S>();
-        }
-
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStructWithStringAndField()
-        {
-            CheckGenericWithStructRestrictionCastValueTypeHelper<Scs>();
-        }
-
-        [Fact]
-        public static void ConvertValueTypeCastGenericWithStructRestrictionAsEnum()
-        {
-            CheckValueTypeCastGenericWithStructRestrictionHelper<E>();
-        }
-
-        [Fact]
-        public static void ConvertValueTypeCastGenericWithStructRestrictionAsStruct()
-        {
-            CheckValueTypeCastGenericWithStructRestrictionHelper<S>();
-        }
-
-        [Fact]
-        public static void ConvertValueTypeCastGenericWithStructRestrictionAsStructWithStringAndField()
-        {
-            CheckValueTypeCastGenericWithStructRestrictionHelper<Scs>();
+            CheckValueTypeCastGenericWithStructRestrictionHelper<Scs>(useInterpreter);
         }
 
         #endregion
 
         #region Generic helpers
 
-        private static void CheckObjectCastGenericHelper<T>()
+        private static void CheckObjectCastGenericHelper<T>(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectCastGeneric<T>(array[i]);
+                VerifyObjectCastGeneric<T>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckObjectCastGenericWithClassRestrictionHelper<Tc>() where Tc : class
+        private static void CheckObjectCastGenericWithClassRestrictionHelper<Tc>(bool useInterpreter) where Tc : class
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectCastGenericWithClassRestriction<Tc>(array[i]);
+                VerifyObjectCastGenericWithClassRestriction<Tc>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckObjectCastGenericWithStructRestrictionHelper<Ts>() where Ts : struct
+        private static void CheckObjectCastGenericWithStructRestrictionHelper<Ts>(bool useInterpreter) where Ts : struct
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectCastGenericWithStructRestriction<Ts>(array[i]);
+                VerifyObjectCastGenericWithStructRestriction<Ts>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckGenericCastObjectHelper<T>()
+        private static void CheckGenericCastObjectHelper<T>(bool useInterpreter)
         {
             T[] array = new T[] { default(T) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericCastObject<T>(array[i]);
+                VerifyGenericCastObject<T>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckGenericWithClassRestrictionCastObjectHelper<Tc>() where Tc : class
+        private static void CheckGenericWithClassRestrictionCastObjectHelper<Tc>(bool useInterpreter) where Tc : class
         {
             Tc[] array = new Tc[] { null, default(Tc) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericWithClassRestrictionCastObject<Tc>(array[i]);
+                VerifyGenericWithClassRestrictionCastObject<Tc>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckGenericWithStructRestrictionCastObjectHelper<Ts>() where Ts : struct
+        private static void CheckGenericWithStructRestrictionCastObjectHelper<Ts>(bool useInterpreter) where Ts : struct
         {
             Ts[] array = new Ts[] { default(Ts), new Ts() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericWithStructRestrictionCastObject<Ts>(array[i]);
+                VerifyGenericWithStructRestrictionCastObject<Ts>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckGenericWithStructRestrictionCastValueTypeHelper<Ts>() where Ts : struct
+        private static void CheckGenericWithStructRestrictionCastValueTypeHelper<Ts>(bool useInterpreter) where Ts : struct
         {
             Ts[] array = new Ts[] { default(Ts), new Ts() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericWithStructRestrictionCastValueType<Ts>(array[i]);
+                VerifyGenericWithStructRestrictionCastValueType<Ts>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckValueTypeCastGenericWithStructRestrictionHelper<Ts>() where Ts : struct
+        private static void CheckValueTypeCastGenericWithStructRestrictionHelper<Ts>(bool useInterpreter) where Ts : struct
         {
             ValueType[] array = new ValueType[] { null, default(S), new Scs(null, new S()), E.A, El.B };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyValueTypeCastGenericWithStructRestriction<Ts>(array[i]);
+                VerifyValueTypeCastGenericWithStructRestriction<Ts>(array[i], useInterpreter);
             }
         }
 
@@ -1068,4053 +1139,1256 @@ namespace System.Linq.Expressions.Tests
 
         #region Test verifiers
 
-        private static void VerifyCustomCastCustom2(C value)
+        private static bool CanBeNull(Type type)
+        {
+            return !type.GetTypeInfo().IsValueType || (type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
+        }
+
+        private static void VerifyCustomCastCustom2(C value, bool useInterpreter)
         {
             Expression<Func<D>> e =
                 Expression.Lambda<Func<D>>(
                     Expression.Convert(Expression.Constant(value, typeof(C)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            D etResult = default(D);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            D csResult = default(D);
-            Exception csException = null;
-            try
-            {
-                csResult = (D)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is D)
+                Assert.Equal((D)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyCustomCastInterface(C value)
+        private static void VerifyCustomCastInterface(C value, bool useInterpreter)
         {
             Expression<Func<I>> e =
                 Expression.Lambda<Func<I>>(
                     Expression.Convert(Expression.Constant(value, typeof(C)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f = e.Compile();
+            Func<I> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            I etResult = default(I);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            I csResult = default(I);
-            Exception csException = null;
-            try
-            {
-                csResult = (I)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyCustomCastIEquatableOfCustom(C value)
+        private static void VerifyCustomCastIEquatableOfCustom(C value, bool useInterpreter)
         {
             Expression<Func<IEquatable<C>>> e =
                 Expression.Lambda<Func<IEquatable<C>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f = e.Compile();
+            Func<IEquatable<C>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEquatable<C> etResult = default(IEquatable<C>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEquatable<C> csResult = default(IEquatable<C>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IEquatable<C>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyCustomCastIEquatableOfCustom2(C value)
+        private static void VerifyCustomCastIEquatableOfCustom2(C value, bool useInterpreter)
         {
             Expression<Func<IEquatable<D>>> e =
                 Expression.Lambda<Func<IEquatable<D>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f = e.Compile();
+            Func<IEquatable<D>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEquatable<D> etResult = default(IEquatable<D>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEquatable<D> csResult = default(IEquatable<D>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IEquatable<D>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is IEquatable<D>)
+                Assert.Equal((IEquatable<D>)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyCustomCastObject(C value)
+        private static void VerifyCustomCastObject(C value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(C)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyCustomArrayCastCustom2Array(C[] value)
+        private static void VerifyCustomArrayCastCustom2Array(C[] value, bool useInterpreter)
         {
             Expression<Func<D[]>> e =
                 Expression.Lambda<Func<D[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(D[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D[]> f = e.Compile();
+            Func<D[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            D[] etResult = default(D[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            D[] csResult = default(D[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (D[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is D[])
+                Assert.Equal((D[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyCustomArrayCastIEnumerableOfCustom(C[] value)
+        private static void VerifyCustomArrayCastIEnumerableOfCustom(C[] value, bool useInterpreter)
         {
             Expression<Func<IEnumerable<C>>> e =
                 Expression.Lambda<Func<IEnumerable<C>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<C>> f = e.Compile();
+            Func<IEnumerable<C>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEnumerable<C> etResult = default(IEnumerable<C>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEnumerable<C> csResult = default(IEnumerable<C>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IEnumerable<C>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyCustomArrayCastIEnumerableOfCustom2(C[] value)
+        private static void VerifyCustomArrayCastIEnumerableOfCustom2(C[] value, bool useInterpreter)
         {
             Expression<Func<IEnumerable<D>>> e =
                 Expression.Lambda<Func<IEnumerable<D>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<D>> f = e.Compile();
+            Func<IEnumerable<D>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEnumerable<D> etResult = default(IEnumerable<D>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEnumerable<D> csResult = default(IEnumerable<D>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IEnumerable<D>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is IEnumerable<D>)
+                Assert.Equal((IEnumerable<D>)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyCustomArrayCastIEnumerableOfInterface(C[] value)
+        private static void VerifyCustomArrayCastIEnumerableOfInterface(C[] value, bool useInterpreter)
         {
             Expression<Func<IEnumerable<I>>> e =
                 Expression.Lambda<Func<IEnumerable<I>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<I>> f = e.Compile();
+            Func<IEnumerable<I>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEnumerable<I> etResult = default(IEnumerable<I>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEnumerable<I> csResult = default(IEnumerable<I>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IEnumerable<I>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyCustomArrayCastIEnumerableOfObject(C[] value)
+        private static void VerifyCustomArrayCastIEnumerableOfObject(C[] value, bool useInterpreter)
         {
             Expression<Func<IEnumerable<object>>> e =
                 Expression.Lambda<Func<IEnumerable<object>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<object>> f = e.Compile();
+            Func<IEnumerable<object>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEnumerable<object> etResult = default(IEnumerable<object>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEnumerable<object> csResult = default(IEnumerable<object>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IEnumerable<object>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyCustomArrayCastIListOfCustom(C[] value)
+        private static void VerifyCustomArrayCastIListOfCustom(C[] value, bool useInterpreter)
         {
             Expression<Func<IList<C>>> e =
                 Expression.Lambda<Func<IList<C>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(IList<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<C>> f = e.Compile();
+            Func<IList<C>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IList<C> etResult = default(IList<C>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IList<C> csResult = default(IList<C>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IList<C>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyCustomArrayCastIListOfCustom2(C[] value)
+        private static void VerifyCustomArrayCastIListOfCustom2(C[] value, bool useInterpreter)
         {
             Expression<Func<IList<D>>> e =
                 Expression.Lambda<Func<IList<D>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(IList<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<D>> f = e.Compile();
+            Func<IList<D>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IList<D> etResult = default(IList<D>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IList<D> csResult = default(IList<D>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IList<D>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is IList<D>)
+                Assert.Equal((IList<D>)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyCustomArrayCastIListOfInterface(C[] value)
+        private static void VerifyCustomArrayCastIListOfInterface(C[] value, bool useInterpreter)
         {
             Expression<Func<IList<I>>> e =
                 Expression.Lambda<Func<IList<I>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(IList<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<I>> f = e.Compile();
+            Func<IList<I>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IList<I> etResult = default(IList<I>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IList<I> csResult = default(IList<I>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IList<I>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyCustomArrayCastIListOfObject(C[] value)
+        private static void VerifyCustomArrayCastIListOfObject(C[] value, bool useInterpreter)
         {
             Expression<Func<IList<object>>> e =
                 Expression.Lambda<Func<IList<object>>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(IList<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<object>> f = e.Compile();
+            Func<IList<object>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IList<object> etResult = default(IList<object>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IList<object> csResult = default(IList<object>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IList<object>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyCustomArrayCastObjectArray(C[] value)
+        private static void VerifyCustomArrayCastObjectArray(C[] value, bool useInterpreter)
         {
             Expression<Func<object[]>> e =
                 Expression.Lambda<Func<object[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(C[])), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object[] etResult = default(object[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object[] csResult = default(object[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (object[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyCustom2CastCustom(D value)
+        private static void VerifyCustom2CastCustom(D value, bool useInterpreter)
         {
             Expression<Func<C>> e =
                 Expression.Lambda<Func<C>>(
                     Expression.Convert(Expression.Constant(value, typeof(D)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C etResult = default(C);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C csResult = default(C);
-            Exception csException = null;
-            try
-            {
-                csResult = (C)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyCustom2CastInterface(D value)
+        private static void VerifyCustom2CastInterface(D value, bool useInterpreter)
         {
             Expression<Func<I>> e =
                 Expression.Lambda<Func<I>>(
                     Expression.Convert(Expression.Constant(value, typeof(D)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f = e.Compile();
+            Func<I> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            I etResult = default(I);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            I csResult = default(I);
-            Exception csException = null;
-            try
-            {
-                csResult = (I)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyCustom2CastIEquatableOfCustom(D value)
+        private static void VerifyCustom2CastIEquatableOfCustom(D value, bool useInterpreter)
         {
             Expression<Func<IEquatable<C>>> e =
                 Expression.Lambda<Func<IEquatable<C>>>(
                     Expression.Convert(Expression.Constant(value, typeof(D)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f = e.Compile();
+            Func<IEquatable<C>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEquatable<C> etResult = default(IEquatable<C>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEquatable<C> csResult = default(IEquatable<C>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IEquatable<C>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyCustom2CastIEquatableOfCustom2(D value)
+        private static void VerifyCustom2CastIEquatableOfCustom2(D value, bool useInterpreter)
         {
             Expression<Func<IEquatable<D>>> e =
                 Expression.Lambda<Func<IEquatable<D>>>(
                     Expression.Convert(Expression.Constant(value, typeof(D)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f = e.Compile();
+            Func<IEquatable<D>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEquatable<D> etResult = default(IEquatable<D>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEquatable<D> csResult = default(IEquatable<D>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IEquatable<D>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyCustom2CastObject(D value)
+        private static void VerifyCustom2CastObject(D value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(D)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyCustom2ArrayCastCustomArray(D[] value)
+        private static void VerifyCustom2ArrayCastCustomArray(D[] value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(D[])), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (C[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is C[])
+                Assert.Equal((C[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyDelegateCastFuncOfObject(Delegate value)
+        private static void VerifyDelegateCastFuncOfObject(Delegate value, bool useInterpreter)
         {
             Expression<Func<Func<object>>> e =
                 Expression.Lambda<Func<Func<object>>>(
                     Expression.Convert(Expression.Constant(value, typeof(Delegate)), typeof(Func<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Func<object>> f = e.Compile();
+            Func<Func<object>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            Func<object> etResult = default(Func<object>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            Func<object> csResult = default(Func<object>);
-            Exception csException = null;
-            try
-            {
-                csResult = (Func<object>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is Func<object>)
+                Assert.Equal((Func<object>)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyDelegateCastObject(Delegate value)
+        private static void VerifyDelegateCastObject(Delegate value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(Delegate)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyEnumCastEnumType(E value)
+        private static void VerifyEnumCastEnumType(E value, bool useInterpreter)
         {
             Expression<Func<Enum>> e =
                 Expression.Lambda<Func<Enum>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Enum> f = e.Compile();
+            Func<Enum> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            Enum etResult = default(Enum);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            Enum csResult = default(Enum);
-            Exception csException = null;
-            try
-            {
-                csResult = (Enum)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyEnumCastObject(E value)
+        private static void VerifyEnumCastObject(E value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(E)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyEnumTypeCastEnum(Enum value)
+        private static void VerifyEnumTypeCastEnum(Enum value, bool useInterpreter)
         {
             Expression<Func<E>> e =
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(Enum)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            E etResult = default(E);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            E csResult = default(E);
-            Exception csException = null;
-            try
-            {
-                csResult = (E)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null)
+                Assert.Throws<NullReferenceException>(() => f());
             else
             {
-                Assert.Equal(csResult, etResult);
+                E expected = default(E);
+                try
+                {
+                    expected = (E)value;
+                }
+                catch(InvalidCastException)
+                {
+                    Assert.Throws<InvalidCastException>(() => f());
+                    return;
+                }
+
+                Assert.Equal(expected, f());
             }
         }
 
-        private static void VerifyEnumTypeCastObject(Enum value)
+        private static void VerifyEnumTypeCastObject(Enum value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(Enum)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyFuncOfObjectCastDelegate(Func<object> value)
+        private static void VerifyFuncOfObjectCastDelegate(Func<object> value, bool useInterpreter)
         {
             Expression<Func<Delegate>> e =
                 Expression.Lambda<Func<Delegate>>(
                     Expression.Convert(Expression.Constant(value, typeof(Func<object>)), typeof(Delegate)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate> f = e.Compile();
+            Func<Delegate> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            Delegate etResult = default(Delegate);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            Delegate csResult = default(Delegate);
-            Exception csException = null;
-            try
-            {
-                csResult = (Delegate)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyInterfaceCastCustom(I value)
+        private static void VerifyInterfaceCastCustom(I value, bool useInterpreter)
         {
             Expression<Func<C>> e =
                 Expression.Lambda<Func<C>>(
                     Expression.Convert(Expression.Constant(value, typeof(I)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C etResult = default(C);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C csResult = default(C);
-            Exception csException = null;
-            try
-            {
-                csResult = (C)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is C)
+                Assert.Equal((C)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyInterfaceCastCustom2(I value)
+        private static void VerifyInterfaceCastCustom2(I value, bool useInterpreter)
         {
             Expression<Func<D>> e =
                 Expression.Lambda<Func<D>>(
                     Expression.Convert(Expression.Constant(value, typeof(I)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            D etResult = default(D);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            D csResult = default(D);
-            Exception csException = null;
-            try
-            {
-                csResult = (D)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is D)
+                Assert.Equal((D)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyInterfaceCastObject(I value)
+        private static void VerifyInterfaceCastObject(I value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(I)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyIEnumerableOfCustomCastCustomArray(IEnumerable<C> value)
+        private static void VerifyIEnumerableOfCustomCastCustomArray(IEnumerable<C> value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (C[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is C[])
+                Assert.Equal((C[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIEnumerableOfCustomCastObjectArray(IEnumerable<C> value)
+        private static void VerifyIEnumerableOfCustomCastObjectArray(IEnumerable<C> value, bool useInterpreter)
         {
             Expression<Func<object[]>> e =
                 Expression.Lambda<Func<object[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object[] etResult = default(object[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object[] csResult = default(object[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (object[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is object[])
+                Assert.Equal((object[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIEnumerableOfCustom2CastCustomArray(IEnumerable<D> value)
+        private static void VerifyIEnumerableOfCustom2CastCustomArray(IEnumerable<D> value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEnumerable<D>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (C[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is C[])
+                Assert.Equal((C[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIEnumerableOfInterfaceCastCustomArray(IEnumerable<I> value)
+        private static void VerifyIEnumerableOfInterfaceCastCustomArray(IEnumerable<I> value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEnumerable<I>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (C[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is C[])
+                Assert.Equal((C[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIEnumerableOfInterfaceCastObjectArray(IEnumerable<I> value)
+        private static void VerifyIEnumerableOfInterfaceCastObjectArray(IEnumerable<I> value, bool useInterpreter)
         {
             Expression<Func<object[]>> e =
                 Expression.Lambda<Func<object[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEnumerable<I>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object[] etResult = default(object[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object[] csResult = default(object[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (object[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is object[])
+                Assert.Equal((object[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIEnumerableOfObjectCastCustomArray(IEnumerable<object> value)
+        private static void VerifyIEnumerableOfObjectCastCustomArray(IEnumerable<object> value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEnumerable<object>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (C[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is C[])
+                Assert.Equal((C[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIEnumerableOfObjectCastObjectArray(IEnumerable<object> value)
+        private static void VerifyIEnumerableOfObjectCastObjectArray(IEnumerable<object> value, bool useInterpreter)
         {
             Expression<Func<object[]>> e =
                 Expression.Lambda<Func<object[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEnumerable<object>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object[] etResult = default(object[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object[] csResult = default(object[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (object[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is object[])
+                Assert.Equal((object[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIEnumerableOfStructCastStructArray(IEnumerable<S> value)
+        private static void VerifyIEnumerableOfStructCastStructArray(IEnumerable<S> value, bool useInterpreter)
         {
             Expression<Func<S[]>> e =
                 Expression.Lambda<Func<S[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEnumerable<S>)), typeof(S[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            S[] etResult = default(S[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            S[] csResult = default(S[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (S[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is S[])
+                Assert.Equal((S[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIEquatableOfCustomCastCustom(IEquatable<C> value)
+        private static void VerifyIEquatableOfCustomCastCustom(IEquatable<C> value, bool useInterpreter)
         {
             Expression<Func<C>> e =
                 Expression.Lambda<Func<C>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEquatable<C>)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C etResult = default(C);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C csResult = default(C);
-            Exception csException = null;
-            try
-            {
-                csResult = (C)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is C)
+                Assert.Equal((C)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIEquatableOfCustomCastCustom2(IEquatable<C> value)
+        private static void VerifyIEquatableOfCustomCastCustom2(IEquatable<C> value, bool useInterpreter)
         {
             Expression<Func<D>> e =
                 Expression.Lambda<Func<D>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEquatable<C>)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            D etResult = default(D);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            D csResult = default(D);
-            Exception csException = null;
-            try
-            {
-                csResult = (D)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is D)
+                Assert.Equal((D)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIEquatableOfCustomCastObject(IEquatable<C> value)
+        private static void VerifyIEquatableOfCustomCastObject(IEquatable<C> value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEquatable<C>)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyIEquatableOfCustom2CastCustom(IEquatable<D> value)
+        private static void VerifyIEquatableOfCustom2CastCustom(IEquatable<D> value, bool useInterpreter)
         {
             Expression<Func<C>> e =
                 Expression.Lambda<Func<C>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEquatable<D>)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C etResult = default(C);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C csResult = default(C);
-            Exception csException = null;
-            try
-            {
-                csResult = (C)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is C)
+                Assert.Equal((C)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIEquatableOfCustom2CastCustom2(IEquatable<D> value)
+        private static void VerifyIEquatableOfCustom2CastCustom2(IEquatable<D> value, bool useInterpreter)
         {
             Expression<Func<D>> e =
                 Expression.Lambda<Func<D>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEquatable<D>)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            D etResult = default(D);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            D csResult = default(D);
-            Exception csException = null;
-            try
-            {
-                csResult = (D)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is D)
+                Assert.Equal((D)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIEquatableOfCustom2CastObject(IEquatable<D> value)
+        private static void VerifyIEquatableOfCustom2CastObject(IEquatable<D> value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEquatable<D>)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyIEquatableOfStructCastStruct(IEquatable<S> value)
+        private static void VerifyIEquatableOfStructCastStruct(IEquatable<S> value, bool useInterpreter)
         {
             Expression<Func<S>> e =
                 Expression.Lambda<Func<S>>(
                     Expression.Convert(Expression.Constant(value, typeof(IEquatable<S>)), typeof(S)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S> f = e.Compile();
+            Func<S> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            S etResult = default(S);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            S csResult = default(S);
-            Exception csException = null;
-            try
-            {
-                csResult = (S)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null)
+                Assert.Throws<NullReferenceException>(() => f());
+            else if (value is S)
+                Assert.Equal((S)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIListOfCustomCastCustomArray(IList<C> value)
+        private static void VerifyIListOfCustomCastCustomArray(IList<C> value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IList<C>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (C[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is C[])
+                Assert.Equal((C[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIListOfCustomCastObjectArray(IList<C> value)
+        private static void VerifyIListOfCustomCastObjectArray(IList<C> value, bool useInterpreter)
         {
             Expression<Func<object[]>> e =
                 Expression.Lambda<Func<object[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IList<C>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object[] etResult = default(object[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object[] csResult = default(object[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (object[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is object[])
+                Assert.Equal((object[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIListOfCustom2CastCustomArray(IList<D> value)
+        private static void VerifyIListOfCustom2CastCustomArray(IList<D> value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IList<D>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (C[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is C[])
+                Assert.Equal((C[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIListOfInterfaceCastCustomArray(IList<I> value)
+        private static void VerifyIListOfInterfaceCastCustomArray(IList<I> value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IList<I>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (C[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is C[])
+                Assert.Equal((C[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIListOfInterfaceCastObjectArray(IList<I> value)
+        private static void VerifyIListOfInterfaceCastObjectArray(IList<I> value, bool useInterpreter)
         {
             Expression<Func<object[]>> e =
                 Expression.Lambda<Func<object[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IList<I>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object[] etResult = default(object[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object[] csResult = default(object[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (object[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is object[])
+                Assert.Equal((object[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIListOfObjectCastCustomArray(IList<object> value)
+        private static void VerifyIListOfObjectCastCustomArray(IList<object> value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IList<object>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (C[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is C[])
+                Assert.Equal((C[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIListOfObjectCastObjectArray(IList<object> value)
+        private static void VerifyIListOfObjectCastObjectArray(IList<object> value, bool useInterpreter)
         {
             Expression<Func<object[]>> e =
                 Expression.Lambda<Func<object[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IList<object>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object[]> f = e.Compile();
+            Func<object[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object[] etResult = default(object[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object[] csResult = default(object[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (object[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is Array)
+                Assert.Equal(value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIListOfStructCastStructArray(IList<S> value)
+        private static void VerifyIListOfStructCastStructArray(IList<S> value, bool useInterpreter)
         {
             Expression<Func<S[]>> e =
                 Expression.Lambda<Func<S[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(IList<S>)), typeof(S[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S[]> f = e.Compile();
+            Func<S[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            S[] etResult = default(S[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            S[] csResult = default(S[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (S[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is Array)
+                Assert.Equal((S[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyIntCastObject(int value)
+        private static void VerifyIntCastObject(int value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyIntCastValueType(int value)
+        private static void VerifyIntCastValueType(int value, bool useInterpreter)
         {
             Expression<Func<ValueType>> e =
                 Expression.Lambda<Func<ValueType>>(
                     Expression.Convert(Expression.Constant(value, typeof(int)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            ValueType etResult = default(ValueType);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            ValueType csResult = default(ValueType);
-            Exception csException = null;
-            try
-            {
-                csResult = (ValueType)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyObjectCastCustom(object value)
+        private static void VerifyObjectCastCustom(object value, bool useInterpreter)
         {
             Expression<Func<C>> e =
                 Expression.Lambda<Func<C>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C> f = e.Compile();
+            Func<C> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C etResult = default(C);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C csResult = default(C);
-            Exception csException = null;
-            try
-            {
-                csResult = (C)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is C)
+                Assert.Equal((C)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectCastCustom2(object value)
+        private static void VerifyObjectCastCustom2(object value, bool useInterpreter)
         {
             Expression<Func<D>> e =
                 Expression.Lambda<Func<D>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<D> f = e.Compile();
+            Func<D> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            D etResult = default(D);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            D csResult = default(D);
-            Exception csException = null;
-            try
-            {
-                csResult = (D)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is D)
+                Assert.Equal((D)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectCastDelegate(object value)
+        private static void VerifyObjectCastDelegate(object value, bool useInterpreter)
         {
             Expression<Func<Delegate>> e =
                 Expression.Lambda<Func<Delegate>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(Delegate)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Delegate> f = e.Compile();
+            Func<Delegate> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            Delegate etResult = default(Delegate);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            Delegate csResult = default(Delegate);
-            Exception csException = null;
-            try
-            {
-                csResult = (Delegate)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is Delegate)
+                Assert.Equal((Delegate)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectCastEnum(object value)
+        private static void VerifyObjectCastEnum(object value, bool useInterpreter)
         {
             Expression<Func<E>> e =
                 Expression.Lambda<Func<E>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<E> f = e.Compile();
+            Func<E> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            E etResult = default(E);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            E csResult = default(E);
-            Exception csException = null;
-            try
-            {
-                csResult = (E)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null)
+                Assert.Throws<NullReferenceException>(() => f());
             else
             {
-                Assert.Equal(csResult, etResult);
+                E expected = default(E);
+                try
+                {
+                    expected = (E)value;
+                }
+                catch (InvalidCastException)
+                {
+                    Assert.Throws<InvalidCastException>(() => f());
+                    return;
+                }
+
+                Assert.Equal(expected, f());
             }
         }
 
-        private static void VerifyObjectCastEnumType(object value)
+        private static void VerifyObjectCastEnumType(object value, bool useInterpreter)
         {
             Expression<Func<Enum>> e =
                 Expression.Lambda<Func<Enum>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Enum> f = e.Compile();
+            Func<Enum> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            Enum etResult = default(Enum);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            Enum csResult = default(Enum);
-            Exception csException = null;
-            try
-            {
-                csResult = (Enum)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is Enum)
+                Assert.Equal((Enum)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectCastInterface(object value)
+        private static void VerifyObjectCastInterface(object value, bool useInterpreter)
         {
             Expression<Func<I>> e =
                 Expression.Lambda<Func<I>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<I> f = e.Compile();
+            Func<I> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            I etResult = default(I);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            I csResult = default(I);
-            Exception csException = null;
-            try
-            {
-                csResult = (I)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is I)
+                Assert.Equal((I)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectCastIEquatableOfCustom(object value)
+        private static void VerifyObjectCastIEquatableOfCustom(object value, bool useInterpreter)
         {
             Expression<Func<IEquatable<C>>> e =
                 Expression.Lambda<Func<IEquatable<C>>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<C>> f = e.Compile();
+            Func<IEquatable<C>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEquatable<C> etResult = default(IEquatable<C>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEquatable<C> csResult = default(IEquatable<C>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IEquatable<C>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is IEquatable<C>)
+                Assert.Equal((IEquatable<C>)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectCastIEquatableOfCustom2(object value)
+        private static void VerifyObjectCastIEquatableOfCustom2(object value, bool useInterpreter)
         {
             Expression<Func<IEquatable<D>>> e =
                 Expression.Lambda<Func<IEquatable<D>>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<D>> f = e.Compile();
+            Func<IEquatable<D>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEquatable<D> etResult = default(IEquatable<D>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEquatable<D> csResult = default(IEquatable<D>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IEquatable<D>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is IEquatable<D>)
+                Assert.Equal((IEquatable<D>)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectCastInt(object value)
+        private static void VerifyObjectCastInt(object value, bool useInterpreter)
         {
             Expression<Func<int>> e =
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            int etResult = default(int);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            int csResult = default(int);
-            Exception csException = null;
-            try
-            {
-                csResult = (int)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null)
+                Assert.Throws<NullReferenceException>(() => f());
+            else if (value is int)
+                Assert.Equal((int)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectCastStruct(object value)
+        private static void VerifyObjectCastStruct(object value, bool useInterpreter)
         {
             Expression<Func<S>> e =
                 Expression.Lambda<Func<S>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(S)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S> f = e.Compile();
+            Func<S> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            S etResult = default(S);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            S csResult = default(S);
-            Exception csException = null;
-            try
-            {
-                csResult = (S)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null)
+                Assert.Throws<NullReferenceException>(() => f());
+            else if (value is S)
+                Assert.Equal((S)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectCastValueType(object value)
+        private static void VerifyObjectCastValueType(object value, bool useInterpreter)
         {
             Expression<Func<ValueType>> e =
                 Expression.Lambda<Func<ValueType>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            ValueType etResult = default(ValueType);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            ValueType csResult = default(ValueType);
-            Exception csException = null;
-            try
-            {
-                csResult = (ValueType)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is ValueType)
+                Assert.Equal((ValueType)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectArrayCastCustomArray(object[] value)
+        private static void VerifyObjectArrayCastCustomArray(object[] value, bool useInterpreter)
         {
             Expression<Func<C[]>> e =
                 Expression.Lambda<Func<C[]>>(
                     Expression.Convert(Expression.Constant(value, typeof(object[])), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<C[]> f = e.Compile();
+            Func<C[]> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            C[] etResult = default(C[]);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            C[] csResult = default(C[]);
-            Exception csException = null;
-            try
-            {
-                csResult = (C[])value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is C[])
+                Assert.Equal((C[])value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectArrayCastIEnumerableOfCustom(object[] value)
+        private static void VerifyObjectArrayCastIEnumerableOfCustom(object[] value, bool useInterpreter)
         {
             Expression<Func<IEnumerable<C>>> e =
                 Expression.Lambda<Func<IEnumerable<C>>>(
                     Expression.Convert(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<C>> f = e.Compile();
+            Func<IEnumerable<C>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEnumerable<C> etResult = default(IEnumerable<C>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEnumerable<C> csResult = default(IEnumerable<C>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IEnumerable<C>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is IEnumerable<C>)
+                Assert.Equal((IEnumerable<C>)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectArrayCastIEnumerableOfInterface(object[] value)
+        private static void VerifyObjectArrayCastIEnumerableOfInterface(object[] value, bool useInterpreter)
         {
             Expression<Func<IEnumerable<I>>> e =
                 Expression.Lambda<Func<IEnumerable<I>>>(
                     Expression.Convert(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<I>> f = e.Compile();
+            Func<IEnumerable<I>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEnumerable<I> etResult = default(IEnumerable<I>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEnumerable<I> csResult = default(IEnumerable<I>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IEnumerable<I>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is IEnumerable<I>)
+                Assert.Equal((IEnumerable<I>)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectArrayCastIEnumerableOfObject(object[] value)
+        private static void VerifyObjectArrayCastIEnumerableOfObject(object[] value, bool useInterpreter)
         {
             Expression<Func<IEnumerable<object>>> e =
                 Expression.Lambda<Func<IEnumerable<object>>>(
                     Expression.Convert(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<object>> f = e.Compile();
+            Func<IEnumerable<object>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEnumerable<object> etResult = default(IEnumerable<object>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEnumerable<object> csResult = default(IEnumerable<object>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IEnumerable<object>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyObjectArrayCastIListOfCustom(object[] value)
+        private static void VerifyObjectArrayCastIListOfCustom(object[] value, bool useInterpreter)
         {
             Expression<Func<IList<C>>> e =
                 Expression.Lambda<Func<IList<C>>>(
                     Expression.Convert(Expression.Constant(value, typeof(object[])), typeof(IList<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<C>> f = e.Compile();
+            Func<IList<C>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IList<C> etResult = default(IList<C>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IList<C> csResult = default(IList<C>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IList<C>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is IList<C>)
+                Assert.Equal((IList<C>)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectArrayCastIListOfInterface(object[] value)
+        private static void VerifyObjectArrayCastIListOfInterface(object[] value, bool useInterpreter)
         {
             Expression<Func<IList<I>>> e =
                 Expression.Lambda<Func<IList<I>>>(
                     Expression.Convert(Expression.Constant(value, typeof(object[])), typeof(IList<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<I>> f = e.Compile();
+            Func<IList<I>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IList<I> etResult = default(IList<I>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IList<I> csResult = default(IList<I>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IList<I>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is IList<I>)
+                Assert.Equal((IList<I>)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectArrayCastIListOfObject(object[] value)
+        private static void VerifyObjectArrayCastIListOfObject(object[] value, bool useInterpreter)
         {
             Expression<Func<IList<object>>> e =
                 Expression.Lambda<Func<IList<object>>>(
                     Expression.Convert(Expression.Constant(value, typeof(object[])), typeof(IList<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<object>> f = e.Compile();
+            Func<IList<object>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IList<object> etResult = default(IList<object>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IList<object> csResult = default(IList<object>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IList<object>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyStructCastIEquatableOfStruct(S value)
+        private static void VerifyStructCastIEquatableOfStruct(S value, bool useInterpreter)
         {
             Expression<Func<IEquatable<S>>> e =
                 Expression.Lambda<Func<IEquatable<S>>>(
                     Expression.Convert(Expression.Constant(value, typeof(S)), typeof(IEquatable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEquatable<S>> f = e.Compile();
+            Func<IEquatable<S>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEquatable<S> etResult = default(IEquatable<S>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEquatable<S> csResult = default(IEquatable<S>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IEquatable<S>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyStructCastObject(S value)
+        private static void VerifyStructCastObject(S value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(S)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyStructCastValueType(S value)
+        private static void VerifyStructCastValueType(S value, bool useInterpreter)
         {
             Expression<Func<ValueType>> e =
                 Expression.Lambda<Func<ValueType>>(
                     Expression.Convert(Expression.Constant(value, typeof(S)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            ValueType etResult = default(ValueType);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            ValueType csResult = default(ValueType);
-            Exception csException = null;
-            try
-            {
-                csResult = (ValueType)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyStructArrayCastIEnumerableOfStruct(S[] value)
+        private static void VerifyStructArrayCastIEnumerableOfStruct(S[] value, bool useInterpreter)
         {
             Expression<Func<IEnumerable<S>>> e =
                 Expression.Lambda<Func<IEnumerable<S>>>(
                     Expression.Convert(Expression.Constant(value, typeof(S[])), typeof(IEnumerable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IEnumerable<S>> f = e.Compile();
+            Func<IEnumerable<S>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IEnumerable<S> etResult = default(IEnumerable<S>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IEnumerable<S> csResult = default(IEnumerable<S>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IEnumerable<S>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyStructArrayCastIListOfStruct(S[] value)
+        private static void VerifyStructArrayCastIListOfStruct(S[] value, bool useInterpreter)
         {
             Expression<Func<IList<S>>> e =
                 Expression.Lambda<Func<IList<S>>>(
                     Expression.Convert(Expression.Constant(value, typeof(S[])), typeof(IList<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<IList<S>> f = e.Compile();
+            Func<IList<S>> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            IList<S> etResult = default(IList<S>);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            IList<S> csResult = default(IList<S>);
-            Exception csException = null;
-            try
-            {
-                csResult = (IList<S>)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyValueTypeCastInt(ValueType value)
+        private static void VerifyValueTypeCastInt(ValueType value, bool useInterpreter)
         {
             Expression<Func<int>> e =
                 Expression.Lambda<Func<int>>(
                     Expression.Convert(Expression.Constant(value, typeof(ValueType)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<int> f = e.Compile();
+            Func<int> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            int etResult = default(int);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            int csResult = default(int);
-            Exception csException = null;
-            try
-            {
-                csResult = (int)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null)
+                Assert.Throws<NullReferenceException>(() => f());
             else
             {
-                Assert.Equal(csResult, etResult);
+                int expected;
+                try
+                {
+                    expected = (int)value;
+                }
+                catch(InvalidCastException)
+                {
+                    Assert.Throws<InvalidCastException>(() => f());
+                    return;
+                }
+                Assert.Equal(expected, f());
             }
         }
 
-        private static void VerifyValueTypeCastObject(ValueType value)
+        private static void VerifyValueTypeCastObject(ValueType value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(ValueType)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyValueTypeCastStruct(ValueType value)
+        private static void VerifyValueTypeCastStruct(ValueType value, bool useInterpreter)
         {
             Expression<Func<S>> e =
                 Expression.Lambda<Func<S>>(
                     Expression.Convert(Expression.Constant(value, typeof(ValueType)), typeof(S)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<S> f = e.Compile();
+            Func<S> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            S etResult = default(S);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            S csResult = default(S);
-            Exception csException = null;
-            try
-            {
-                csResult = (S)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null)
+                Assert.Throws<NullReferenceException>(() => f());
+            else if (value is S)
+                Assert.Equal((S)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectCastGeneric<T>(object value)
+        private static void VerifyObjectCastGeneric<T>(object value, bool useInterpreter)
         {
             Expression<Func<T>> e =
                 Expression.Lambda<Func<T>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(T)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<T> f = e.Compile();
+            Func<T> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            T etResult = default(T);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            T csResult = default(T);
-            Exception csException = null;
-            try
-            {
-                csResult = (T)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null && !(CanBeNull(typeof(T))))
+                Assert.Throws<NullReferenceException>(() => f());
+            else if (value == null || value is T)
+                Assert.Equal((T)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectCastGenericWithClassRestriction<Tc>(object value) where Tc : class
+        private static void VerifyLongEnumCastEnum(El value, bool useInterpreter)
+        {
+            Expression<Func<E>> e = Expression.Lambda<Func<E>>(
+                Expression.Convert(Expression.Constant(value, typeof(El)), typeof(E)));
+            Func<E> f = e.Compile(useInterpreter);
+
+            Assert.Equal((E)value, f());
+        }
+
+        private static void VerifyEnumCastLongEnum(E value, bool useInterpreter)
+        {
+            Expression<Func<El>> e = Expression.Lambda<Func<El>>(
+                Expression.Convert(Expression.Constant(value, typeof(E)), typeof(El)));
+            Func<El> f = e.Compile(useInterpreter);
+
+            Assert.Equal((El)value, f());
+        }
+
+        private static void VerifyUnsignedEnumCastEnum(Eu value, bool useInterpreter)
+        {
+            Expression<Func<E>> e = Expression.Lambda<Func<E>>(
+                Expression.Convert(Expression.Constant(value, typeof(Eu)), typeof(E)));
+            Func<E> f = e.Compile(useInterpreter);
+
+            Assert.Equal((E)value, f());
+        }
+
+        private static void VerifyUnsignedEnumInObjectCastEnum(Eu value, bool useInterpreter)
+        {
+            Expression<Func<E>> e = Expression.Lambda<Func<E>>(
+                Expression.Convert(Expression.Constant(value, typeof(object)), typeof(E)));
+            Func<E> f = e.Compile(useInterpreter);
+
+            Assert.Throws<InvalidCastException>(() => f());
+        }
+
+        private static void VerifyObjectCastGenericWithClassRestriction<Tc>(object value, bool useInterpreter) where Tc : class
         {
             Expression<Func<Tc>> e =
                 Expression.Lambda<Func<Tc>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(Tc)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Tc> f = e.Compile();
+            Func<Tc> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            Tc etResult = default(Tc);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            Tc csResult = default(Tc);
-            Exception csException = null;
-            try
-            {
-                csResult = (Tc)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null || value is Tc)
+                Assert.Equal((Tc)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyObjectCastGenericWithStructRestriction<Ts>(object value) where Ts : struct
+        private static void VerifyObjectCastGenericWithStructRestriction<Ts>(object value, bool useInterpreter) where Ts : struct
         {
             Expression<Func<Ts>> e =
                 Expression.Lambda<Func<Ts>>(
                     Expression.Convert(Expression.Constant(value, typeof(object)), typeof(Ts)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts> f = e.Compile();
+            Func<Ts> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            Ts etResult = default(Ts);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            Ts csResult = default(Ts);
-            Exception csException = null;
-            try
-            {
-                csResult = (Ts)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null)
+                Assert.Throws<NullReferenceException>(() => f());
+            else if (value is Ts)
+                Assert.Equal((Ts)value, f());
             else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+                Assert.Throws<InvalidCastException>(() => f());
         }
 
-        private static void VerifyGenericCastObject<T>(T value)
+        private static void VerifyGenericCastObject<T>(T value, bool useInterpreter)
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(T)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyGenericWithClassRestrictionCastObject<Tc>(Tc value) where Tc : class
+        private static void VerifyGenericWithClassRestrictionCastObject<Tc>(Tc value, bool useInterpreter) where Tc : class
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(Tc)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyGenericWithStructRestrictionCastObject<Ts>(Ts value) where Ts : struct
+        private static void VerifyGenericWithStructRestrictionCastObject<Ts>(Ts value, bool useInterpreter) where Ts : struct
         {
             Expression<Func<object>> e =
                 Expression.Lambda<Func<object>>(
                     Expression.Convert(Expression.Constant(value, typeof(Ts)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<object> f = e.Compile();
+            Func<object> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            object etResult = default(object);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            object csResult = default(object);
-            Exception csException = null;
-            try
-            {
-                csResult = (object)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyGenericWithStructRestrictionCastValueType<Ts>(Ts value) where Ts : struct
+        private static void VerifyGenericWithStructRestrictionCastValueType<Ts>(Ts value, bool useInterpreter) where Ts : struct
         {
             Expression<Func<ValueType>> e =
                 Expression.Lambda<Func<ValueType>>(
                     Expression.Convert(Expression.Constant(value, typeof(Ts)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<ValueType> f = e.Compile();
+            Func<ValueType> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            ValueType etResult = default(ValueType);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            ValueType csResult = default(ValueType);
-            Exception csException = null;
-            try
-            {
-                csResult = (ValueType)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value, f());
         }
 
-        private static void VerifyValueTypeCastGenericWithStructRestriction<Ts>(ValueType value) where Ts : struct
+        private static void VerifyValueTypeCastGenericWithStructRestriction<Ts>(ValueType value, bool useInterpreter) where Ts : struct
         {
             Expression<Func<Ts>> e =
                 Expression.Lambda<Func<Ts>>(
                     Expression.Convert(Expression.Constant(value, typeof(ValueType)), typeof(Ts)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<Ts> f = e.Compile();
+            Func<Ts> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            Ts etResult = default(Ts);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            Ts csResult = default(Ts);
-            Exception csException = null;
-            try
-            {
-                csResult = (Ts)value;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
+            if (value == null)
+                Assert.Throws<NullReferenceException>(() => f());
             else
             {
-                Assert.Equal(csResult, etResult);
+                Ts expected = default(Ts);
+                try
+                {
+                    expected = f();
+                }
+                catch(InvalidCastException)
+                {
+                    Assert.Throws<InvalidCastException>(() => f());
+                    return;
+                }
+
+                Assert.Equal(expected, f());
             }
         }
 

--- a/src/System.Linq.Expressions/tests/Cast/IsNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/IsNullableTests.cs
@@ -12,131 +12,131 @@ namespace System.Linq.Expressions.Tests
     {
         #region Test methods
 
-        [Fact]
-        public static void CheckNullableEnumIsEnumTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableEnumIsEnumTypeTest(bool useInterpreter)
         {
             E?[] array = new E?[] { null, (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableEnumIsEnumType(array[i]);
+                VerifyNullableEnumIsEnumType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableEnumIsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableEnumIsObjectTest(bool useInterpreter)
         {
             E?[] array = new E?[] { null, (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableEnumIsObject(array[i]);
+                VerifyNullableEnumIsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableIntIsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableIntIsObjectTest(bool useInterpreter)
         {
             int?[] array = new int?[] { null, 0, 1, -1, int.MinValue, int.MaxValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableIntIsObject(array[i]);
+                VerifyNullableIntIsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableIntIsValueTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableIntIsValueTypeTest(bool useInterpreter)
         {
             int?[] array = new int?[] { null, 0, 1, -1, int.MinValue, int.MaxValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableIntIsValueType(array[i]);
+                VerifyNullableIntIsValueType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableStructIsIEquatableOfStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableStructIsIEquatableOfStructTest(bool useInterpreter)
         {
             S?[] array = new S?[] { null, default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableStructIsIEquatableOfStruct(array[i]);
+                VerifyNullableStructIsIEquatableOfStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableStructIsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableStructIsObjectTest(bool useInterpreter)
         {
             S?[] array = new S?[] { null, default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableStructIsObject(array[i]);
+                VerifyNullableStructIsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckNullableStructIsValueTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableStructIsValueTypeTest(bool useInterpreter)
         {
             S?[] array = new S?[] { null, default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyNullableStructIsValueType(array[i]);
+                VerifyNullableStructIsValueType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastObjectAsEnum()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastObjectAsEnum(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionIsObjectHelper<E>();
+            CheckGenericWithStructRestrictionIsObjectHelper<E>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastObjectAsStruct()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastObjectAsStruct(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionIsObjectHelper<S>();
+            CheckGenericWithStructRestrictionIsObjectHelper<S>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastObjectAsStructWithStringAndField()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastObjectAsStructWithStringAndField(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionIsObjectHelper<Scs>();
+            CheckGenericWithStructRestrictionIsObjectHelper<Scs>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastValueTypeAsEnum()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastValueTypeAsEnum(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionIsValueTypeHelper<E>();
+            CheckGenericWithStructRestrictionIsValueTypeHelper<E>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStruct()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStruct(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionIsValueTypeHelper<S>();
+            CheckGenericWithStructRestrictionIsValueTypeHelper<S>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStructWithStringAndField()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStructWithStringAndField(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionIsValueTypeHelper<Scs>();
+            CheckGenericWithStructRestrictionIsValueTypeHelper<Scs>(useInterpreter);
         }
 
         #endregion
 
         #region Generic helpers
 
-        private static void CheckGenericWithStructRestrictionIsObjectHelper<Ts>() where Ts : struct
+        private static void CheckGenericWithStructRestrictionIsObjectHelper<Ts>(bool useInterpreter) where Ts : struct
         {
             Ts[] array = new Ts[] { default(Ts), new Ts() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericWithStructRestrictionIsObject<Ts>(array[i]);
+                VerifyGenericWithStructRestrictionIsObject<Ts>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckGenericWithStructRestrictionIsValueTypeHelper<Ts>() where Ts : struct
+        private static void CheckGenericWithStructRestrictionIsValueTypeHelper<Ts>(bool useInterpreter) where Ts : struct
         {
             Ts[] array = new Ts[] { default(Ts), new Ts() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericWithStructRestrictionIsValueType<Ts>(array[i]);
+                VerifyGenericWithStructRestrictionIsValueType<Ts>(array[i], useInterpreter);
             }
         }
 
@@ -144,338 +144,100 @@ namespace System.Linq.Expressions.Tests
 
         #region Test verifiers
 
-        private static void VerifyNullableEnumIsEnumType(E? value)
+        private static void VerifyNullableEnumIsEnumType(E? value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(E?)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is Enum;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value.HasValue, f());
         }
 
-        private static void VerifyNullableEnumIsObject(E? value)
+        private static void VerifyNullableEnumIsObject(E? value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(E?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value.HasValue, f());
         }
 
-        private static void VerifyNullableIntIsObject(int? value)
+        private static void VerifyNullableIntIsObject(int? value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(int?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value.HasValue, f());
         }
 
-        private static void VerifyNullableIntIsValueType(int? value)
+        private static void VerifyNullableIntIsValueType(int? value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(int?)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is ValueType;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value.HasValue, f());
         }
 
-        private static void VerifyNullableStructIsIEquatableOfStruct(S? value)
+        private static void VerifyNullableStructIsIEquatableOfStruct(S? value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(S?)), typeof(IEquatable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IEquatable<S>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value.HasValue, f());
         }
 
-        private static void VerifyNullableStructIsObject(S? value)
+        private static void VerifyNullableStructIsObject(S? value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(S?)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value.HasValue, f());
         }
 
-        private static void VerifyNullableStructIsValueType(S? value)
+        private static void VerifyNullableStructIsValueType(S? value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(S?)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is ValueType;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value.HasValue, f());
         }
 
-        private static void VerifyGenericWithStructRestrictionIsObject<Ts>(Ts value) where Ts : struct
+        private static void VerifyGenericWithStructRestrictionIsObject<Ts>(Ts value, bool useInterpreter) where Ts : struct
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Ts)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
             Assert.True(f());
         }
 
-        private static void VerifyGenericWithStructRestrictionIsValueType<Ts>(Ts value) where Ts : struct
+        private static void VerifyGenericWithStructRestrictionIsValueType<Ts>(Ts value, bool useInterpreter) where Ts : struct
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Ts)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
             Assert.True(f());
         }
 

--- a/src/System.Linq.Expressions/tests/Cast/IsTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/IsTests.cs
@@ -12,1055 +12,1055 @@ namespace System.Linq.Expressions.Tests
     {
         #region Test methods
 
-        [Fact]
-        public static void CheckCustomIsCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomIsCustom2Test(bool useInterpreter)
         {
             C[] array = new C[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomIsCustom2(array[i]);
+                VerifyCustomIsCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomIsInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomIsInterfaceTest(bool useInterpreter)
         {
             C[] array = new C[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomIsInterface(array[i]);
+                VerifyCustomIsInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomIsIEquatableOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomIsIEquatableOfCustomTest(bool useInterpreter)
         {
             C[] array = new C[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomIsIEquatableOfCustom(array[i]);
+                VerifyCustomIsIEquatableOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomIsIEquatableOfCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomIsIEquatableOfCustom2Test(bool useInterpreter)
         {
             C[] array = new C[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomIsIEquatableOfCustom2(array[i]);
+                VerifyCustomIsIEquatableOfCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomIsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomIsObjectTest(bool useInterpreter)
         {
             C[] array = new C[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomIsObject(array[i]);
+                VerifyCustomIsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayIsCustom2ArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayIsCustom2ArrayTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayIsCustom2Array(array[i]);
+                VerifyCustomArrayIsCustom2Array(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayIsIEnumerableOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayIsIEnumerableOfCustomTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayIsIEnumerableOfCustom(array[i]);
+                VerifyCustomArrayIsIEnumerableOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayIsIEnumerableOfCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayIsIEnumerableOfCustom2Test(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayIsIEnumerableOfCustom2(array[i]);
+                VerifyCustomArrayIsIEnumerableOfCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayIsIEnumerableOfInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayIsIEnumerableOfInterfaceTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayIsIEnumerableOfInterface(array[i]);
+                VerifyCustomArrayIsIEnumerableOfInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayIsIEnumerableOfObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayIsIEnumerableOfObjectTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayIsIEnumerableOfObject(array[i]);
+                VerifyCustomArrayIsIEnumerableOfObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayIsIListOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayIsIListOfCustomTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayIsIListOfCustom(array[i]);
+                VerifyCustomArrayIsIListOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayIsIListOfCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayIsIListOfCustom2Test(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayIsIListOfCustom2(array[i]);
+                VerifyCustomArrayIsIListOfCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayIsIListOfInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayIsIListOfInterfaceTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayIsIListOfInterface(array[i]);
+                VerifyCustomArrayIsIListOfInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayIsIListOfObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayIsIListOfObjectTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayIsIListOfObject(array[i]);
+                VerifyCustomArrayIsIListOfObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustomArrayIsObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustomArrayIsObjectArrayTest(bool useInterpreter)
         {
             C[][] array = new C[][] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustomArrayIsObjectArray(array[i]);
+                VerifyCustomArrayIsObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2IsCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2IsCustomTest(bool useInterpreter)
         {
             D[] array = new D[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2IsCustom(array[i]);
+                VerifyCustom2IsCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2IsInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2IsInterfaceTest(bool useInterpreter)
         {
             D[] array = new D[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2IsInterface(array[i]);
+                VerifyCustom2IsInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2IsIEquatableOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2IsIEquatableOfCustomTest(bool useInterpreter)
         {
             D[] array = new D[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2IsIEquatableOfCustom(array[i]);
+                VerifyCustom2IsIEquatableOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2IsIEquatableOfCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2IsIEquatableOfCustom2Test(bool useInterpreter)
         {
             D[] array = new D[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2IsIEquatableOfCustom2(array[i]);
+                VerifyCustom2IsIEquatableOfCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2IsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2IsObjectTest(bool useInterpreter)
         {
             D[] array = new D[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2IsObject(array[i]);
+                VerifyCustom2IsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckCustom2ArrayIsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckCustom2ArrayIsCustomArrayTest(bool useInterpreter)
         {
             D[][] array = new D[][] { null, new D[] { null, new D(), new D(0), new D(5) }, new D[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyCustom2ArrayIsCustomArray(array[i]);
+                VerifyCustom2ArrayIsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckDelegateIsFuncOfObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckDelegateIsFuncOfObjectTest(bool useInterpreter)
         {
             Delegate[] array = new Delegate[] { null, (Func<object>)delegate () { return null; }, (Func<int, int>)delegate (int i) { return i + 1; }, (Action<object>)delegate { } };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyDelegateIsFuncOfObject(array[i]);
+                VerifyDelegateIsFuncOfObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckDelegateIsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckDelegateIsObjectTest(bool useInterpreter)
         {
             Delegate[] array = new Delegate[] { null, (Func<object>)delegate () { return null; }, (Func<int, int>)delegate (int i) { return i + 1; }, (Action<object>)delegate { } };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyDelegateIsObject(array[i]);
+                VerifyDelegateIsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckEnumIsEnumTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckEnumIsEnumTypeTest(bool useInterpreter)
         {
             E[] array = new E[] { (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyEnumIsEnumType(array[i]);
+                VerifyEnumIsEnumType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckEnumIsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckEnumIsObjectTest(bool useInterpreter)
         {
             E[] array = new E[] { (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyEnumIsObject(array[i]);
+                VerifyEnumIsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckEnumTypeIsEnumTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckEnumTypeIsEnumTest(bool useInterpreter)
         {
             Enum[] array = new Enum[] { null, (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue, (El)0, El.A, El.B, (El)long.MaxValue, (El)long.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyEnumTypeIsEnum(array[i]);
+                VerifyEnumTypeIsEnum(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckEnumTypeIsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckEnumTypeIsObjectTest(bool useInterpreter)
         {
             Enum[] array = new Enum[] { null, (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue, (El)0, El.A, El.B, (El)long.MaxValue, (El)long.MinValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyEnumTypeIsObject(array[i]);
+                VerifyEnumTypeIsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckFuncOfObjectIsDelegateTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckFuncOfObjectIsDelegateTest(bool useInterpreter)
         {
             Func<object>[] array = new Func<object>[] { null, (Func<object>)delegate () { return null; } };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyFuncOfObjectIsDelegate(array[i]);
+                VerifyFuncOfObjectIsDelegate(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckInterfaceIsCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckInterfaceIsCustomTest(bool useInterpreter)
         {
             I[] array = new I[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyInterfaceIsCustom(array[i]);
+                VerifyInterfaceIsCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckInterfaceIsCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckInterfaceIsCustom2Test(bool useInterpreter)
         {
             I[] array = new I[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyInterfaceIsCustom2(array[i]);
+                VerifyInterfaceIsCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckInterfaceIsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckInterfaceIsObjectTest(bool useInterpreter)
         {
             I[] array = new I[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyInterfaceIsObject(array[i]);
+                VerifyInterfaceIsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfCustomIsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfCustomIsCustomArrayTest(bool useInterpreter)
         {
             IEnumerable<C>[] array = new IEnumerable<C>[] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10], new List<C>(), new List<C>(new C[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfCustomIsCustomArray(array[i]);
+                VerifyIEnumerableOfCustomIsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfCustomIsObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfCustomIsObjectArrayTest(bool useInterpreter)
         {
             IEnumerable<C>[] array = new IEnumerable<C>[] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10], new List<C>(), new List<C>(new C[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfCustomIsObjectArray(array[i]);
+                VerifyIEnumerableOfCustomIsObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfCustom2IsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfCustom2IsCustomArrayTest(bool useInterpreter)
         {
             IEnumerable<D>[] array = new IEnumerable<D>[] { null, new D[] { null, new D(), new D(0), new D(5) }, new D[10], new List<D>(), new List<D>(new D[] { null, new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfCustom2IsCustomArray(array[i]);
+                VerifyIEnumerableOfCustom2IsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfInterfaceIsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfInterfaceIsCustomArrayTest(bool useInterpreter)
         {
             IEnumerable<I>[] array = new IEnumerable<I>[] { null, new I[] { null, new C(), new D(), new D(0), new D(5) }, new I[10], new List<I>(), new List<I>(new I[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfInterfaceIsCustomArray(array[i]);
+                VerifyIEnumerableOfInterfaceIsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfInterfaceIsObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfInterfaceIsObjectArrayTest(bool useInterpreter)
         {
             IEnumerable<I>[] array = new IEnumerable<I>[] { null, new I[] { null, new C(), new D(), new D(0), new D(5) }, new I[10], new List<I>(), new List<I>(new I[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfInterfaceIsObjectArray(array[i]);
+                VerifyIEnumerableOfInterfaceIsObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfObjectIsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfObjectIsCustomArrayTest(bool useInterpreter)
         {
             IEnumerable<object>[] array = new IEnumerable<object>[] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10], new List<object>(), new List<object>(new object[] { null, new object(), new C(), new D(3) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfObjectIsCustomArray(array[i]);
+                VerifyIEnumerableOfObjectIsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfObjectIsObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfObjectIsObjectArrayTest(bool useInterpreter)
         {
             IEnumerable<object>[] array = new IEnumerable<object>[] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10], new List<object>(), new List<object>(new object[] { null, new object(), new C(), new D(3) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfObjectIsObjectArray(array[i]);
+                VerifyIEnumerableOfObjectIsObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEnumerableOfStructIsStructArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEnumerableOfStructIsStructArrayTest(bool useInterpreter)
         {
             IEnumerable<S>[] array = new IEnumerable<S>[] { null, new S[] { default(S), new S() }, new S[10], new List<S>(), new List<S>(new S[] { default(S), new S() }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEnumerableOfStructIsStructArray(array[i]);
+                VerifyIEnumerableOfStructIsStructArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEquatableOfCustomIsCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEquatableOfCustomIsCustomTest(bool useInterpreter)
         {
             IEquatable<C>[] array = new IEquatable<C>[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEquatableOfCustomIsCustom(array[i]);
+                VerifyIEquatableOfCustomIsCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEquatableOfCustomIsCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEquatableOfCustomIsCustom2Test(bool useInterpreter)
         {
             IEquatable<C>[] array = new IEquatable<C>[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEquatableOfCustomIsCustom2(array[i]);
+                VerifyIEquatableOfCustomIsCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEquatableOfCustomIsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEquatableOfCustomIsObjectTest(bool useInterpreter)
         {
             IEquatable<C>[] array = new IEquatable<C>[] { null, new C(), new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEquatableOfCustomIsObject(array[i]);
+                VerifyIEquatableOfCustomIsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEquatableOfCustom2IsCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEquatableOfCustom2IsCustomTest(bool useInterpreter)
         {
             IEquatable<D>[] array = new IEquatable<D>[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEquatableOfCustom2IsCustom(array[i]);
+                VerifyIEquatableOfCustom2IsCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEquatableOfCustom2IsCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEquatableOfCustom2IsCustom2Test(bool useInterpreter)
         {
             IEquatable<D>[] array = new IEquatable<D>[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEquatableOfCustom2IsCustom2(array[i]);
+                VerifyIEquatableOfCustom2IsCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEquatableOfCustom2IsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEquatableOfCustom2IsObjectTest(bool useInterpreter)
         {
             IEquatable<D>[] array = new IEquatable<D>[] { null, new D(), new D(0), new D(5) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEquatableOfCustom2IsObject(array[i]);
+                VerifyIEquatableOfCustom2IsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIEquatableOfStructIsStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIEquatableOfStructIsStructTest(bool useInterpreter)
         {
             IEquatable<S>[] array = new IEquatable<S>[] { null };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIEquatableOfStructIsStruct(array[i]);
+                VerifyIEquatableOfStructIsStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfCustomIsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfCustomIsCustomArrayTest(bool useInterpreter)
         {
             IList<C>[] array = new IList<C>[] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10], new List<C>(), new List<C>(new C[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfCustomIsCustomArray(array[i]);
+                VerifyIListOfCustomIsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfCustomIsObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfCustomIsObjectArrayTest(bool useInterpreter)
         {
             IList<C>[] array = new IList<C>[] { null, new C[] { null, new C(), new D(), new D(0), new D(5) }, new C[10], new List<C>(), new List<C>(new C[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfCustomIsObjectArray(array[i]);
+                VerifyIListOfCustomIsObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfCustom2IsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfCustom2IsCustomArrayTest(bool useInterpreter)
         {
             IList<D>[] array = new IList<D>[] { null, new D[] { null, new D(), new D(0), new D(5) }, new D[10], new List<D>(), new List<D>(new D[] { null, new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfCustom2IsCustomArray(array[i]);
+                VerifyIListOfCustom2IsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfInterfaceIsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfInterfaceIsCustomArrayTest(bool useInterpreter)
         {
             IList<I>[] array = new IList<I>[] { null, new I[] { null, new C(), new D(), new D(0), new D(5) }, new I[10], new List<I>(), new List<I>(new I[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfInterfaceIsCustomArray(array[i]);
+                VerifyIListOfInterfaceIsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfInterfaceIsObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfInterfaceIsObjectArrayTest(bool useInterpreter)
         {
             IList<I>[] array = new IList<I>[] { null, new I[] { null, new C(), new D(), new D(0), new D(5) }, new I[10], new List<I>(), new List<I>(new I[] { null, new C(), new D(), new D(0), new D(5) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfInterfaceIsObjectArray(array[i]);
+                VerifyIListOfInterfaceIsObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfObjectIsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfObjectIsCustomArrayTest(bool useInterpreter)
         {
             IList<object>[] array = new IList<object>[] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10], new List<object>(), new List<object>(new object[] { null, new object(), new C(), new D(3) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfObjectIsCustomArray(array[i]);
+                VerifyIListOfObjectIsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfObjectIsObjectArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfObjectIsObjectArrayTest(bool useInterpreter)
         {
             IList<object>[] array = new IList<object>[] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10], new List<object>(), new List<object>(new object[] { null, new object(), new C(), new D(3) }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfObjectIsObjectArray(array[i]);
+                VerifyIListOfObjectIsObjectArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIListOfStructIsStructArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIListOfStructIsStructArrayTest(bool useInterpreter)
         {
             IList<S>[] array = new IList<S>[] { null, new S[] { default(S), new S() }, new S[10], new List<S>(), new List<S>(new S[] { default(S), new S() }) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIListOfStructIsStructArray(array[i]);
+                VerifyIListOfStructIsStructArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIntIsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIntIsObjectTest(bool useInterpreter)
         {
             int[] array = new int[] { 0, 1, -1, int.MinValue, int.MaxValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIntIsObject(array[i]);
+                VerifyIntIsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckIntIsValueTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckIntIsValueTypeTest(bool useInterpreter)
         {
             int[] array = new int[] { 0, 1, -1, int.MinValue, int.MaxValue };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyIntIsValueType(array[i]);
+                VerifyIntIsValueType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectIsCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectIsCustomTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectIsCustom(array[i]);
+                VerifyObjectIsCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectIsCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectIsCustom2Test(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectIsCustom2(array[i]);
+                VerifyObjectIsCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectIsDelegateTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectIsDelegateTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectIsDelegate(array[i]);
+                VerifyObjectIsDelegate(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectIsEnumTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectIsEnumTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectIsEnum(array[i]);
+                VerifyObjectIsEnum(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectIsEnumTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectIsEnumTypeTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectIsEnumType(array[i]);
+                VerifyObjectIsEnumType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectIsInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectIsInterfaceTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectIsInterface(array[i]);
+                VerifyObjectIsInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectIsIEquatableOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectIsIEquatableOfCustomTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectIsIEquatableOfCustom(array[i]);
+                VerifyObjectIsIEquatableOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectIsIEquatableOfCustom2Test()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectIsIEquatableOfCustom2Test(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectIsIEquatableOfCustom2(array[i]);
+                VerifyObjectIsIEquatableOfCustom2(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectIsIntTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectIsIntTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectIsInt(array[i]);
+                VerifyObjectIsInt(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectIsStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectIsStructTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectIsStruct(array[i]);
+                VerifyObjectIsStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectIsValueTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectIsValueTypeTest(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectIsValueType(array[i]);
+                VerifyObjectIsValueType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayIsCustomArrayTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayIsCustomArrayTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayIsCustomArray(array[i]);
+                VerifyObjectArrayIsCustomArray(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayIsIEnumerableOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayIsIEnumerableOfCustomTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayIsIEnumerableOfCustom(array[i]);
+                VerifyObjectArrayIsIEnumerableOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayIsIEnumerableOfInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayIsIEnumerableOfInterfaceTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayIsIEnumerableOfInterface(array[i]);
+                VerifyObjectArrayIsIEnumerableOfInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayIsIEnumerableOfObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayIsIEnumerableOfObjectTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayIsIEnumerableOfObject(array[i]);
+                VerifyObjectArrayIsIEnumerableOfObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayIsIListOfCustomTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayIsIListOfCustomTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayIsIListOfCustom(array[i]);
+                VerifyObjectArrayIsIListOfCustom(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayIsIListOfInterfaceTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayIsIListOfInterfaceTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayIsIListOfInterface(array[i]);
+                VerifyObjectArrayIsIListOfInterface(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckObjectArrayIsIListOfObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckObjectArrayIsIListOfObjectTest(bool useInterpreter)
         {
             object[][] array = new object[][] { null, new object[] { null, new object(), new C(), new D(3) }, new object[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectArrayIsIListOfObject(array[i]);
+                VerifyObjectArrayIsIListOfObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckStructIsIEquatableOfStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckStructIsIEquatableOfStructTest(bool useInterpreter)
         {
             S[] array = new S[] { default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyStructIsIEquatableOfStruct(array[i]);
+                VerifyStructIsIEquatableOfStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckStructIsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckStructIsObjectTest(bool useInterpreter)
         {
             S[] array = new S[] { default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyStructIsObject(array[i]);
+                VerifyStructIsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckStructIsValueTypeTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckStructIsValueTypeTest(bool useInterpreter)
         {
             S[] array = new S[] { default(S), new S() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyStructIsValueType(array[i]);
+                VerifyStructIsValueType(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckStructArrayIsIEnumerableOfStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckStructArrayIsIEnumerableOfStructTest(bool useInterpreter)
         {
             S[][] array = new S[][] { null, new S[] { default(S), new S() }, new S[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyStructArrayIsIEnumerableOfStruct(array[i]);
+                VerifyStructArrayIsIEnumerableOfStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckStructArrayIsIListOfStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckStructArrayIsIListOfStructTest(bool useInterpreter)
         {
             S[][] array = new S[][] { null, new S[] { default(S), new S() }, new S[10] };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyStructArrayIsIListOfStruct(array[i]);
+                VerifyStructArrayIsIListOfStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckValueTypeIsIntTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckValueTypeIsIntTest(bool useInterpreter)
         {
             ValueType[] array = new ValueType[] { null, default(S), new Scs(null, new S()), E.A, El.B };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyValueTypeIsInt(array[i]);
+                VerifyValueTypeIsInt(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckValueTypeIsObjectTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckValueTypeIsObjectTest(bool useInterpreter)
         {
             ValueType[] array = new ValueType[] { null, default(S), new Scs(null, new S()), E.A, El.B };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyValueTypeIsObject(array[i]);
+                VerifyValueTypeIsObject(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void CheckValueTypeIsStructTest()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckValueTypeIsStructTest(bool useInterpreter)
         {
             ValueType[] array = new ValueType[] { null, default(S), new Scs(null, new S()), E.A, El.B };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyValueTypeIsStruct(array[i]);
+                VerifyValueTypeIsStruct(array[i], useInterpreter);
             }
         }
 
-        [Fact]
-        public static void ConvertObjectCastGenericAsCustom()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericAsCustom(bool useInterpreter)
         {
-            CheckObjectIsGenericHelper<C>();
+            CheckObjectIsGenericHelper<C>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertObjectCastGenericAsEnum()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericAsEnum(bool useInterpreter)
         {
-            CheckObjectIsGenericHelper<E>();
+            CheckObjectIsGenericHelper<E>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertObjectCastGenericAsObject()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericAsObject(bool useInterpreter)
         {
-            CheckObjectIsGenericHelper<object>();
+            CheckObjectIsGenericHelper<object>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertObjectCastGenericAsStruct()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericAsStruct(bool useInterpreter)
         {
-            CheckObjectIsGenericHelper<S>();
+            CheckObjectIsGenericHelper<S>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertObjectCastGenericAsStructWithStringAndField()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericAsStructWithStringAndField(bool useInterpreter)
         {
-            CheckObjectIsGenericHelper<Scs>();
+            CheckObjectIsGenericHelper<Scs>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertObjectCastGenericWithClassRestrictionAsCustom()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericWithClassRestrictionAsCustom(bool useInterpreter)
         {
-            CheckObjectIsGenericWithClassRestrictionHelper<C>();
+            CheckObjectIsGenericWithClassRestrictionHelper<C>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertObjectCastGenericWithClassRestrictionAsObject()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericWithClassRestrictionAsObject(bool useInterpreter)
         {
-            CheckObjectIsGenericWithClassRestrictionHelper<object>();
+            CheckObjectIsGenericWithClassRestrictionHelper<object>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertObjectCastGenericWithStructRestrictionAsEnum()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericWithStructRestrictionAsEnum(bool useInterpreter)
         {
-            CheckObjectIsGenericWithStructRestrictionHelper<E>();
+            CheckObjectIsGenericWithStructRestrictionHelper<E>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertObjectCastGenericWithStructRestrictionAsStruct()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericWithStructRestrictionAsStruct(bool useInterpreter)
         {
-            CheckObjectIsGenericWithStructRestrictionHelper<S>();
+            CheckObjectIsGenericWithStructRestrictionHelper<S>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertObjectCastGenericWithStructRestrictionAsStructWithStringAndField()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertObjectCastGenericWithStructRestrictionAsStructWithStringAndField(bool useInterpreter)
         {
-            CheckObjectIsGenericWithStructRestrictionHelper<Scs>();
+            CheckObjectIsGenericWithStructRestrictionHelper<Scs>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericCastObjectAsCustom()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericCastObjectAsCustom(bool useInterpreter)
         {
-            CheckGenericIsObjectHelper<C>();
+            CheckGenericIsObjectHelper<C>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericCastObjectAsEnum()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericCastObjectAsEnum(bool useInterpreter)
         {
-            CheckGenericIsObjectHelper<E>();
+            CheckGenericIsObjectHelper<E>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericCastObjectAsObject()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericCastObjectAsObject(bool useInterpreter)
         {
-            CheckGenericIsObjectHelper<object>();
+            CheckGenericIsObjectHelper<object>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericCastObjectAsStruct()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericCastObjectAsStruct(bool useInterpreter)
         {
-            CheckGenericIsObjectHelper<S>();
+            CheckGenericIsObjectHelper<S>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericCastObjectAsStructWithStringAndField()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericCastObjectAsStructWithStringAndField(bool useInterpreter)
         {
-            CheckGenericIsObjectHelper<Scs>();
+            CheckGenericIsObjectHelper<Scs>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithClassRestrictionCastObjectAsCustom()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithClassRestrictionCastObjectAsCustom(bool useInterpreter)
         {
-            CheckGenericWithClassRestrictionIsObjectHelper<C>();
+            CheckGenericWithClassRestrictionIsObjectHelper<C>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithClassRestrictionCastObjectAsObject()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithClassRestrictionCastObjectAsObject(bool useInterpreter)
         {
-            CheckGenericWithClassRestrictionIsObjectHelper<object>();
+            CheckGenericWithClassRestrictionIsObjectHelper<object>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastObjectAsEnum()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastObjectAsEnum(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionIsObjectHelper<E>();
+            CheckGenericWithStructRestrictionIsObjectHelper<E>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastObjectAsStruct()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastObjectAsStruct(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionIsObjectHelper<S>();
+            CheckGenericWithStructRestrictionIsObjectHelper<S>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastObjectAsStructWithStringAndField()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastObjectAsStructWithStringAndField(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionIsObjectHelper<Scs>();
+            CheckGenericWithStructRestrictionIsObjectHelper<Scs>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastValueTypeAsEnum()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastValueTypeAsEnum(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionIsValueTypeHelper<E>();
+            CheckGenericWithStructRestrictionIsValueTypeHelper<E>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStruct()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStruct(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionIsValueTypeHelper<S>();
+            CheckGenericWithStructRestrictionIsValueTypeHelper<S>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStructWithStringAndField()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertGenericWithStructRestrictionCastValueTypeAsStructWithStringAndField(bool useInterpreter)
         {
-            CheckGenericWithStructRestrictionIsValueTypeHelper<Scs>();
+            CheckGenericWithStructRestrictionIsValueTypeHelper<Scs>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertValueTypeCastGenericWithStructRestrictionAsEnum()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertValueTypeCastGenericWithStructRestrictionAsEnum(bool useInterpreter)
         {
-            CheckValueTypeIsGenericWithStructRestrictionHelper<E>();
+            CheckValueTypeIsGenericWithStructRestrictionHelper<E>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertValueTypeCastGenericWithStructRestrictionAsStruct()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertValueTypeCastGenericWithStructRestrictionAsStruct(bool useInterpreter)
         {
-            CheckValueTypeIsGenericWithStructRestrictionHelper<S>();
+            CheckValueTypeIsGenericWithStructRestrictionHelper<S>(useInterpreter);
         }
 
-        [Fact]
-        public static void ConvertValueTypeCastGenericWithStructRestrictionAsStructWithStringAndField()
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertValueTypeCastGenericWithStructRestrictionAsStructWithStringAndField(bool useInterpreter)
         {
-            CheckValueTypeIsGenericWithStructRestrictionHelper<Scs>();
+            CheckValueTypeIsGenericWithStructRestrictionHelper<Scs>(useInterpreter);
         }
 
         #endregion
 
         #region Generic helpers
 
-        private static void CheckObjectIsGenericHelper<T>()
+        private static void CheckObjectIsGenericHelper<T>(bool useInterpreter)
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectIsGeneric<T>(array[i]);
+                VerifyObjectIsGeneric<T>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckObjectIsGenericWithClassRestrictionHelper<Tc>() where Tc : class
+        private static void CheckObjectIsGenericWithClassRestrictionHelper<Tc>(bool useInterpreter) where Tc : class
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectIsGenericWithClassRestriction<Tc>(array[i]);
+                VerifyObjectIsGenericWithClassRestriction<Tc>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckObjectIsGenericWithStructRestrictionHelper<Ts>() where Ts : struct
+        private static void CheckObjectIsGenericWithStructRestrictionHelper<Ts>(bool useInterpreter) where Ts : struct
         {
             object[] array = new object[] { null, new object(), new C(), new D(3) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyObjectIsGenericWithStructRestriction<Ts>(array[i]);
+                VerifyObjectIsGenericWithStructRestriction<Ts>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckGenericIsObjectHelper<T>()
+        private static void CheckGenericIsObjectHelper<T>(bool useInterpreter)
         {
             T[] array = new T[] { default(T) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericIsObject<T>(array[i]);
+                VerifyGenericIsObject<T>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckGenericWithClassRestrictionIsObjectHelper<Tc>() where Tc : class
+        private static void CheckGenericWithClassRestrictionIsObjectHelper<Tc>(bool useInterpreter) where Tc : class
         {
             Tc[] array = new Tc[] { null, default(Tc) };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericWithClassRestrictionIsObject<Tc>(array[i]);
+                VerifyGenericWithClassRestrictionIsObject<Tc>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckGenericWithStructRestrictionIsObjectHelper<Ts>() where Ts : struct
+        private static void CheckGenericWithStructRestrictionIsObjectHelper<Ts>(bool useInterpreter) where Ts : struct
         {
             Ts[] array = new Ts[] { default(Ts), new Ts() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericWithStructRestrictionIsObject<Ts>(array[i]);
+                VerifyGenericWithStructRestrictionIsObject<Ts>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckGenericWithStructRestrictionIsValueTypeHelper<Ts>() where Ts : struct
+        private static void CheckGenericWithStructRestrictionIsValueTypeHelper<Ts>(bool useInterpreter) where Ts : struct
         {
             Ts[] array = new Ts[] { default(Ts), new Ts() };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyGenericWithStructRestrictionIsValueType<Ts>(array[i]);
+                VerifyGenericWithStructRestrictionIsValueType<Ts>(array[i], useInterpreter);
             }
         }
 
-        private static void CheckValueTypeIsGenericWithStructRestrictionHelper<Ts>() where Ts : struct
+        private static void CheckValueTypeIsGenericWithStructRestrictionHelper<Ts>(bool useInterpreter) where Ts : struct
         {
             ValueType[] array = new ValueType[] { null, default(S), new Scs(null, new S()), E.A, El.B };
             for (int i = 0; i < array.Length; i++)
             {
-                VerifyValueTypeIsGenericWithStructRestriction<Ts>(array[i]);
+                VerifyValueTypeIsGenericWithStructRestriction<Ts>(array[i], useInterpreter);
             }
         }
 
@@ -1068,3739 +1068,985 @@ namespace System.Linq.Expressions.Tests
 
         #region Test verifiers
 
-        private static void VerifyCustomIsCustom2(C value)
+        private static void VerifyCustomIsCustom2(C value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is D;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is D, f());
         }
 
-        private static void VerifyCustomIsInterface(C value)
+        private static void VerifyCustomIsInterface(C value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is I;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyCustomIsIEquatableOfCustom(C value)
+        private static void VerifyCustomIsIEquatableOfCustom(C value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IEquatable<C>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyCustomIsIEquatableOfCustom2(C value)
+        private static void VerifyCustomIsIEquatableOfCustom2(C value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IEquatable<D>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is IEquatable<D>, f());
         }
 
-        private static void VerifyCustomIsObject(C value)
+        private static void VerifyCustomIsObject(C value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyCustomArrayIsCustom2Array(C[] value)
+        private static void VerifyCustomArrayIsCustom2Array(C[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(D[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is D[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is D[], f());
         }
 
-        private static void VerifyCustomArrayIsIEnumerableOfCustom(C[] value)
+        private static void VerifyCustomArrayIsIEnumerableOfCustom(C[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IEnumerable<C>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyCustomArrayIsIEnumerableOfCustom2(C[] value)
+        private static void VerifyCustomArrayIsIEnumerableOfCustom2(C[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IEnumerable<D>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is IEnumerable<D>, f());
         }
 
-        private static void VerifyCustomArrayIsIEnumerableOfInterface(C[] value)
+        private static void VerifyCustomArrayIsIEnumerableOfInterface(C[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IEnumerable<I>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyCustomArrayIsIEnumerableOfObject(C[] value)
+        private static void VerifyCustomArrayIsIEnumerableOfObject(C[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(IEnumerable<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IEnumerable<object>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyCustomArrayIsIListOfCustom(C[] value)
+        private static void VerifyCustomArrayIsIListOfCustom(C[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(IList<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IList<C>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyCustomArrayIsIListOfCustom2(C[] value)
+        private static void VerifyCustomArrayIsIListOfCustom2(C[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(IList<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IList<D>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is IList<D>, f());
         }
 
-        private static void VerifyCustomArrayIsIListOfInterface(C[] value)
+        private static void VerifyCustomArrayIsIListOfInterface(C[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(IList<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IList<I>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyCustomArrayIsIListOfObject(C[] value)
+        private static void VerifyCustomArrayIsIListOfObject(C[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(IList<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IList<object>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyCustomArrayIsObjectArray(C[] value)
+        private static void VerifyCustomArrayIsObjectArray(C[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(C[])), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyCustom2IsCustom(D value)
+        private static void VerifyCustom2IsCustom(D value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(D)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is C;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyCustom2IsInterface(D value)
+        private static void VerifyCustom2IsInterface(D value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(D)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is I;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyCustom2IsIEquatableOfCustom(D value)
+        private static void VerifyCustom2IsIEquatableOfCustom(D value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(D)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IEquatable<C>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyCustom2IsIEquatableOfCustom2(D value)
+        private static void VerifyCustom2IsIEquatableOfCustom2(D value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(D)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IEquatable<D>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyCustom2IsObject(D value)
+        private static void VerifyCustom2IsObject(D value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(D)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyCustom2ArrayIsCustomArray(D[] value)
+        private static void VerifyCustom2ArrayIsCustomArray(D[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(D[])), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is C[], f());
         }
 
-        private static void VerifyDelegateIsFuncOfObject(Delegate value)
+        private static void VerifyDelegateIsFuncOfObject(Delegate value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Delegate)), typeof(Func<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is Func<object>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is Func<object>, f());
         }
 
-        private static void VerifyDelegateIsObject(Delegate value)
+        private static void VerifyDelegateIsObject(Delegate value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Delegate)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyEnumIsEnumType(E value)
+        private static void VerifyEnumIsEnumType(E value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(E)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
             Assert.True(f());
         }
 
-        private static void VerifyEnumIsObject(E value)
+        private static void VerifyEnumIsObject(E value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(E)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
             Assert.True(f());
         }
 
-        private static void VerifyEnumTypeIsEnum(Enum value)
+        private static void VerifyEnumTypeIsEnum(Enum value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Enum)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is E;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is E, f());
         }
 
-        private static void VerifyEnumTypeIsObject(Enum value)
+        private static void VerifyEnumTypeIsObject(Enum value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Enum)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyFuncOfObjectIsDelegate(Func<object> value)
+        private static void VerifyFuncOfObjectIsDelegate(Func<object> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Func<object>)), typeof(Delegate)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is Delegate;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyInterfaceIsCustom(I value)
+        private static void VerifyInterfaceIsCustom(I value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(I)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is C;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is C, f());
         }
 
-        private static void VerifyInterfaceIsCustom2(I value)
+        private static void VerifyInterfaceIsCustom2(I value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(I)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is D;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is D, f());
         }
 
-        private static void VerifyInterfaceIsObject(I value)
+        private static void VerifyInterfaceIsObject(I value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(I)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyIEnumerableOfCustomIsCustomArray(IEnumerable<C> value)
+        private static void VerifyIEnumerableOfCustomIsCustomArray(IEnumerable<C> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is C[], f());
         }
 
-        private static void VerifyIEnumerableOfCustomIsObjectArray(IEnumerable<C> value)
+        private static void VerifyIEnumerableOfCustomIsObjectArray(IEnumerable<C> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEnumerable<C>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is object[], f());
         }
 
-        private static void VerifyIEnumerableOfCustom2IsCustomArray(IEnumerable<D> value)
+        private static void VerifyIEnumerableOfCustom2IsCustomArray(IEnumerable<D> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEnumerable<D>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is C[], f());
         }
 
-        private static void VerifyIEnumerableOfInterfaceIsCustomArray(IEnumerable<I> value)
+        private static void VerifyIEnumerableOfInterfaceIsCustomArray(IEnumerable<I> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEnumerable<I>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is C[], f());
         }
 
-        private static void VerifyIEnumerableOfInterfaceIsObjectArray(IEnumerable<I> value)
+        private static void VerifyIEnumerableOfInterfaceIsObjectArray(IEnumerable<I> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEnumerable<I>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is object[], f());
         }
 
-        private static void VerifyIEnumerableOfObjectIsCustomArray(IEnumerable<object> value)
+        private static void VerifyIEnumerableOfObjectIsCustomArray(IEnumerable<object> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEnumerable<object>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is C[], f());
         }
 
-        private static void VerifyIEnumerableOfObjectIsObjectArray(IEnumerable<object> value)
+        private static void VerifyIEnumerableOfObjectIsObjectArray(IEnumerable<object> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEnumerable<object>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is object[], f());
         }
 
-        private static void VerifyIEnumerableOfStructIsStructArray(IEnumerable<S> value)
+        private static void VerifyIEnumerableOfStructIsStructArray(IEnumerable<S> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEnumerable<S>)), typeof(S[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is S[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is S[], f());
         }
 
-        private static void VerifyIEquatableOfCustomIsCustom(IEquatable<C> value)
+        private static void VerifyIEquatableOfCustomIsCustom(IEquatable<C> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEquatable<C>)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is C;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is C, f());
         }
 
-        private static void VerifyIEquatableOfCustomIsCustom2(IEquatable<C> value)
+        private static void VerifyIEquatableOfCustomIsCustom2(IEquatable<C> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEquatable<C>)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is D;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is D, f());
         }
 
-        private static void VerifyIEquatableOfCustomIsObject(IEquatable<C> value)
+        private static void VerifyIEquatableOfCustomIsObject(IEquatable<C> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEquatable<C>)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyIEquatableOfCustom2IsCustom(IEquatable<D> value)
+        private static void VerifyIEquatableOfCustom2IsCustom(IEquatable<D> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEquatable<D>)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is C;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is C, f());
         }
 
-        private static void VerifyIEquatableOfCustom2IsCustom2(IEquatable<D> value)
+        private static void VerifyIEquatableOfCustom2IsCustom2(IEquatable<D> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEquatable<D>)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is D;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is D, f());
         }
 
-        private static void VerifyIEquatableOfCustom2IsObject(IEquatable<D> value)
+        private static void VerifyIEquatableOfCustom2IsObject(IEquatable<D> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEquatable<D>)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyIEquatableOfStructIsStruct(IEquatable<S> value)
+        private static void VerifyIEquatableOfStructIsStruct(IEquatable<S> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IEquatable<S>)), typeof(S)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is S;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is S, f());
         }
 
-        private static void VerifyIListOfCustomIsCustomArray(IList<C> value)
+        private static void VerifyIListOfCustomIsCustomArray(IList<C> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IList<C>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is C[], f());
         }
 
-        private static void VerifyIListOfCustomIsObjectArray(IList<C> value)
+        private static void VerifyIListOfCustomIsObjectArray(IList<C> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IList<C>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is object[], f());
         }
 
-        private static void VerifyIListOfCustom2IsCustomArray(IList<D> value)
+        private static void VerifyIListOfCustom2IsCustomArray(IList<D> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IList<D>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is C[], f());
         }
 
-        private static void VerifyIListOfInterfaceIsCustomArray(IList<I> value)
+        private static void VerifyIListOfInterfaceIsCustomArray(IList<I> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IList<I>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is C[], f());
         }
 
-        private static void VerifyIListOfInterfaceIsObjectArray(IList<I> value)
+        private static void VerifyIListOfInterfaceIsObjectArray(IList<I> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IList<I>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is object[], f());
         }
 
-        private static void VerifyIListOfObjectIsCustomArray(IList<object> value)
+        private static void VerifyIListOfObjectIsCustomArray(IList<object> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IList<object>)), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is C[], f());
         }
 
-        private static void VerifyIListOfObjectIsObjectArray(IList<object> value)
+        private static void VerifyIListOfObjectIsObjectArray(IList<object> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IList<object>)), typeof(object[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is object[], f());
         }
 
-        private static void VerifyIListOfStructIsStructArray(IList<S> value)
+        private static void VerifyIListOfStructIsStructArray(IList<S> value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(IList<S>)), typeof(S[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is S[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is S[], f());
         }
 
-        private static void VerifyIntIsObject(int value)
+        private static void VerifyIntIsObject(int value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(int)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
             Assert.True(f());
         }
 
-        private static void VerifyIntIsValueType(int value)
+        private static void VerifyIntIsValueType(int value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(int)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
             Assert.True(f());
         }
 
-        private static void VerifyObjectIsCustom(object value)
+        private static void VerifyObjectIsCustom(object value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(C)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is C;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is C, f());
         }
 
-        private static void VerifyObjectIsCustom2(object value)
+        private static void VerifyObjectIsCustom2(object value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(D)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is D;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is D, f());
         }
 
-        private static void VerifyObjectIsDelegate(object value)
+        private static void VerifyObjectIsDelegate(object value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(Delegate)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is Delegate;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is Delegate, f());
         }
 
-        private static void VerifyObjectIsEnum(object value)
+        private static void VerifyObjectIsEnum(object value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(E)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is E;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is E, f());
         }
 
-        private static void VerifyObjectIsEnumType(object value)
+        private static void VerifyObjectIsEnumType(object value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(Enum)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is Enum;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is Enum, f());
         }
 
-        private static void VerifyObjectIsInterface(object value)
+        private static void VerifyObjectIsInterface(object value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(I)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is I;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is I, f());
         }
 
-        private static void VerifyObjectIsIEquatableOfCustom(object value)
+        private static void VerifyObjectIsIEquatableOfCustom(object value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(IEquatable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IEquatable<C>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is IEquatable<C>, f());
         }
 
-        private static void VerifyObjectIsIEquatableOfCustom2(object value)
+        private static void VerifyObjectIsIEquatableOfCustom2(object value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(IEquatable<D>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IEquatable<D>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is IEquatable<D>, f());
         }
 
-        private static void VerifyObjectIsInt(object value)
+        private static void VerifyObjectIsInt(object value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is int;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is int, f());
         }
 
-        private static void VerifyObjectIsStruct(object value)
+        private static void VerifyObjectIsStruct(object value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(S)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is S;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is S, f());
         }
 
-        private static void VerifyObjectIsValueType(object value)
+        private static void VerifyObjectIsValueType(object value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is ValueType;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is ValueType, f());
         }
 
-        private static void VerifyObjectArrayIsCustomArray(object[] value)
+        private static void VerifyObjectArrayIsCustomArray(object[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object[])), typeof(C[])),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is C[];
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is C[], f());
         }
 
-        private static void VerifyObjectArrayIsIEnumerableOfCustom(object[] value)
+        private static void VerifyObjectArrayIsIEnumerableOfCustom(object[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IEnumerable<C>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is IEnumerable<C>, f());
         }
 
-        private static void VerifyObjectArrayIsIEnumerableOfInterface(object[] value)
+        private static void VerifyObjectArrayIsIEnumerableOfInterface(object[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IEnumerable<I>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is IEnumerable<I>, f());
         }
 
-        private static void VerifyObjectArrayIsIEnumerableOfObject(object[] value)
+        private static void VerifyObjectArrayIsIEnumerableOfObject(object[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object[])), typeof(IEnumerable<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IEnumerable<object>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyObjectArrayIsIListOfCustom(object[] value)
+        private static void VerifyObjectArrayIsIListOfCustom(object[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object[])), typeof(IList<C>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IList<C>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is IList<C>, f());
         }
 
-        private static void VerifyObjectArrayIsIListOfInterface(object[] value)
+        private static void VerifyObjectArrayIsIListOfInterface(object[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object[])), typeof(IList<I>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IList<I>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is IList<I>, f());
         }
 
-        private static void VerifyObjectArrayIsIListOfObject(object[] value)
+        private static void VerifyObjectArrayIsIListOfObject(object[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object[])), typeof(IList<object>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IList<object>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyStructIsIEquatableOfStruct(S value)
+        private static void VerifyStructIsIEquatableOfStruct(S value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(S)), typeof(IEquatable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
             Assert.True(f());
         }
 
-        private static void VerifyStructIsObject(S value)
+        private static void VerifyStructIsObject(S value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(S)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
             Assert.True(f());
         }
 
-        private static void VerifyStructIsValueType(S value)
+        private static void VerifyStructIsValueType(S value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(S)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
             Assert.True(f());
         }
 
-        private static void VerifyStructArrayIsIEnumerableOfStruct(S[] value)
+        private static void VerifyStructArrayIsIEnumerableOfStruct(S[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(S[])), typeof(IEnumerable<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IEnumerable<S>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyStructArrayIsIListOfStruct(S[] value)
+        private static void VerifyStructArrayIsIListOfStruct(S[] value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(S[])), typeof(IList<S>)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is IList<S>;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyValueTypeIsInt(ValueType value)
+        private static void VerifyValueTypeIsInt(ValueType value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(ValueType)), typeof(int)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is int;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is int, f());
         }
 
-        private static void VerifyValueTypeIsObject(ValueType value)
+        private static void VerifyValueTypeIsObject(ValueType value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(ValueType)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyValueTypeIsStruct(ValueType value)
+        private static void VerifyValueTypeIsStruct(ValueType value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(ValueType)), typeof(S)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is S;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is S, f());
         }
 
-        private static void VerifyObjectIsGeneric<T>(object value)
+        private static void VerifyObjectIsGeneric<T>(object value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(T)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is T;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is T, f());
         }
 
-        private static void VerifyObjectIsGenericWithClassRestriction<Tc>(object value) where Tc : class
+        private static void VerifyObjectIsGenericWithClassRestriction<Tc>(object value, bool useInterpreter) where Tc : class
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(Tc)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is Tc;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is Tc, f());
         }
 
-        private static void VerifyObjectIsGenericWithStructRestriction<Ts>(object value) where Ts : struct
+        private static void VerifyObjectIsGenericWithStructRestriction<Ts>(object value, bool useInterpreter) where Ts : struct
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(object)), typeof(Ts)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is Ts;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is Ts, f());
         }
 
-        private static void VerifyGenericIsObject<T>(T value)
+        private static void VerifyGenericIsObject<T>(T value, bool useInterpreter)
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(T)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyGenericWithClassRestrictionIsObject<Tc>(Tc value) where Tc : class
+        private static void VerifyGenericWithClassRestrictionIsObject<Tc>(Tc value, bool useInterpreter) where Tc : class
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Tc)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is object;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value != null, f());
         }
 
-        private static void VerifyGenericWithStructRestrictionIsObject<Ts>(Ts value) where Ts : struct
+        private static void VerifyGenericWithStructRestrictionIsObject<Ts>(Ts value, bool useInterpreter) where Ts : struct
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Ts)), typeof(object)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
             Assert.True(f());
         }
 
-        private static void VerifyGenericWithStructRestrictionIsValueType<Ts>(Ts value) where Ts : struct
+        private static void VerifyGenericWithStructRestrictionIsValueType<Ts>(Ts value, bool useInterpreter) where Ts : struct
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(Ts)), typeof(ValueType)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
             Assert.True(f());
         }
 
-        private static void VerifyValueTypeIsGenericWithStructRestriction<Ts>(ValueType value) where Ts : struct
+        private static void VerifyValueTypeIsGenericWithStructRestriction<Ts>(ValueType value, bool useInterpreter) where Ts : struct
         {
             Expression<Func<bool>> e =
                 Expression.Lambda<Func<bool>>(
                     Expression.TypeIs(Expression.Constant(value, typeof(ValueType)), typeof(Ts)),
                     Enumerable.Empty<ParameterExpression>());
-            Func<bool> f = e.Compile();
+            Func<bool> f = e.Compile(useInterpreter);
 
-            // compute the value with the expression tree
-            bool etResult = default(bool);
-            Exception etException = null;
-            try
-            {
-                etResult = f();
-            }
-            catch (Exception ex)
-            {
-                etException = ex;
-            }
-
-            // compute the value with regular IL
-            bool csResult = default(bool);
-            Exception csException = null;
-            try
-            {
-                csResult = value is Ts;
-            }
-            catch (Exception ex)
-            {
-                csException = ex;
-            }
-
-            // either both should have failed the same way or they should both produce the same result
-            if (etException != null || csException != null)
-            {
-                Assert.NotNull(etException);
-                Assert.NotNull(csException);
-                Assert.Equal(csException.GetType(), etException.GetType());
-            }
-            else
-            {
-                Assert.Equal(csResult, etResult);
-            }
+            Assert.Equal(value is Ts, f());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -85,6 +85,13 @@ namespace System.Linq.Expressions.Tests
         C
     }
 
+    public enum Eu : uint
+    {
+        Bagahi,
+        Laca,
+        Bachahé
+    }
+
     public struct S : IEquatable<S>
     {
         public override bool Equals(object o)


### PR DESCRIPTION
Convert to enumerable types correctly in interpreter.

Fixes #7169.

Also:

Compilation types through attribute in casting tests.

Change verification of exceptions to test specific inputs having specific exceptions, rather than try-and-repeat: Less exceptions thrown and caught, better-defined tests.

Add some extra cases to enumerable casting tests.

(These test changes led to finding this issue)

cc @stephentoub, @VSadov