### PR TITLE
Add HttpClientHandler tests for server certificates

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.VersionInfo.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.VersionInfo.cs
@@ -2,18 +2,49 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
     internal static partial class Http
     {
-        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_GetCurlVersionInfo")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool GetCurlVersionInfo(
-            out int age,
-            [MarshalAs(UnmanagedType.Bool)] out bool supportsSsl,
-            [MarshalAs(UnmanagedType.Bool)] out bool supportsAutoDecompression,
-            [MarshalAs(UnmanagedType.Bool)] out bool supportsHttp2Multiplexing);
+        [Flags]
+        internal enum CurlFeatures : int
+        {
+            CURL_VERSION_IPV6 = (1 << 0),
+            CURL_VERSION_KERBEROS4 = (1 << 1),
+            CURL_VERSION_SSL = (1 << 2),
+            CURL_VERSION_LIBZ = (1 << 3),
+            CURL_VERSION_NTLM = (1 << 4),
+            CURL_VERSION_GSSNEGOTIATE = (1 << 5),
+            CURL_VERSION_DEBUG = (1 << 6),
+            CURL_VERSION_ASYNCHDNS = (1 << 7),
+            CURL_VERSION_SPNEGO = (1 << 8),
+            CURL_VERSION_LARGEFILE = (1 << 9),
+            CURL_VERSION_IDN = (1 << 10),
+            CURL_VERSION_SSPI = (1 << 11),
+            CURL_VERSION_CONV = (1 << 12),
+            CURL_VERSION_CURLDEBUG = (1 << 13),
+            CURL_VERSION_TLSAUTH_SRP = (1 << 14),
+            CURL_VERSION_NTLM_WB = (1 << 15),
+            CURL_VERSION_HTTP2 = (1 << 16),
+            CURL_VERSION_GSSAPI = (1 << 17),
+            CURL_VERSION_KERBEROS5 = (1 << 18),
+            CURL_VERSION_UNIX_SOCKETS = (1 << 19),
+            CURL_VERSION_PSL = (1 << 20),
+        };
+
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_GetSupportedFeatures")]
+        internal static extern CurlFeatures GetSupportedFeatures();
+
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_GetSupportsHttp2Multiplexing")]
+        internal static extern bool GetSupportsHttp2Multiplexing();
+
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_GetVersionDescription")]
+        internal static extern string GetVersionDescription();
+
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_GetSslVersionDescription")]
+        internal static extern string GetSslVersionDescription();
     }
 }

--- a/src/Common/tests/System/Net/HttpTestServers.cs
+++ b/src/Common/tests/System/Net/HttpTestServers.cs
@@ -18,6 +18,7 @@ namespace System.Net.Test.Common
         public const string ExpiredCertRemoteServer = "https://expired.badssl.com/";
         public const string WrongHostNameCertRemoteServer = "https://wrong.host.badssl.com/";
         public const string SelfSignedCertRemoteServer = "https://self-signed.badssl.com/";
+        public const string RevokedCertRemoteServer = "https://revoked.grc.com/";
 
         private const string HttpScheme = "http";
         private const string HttpsScheme = "https";

--- a/src/Common/tests/System/Net/HttpTestServers.cs
+++ b/src/Common/tests/System/Net/HttpTestServers.cs
@@ -15,6 +15,10 @@ namespace System.Net.Test.Common
         public const string TLSv11RemoteServer = "https://www.ssllabs.com:10302/";
         public const string TLSv12RemoteServer = "https://www.ssllabs.com:10303/";
 
+        public const string ExpiredCertRemoteServer = "https://expired.badssl.com/";
+        public const string WrongHostNameCertRemoteServer = "https://wrong.host.badssl.com/";
+        public const string SelfSignedCertRemoteServer = "https://self-signed.badssl.com/";
+
         private const string HttpScheme = "http";
         private const string HttpsScheme = "https";
 

--- a/src/Native/System.Net.Http.Native/pal_versioninfo.cpp
+++ b/src/Native/System.Net.Http.Native/pal_versioninfo.cpp
@@ -5,8 +5,71 @@
 #include "pal_config.h"
 #include "pal_versioninfo.h"
 
+#include <string.h>
 #include <curl/curl.h>
 
+static_assert(PAL_CURL_VERSION_IPV6 == CURL_VERSION_IPV6, "");
+static_assert(PAL_CURL_VERSION_KERBEROS4 == CURL_VERSION_KERBEROS4, "");
+static_assert(PAL_CURL_VERSION_SSL == CURL_VERSION_SSL, "");
+static_assert(PAL_CURL_VERSION_LIBZ == CURL_VERSION_LIBZ, "");
+static_assert(PAL_CURL_VERSION_NTLM == CURL_VERSION_NTLM, "");
+static_assert(PAL_CURL_VERSION_GSSNEGOTIATE == CURL_VERSION_GSSNEGOTIATE, "");
+static_assert(PAL_CURL_VERSION_DEBUG == CURL_VERSION_DEBUG, "");
+static_assert(PAL_CURL_VERSION_ASYNCHDNS == CURL_VERSION_ASYNCHDNS, "");
+static_assert(PAL_CURL_VERSION_SPNEGO == CURL_VERSION_SPNEGO, "");
+static_assert(PAL_CURL_VERSION_LARGEFILE == CURL_VERSION_LARGEFILE, "");
+static_assert(PAL_CURL_VERSION_IDN == CURL_VERSION_IDN, "");
+static_assert(PAL_CURL_VERSION_SSPI == CURL_VERSION_SSPI, "");
+static_assert(PAL_CURL_VERSION_CONV == CURL_VERSION_CONV, "");
+static_assert(PAL_CURL_VERSION_CURLDEBUG == CURL_VERSION_CURLDEBUG, "");
+static_assert(PAL_CURL_VERSION_TLSAUTH_SRP == CURL_VERSION_TLSAUTH_SRP, "");
+static_assert(PAL_CURL_VERSION_NTLM_WB == CURL_VERSION_NTLM_WB, "");
+#ifdef CURL_VERSION_HTTP2
+static_assert(PAL_CURL_VERSION_HTTP2 == CURL_VERSION_HTTP2, "");
+#endif
+#ifdef CURL_VERSION_GSSAPI
+static_assert(PAL_CURL_VERSION_GSSAPI == CURL_VERSION_GSSAPI, "");
+#endif
+#ifdef CURL_VERSION_KERBEROS5
+static_assert(PAL_CURL_VERSION_KERBEROS5 == CURL_VERSION_KERBEROS5, "");
+#endif
+#ifdef CURL_VERSION_UNIX_SOCKETS
+static_assert(PAL_CURL_VERSION_UNIX_SOCKETS == CURL_VERSION_UNIX_SOCKETS, "");
+#endif
+#ifdef CURL_VERSION_PSL
+static_assert(PAL_CURL_VERSION_PSL == CURL_VERSION_PSL, "");
+#endif
+
+extern "C" int32_t HttpNative_GetSupportedFeatures()
+{
+    curl_version_info_data* info = curl_version_info(CURLVERSION_NOW);
+    return info != nullptr ? info->features : 0;
+}
+
+extern "C" int32_t HttpNative_GetSupportsHttp2Multiplexing()
+{
+#if HAVE_CURLPIPE_MULTIPLEX
+    curl_version_info_data* info = curl_version_info(CURLVERSION_NOW);
+    return info != nullptr && (info->features & CURL_VERSION_HTTP2) == CURL_VERSION_HTTP2 ? 1 : 0;
+#else
+    return 0;
+#endif
+}
+
+extern "C" char* HttpNative_GetVersionDescription()
+{
+    curl_version_info_data* info = curl_version_info(CURLVERSION_NOW);
+    return info != nullptr && info->version != nullptr ? strdup(info->version) : nullptr;
+}
+
+extern "C" char* HttpNative_GetSslVersionDescription()
+{
+    curl_version_info_data* info = curl_version_info(CURLVERSION_NOW);
+    return info != nullptr && info->ssl_version != nullptr ? strdup(info->ssl_version) : nullptr;
+}
+
+// TODO: Remove HttpNative_GetCurlVersionInfo once the build containing the above functions
+//       is available as part of a package.
 extern "C" int32_t HttpNative_GetCurlVersionInfo(int32_t* age,
                                                  int32_t* supportsSsl,
                                                  int32_t* supportsAutoDecompression,

--- a/src/Native/System.Net.Http.Native/pal_versioninfo.h
+++ b/src/Native/System.Net.Http.Native/pal_versioninfo.h
@@ -3,15 +3,56 @@
 // See the LICENSE file in the project root for more information.
 
 #pragma once
-
 #include "pal_types.h"
 
-/*
-Gets the curl version information.
-
-Returns 1 upon success, otherwise 0.
+/**
+* Constants from curl.h for supported features
 */
-extern "C" int32_t HttpNative_GetCurlVersionInfo(int32_t* age,
-                                                 int32_t* supportsSsl,
-                                                 int32_t* supportsAutoDecompression,
-                                                 int32_t* supportsHttp2Multiplexing);
+enum CurlFeatures : int32_t
+{
+    PAL_CURL_VERSION_IPV6 =         (1<<0),
+    PAL_CURL_VERSION_KERBEROS4 =    (1<<1),
+    PAL_CURL_VERSION_SSL =          (1<<2),
+    PAL_CURL_VERSION_LIBZ =         (1<<3),
+    PAL_CURL_VERSION_NTLM =         (1<<4),
+    PAL_CURL_VERSION_GSSNEGOTIATE = (1<<5),
+    PAL_CURL_VERSION_DEBUG =        (1<<6),
+    PAL_CURL_VERSION_ASYNCHDNS =    (1<<7),
+    PAL_CURL_VERSION_SPNEGO =       (1<<8),
+    PAL_CURL_VERSION_LARGEFILE =    (1<<9),
+    PAL_CURL_VERSION_IDN =          (1<<10),
+    PAL_CURL_VERSION_SSPI =         (1<<11),
+    PAL_CURL_VERSION_CONV =         (1<<12),
+    PAL_CURL_VERSION_CURLDEBUG =    (1<<13),
+    PAL_CURL_VERSION_TLSAUTH_SRP =  (1<<14),
+    PAL_CURL_VERSION_NTLM_WB =      (1<<15),
+    PAL_CURL_VERSION_HTTP2 =        (1<<16),
+    PAL_CURL_VERSION_GSSAPI =       (1<<17),
+    PAL_CURL_VERSION_KERBEROS5 =    (1<<18),
+    PAL_CURL_VERSION_UNIX_SOCKETS = (1<<19),
+    PAL_CURL_VERSION_PSL =          (1<<20),
+};
+
+/*
+Gets the features supported by libcurl.
+
+Returns 1 if multiplexing is supported, otherwise 0.
+*/
+extern "C" int32_t HttpNative_GetSupportedFeatures();
+
+/*
+Gets the features supported by libcurl.
+
+Returns 1 if multiplexing is supported, otherwise 0.
+*/
+extern "C" int32_t HttpNative_GetSupportsHttp2Multiplexing();
+
+/*
+Gets a string description of the version in use.
+*/
+extern "C" char* HttpNative_GetVersionDescription();
+
+/*
+Gets a string description of the SSL version in use.
+*/
+extern "C" char* HttpNative_GetSslVersionDescription();

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -298,19 +298,13 @@
     <value>CookieContainer property must not be null.</value>
   </data>
   <data name="net_http_unix_invalid_certcallback_option" xml:space="preserve">
-    <value>Client certificates and server certificate validation are supported only with a libcurl with a libssl-compatible backend.</value>
+    <value>The libcurl library in use ({0}) and its SSL backend ("{1}") do not support custom client certificates nor custom server certificate validation. A libcurl built with OpenSSL is required.</value>
   </data>
   <data name="net_http_unix_invalid_credential" xml:space="preserve">
-    <value>The libcurl library in use does not support different credentials for different authentication schemes.</value>
-  </data>
-  <data name="net_http_unix_https_libcurl_no_versioninfo" xml:space="preserve">
-    <value>The attempt to access libcurl version information failed unexpectedly.</value>
-  </data>
-  <data name="net_http_unix_https_libcurl_too_old" xml:space="preserve">
-    <value>The libcurl library in use is too old.</value>
+    <value>The libcurl library in use ({0}) does not support different credentials for different authentication schemes.</value>
   </data>
   <data name="net_http_unix_https_support_unavailable_libcurl" xml:space="preserve">
-    <value>The libcurl library in use does not support https.</value>
+    <value>The libcurl library in use ({0}) does not support HTTPS.</value>
   </data>
   <data name="ArgumentOutOfRange_FileLengthTooBig" xml:space="preserve">
     <value>Specified file length was too large for the file system.</value>

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -298,7 +298,7 @@
     <value>CookieContainer property must not be null.</value>
   </data>
   <data name="net_http_unix_invalid_certcallback_option" xml:space="preserve">
-    <value>The libcurl library in use ({0}) and its SSL backend ("{1}") do not support custom client certificates nor custom server certificate validation. A libcurl built with OpenSSL is required.</value>
+    <value>The libcurl library in use ({0}) and its SSL backend ("{1}") do not support custom handling of certificates. A libcurl built with OpenSSL is required.</value>
   </data>
   <data name="net_http_unix_invalid_credential" xml:space="preserve">
     <value>The libcurl library in use ({0}) does not support different credentials for different authentication schemes.</value>

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
@@ -78,7 +78,8 @@ namespace System.Net.Http
                             easy._handler.ServerCertificateValidationCallback != null ||
                             easy._handler.CheckCertificateRevocationList)
                         {
-                            throw new PlatformNotSupportedException(SR.net_http_unix_invalid_certcallback_option);
+                            throw new PlatformNotSupportedException(
+                                SR.Format(SR.net_http_unix_invalid_certcallback_option, CurlVersionDescription, CurlSslVersionDescription));
                         }
                         break;
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -1,0 +1,156 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Net.Security;
+using System.Net.Test.Common;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Tests
+{
+    public class HttpClientHandler_ServerCertificates_Test
+    {
+        [Fact]
+        public async Task NoCallback_ValidCertificate_CallbackNotCalled()
+        {
+            var handler = new HttpClientHandler();
+            using (var client = new HttpClient(handler))
+            {
+                Assert.Null(handler.ServerCertificateValidationCallback);
+                Assert.False(handler.CheckCertificateRevocationList);
+
+                using (HttpResponseMessage response = await client.GetAsync(HttpTestServers.SecureRemoteEchoServer))
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
+
+                Assert.Throws<InvalidOperationException>(() => handler.ServerCertificateValidationCallback = null);
+                Assert.Throws<InvalidOperationException>(() => handler.CheckCertificateRevocationList = false);
+            }
+        }
+
+        [Fact]
+        public async Task UseCallback_NotSecureConnection_CallbackNotCalled()
+        {
+            var handler = new HttpClientHandler();
+            using (var client = new HttpClient(handler))
+            {
+                bool callbackCalled = false;
+                handler.ServerCertificateValidationCallback = delegate { callbackCalled = true; return true; };
+
+                using (HttpResponseMessage response = await client.GetAsync(HttpTestServers.RemoteEchoServer))
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
+
+                Assert.False(callbackCalled);
+            }
+        }
+
+        public static IEnumerable<object[]> UseCallback_ValidCertificate_ExpectedValuesDuringCallback_Urls()
+        {
+            foreach (bool checkRevocation in new[] { true, false })
+            {
+                yield return new object[] { HttpTestServers.SecureRemoteEchoServer, checkRevocation };
+                yield return new object[] { HttpTestServers.RedirectUriForDestinationUri(true, HttpTestServers.SecureRemoteEchoServer, 1), checkRevocation };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(UseCallback_ValidCertificate_ExpectedValuesDuringCallback_Urls))]
+        public async Task UseCallback_ValidCertificate_ExpectedValuesDuringCallback(Uri url, bool checkRevocation)
+        {
+            var handler = new HttpClientHandler();
+            using (var client = new HttpClient(handler))
+            {
+                bool callbackCalled = false;
+                handler.CheckCertificateRevocationList = checkRevocation;
+                handler.ServerCertificateValidationCallback = (request, cert, chain, errors) => {
+                    callbackCalled = true;
+                    Assert.NotNull(request);
+                    Assert.Equal(SslPolicyErrors.None, errors);
+                    Assert.True(chain.ChainElements.Count > 0);
+                    Assert.NotEmpty(cert.Subject);
+                    Assert.Equal(checkRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck, chain.ChainPolicy.RevocationMode);
+                    return true;
+                };
+
+                using (HttpResponseMessage response = await client.GetAsync(url))
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
+
+                Assert.True(callbackCalled);
+            }
+        }
+
+        [Fact]
+        public async Task UseCallback_CallbackReturnsFailure_ThrowsException()
+        {
+            var handler = new HttpClientHandler();
+            using (var client = new HttpClient(handler))
+            {
+                handler.ServerCertificateValidationCallback = delegate { return false; };
+                await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(HttpTestServers.SecureRemoteEchoServer));
+            }
+        }
+
+        [Fact]
+        public async Task UseCallback_CallbackThrowsException_ExceptionPropagates()
+        {
+            var handler = new HttpClientHandler();
+            using (var client = new HttpClient(handler))
+            {
+                var e = new DivideByZeroException();
+                handler.ServerCertificateValidationCallback = delegate { throw e; };
+                Assert.Same(e, await Assert.ThrowsAsync<DivideByZeroException>(() => client.GetAsync(HttpTestServers.SecureRemoteEchoServer)));
+            }
+        }
+
+        [Theory]
+        [InlineData(HttpTestServers.ExpiredCertRemoteServer)]
+        [InlineData(HttpTestServers.SelfSignedCertRemoteServer)]
+        [InlineData(HttpTestServers.WrongHostNameCertRemoteServer)]
+        public async Task NoCallback_BadCertificate_ThrowsException(string url)
+        {
+            using (var client = new HttpClient())
+            {
+                await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url));
+            }
+        }
+
+        [Theory]
+        [InlineData(HttpTestServers.ExpiredCertRemoteServer, SslPolicyErrors.RemoteCertificateChainErrors)]
+        [InlineData(HttpTestServers.SelfSignedCertRemoteServer, SslPolicyErrors.RemoteCertificateChainErrors)]
+        [InlineData(HttpTestServers.WrongHostNameCertRemoteServer, SslPolicyErrors.RemoteCertificateNameMismatch)]
+        public async Task UseCallback_BadCertificate_ExpectedPolicyErrors(string url, SslPolicyErrors expectedErrors)
+        {
+            var handler = new HttpClientHandler();
+            using (var client = new HttpClient(handler))
+            {
+                bool callbackCalled = false;
+
+                handler.ServerCertificateValidationCallback = (request, cert, chain, errors) =>
+                {
+                    callbackCalled = true;
+                    Assert.NotNull(request);
+                    Assert.NotNull(cert);
+                    Assert.NotNull(chain);
+                    Assert.Equal(expectedErrors, errors);
+                    return true;
+                };
+
+                using (HttpResponseMessage response = await client.GetAsync(url))
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
+
+                Assert.True(callbackCalled);
+            }
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -54,6 +54,9 @@
     <Compile Include="TestHelper.cs" />
     <Compile Include="XunitTestAssemblyAttributes.cs" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
+    <Compile Include="HttpClientHandlerTest.ServerCertificates.cs" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Net.Http.csproj">
       <Project>{1D422B1D-D7C4-41B9-862D-EB3D98DF37DE}</Project>

--- a/src/System.Net.Http/tests/FunctionalTests/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/project.json
@@ -12,6 +12,7 @@
     "System.ObjectModel": "4.0.12-rc3-23923",
     "System.Runtime.Extensions": "4.1.0-rc3-23923",
     "System.Security.Cryptography.Algorithms": "4.1.0-rc3-23923",
+    "System.Security.Cryptography.X509Certificates": "4.1.0-rc3-23923",
     "System.Text.Encoding": "4.0.11-rc3-23923",
     "System.Text.RegularExpressions": "4.0.12-rc3-23923",
     "System.Threading.Tasks": "4.0.11-rc3-23923",


### PR DESCRIPTION
Based in part on the ones for WinHttpHandler.  Right now these tests are only included for Unix.

cc: @davidsh, @bartonjs