### PR TITLE
Throw on duplicate key in Sorted‎List ctor from Dictionary.Tests.cs

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -152,10 +152,28 @@ namespace System.Collections.Generic
             if (dictionary == null)
                 throw new ArgumentNullException(nameof(dictionary));
 
-            dictionary.Keys.CopyTo(_keys, 0);
-            dictionary.Values.CopyTo(_values, 0);
-            Array.Sort<TKey, TValue>(_keys, _values, comparer);
-            _size = dictionary.Count;
+            int count = dictionary.Count;
+            if (count != 0)
+            {
+                TKey[] keys = _keys;
+                dictionary.Keys.CopyTo(keys, 0);
+                dictionary.Values.CopyTo(_values, 0);
+                Debug.Assert(count == _keys.Length);
+                if (count > 1)
+                {
+                    Array.Sort<TKey, TValue>(keys, _values, comparer);
+                    comparer = Comparer; // obtain default if this is null.
+                    for (int i = 1; i != keys.Length; ++i)
+                    {
+                        if (comparer.Compare(keys[i - 1], keys[i]) == 0)
+                        {
+                            throw new ArgumentException(SR.Format(SR.Argument_AddingDuplicate, keys[i]));
+                        }
+                    }
+                }
+            }
+
+            _size = count;
         }
 
         // Adds an entry with the given key and value to this sorted list. An

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
@@ -226,6 +226,13 @@ namespace System.Collections.Tests
             TestCopyConstructor(size, keyValueSelector, dictionarySelector, comparer);
         }
 
+        [Fact]
+        public void CantAcceptDuplicateKeysFromSourceDictionary()
+        {
+            Dictionary<string, int> source = new Dictionary<string, int> { { "a", 1 }, { "A", 1 } };
+            Assert.Throws<ArgumentException>(null, () => new Dictionary<string, int>(source, StringComparer.OrdinalIgnoreCase));
+        }
+
         public static IEnumerable<object[]> CopyConstructorStringComparerData
         {
             get

--- a/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Tests.cs
@@ -129,6 +129,13 @@ namespace System.Collections.Tests
             }
         }
 
+        [Fact]
+        public void CantAcceptDuplicateKeysFromSourceDictionary()
+        {
+            Dictionary<string, int> source = new Dictionary<string, int> { { "a", 1 }, { "A", 1 } };
+            Assert.Throws<ArgumentException>(null, () => new SortedDictionary<string, int>(source, StringComparer.OrdinalIgnoreCase));
+        }
+
         #endregion
 
         #region ICollection tests

--- a/src/System.Collections/tests/Generic/SortedList/SortedList.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedList/SortedList.Tests.cs
@@ -118,6 +118,14 @@ namespace System.Collections.Tests
             }
         }
 
+        [Fact]
+        public void CantAcceptDuplicateKeysFromSourceDictionary()
+        {
+            Dictionary<string, int> source = new Dictionary<string, int> { { "a", 1 }, { "A", 1 } };
+            Assert.Throws<ArgumentException>(null, () => new SortedList<string, int>(source, StringComparer.OrdinalIgnoreCase));
+        }
+
+
         #endregion
 
         #region ICollection tests


### PR DESCRIPTION
Fixes #7019

Also include relevant tests for `Dictionary` and `SortedDictionary` as well as `SortedList` to guard against comparable regressions.