### PR TITLE
Split _queueLock into multiple locks

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -449,7 +449,14 @@ namespace System.Net.Sockets
         private bool _nonBlockingSet;
         private bool _connectFailed;
 
-        private object _queueLock = new object();
+        //
+        // We have separate locks for send and receive queues, so they can proceed concurrently.  Accept and connect
+        // use the same lock as send, since they can't happen concurrently anyway.  
+        //
+        private object _sendAcceptConnectLock = new object();
+        private object _receiveLock = new object();
+
+        private object _registerLock = new object();
 
         public SocketAsyncContext(SafeCloseSocket socket)
         {
@@ -458,36 +465,43 @@ namespace System.Net.Sockets
 
         private void Register(Interop.Sys.SocketEvents events)
         {
-            Debug.Assert(Monitor.IsEntered(_queueLock), "Expected _queueLock to be held");
-            Debug.Assert((_registeredEvents & events) == Interop.Sys.SocketEvents.None, $"Unexpected values: _registeredEvents={_registeredEvents}, events={events}");
-
-            if (!_asyncEngineToken.WasAllocated)
+            lock (_registerLock)
             {
-                _asyncEngineToken = new SocketAsyncEngine.Token(this);
+                Debug.Assert((_registeredEvents & events) == Interop.Sys.SocketEvents.None, $"Unexpected values: _registeredEvents={_registeredEvents}, events={events}");
+
+                if (!_asyncEngineToken.WasAllocated)
+                {
+                    _asyncEngineToken = new SocketAsyncEngine.Token(this);
+                }
+
+                events |= _registeredEvents;
+
+                Interop.Error errorCode;
+                if (!_asyncEngineToken.TryRegister(_socket, _registeredEvents, events, out errorCode))
+                {
+                    // TODO: throw an appropriate exception
+                    throw new Exception(string.Format("SocketAsyncContext.Register: {0}", errorCode));
+                }
+
+                _registeredEvents = events;
             }
-
-            events |= _registeredEvents;
-
-            Interop.Error errorCode;
-            if (!_asyncEngineToken.TryRegister(_socket, _registeredEvents, events, out errorCode))
-            {
-                // TODO: throw an appropriate exception
-                throw new Exception(string.Format("SocketAsyncContext.Register: {0}", errorCode));
-            }
-
-            _registeredEvents = events;
         }
 
         public void Close()
         {
-            lock (_queueLock)
+            // Drain queues
+            lock (_sendAcceptConnectLock)
             {
-                // Drain queues
-
                 _acceptOrConnectQueue.StopAndAbort();
                 _sendQueue.StopAndAbort();
+            }
+            lock (_receiveLock)
+            {
                 _receiveQueue.StopAndAbort();
+            }
 
+            lock (_registerLock)
+            { 
                 // Freeing the token will prevent any future event delivery.  This socket will be unregistered
                 // from the event port automatically by the OS when it's closed.
                 _asyncEngineToken.Free();
@@ -532,10 +546,10 @@ namespace System.Net.Sockets
             }
         }
 
-        private bool TryBeginOperation<TOperation>(ref OperationQueue<TOperation> queue, TOperation operation, Interop.Sys.SocketEvents events, bool maintainOrder, out bool isStopped)
+        private bool TryBeginOperation<TOperation>(ref OperationQueue<TOperation> queue, object queueLock, TOperation operation, Interop.Sys.SocketEvents events, bool maintainOrder, out bool isStopped)
             where TOperation : AsyncOperation
         {
-            lock (_queueLock)
+            lock (queueLock)
             {
                 switch (queue.State)
                 {
@@ -589,7 +603,7 @@ namespace System.Net.Sockets
                 };
 
                 bool isStopped;
-                while (!TryBeginOperation(ref _acceptOrConnectQueue, operation, Interop.Sys.SocketEvents.Read, maintainOrder: false, isStopped: out isStopped))
+                while (!TryBeginOperation(ref _acceptOrConnectQueue, _sendAcceptConnectLock, operation, Interop.Sys.SocketEvents.Read, maintainOrder: false, isStopped: out isStopped))
                 {
                     if (isStopped)
                     {
@@ -649,7 +663,7 @@ namespace System.Net.Sockets
             };
 
             bool isStopped;
-            while (!TryBeginOperation(ref _acceptOrConnectQueue, operation, Interop.Sys.SocketEvents.Read, maintainOrder: false, isStopped: out isStopped))
+            while (!TryBeginOperation(ref _acceptOrConnectQueue, _sendAcceptConnectLock, operation, Interop.Sys.SocketEvents.Read, maintainOrder: false, isStopped: out isStopped))
             {
                 if (isStopped)
                 {
@@ -689,7 +703,7 @@ namespace System.Net.Sockets
                 };
 
                 bool isStopped;
-                while (!TryBeginOperation(ref _acceptOrConnectQueue, operation, Interop.Sys.SocketEvents.Write, maintainOrder: false, isStopped: out isStopped))
+                while (!TryBeginOperation(ref _acceptOrConnectQueue, _sendAcceptConnectLock, operation, Interop.Sys.SocketEvents.Write, maintainOrder: false, isStopped: out isStopped))
                 {
                     if (isStopped)
                     {
@@ -736,7 +750,7 @@ namespace System.Net.Sockets
             };
 
             bool isStopped;
-            while (!TryBeginOperation(ref _acceptOrConnectQueue, operation, Interop.Sys.SocketEvents.Write, maintainOrder: false, isStopped: out isStopped))
+            while (!TryBeginOperation(ref _acceptOrConnectQueue, _sendAcceptConnectLock, operation, Interop.Sys.SocketEvents.Write, maintainOrder: false, isStopped: out isStopped))
             {
                 if (isStopped)
                 {
@@ -771,7 +785,7 @@ namespace System.Net.Sockets
             try
             {
                 ReceiveOperation operation;
-                lock (_queueLock)
+                lock (_receiveLock)
                 {
                     SocketFlags receivedFlags;
                     SocketError errorCode;
@@ -797,7 +811,7 @@ namespace System.Net.Sockets
                     };
 
                     bool isStopped;
-                    while (!TryBeginOperation(ref _receiveQueue, operation, Interop.Sys.SocketEvents.Read, maintainOrder: true, isStopped: out isStopped))
+                    while (!TryBeginOperation(ref _receiveQueue, _receiveLock, operation, Interop.Sys.SocketEvents.Read, maintainOrder: true, isStopped: out isStopped))
                     {
                         if (isStopped)
                         {
@@ -832,7 +846,7 @@ namespace System.Net.Sockets
         {
             SetNonBlocking();
 
-            lock (_queueLock)
+            lock (_receiveLock)
             {
                 int bytesReceived;
                 SocketFlags receivedFlags;
@@ -864,7 +878,7 @@ namespace System.Net.Sockets
                 };
 
                 bool isStopped;
-                while (!TryBeginOperation(ref _receiveQueue, operation, Interop.Sys.SocketEvents.Read, maintainOrder: true, isStopped: out isStopped))
+                while (!TryBeginOperation(ref _receiveQueue, _receiveLock, operation, Interop.Sys.SocketEvents.Read, maintainOrder: true, isStopped: out isStopped))
                 {
                     if (isStopped)
                     {
@@ -900,7 +914,7 @@ namespace System.Net.Sockets
             {
                 ReceiveOperation operation;
 
-                lock (_queueLock)
+                lock (_receiveLock)
                 {
                     SocketFlags receivedFlags;
                     SocketError errorCode;
@@ -923,7 +937,7 @@ namespace System.Net.Sockets
                     };
 
                     bool isStopped;
-                    while (!TryBeginOperation(ref _receiveQueue, operation, Interop.Sys.SocketEvents.Read, maintainOrder: true, isStopped: out isStopped))
+                    while (!TryBeginOperation(ref _receiveQueue, _receiveLock, operation, Interop.Sys.SocketEvents.Read, maintainOrder: true, isStopped: out isStopped))
                     {
                         if (isStopped)
                         {
@@ -961,7 +975,7 @@ namespace System.Net.Sockets
 
             ReceiveOperation operation;
 
-            lock (_queueLock)
+            lock (_receiveLock)
             {
                 int bytesReceived;
                 SocketFlags receivedFlags;
@@ -990,7 +1004,7 @@ namespace System.Net.Sockets
                 };
 
                 bool isStopped;
-                while (!TryBeginOperation(ref _receiveQueue, operation, Interop.Sys.SocketEvents.Read, maintainOrder: true, isStopped: out isStopped))
+                while (!TryBeginOperation(ref _receiveQueue, _receiveLock, operation, Interop.Sys.SocketEvents.Read, maintainOrder: true, isStopped: out isStopped))
                 {
                     if (isStopped)
                     {
@@ -1016,7 +1030,7 @@ namespace System.Net.Sockets
             {
                 ReceiveMessageFromOperation operation;
 
-                lock (_queueLock)
+                lock (_receiveLock)
                 {
                     SocketFlags receivedFlags;
                     SocketError errorCode;
@@ -1043,7 +1057,7 @@ namespace System.Net.Sockets
                     };
 
                     bool isStopped;
-                    while (!TryBeginOperation(ref _receiveQueue, operation, Interop.Sys.SocketEvents.Read, maintainOrder: true, isStopped: out isStopped))
+                    while (!TryBeginOperation(ref _receiveQueue, _receiveLock, operation, Interop.Sys.SocketEvents.Read, maintainOrder: true, isStopped: out isStopped))
                     {
                         if (isStopped)
                         {
@@ -1082,7 +1096,7 @@ namespace System.Net.Sockets
         {
             SetNonBlocking();
 
-            lock (_queueLock)
+            lock (_receiveLock)
             {
                 int bytesReceived;
                 SocketFlags receivedFlags;
@@ -1117,7 +1131,7 @@ namespace System.Net.Sockets
                 };
 
                 bool isStopped;
-                while (!TryBeginOperation(ref _receiveQueue, operation, Interop.Sys.SocketEvents.Read, maintainOrder: true, isStopped: out isStopped))
+                while (!TryBeginOperation(ref _receiveQueue, _receiveLock, operation, Interop.Sys.SocketEvents.Read, maintainOrder: true, isStopped: out isStopped))
                 {
                     if (isStopped)
                     {
@@ -1153,7 +1167,7 @@ namespace System.Net.Sockets
             {
                 SendOperation operation;
 
-                lock (_queueLock)
+                lock (_sendAcceptConnectLock)
                 {
                     bytesSent = 0;
                     SocketError errorCode;
@@ -1179,7 +1193,7 @@ namespace System.Net.Sockets
                     };
 
                     bool isStopped;
-                    while (!TryBeginOperation(ref _sendQueue, operation, Interop.Sys.SocketEvents.Write, maintainOrder: true, isStopped: out isStopped))
+                    while (!TryBeginOperation(ref _sendQueue, _sendAcceptConnectLock, operation, Interop.Sys.SocketEvents.Write, maintainOrder: true, isStopped: out isStopped))
                     {
                         if (isStopped)
                         {
@@ -1209,7 +1223,7 @@ namespace System.Net.Sockets
         {
             SetNonBlocking();
 
-            lock (_queueLock)
+            lock (_sendAcceptConnectLock)
             {
                 int bytesSent = 0;
                 SocketError errorCode;
@@ -1241,7 +1255,7 @@ namespace System.Net.Sockets
                 };
 
                 bool isStopped;
-                while (!TryBeginOperation(ref _sendQueue, operation, Interop.Sys.SocketEvents.Write, maintainOrder: true, isStopped: out isStopped))
+                while (!TryBeginOperation(ref _sendQueue, _sendAcceptConnectLock, operation, Interop.Sys.SocketEvents.Write, maintainOrder: true, isStopped: out isStopped))
                 {
                     if (isStopped)
                     {
@@ -1277,7 +1291,7 @@ namespace System.Net.Sockets
             {
                 SendOperation operation;
 
-                lock (_queueLock)
+                lock (_sendAcceptConnectLock)
                 {
                     bytesSent = 0;
                     int bufferIndex = 0;
@@ -1305,7 +1319,7 @@ namespace System.Net.Sockets
                     };
 
                     bool isStopped;
-                    while (!TryBeginOperation(ref _sendQueue, operation, Interop.Sys.SocketEvents.Write, maintainOrder: true, isStopped: out isStopped))
+                    while (!TryBeginOperation(ref _sendQueue, _sendAcceptConnectLock, operation, Interop.Sys.SocketEvents.Write, maintainOrder: true, isStopped: out isStopped))
                     {
                         if (isStopped)
                         {
@@ -1335,7 +1349,7 @@ namespace System.Net.Sockets
         {
             SetNonBlocking();
 
-            lock (_queueLock)
+            lock (_sendAcceptConnectLock)
             {
                 int bufferIndex = 0;
                 int offset = 0;
@@ -1368,7 +1382,7 @@ namespace System.Net.Sockets
                 };
 
                 bool isStopped;
-                while (!TryBeginOperation(ref _sendQueue, operation, Interop.Sys.SocketEvents.Write, maintainOrder: true, isStopped: out isStopped))
+                while (!TryBeginOperation(ref _sendQueue, _sendAcceptConnectLock, operation, Interop.Sys.SocketEvents.Write, maintainOrder: true, isStopped: out isStopped))
                 {
                     if (isStopped)
                     {
@@ -1387,26 +1401,32 @@ namespace System.Net.Sockets
 
         public unsafe void HandleEvents(Interop.Sys.SocketEvents events)
         {
-            lock (_queueLock)
+            if ((events & Interop.Sys.SocketEvents.Error) != 0)
             {
-                if ((events & Interop.Sys.SocketEvents.Error) != 0)
-                {
-                    // Set the Read and Write flags as well; the processing for these events
-                    // will pick up the error.
-                    events |= Interop.Sys.SocketEvents.Read | Interop.Sys.SocketEvents.Write;
-                }
+                // Set the Read and Write flags as well; the processing for these events
+                // will pick up the error.
+                events |= Interop.Sys.SocketEvents.Read | Interop.Sys.SocketEvents.Write;
+            }
 
-                if ((events & Interop.Sys.SocketEvents.Read) != 0)
+            if ((events & Interop.Sys.SocketEvents.Read) != 0)
+            {
+                lock (_sendAcceptConnectLock)
                 {
                     if (_acceptOrConnectQueue.AllOfType<AcceptOperation>())
                     {
                         _acceptOrConnectQueue.Complete(this);
                     }
-
-                    _receiveQueue.Complete(this);
                 }
 
-                if ((events & Interop.Sys.SocketEvents.Write) != 0)
+                lock (_receiveLock)
+                {
+                    _receiveQueue.Complete(this);
+                }
+            }
+
+            if ((events & Interop.Sys.SocketEvents.Write) != 0)
+            {
+                lock (_sendAcceptConnectLock)
                 {
                     if (_acceptOrConnectQueue.AllOfType<ConnectOperation>())
                     {


### PR DESCRIPTION
#6838 introduced a new issue; with a single lock, it was impossible to have a Send proceed concurrently with a Receive, which should work.  This caused a [hang in the .NET CLI tests](https://github.com/dotnet/cli/pull/1990#issuecomment-200500819).

This change splits the lock into two, plus adds a third lock to cover event registration.  (This used to be covered by _queueLock as well, but cannot be covered by the two new locks without lock ordering issues).  This is admittedly a bit of a mess; I'll clean this up as part of #6912.

Will add additional testing for this case separately, but we need to get this in ASAP to unblock the CLI.

@stephentoub @eerhardt