### PR TITLE
Fix WinHttpHandler session handle initialization

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
@@ -41,7 +41,7 @@ namespace System.Net.Http
                 return;
             }
             
-            Debug.WriteLine(message);
+            WriteLine(message);
         }
 
         public static void Trace(string format, bool arg0)
@@ -51,7 +51,7 @@ namespace System.Net.Http
                 return;
             }
             
-            Debug.WriteLine(format, arg0);
+            WriteLine(format, arg0);
         }
 
         public static void Trace(string format, int arg0)
@@ -61,7 +61,17 @@ namespace System.Net.Http
                 return;
             }
             
-            Debug.WriteLine(format, arg0);
+            WriteLine(format, arg0);
+        }
+
+        public static void Trace(string format, uint arg0)
+        {
+            if (!IsTraceEnabled())
+            {
+                return;
+            }
+            
+            WriteLine(format, arg0);
         }
 
         public static void Trace(string format, string arg0)
@@ -71,7 +81,7 @@ namespace System.Net.Http
                 return;
             }
             
-            Debug.WriteLine(format, arg0);
+            WriteLine(format, arg0);
         }
 
         public static void Trace(string format, string arg0, string arg1)
@@ -81,7 +91,7 @@ namespace System.Net.Http
                 return;
             }
             
-            Debug.WriteLine(format, arg0, arg1);
+            WriteLine(format, arg0, arg1);
         }
 
         public static void Trace(string format, IntPtr arg0, bool arg1, bool arg2)
@@ -91,7 +101,7 @@ namespace System.Net.Http
                 return;
             }
             
-            Debug.WriteLine(format, arg0, arg1, arg2);
+            WriteLine(format, arg0, arg1, arg2);
         }
 
         public static void Trace(string format, string arg0, bool arg1, string arg2, string arg3)
@@ -101,7 +111,7 @@ namespace System.Net.Http
                 return;
             }
             
-            Debug.WriteLine(format, arg0, arg1, arg2, arg3);
+            WriteLine(format, arg0, arg1, arg2, arg3);
         }
 
         public static void TraceCallbackStatus(string message, IntPtr handle, IntPtr context, uint status)
@@ -111,7 +121,7 @@ namespace System.Net.Http
                 return;
             }
 
-            Debug.WriteLine(
+            WriteLine(
                 "{0}: handle=0x{1:X}, context=0x{2:X}, {3}",
                 message,
                 handle,
@@ -129,13 +139,26 @@ namespace System.Net.Http
             uint apiIndex = (uint)asyncResult.dwResult.ToInt32();
             uint error = asyncResult.dwError;
 
-            Debug.WriteLine(
+            WriteLine(
                 "{0}: api={1}, error={2}({3}) \"{4}\"",
                 message,
                 GetNameFromApiIndex(apiIndex),
                 GetNameFromError(error),
                 error,
                 WinHttpException.GetErrorMessage((int)error));
+        }
+
+        private static void WriteLine(string message)
+        {
+            int id = Environment.CurrentManagedThreadId;
+            Debug.WriteLine("[{0}] {1}", id, message);
+        }
+
+        private static void WriteLine(string format, params object[] args)
+        {
+            string message = string.Format(format, args);
+            int id = Environment.CurrentManagedThreadId;
+            Debug.WriteLine("[{0}] {1}", id, message);
         }
 
         private static string GetNameFromApiIndex(uint index)


### PR DESCRIPTION
A test running on Windows 7 was doing multiple parallel requests using the same HttpClient but throwing an unexpected winHTTP error. The problem only occurred on Windows 7 because the proxy initialization code in WinHttpHandler is different for that platform. In general, there is only one session handle created per handler and it is shared with multiple requests. The "init once" logic was faulty because it was setting the `_sessionHandle` field too early before everything was init'd. In addition, this exposed another bug where the session handle options were repeatedly set for each request even though they should only have been set once.

Fixed up the EnsureSessionHandleExists method to do the proper initialization. Also added more tracing.

Fixes #7085