### PR TITLE
Minor fix to clean when called without parameters

### DIFF
--- a/clean.cmd
+++ b/clean.cmd
@@ -4,6 +4,8 @@ setlocal
 set cleanlog=%~dp0clean.log
 echo Running Clean.cmd %* > %cleanlog%
 
+set clean_successful=true
+
 if [%1] == [] (
   set clean_targets=Clean;
   goto Begin
@@ -14,7 +16,6 @@ set clean_src=
 set clean_tools=
 set clean_environment=
 set clean_all=
-set clean_successful=true
 
 :Loop
 if [%1] == [] goto Begin


### PR DESCRIPTION
When calling clean.cmd without options clean_successful is not set to true so even if clean succeeds, the message is that it failed.
This change fixes that.