### PR TITLE
Enable System.Diagnostics.TextWriterTraceListener on Linux

### DIFF
--- a/src/System.Diagnostics.TextWriterTraceListener/tests/System.Diagnostics.TextWriterTraceListener.Tests.csproj
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/System.Diagnostics.TextWriterTraceListener.Tests.csproj
@@ -8,7 +8,6 @@
     <RootNamespace>System.Diagnostics.TextWriterTraceListener.Tests</RootNamespace>
     <AssemblyName>System.Diagnostics.TextWriterTraceListener.Tests</AssemblyName>
     <ProjectGuid>{92A9467A-9F7E-4294-A7D5-7B59F2E54ABE}</ProjectGuid>
-    <UnsupportedPlatforms>Linux</UnsupportedPlatforms> <!-- TODO #6240: Tests failing with FileNotFoundExceptions -->
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/project.json
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/project.json
@@ -20,10 +20,13 @@
       "imports": "portable-net45+win8"
     }
   },
-  "runtimes": {
-    "win7-x86": {},
-    "win7-x64": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {}
-  }
+   "runtimes": { 
+     "win7-x64": {}, 
+     "win7-x86": {}, 
+     "ubuntu.14.04-x64": {}, 
+     "osx.10.10-x64": {}, 
+     "centos.7-x64": {}, 
+     "rhel.7-x64": {}, 
+     "debian.8.2-x64": {} 
+   } 
 }


### PR DESCRIPTION
System.Diagnostics.TextWriterTraceListener tests were disabled on Linux with issue #6240.  The failures were occurring on CentOS because it was a new platform, but the S.D.TWTL tests had an explicit runtime section in their project.json which did not include centos, therefore TraceSource was not extracted from the packaging.  This change removes the runtimes section from project.json in favor of the auto-RID.

I validated this on RHEL, which has since taken over for CentOS.  I'll be using Jenkins validation in this PR to validate on other platforms.