### PR TITLE
Add AsnEncodedDataCollection to S.S.C.Encoding.

### DIFF
--- a/src/System.Security.Cryptography.Encoding/ref/System.Security.Cryptography.Encoding.cs
+++ b/src/System.Security.Cryptography.Encoding/ref/System.Security.Cryptography.Encoding.cs
@@ -66,4 +66,29 @@ namespace System.Security.Cryptography
         SignatureAlgorithm = 4,
         Template = 9,
     }
+
+    public sealed class AsnEncodedDataCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public AsnEncodedDataCollection() { }
+        public AsnEncodedDataCollection(AsnEncodedData asnEncodedData) { }
+        public int Count { get { return default(int); } }
+        bool System.Collections.ICollection.IsSynchronized { get { return default(bool); } }
+        object System.Collections.ICollection.SyncRoot { get { return default(object); } }
+        public AsnEncodedData this[int index] { get { return default(AsnEncodedData); } }
+        public int Add(AsnEncodedData asnEncodedData) { return default(int); }
+        public void CopyTo(AsnEncodedData[] array, int index) { }
+        public AsnEncodedDataEnumerator GetEnumerator() { return default(AsnEncodedDataEnumerator); }
+        public void Remove(AsnEncodedData asnEncodedData) { }
+        void System.Collections.ICollection.CopyTo(Array array, int index) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return default(System.Collections.IEnumerator); }
+    }
+
+    public sealed class AsnEncodedDataEnumerator : System.Collections.IEnumerator
+    {
+        private AsnEncodedDataEnumerator() { }
+        public AsnEncodedData Current { get { return default(AsnEncodedData); } }
+        object System.Collections.IEnumerator.Current { get { return default(object); } }
+        public bool MoveNext() { return default(bool); }
+        public void Reset() { }
+    }
 }

--- a/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
+++ b/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
@@ -28,6 +28,8 @@
     <Compile Include="Internal\Cryptography\Helpers.cs" />
     <Compile Include="Internal\Cryptography\OidLookup.cs" />
     <Compile Include="System\Security\Cryptography\AsnEncodedData.cs" />
+    <Compile Include="System\Security\Cryptography\AsnEncodedDataCollection.cs" />
+    <Compile Include="System\Security\Cryptography\AsnEncodedDataEnumerator.cs" />
     <Compile Include="System\Security\Cryptography\Oid.cs" />
     <Compile Include="System\Security\Cryptography\OidCollection.cs" />
     <Compile Include="System\Security\Cryptography\OidEnumerator.cs" />

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/AsnEncodedDataCollection.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/AsnEncodedDataCollection.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Security.Cryptography
+{
+    public sealed class AsnEncodedDataCollection : ICollection
+    {
+        public AsnEncodedDataCollection()
+        {
+            _list = new List<AsnEncodedData>();
+        }
+
+        public AsnEncodedDataCollection(AsnEncodedData asnEncodedData)
+            : this()
+        {
+            _list.Add(asnEncodedData);
+        }
+
+        public int Add(AsnEncodedData asnEncodedData)
+        {
+            if (asnEncodedData == null)
+                throw new ArgumentNullException(nameof(asnEncodedData));
+
+            int indexOfNewItem = _list.Count;
+            _list.Add(asnEncodedData);
+            return indexOfNewItem;
+        }
+
+        public void Remove(AsnEncodedData asnEncodedData)
+        {
+            if (asnEncodedData == null)
+                throw new ArgumentNullException(nameof(asnEncodedData));
+            _list.Remove(asnEncodedData);
+        }
+
+        public AsnEncodedData this[int index]
+        {
+            get
+            {
+                return _list[index];
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                return _list.Count;
+            }
+        }
+
+        public AsnEncodedDataEnumerator GetEnumerator()
+        {
+            return new AsnEncodedDataEnumerator(this);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        void ICollection.CopyTo(Array array, int index)
+        {
+            if (array == null)
+                throw new ArgumentNullException(nameof(array));
+            if (array.Rank != 1)
+                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+            if (index < 0 || index >= array.Length)
+                throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
+            if (Count > array.Length - index)
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+
+            for (int i = 0; i < Count; i++)
+            {
+                array.SetValue(this[i], index);
+                index++;
+            }
+        }
+
+        public void CopyTo(AsnEncodedData[] array, int index)
+        {
+            ((ICollection)this).CopyTo(array, index);
+        }
+
+        bool ICollection.IsSynchronized
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        object ICollection.SyncRoot
+        {
+            get
+            {
+                return this;
+            }
+        }
+
+        private readonly List<AsnEncodedData> _list;
+    }
+}

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/AsnEncodedDataEnumerator.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/AsnEncodedDataEnumerator.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Security.Cryptography
+{
+    public sealed class AsnEncodedDataEnumerator : IEnumerator
+    {
+        internal AsnEncodedDataEnumerator(AsnEncodedDataCollection asnEncodedDatas)
+        {
+            _asnEncodedDatas = asnEncodedDatas;
+            _current = -1;
+        }
+
+        public AsnEncodedData Current
+        {
+            get
+            {
+                return _asnEncodedDatas[_current];
+            }
+        }
+
+        object IEnumerator.Current
+        {
+            get
+            {
+                return _asnEncodedDatas[_current];
+            }
+        }
+
+        public bool MoveNext()
+        {
+            if (_current >= _asnEncodedDatas.Count - 1)
+                return false;
+            _current++;
+            return true;
+        }
+
+        public void Reset()
+        {
+            _current = -1;
+        }
+
+        private readonly AsnEncodedDataCollection _asnEncodedDatas;
+        private int _current;
+    }
+}

--- a/src/System.Security.Cryptography.Encoding/tests/AsnEncodedDataCollectionTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/AsnEncodedDataCollectionTests.cs
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Text;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Security.Cryptography.Encoding.Tests
+{
+    public static class AsnEncodedDataCollectionTests
+    {
+        [Fact]
+        public static void Nullary()
+        {
+            AsnEncodedDataCollection c = new AsnEncodedDataCollection();
+            AssertEquals(c, Array.Empty<AsnEncodedData>());
+        }
+
+        [Fact]
+        public static void Oneary()
+        {
+            AsnEncodedData a0 = new AsnEncodedData("1.0", Array.Empty<byte>());
+            AsnEncodedDataCollection c = new AsnEncodedDataCollection(a0);
+            AssertEquals(c, new AsnEncodedData[] { a0 });
+        }
+
+        [Fact]
+        public static void Add()
+        {
+            AsnEncodedData a0 = new AsnEncodedData("1.0", Array.Empty<byte>());
+            AsnEncodedData a1 = new AsnEncodedData("1.1", Array.Empty<byte>());
+            AsnEncodedData a2 = new AsnEncodedData("1.2", Array.Empty<byte>());
+
+            AsnEncodedDataCollection c = new AsnEncodedDataCollection();
+            int index;
+            index = c.Add(a0);
+            Assert.Equal(0, index);
+            index = c.Add(a1);
+            Assert.Equal(1, index);
+            index = c.Add(a2);
+            Assert.Equal(2, index);
+
+            AssertEquals(c, new AsnEncodedData[] { a0, a1, a2 });
+        }
+
+        [Fact]
+        public static void Remove()
+        {
+            AsnEncodedData a0 = new AsnEncodedData("1.0", Array.Empty<byte>());
+            AsnEncodedData a1 = new AsnEncodedData("1.1", Array.Empty<byte>());
+            AsnEncodedData a2 = new AsnEncodedData("1.2", Array.Empty<byte>());
+
+            AsnEncodedDataCollection c = new AsnEncodedDataCollection();
+            int index;
+            index = c.Add(a0);
+            Assert.Equal(0, index);
+            index = c.Add(a1);
+            Assert.Equal(1, index);
+            index = c.Add(a2);
+            Assert.Equal(2, index);
+
+            c.Remove(a1);
+
+            AssertEquals(c, new AsnEncodedData[] { a0, a2 });
+        }
+
+        [Fact]
+        public static void AddNegative()
+        {
+            AsnEncodedDataCollection c = new AsnEncodedDataCollection();
+            Assert.Throws<ArgumentNullException>(() => c.Add(null));
+        }
+
+        [Fact]
+        public static void RemoveNegative()
+        {
+            AsnEncodedDataCollection c = new AsnEncodedDataCollection();
+            Assert.Throws<ArgumentNullException>(() => c.Remove(null));
+        }
+
+        [Fact]
+        public static void RemoveNonExistent()
+        {
+            AsnEncodedDataCollection c = new AsnEncodedDataCollection();
+            AsnEncodedData a0 = new AsnEncodedData("1.0", Array.Empty<byte>());
+            c.Remove(a0);  // You can "remove" items that aren't in the collection - this is defined as a NOP.
+        }
+
+        [Fact]
+        public static void IndexOutOfBounds()
+        {
+            AsnEncodedData a0 = new AsnEncodedData("1.0", Array.Empty<byte>());
+            AsnEncodedData a1 = new AsnEncodedData("1.1", Array.Empty<byte>());
+            AsnEncodedData a2 = new AsnEncodedData("1.2", Array.Empty<byte>());
+
+            AsnEncodedDataCollection c = new AsnEncodedDataCollection();
+            c.Add(a0);
+            c.Add(a1);
+            c.Add(a2);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => c[-1]);
+            Assert.Throws<ArgumentOutOfRangeException>(() => c[3]);
+        }
+
+        [Fact]
+        public static void CopyExceptions()
+        {
+            AsnEncodedData a0 = new AsnEncodedData("1.0", Array.Empty<byte>());
+            AsnEncodedData a1 = new AsnEncodedData("1.1", Array.Empty<byte>());
+            AsnEncodedData a2 = new AsnEncodedData("1.2", Array.Empty<byte>());
+
+            AsnEncodedDataCollection c = new AsnEncodedDataCollection();
+            c.Add(a0);
+            c.Add(a1);
+            c.Add(a2);
+
+            Assert.Throws<ArgumentNullException>(() => c.CopyTo(null, 0));
+            AsnEncodedData[] a = new AsnEncodedData[3];
+            Assert.Throws<ArgumentOutOfRangeException>(() => c.CopyTo(a, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => c.CopyTo(a, 3));
+            Assert.Throws<ArgumentException>(() => c.CopyTo(a, 1));
+        }
+
+
+        private static void AssertEquals(AsnEncodedDataCollection c, IList<AsnEncodedData> expected)
+        {
+            Assert.Equal(expected.Count, c.Count);
+
+            for (int i = 0; i < c.Count; i++)
+            {
+                Assert.Equal(expected[i], c[i]);
+            }
+
+            int index = 0;
+            foreach (AsnEncodedData a in c)
+            {
+                Assert.Equal(expected[index++], a);
+            }
+            Assert.Equal(c.Count, index);
+
+            ValidateEnumerator(c.GetEnumerator(), expected);
+            ValidateEnumerator(((ICollection)c).GetEnumerator(), expected);
+
+            AsnEncodedData[] dumped = new AsnEncodedData[c.Count + 3];
+            c.CopyTo(dumped, 2);
+            Assert.Equal(null, dumped[0]);
+            Assert.Equal(null, dumped[1]);
+            Assert.Equal(null, dumped[dumped.Length - 1]);
+            Assert.Equal<AsnEncodedData>(expected, dumped.Skip(2).Take(c.Count));
+        }
+
+        private static void ValidateEnumerator(IEnumerator enumerator, IList<AsnEncodedData> expected)
+        {
+            foreach (AsnEncodedData e in expected)
+            {
+                Assert.True(enumerator.MoveNext());
+                AsnEncodedData actual = (AsnEncodedData)(enumerator.Current);
+                Assert.Equal(e, actual);
+            }
+            Assert.False(enumerator.MoveNext());
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
+++ b/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsnEncodedData.cs" />
+    <Compile Include="AsnEncodedDataCollectionTests.cs" />
     <Compile Include="DerEncoderTests.cs" />
     <Compile Include="DerSequenceReaderTests.cs" />
     <Compile Include="Oid.cs" />


### PR DESCRIPTION
This unblocks future work to bring the Pkcs namespace
over (as one of its classes publically references
AsnEncodedDataCollection.)

Boring port of http://index/#System/asnencodeddata.cs,d75ed3ab3abbb804
(dropping the "do incoming items match the m_oid value" check since
this only activates on a private field that no ever sets being non-null.)