### PR TITLE
Run VsDevCmd.bat as part of init-tools

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -12,19 +12,6 @@ set "__args=%*"
 if /i [%1] == [native] (set __buildSpec=native&&set "__args=%__args:~6%"&&shift&&goto Tools)
 if /i [%1] == [managed] (set __buildSpec=managed&&set "__args=%__args:~7%"&&shift&&goto Tools)
 
-:Tools
-:: Setup VS
-if not defined VisualStudioVersion (
-    if defined VS140COMNTOOLS (
-        call "%VS140COMNTOOLS%\VsDevCmd.bat"
-        goto :Build
-    )
-
-    echo Error: build.cmd requires Visual Studio 2015.
-    echo        Please see https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md for build instructions.
-    exit /b 1
-)
-
 :Build
 :: Restore the Tools directory
 call %~dp0init-tools.cmd

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -1,4 +1,17 @@
 @echo off
+
+:Tools
+:: Setup VS
+if not defined VisualStudioVersion (
+  if defined VS140COMNTOOLS (
+      call "%VS140COMNTOOLS%\VsDevCmd.bat"
+  ) else (
+      echo Error: We require Visual Studio 2015.
+      echo        Please see https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md for build instructions.
+      exit /b 1
+  )
+)
+
 setlocal
 
 REM Workaround https://github.com/dotnet/coreclr/issues/2153


### PR DESCRIPTION
The dev workflow scripts doesn't work in a vanilla cmd. We are now going to call VsDevCmd.bat from init-tools.cmd and not from build.cmd to make the env. variables (like setting msbuild in the path) available for all the scripts that we use.

cc: @jhendrixMSFT @joperezr @weshaggard