### PR TITLE
Baseline Win7 CNG symmetric encryption tests

### DIFF
--- a/src/System.Security.Cryptography.Cng/tests/AesProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/AesProvider.cs
@@ -2,15 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 namespace System.Security.Cryptography.Encryption.Aes.Tests
 {
     using Aes = System.Security.Cryptography.Aes;
 
     public class AesProvider : IAesProvider
     {
+        // Issue 7201: Windows 7 (Microsoft Windows 6.1) KSP does not support
+        // AES, so temporarily recycle the BCrypt.dll-based implementation
+        // from the Algorithms library, pending a change to make ephemeral
+        // keys always use BCrypt.
+        private static readonly Func<Aes> s_creator =
+            RuntimeInformation.OSDescription.Contains("Windows 6.1") ? Aes.Create : (Func<Aes>)(() => new AesCng());
+
         public Aes Create()
         {
-            return new AesCng();
+            return s_creator();
         }
     }
 

--- a/src/System.Security.Cryptography.Cng/tests/TripleDESCngProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/TripleDESCngProvider.cs
@@ -2,13 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 namespace System.Security.Cryptography.Encryption.TripleDes.Tests
 {
     public class TripleDESCngProvider : ITripleDESProvider
     {
+        // Issue 7201: Windows 7 (Microsoft Windows 6.1) KSP does not support
+        // 3DES, so temporarily recycle the BCrypt.dll-based implementation
+        // from the Algorithms library, pending a change to make ephemeral
+        // keys always use BCrypt.
+        private static readonly Func<TripleDES> s_creator =
+            RuntimeInformation.OSDescription.Contains("Windows 6.1") ? TripleDES.Create : (Func<TripleDES>)(() => new TripleDESCng());
+
         public TripleDES Create()
         {
-            return new TripleDESCng();
+            return s_creator();
         }
     }
 


### PR DESCRIPTION
AesCng and TripleDESCng both do their cryptographic operations via NCrypt
exclusively.  On Windows 7 the software key provider does not support
symmetric encryption, so this fails.

This change makes Win7 use the implementation from S.S.C.Algorithms until
the proper fix of using BCrypt when possible and NCrypt only when required
is completed.

This will eliminate the last of the failures reported by #7086 in master; and a similar change
(with comments less suggestive of "wait for a fix") will be submitted for RC2.

cc: @stephentoub @AtsushiKan