### PR TITLE
Remove an unnecessary owner checking assert in TdsParserStateObject.Cancel

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
@@ -614,7 +614,6 @@ namespace System.Data.SqlClient
         internal void Cancel(object caller)
         {
             Debug.Assert(!(caller is int), "Incorrectly calling this API using the caller's objectID");
-            Debug.Assert(_owner.Target == caller, "Someone other than the stateObj's owner is attempting to cancel");
             bool hasLock = false;
             try
             {


### PR DESCRIPTION
When calling SqlCommand.Cancel, the underlying TdsParserStateObject has an assert that checks if the caller is actually the state object's owner. The problem is that during execution the owner of the state object can change. For example, the owner can be set to null when the session is being closed, or can be set to a SqlDataReader once the reader takes ownership of the underlying session. So this ownership assert can be hit during normal execution, and errors from Cancel aren't even really given much weight to begin with. 

From the documentation: "If there is nothing to cancel, **nothing occurs**. However, if there is a command in process, and the attempt to cancel fails, **no exception is generated**. " (From: https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlcommand.cancel(v=vs.110).aspx)

So I propose removing this assert, since it's throwing an error for an expected & unremarkable situation. Cancel checks that the owner is correct before cancelling, anyway (https://github.com/dotnet/corefx/blob/master/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs#L630).