### PR TITLE
Re-enable specialized collections tests disabled on unix

### DIFF
--- a/src/System.Collections.Specialized/tests/NameValueCollection/AddNVCTests.cs
+++ b/src/System.Collections.Specialized/tests/NameValueCollection/AddNVCTests.cs
@@ -14,7 +14,6 @@ namespace System.Collections.Specialized.Tests
         public const int MAX_LEN = 50;          // max length of random strings
 
         [Fact]
-        [ActiveIssue(2769, PlatformID.AnyUnix)]
         public void Test01()
         {
             IntlStrings intl;

--- a/src/System.Collections.Specialized/tests/NameValueCollection/AddStrStrTests.cs
+++ b/src/System.Collections.Specialized/tests/NameValueCollection/AddStrStrTests.cs
@@ -15,7 +15,6 @@ namespace System.Collections.Specialized.Tests
         public const int MAX_LEN = 50;          // max length of random strings
 
         [Fact]
-        [ActiveIssue(2769, PlatformID.AnyUnix)]
         public void Test01()
         {
             IntlStrings intl;

--- a/src/System.Collections.Specialized/tests/NameValueCollection/GetItemStrTests.cs
+++ b/src/System.Collections.Specialized/tests/NameValueCollection/GetItemStrTests.cs
@@ -15,7 +15,6 @@ namespace System.Collections.Specialized.Tests
         public const int MAX_LEN = 50;          // max length of random strings
 
         [Fact]
-        [ActiveIssue(2769, PlatformID.AnyUnix)]
         public void Test01()
         {
             IntlStrings intl;

--- a/src/System.Collections.Specialized/tests/NameValueCollection/GetStrTests.cs
+++ b/src/System.Collections.Specialized/tests/NameValueCollection/GetStrTests.cs
@@ -15,7 +15,6 @@ namespace System.Collections.Specialized.Tests
         public const int MAX_LEN = 50;          // max length of random strings
 
         [Fact]
-        [ActiveIssue(2769, PlatformID.AnyUnix)]
         public void Test01()
         {
             IntlStrings intl;

--- a/src/System.Collections.Specialized/tests/NameValueCollection/GetValuesStrTests.cs
+++ b/src/System.Collections.Specialized/tests/NameValueCollection/GetValuesStrTests.cs
@@ -15,7 +15,6 @@ namespace System.Collections.Specialized.Tests
         public const int MAX_LEN = 50;          // max length of random strings
 
         [Fact]
-        [ActiveIssue(2769, PlatformID.AnyUnix)]
         public void Test01()
         {
             IntlStrings intl;

--- a/src/System.Collections.Specialized/tests/NameValueCollection/RemoveStrTests.cs
+++ b/src/System.Collections.Specialized/tests/NameValueCollection/RemoveStrTests.cs
@@ -15,7 +15,6 @@ namespace System.Collections.Specialized.Tests
         public const int MAX_LEN = 50;          // max length of random strings
 
         [Fact]
-        [ActiveIssue(2769, PlatformID.AnyUnix)]
         public void Test01()
         {
             IntlStrings intl;

--- a/src/System.Collections.Specialized/tests/NameValueCollection/SetItemStrStrTests.cs
+++ b/src/System.Collections.Specialized/tests/NameValueCollection/SetItemStrStrTests.cs
@@ -15,7 +15,6 @@ namespace System.Collections.Specialized.Tests
         public const int MAX_LEN = 50;          // max length of random strings
 
         [Fact]
-        [ActiveIssue(2769, PlatformID.AnyUnix)]
         public void Test01()
         {
             IntlStrings intl;

--- a/src/System.Collections.Specialized/tests/NameValueCollection/SetStrStrTests.cs
+++ b/src/System.Collections.Specialized/tests/NameValueCollection/SetStrStrTests.cs
@@ -15,7 +15,6 @@ namespace System.Collections.Specialized.Tests
         public const int MAX_LEN = 50;          // max length of random strings
 
         [Fact]
-        [ActiveIssue(2769, PlatformID.AnyUnix)]
         public void Test01()
         {
             IntlStrings intl;


### PR DESCRIPTION
Not sure why these are still disabled...?  I ran them locally on Linux and they passed, so submitting a PR.
https://github.com/dotnet/corefx/issues/2769
cc: @ellismg