### PR TITLE
Remove 4000 random tests from System.Globalization.Tests

### DIFF
--- a/src/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
@@ -13,8 +13,6 @@ namespace System.Globalization.Tests
         private static CompareInfo s_currentCompare = CultureInfo.CurrentCulture.CompareInfo;
         private static CompareInfo s_hungarianCompare = new CultureInfo("hu-HU").CompareInfo;
         private static CompareInfo s_turkishCompare = new CultureInfo("tr-TR").CompareInfo;
-
-        private static readonly RandomDataGenerator s_randomDataGenerator = new RandomDataGenerator();
         
         // On Windows, hiragana characters sort after katakana.
         // On ICU, it is the opposite
@@ -415,27 +413,6 @@ namespace System.Globalization.Tests
                 }
             }
             return char.MinValue; // There are no unassigned Unicode characters from \u0000 - \uFFFF
-        }
-
-        private static int PredictCompareOrdinalResult(string string1, string string2)
-        {
-            if (string1 == null)
-            {
-                if (string2 == null) return 0;
-                else return -1;
-            }
-            if (string2 == null) return 1;
-
-            for (int i = 0; i < string1.Length; i++)
-            {
-                if (i >= string2.Length) return 1;
-                if (string1[i] > string2[i]) return 1;
-                if (string1[i] < string2[i]) return -1;
-            }
-
-            if (string2.Length > string1.Length) return -1;
-
-            return 0;
         }
     }
 }

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -14,8 +14,6 @@ namespace System.Globalization.Tests
         private static CompareInfo s_hungarianCompare = new CultureInfo("hu-HU").CompareInfo;
         private static CompareInfo s_turkishCompare = new CultureInfo("tr-TR").CompareInfo;
 
-        private static readonly RandomDataGenerator s_randomDataGenerator = new RandomDataGenerator();
-
         public static IEnumerable<object[]> IndexOf_TestData()
         {
             // Empty string
@@ -63,30 +61,6 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "cbabababdbaba", "ab", 0, 13, CompareOptions.None, 2 };
         }
 
-        public static IEnumerable<object[]> IndexOf_Random_TestData()
-        {
-            string[] interestingStrings = new string[] { "", "a", "1", "-", "A", "!", "abc", "aBc", "a\u0400Bc", "I", "i", "\u0130", "\u0131", "A", "\uFF21", "\uFE57" };
-            foreach (string string1 in interestingStrings)
-            {
-                foreach (string string2 in interestingStrings)
-                {
-                    yield return new object[] { s_currentCompare, string1, string2, 0, string1.Length, CompareOptions.Ordinal, PredictIndexOfOrdinalResult(string1, string2) };
-                }
-            }
-
-            // Random
-            for (int i = 0; i < 1000; i++)
-            {
-                string string1 = s_randomDataGenerator.GetString(-55, false, 5, 20);
-                string string2 = s_randomDataGenerator.GetString(-55, false, 5, 20);
-                string string3 = string1 + string2;
-                yield return new object[] { s_currentCompare, string1, string1, 0, string1.Length, CompareOptions.Ordinal, 0 };
-                yield return new object[] { s_currentCompare, string2, string2, 0, string2.Length, CompareOptions.Ordinal, 0 };
-                yield return new object[] { s_currentCompare, string1, string2, 0, string1.Length, CompareOptions.Ordinal, PredictIndexOfOrdinalResult(string1, string2) };
-                yield return new object[] { s_currentCompare, string3, string2, 0, string3.Length, CompareOptions.Ordinal, PredictIndexOfOrdinalResult(string3, string2) };
-            }
-        }
-
         public static IEnumerable<object[]> IndexOf_Aesc_Ligature_TestData()
         {
             // Searches for the ligature Æ
@@ -125,7 +99,6 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(IndexOf_TestData))]
-        [MemberData(nameof(IndexOf_Random_TestData))]
         [MemberData(nameof(IndexOf_U_WithDiaeresis_TestData))]
         public void IndexOf_String(CompareInfo compareInfo, string source, string value, int startIndex, int count, CompareOptions options, int expected)
         {
@@ -333,38 +306,6 @@ namespace System.Globalization.Tests
                 }
             }
             return char.MinValue; // There are no unassigned unicode characters from \u0000 - \uFFFF
-        }
-
-        private static int PredictIndexOfOrdinalResult(string string1, string string2)
-        {
-            if (string1 == null)
-            {
-                if (string2 == null) return 0;
-                else return -1;
-            }
-            if (string2 == null) return -1;
-
-            if (string2.Length > string1.Length) return -1;
-
-            for (int i = 0; i <= string1.Length - string2.Length; i++)
-            {
-                bool match = true;
-                for (int j = 0; j < string2.Length; j++)
-                {
-                    if (string1[i + j] != string2[j])
-                    {
-                        match = false;
-                        break;
-                    }
-                }
-                if (match) return i;
-            }
-            return -1;
-        }
-
-        private static int NormalizeCompare(int result)
-        {
-            return Math.Sign(result);
         }
     }
 }

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -59,6 +59,46 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "More Test's", "Tests", 0, 11, CompareOptions.IgnoreSymbols, 5 };
             yield return new object[] { s_invariantCompare, "More Test's", "Tests", 0, 11, CompareOptions.None, -1 };
             yield return new object[] { s_invariantCompare, "cbabababdbaba", "ab", 0, 13, CompareOptions.None, 2 };
+
+            // Ordinal should be case-sensitive
+            yield return new object[] { s_currentCompare, "a", "a", 0, 1, CompareOptions.Ordinal, 0 };
+            yield return new object[] { s_currentCompare, "a", "A", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "abc", "aBc", 0, 3, CompareOptions.Ordinal, -1 };
+
+            // Ordinal with numbers and symbols
+            yield return new object[] { s_currentCompare, "a", "1", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "1", "1", 0, 1, CompareOptions.Ordinal, 0 };
+            yield return new object[] { s_currentCompare, "1", "!", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "a", "-", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "-", "-", 0, 1, CompareOptions.Ordinal, 0 };
+            yield return new object[] { s_currentCompare, "-", "!", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "!", "!", 0, 1, CompareOptions.Ordinal, 0 };
+
+            // Ordinal with unicode
+            yield return new object[] { s_currentCompare, "\uFF21", "\uFE57", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "\uFE57", "\uFF21", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "\uFF21", "a\u0400Bc", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "\uFE57", "a\u0400Bc", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "a", "a\u0400Bc", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "a\u0400Bc", "a", 0, 4, CompareOptions.Ordinal, 0 };
+
+            // Ordinal with I or i (American and Turkish)
+            yield return new object[] { s_currentCompare, "I", "i", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "I", "I", 0, 1, CompareOptions.Ordinal, 0 };
+            yield return new object[] { s_currentCompare, "i", "I", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "i", "i", 0, 1, CompareOptions.Ordinal, 0 };
+            yield return new object[] { s_currentCompare, "I", "\u0130", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "\u0130", "I", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "i", "\u0130", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "\u0130", "i", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "I", "\u0131", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "\0131", "I", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "i", "\u0131", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "\u0131", "i", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "\u0130", "\u0130", 0, 1, CompareOptions.Ordinal, 0 };
+            yield return new object[] { s_currentCompare, "\u0131", "\u0131", 0, 1, CompareOptions.Ordinal, 0 };
+            yield return new object[] { s_currentCompare, "\u0130", "\u0131", 0, 1, CompareOptions.Ordinal, -1 };
+            yield return new object[] { s_currentCompare, "\u0131", "\u0130", 0, 1, CompareOptions.Ordinal, -1 };
         }
 
         public static IEnumerable<object[]> IndexOf_Aesc_Ligature_TestData()


### PR DESCRIPTION
- Also removes some now unused methods/variables in Compare tests

Before:
```
=== TEST EXECUTION SUMMARY ===
     System.Globalization.Tests  Total: 5247, Errors: 0, Failed: 0, Skipped: 0, Time: 1.159s
```
After:
```
=== TEST EXECUTION SUMMARY ===
     System.Globalization.Tests  Total: 991, Errors: 0, Failed: 0, Skipped: 0, Time: 1.093s
```

Similar to #7218
/cc @stephentoub @tarekgh @weshaggard