### PR TITLE
Add assert for status code to cookies test

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -547,6 +547,7 @@ namespace System.Net.Http.Functional.Tests
             using (var client = new HttpClient(handler))
             using (HttpResponseMessage response = await client.GetAsync(url))
             {
+                Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
                 CookieCollection cookies = handler.CookieContainer.GetCookies(new Uri(url));
 
                 Assert.Equal(3, handler.CookieContainer.Count);


### PR DESCRIPTION
This test failed once, and I expect it was just due to a network blip that caused the request to fail, but since we're not currently checking the http status code, I can't be sure.  As such, I'm just adding another assert for the expected status code, and if this repros again, we'll know whether that's the issue.

Closes https://github.com/dotnet/corefx/issues/7234