### PR TITLE
[Port to RC2] Fix/Baseline CNG tests on Windows 7

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
@@ -8,6 +8,7 @@ namespace System.Security.Cryptography.Rsa.Tests
     {
         RSA Create();
         RSA Create(int keySize);
+        bool Supports384PrivateKey { get; }
     }
 
     public static partial class RSAFactory
@@ -20,6 +21,11 @@ namespace System.Security.Cryptography.Rsa.Tests
         public static RSA Create(int keySize)
         {
             return s_provider.Create(keySize);
+        }
+
+        public static bool Supports384PrivateKey
+        {
+            get { return s_provider.Supports384PrivateKey; }
         }
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
@@ -37,7 +37,22 @@ namespace System.Security.Cryptography.Rsa.Tests
                 0x11, 0xE0, 0x6E, 0xD2, 0x22, 0x75, 0xE7, 0x7C,
             };
 
-            ExpectSignature(expectedSignature, TestData.HelloBytes, "SHA1", TestData.RSA384Parameters);
+            try
+            {
+                ExpectSignature(expectedSignature, TestData.HelloBytes, "SHA1", TestData.RSA384Parameters);
+
+                Assert.True(RSAFactory.Supports384PrivateKey, "RSAFactory.Supports384PrivateKey");
+            }
+            catch (CryptographicException)
+            {
+                // If the provider is not known to fail loading a 384-bit key, let the exception be the
+                // test failure. (If it is known to fail loading that key, we've now suppressed the throw,
+                // and the test will pass.)
+                if (RSAFactory.Supports384PrivateKey)
+                {
+                    throw;
+                }
+            }
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
@@ -2,10 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 namespace System.Security.Cryptography.Rsa.Tests
 {
     public class DefaultRSAProvider : IRSAProvider
     {
+        private bool? _supports384PrivateKey;
+
         public RSA Create()
         {
             return RSA.Create();
@@ -16,6 +20,27 @@ namespace System.Security.Cryptography.Rsa.Tests
             RSA rsa = Create();
             rsa.KeySize = keySize;
             return rsa;
+        }
+
+        public bool Supports384PrivateKey
+        {
+            get
+            {
+                if (!_supports384PrivateKey.HasValue)
+                {
+                    bool hasSupport = true;
+
+                    // For Windows 7 (Microsoft Windows 6.1) this is false for RSACng.
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        hasSupport = !RuntimeInformation.OSDescription.Contains("Windows 6.1");
+                    }
+
+                    _supports384PrivateKey = hasSupport;
+                }
+
+                return _supports384PrivateKey.Value;
+            }
         }
     }
 

--- a/src/System.Security.Cryptography.Algorithms/tests/project.json
+++ b/src/System.Security.Cryptography.Algorithms/tests/project.json
@@ -6,6 +6,7 @@
     "System.ObjectModel": "4.0.12-rc2-23921",
     "System.Runtime": "4.1.0-rc2-23921",
     "System.Runtime.Extensions": "4.1.0-rc2-23921",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23921",
     "System.Runtime.Numerics": "4.0.1-rc2-23921",
     "System.Security.Cryptography.Primitives": "4.0.0-rc2-23921",
     "System.Text.Encoding.Extensions": "4.0.11-rc2-23921",

--- a/src/System.Security.Cryptography.Cng/tests/AesProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/AesProvider.cs
@@ -2,15 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 namespace System.Security.Cryptography.Encryption.Aes.Tests
 {
     using Aes = System.Security.Cryptography.Aes;
 
     public class AesProvider : IAesProvider
     {
+        // Windows 7 (Microsoft Windows 6.1) KSP does not support AES, so temporarily recycle the BCrypt.dll-based
+        // implementation from the Algorithms library.
+        private static readonly Func<Aes> s_creator =
+            RuntimeInformation.OSDescription.Contains("Windows 6.1") ? Aes.Create : (Func<Aes>)(() => new AesCng());
+
         public Aes Create()
         {
-            return new AesCng();
+            return s_creator();
         }
     }
 

--- a/src/System.Security.Cryptography.Cng/tests/RSACngProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/RSACngProvider.cs
@@ -2,10 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 namespace System.Security.Cryptography.Rsa.Tests
 {
     public class RSACngProvider : IRSAProvider
     {
+        private bool? _supports384PrivateKey;
+
         public RSA Create()
         {
             return new RSACng();
@@ -14,6 +18,20 @@ namespace System.Security.Cryptography.Rsa.Tests
         public RSA Create(int keySize)
         {
             return new RSACng(keySize);
+        }
+
+        public bool Supports384PrivateKey
+        {
+            get
+            {
+                if (!_supports384PrivateKey.HasValue)
+                {
+                    // For Windows 7 (Microsoft Windows 6.1) this is false for RSACng.
+                    _supports384PrivateKey = !RuntimeInformation.OSDescription.Contains("Windows 6.1");
+                }
+
+                return _supports384PrivateKey.Value;
+            }
         }
     }
 

--- a/src/System.Security.Cryptography.Cng/tests/RsaCngTests.cs
+++ b/src/System.Security.Cryptography.Cng/tests/RsaCngTests.cs
@@ -90,7 +90,23 @@ namespace System.Security.Cryptography.Cng.Tests
                 "722DEFDF48144A6D88A780144FCEA66BDCDA50D6071C54E5D0DA5B").HexToByteArray();
 
             RSAParameters expected = System.Security.Cryptography.Rsa.Tests.TestData.RSA384Parameters;
-            RSACng_Ctor_UnusualKeysize(ExpectedKeySize, keyBlob, expected);
+
+            try
+            {
+                RSACng_Ctor_UnusualKeysize(ExpectedKeySize, keyBlob, expected);
+
+                Assert.True(Rsa.Tests.RSAFactory.Supports384PrivateKey, "RSAFactory.Supports384PrivateKey");
+            }
+            catch (CryptographicException)
+            {
+                // If the provider is not known to fail loading a 384-bit key, let the exception be the
+                // test failure. (If it is known to fail loading that key, we've now suppressed the throw,
+                // and the test will pass.)
+                if (Rsa.Tests.RSAFactory.Supports384PrivateKey)
+                {
+                    throw;
+                }
+            }
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.Cng/tests/TripleDESCngProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/TripleDESCngProvider.cs
@@ -2,13 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 namespace System.Security.Cryptography.Encryption.TripleDes.Tests
 {
     public class TripleDESCngProvider : ITripleDESProvider
     {
+        // Windows 7 (Microsoft Windows 6.1) KSP does not support 3DES, so temporarily recycle the BCrypt.dll-based
+        // implementation from the Algorithms library.
+        private static readonly Func<TripleDES> s_creator =
+            RuntimeInformation.OSDescription.Contains("Windows 6.1") ? TripleDES.Create : (Func<TripleDES>)(() => new TripleDESCng());
+
         public TripleDES Create()
         {
-            return new TripleDESCng();
+            return s_creator();
         }
     }
 

--- a/src/System.Security.Cryptography.Cng/tests/project.json
+++ b/src/System.Security.Cryptography.Cng/tests/project.json
@@ -6,6 +6,7 @@
     "System.Linq.Expressions": "4.0.11-rc2-23921",
     "System.ObjectModel": "4.0.12-rc2-23921",
     "System.Runtime": "4.1.0-rc2-23921",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23921",
     "System.Runtime.Extensions": "4.1.0-rc2-23921",
     "System.Runtime.Numerics": "4.0.1-rc2-23921",
     "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23921",

--- a/src/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderProvider.cs
+++ b/src/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderProvider.cs
@@ -15,6 +15,11 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             return new RSACryptoServiceProvider(keySize);
         }
+        
+        public bool Supports384PrivateKey
+        {
+            get { return true; }
+        }
     }
 
     public partial class RSAFactory

--- a/src/System.Security.Cryptography.OpenSsl/tests/RSAOpenSslProvider.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/RSAOpenSslProvider.cs
@@ -15,6 +15,11 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             return new RSAOpenSsl(keySize);
         }
+
+        public bool Supports384PrivateKey
+        {
+            get { return true; }
+        }
     }
 
     public partial class RSAFactory


### PR DESCRIPTION
This ports #7210 (RSA-384) and #7222 (AesCng, TripleDESCng) to get the failing Win7 crypto tests passing.

Fixes #7086.