### PR TITLE
Create build-tests.cmd

### DIFF
--- a/build-tests.cmd
+++ b/build-tests.cmd
@@ -1,0 +1,24 @@
+@if "%_echo%" neq "on" echo off
+setlocal
+
+set buildTests=build-tests.log
+echo Running build-tests.cmd %* > %buildTests%
+
+if /I [%1] == [/?] goto Usage
+if /I [%1] == [/help] goto Usage
+
+echo msbuild.exe %~dp0src\tests.builds /nologo /maxcpucount /v:minimal /clp:Summary /nodeReuse:false /flp:v=detailed;Append;LogFile=%buildTests% %*>> %buildTests%
+call msbuild.exe %~dp0src\tests.builds /nologo /maxcpucount /v:minimal /clp:Summary /nodeReuse:false /flp:v=detailed;Append;LogFile=%buildTests% %*
+if NOT [%ERRORLEVEL%]==[0] (
+  echo ERROR: An error occurred while building the tests, see %buildTests% for more details.
+  exit /b
+)
+
+echo Done Building tests.
+exit /b
+
+:Usage
+echo.
+echo Builds the tests that are in the repository.
+echo No option parameters.
+exit /b

--- a/build.proj
+++ b/build.proj
@@ -17,6 +17,8 @@
     <RestoreDuringBuild Condition="'$(RestoreDuringBuild)'==''">true</RestoreDuringBuild>
     <!-- To disable building packages, set BuildPackages=false or pass /p:BuildPackages=false.-->
     <BuildPackages Condition="'$(BuildPackages)'==''">true</BuildPackages>
+    <!-- To disable building tests, set BuildTests=false or pass /p:BuildTests=false.-->
+    <BuildTests Condition="'$(BuildTests)'==''">true</BuildTests>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,6 +26,7 @@
       <!-- For the root traversal default filter the OSGroup to the OSEnvironment which is the OS we are running on -->
       <FilterToOSGroup Condition="'$(_OriginalOSGroup)' == ''">$(OSEnvironment)</FilterToOSGroup>
     </Project>
+    <Project Include="src\tests.builds" Condition="$(BuildTests)=='true'"/>
     <!-- signing must happen before packaging -->
     <Project Include="src\sign.builds" />
     <Project Include="src\packages.builds" Condition="'$(BuildPackages)'=='true'"/>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -4,7 +4,6 @@
   <ItemGroup>
     <Project Include="ref.builds" />
     <Project Include="src.builds" />
-    <Project Include="tests.builds" />
   </ItemGroup>
 
   <Import Project="..\dir.targets" />

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Capture OSGroup passed to command line for setting default FilterToOSGroup value below -->
+    <_OriginalOSGroup>$(OSGroup)</_OriginalOSGroup>
+  </PropertyGroup>
+  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <FilterToOSGroup Condition="'$(_OriginalOSGroup)' == ''">$(OSEnvironment)</FilterToOSGroup>
+  </PropertyGroup>
+  
   <ItemGroup>
     <ExcludeProjects Condition="'$(OSEnvironment)'!='Windows_NT'" Include="**\Microsoft.VisualBasic.Tests.csproj" />
     <ExcludeProjects Condition="'$(OSGroup)'=='Windows_NT'" Include="**\System.Security.Cryptography.OpenSsl.Tests.csproj" />


### PR DESCRIPTION
Build tests as a separate task of build.cmd with a build-tests.cmd script. 
When we build passing /p:SkipTests=true the tests are built but not executed. With this change, /p:SkipTests=true allows us to not build nor execute the tests.

cc: @weshaggard @naamunds @chcosta