### PR TITLE
Use x64 instead of AnyCPU on native windows similar to Unix for output folder structure.

### DIFF
--- a/src/Native/Windows/build-native.cmd
+++ b/src/Native/Windows/build-native.cmd
@@ -7,7 +7,7 @@ set __sourceDir=%~dp0
 set __binDir=%~dp0..\..\..\bin
 set __CMakeBinDir=""
 set __IntermediatesDir=""
-set __BuildArch=AnyCPU
+set __BuildArch=x64
 set __VCBuildArch=x86_amd64
 set CMAKE_BUILD_TYPE=Debug
 
@@ -22,7 +22,7 @@ if /i [%1] == [/p:ConfigurationGroup]    (
     exit /b 1
 )
 if /i [%1] == [/p:Platform]    (
-    if /i [%2] == [AnyCPU]  (set __BuildArch=AnyCPU&&set __VCBuildArch=x86_amd64&&shift&&shift&goto Arg_Loop)
+    if /i [%2] == [AnyCPU]  (set __BuildArch=x64&&set __VCBuildArch=x86_amd64&&shift&&shift&goto Arg_Loop)
     if /i [%2] == [x86]     (set __BuildArch=x86&&set __VCBuildArch=x86&&shift&&shift&goto Arg_Loop)
     if /i [%2] == [arm]     (set __BuildArch=arm&&set __VCBuildArch=x86_arm&&shift&&shift&goto Arg_Loop)
     if /i [%2] == [x64]     (set __BuildArch=x64&&set __VCBuildArch=x86_amd64&&shift&&shift&goto Arg_Loop)
@@ -93,10 +93,6 @@ if %__IntermediatesDir% == "" (
     set "__CMakeBinDir=%__CMakeBinDir:\=/%"
     set "__IntermediatesDir=%__IntermediatesDir:\=/%"
 
-:: We wanted to allow AnyCPU for folder creation purposes, but it doesn't make sense for a native build. Default to something else for the actual building.
-if "%__BuildArch%" == "AnyCPU" (
-    set __BuildArch=x64
-)
 echo %__CMakeBinDir%
 
 :: Check that the intermediate directory exists so we can place our cmake build tree there


### PR DESCRIPTION
cc @stephentoub @joshfree @ianhays 

Reference: #7081, dotnet/buildtools#579

Right now, Windows Native bits are being dropped to Windows_NT.AnyCPU.${ConfigurationGroup}/Native, where AnyCPU doesn't make sense for native. Changing this to be specific to x64, x86, arm, to enable automation of buildtools across all platforms, being in parity with Unix output folder structure.