### PR TITLE
Fix and re-enable XmlConvert test

### DIFF
--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/ToTypeTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/ToTypeTests.cs
@@ -606,10 +606,10 @@ namespace System.Xml.Tests
             string expDateTime = String.Format("2002-12-30T23:15:55.1{0:+0#;-0#}:{1:00}", span.Hours, span.Minutes);
 
             CError.Compare(XmlConvert.ToString(dt), expDateTime, "datetime");
-            dt = new DateTime(1, 1, 1, 23, 59, 59);
+            dt = new DateTime(2000, 1, 1, 23, 59, 59);
             dt = dt.AddTicks(9999999);
             span = TimeZoneInfo.Local.GetUtcOffset(dt);
-            expDateTime = String.Format("0001-01-01T23:59:59.9999999{0:+0#;-0#}:{1:00}", span.Hours, span.Minutes);
+            expDateTime = String.Format("2000-01-01T23:59:59.9999999{0:+0#;-0#}:{1:00}", span.Hours, span.Minutes);
             CError.Compare(XmlConvert.ToString(dt), expDateTime, "millisecs");
 
             dt = new DateTime(2002, 12, 30, 23, 15, 55);

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlConvertTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlConvertTests.cs
@@ -53,8 +53,6 @@ namespace System.Xml.Tests
 
         [Fact]
         [OuterLoop]
-        [ActiveIssue(5462, PlatformID.AnyUnix)]
-        [ActiveIssue(1303, PlatformID.Windows)]
         public static void ToTypeTests()
         {
             RunTestCase(new ToTypeTests { Attribute = new TestCase { Name = "XmlConvert type conversion functions", Desc = "XmlConvert" } });


### PR DESCRIPTION
The Windows issue was already closed, but the test was still deactivated for it.  

The Unix issue is due to timezone information differing for the ancient date being used; this is "by design", and since this is a test of formatting rather than calendars and timezones, I've simply changed to a more recent date where the timezone information matches.

Fixes #5462
Related to #1303