### PR TITLE
Disable setting DEBUG flag for debug zlib builds

### DIFF
--- a/src/Native/Windows/CMakeLists.txt
+++ b/src/Native/Windows/CMakeLists.txt
@@ -28,7 +28,9 @@ endif ()
 
 string(TOUPPER ${CMAKE_BUILD_TYPE} UPPERCASE_CMAKE_BUILD_TYPE)
 if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG)
-    add_definitions(-DDEBUG)
+    # Do not define DEBUG. zlib has asserts under DEBUG for non-catastrophic cases,
+    # such as on bad user-provided inputs.  We leave NDEBUG defined, however,
+    # as other asserts should still be included.
 elseif (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
     add_definitions(-DNDEBUG)
 else ()


### PR DESCRIPTION
zlib has asserts that fire and take down the process when provided with bad inputs, which our tests do.

Fixes #7197
(If this is the right fix, replaces https://github.com/dotnet/corefx/pull/7219.)

cc: @bjjones, @mellinoe