### PR TITLE
Fix BufferBlock race condition between completion and consumption

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/BufferBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/BufferBlock.cs
@@ -348,6 +348,7 @@ namespace System.Threading.Tasks.Dataflow
                 KeyValuePair<ISourceBlock<T>, DataflowMessageHeader> sourceAndMessage;
                 lock (IncomingLock)
                 {
+                    if (_targetDecliningPermanently) return false;
                     if (!_boundingState.CountIsLessThanBound) return false;
                     if (!_boundingState.PostponedMessages.TryPop(out sourceAndMessage)) return false;
 


### PR DESCRIPTION
A failed test in CI highlighted a rare race condition in the BufferBlock implementation.  When a bounded buffer block has postponed messages waiting to be consumed and room becomes available, it’ll queue a task to consume those messages from the relevant sources.  It should stop consuming messages after it’s been marked as complete, but if the consuming task is already running when the buffer is marked as complete, it may end up still consuming as many messages as have been postponed due to missing a check in that consuming task for having been marked as completed.  The fix is simply to add in that check before dequeueing the next postponed message.

Prior to the fix, I ran the test 1,000,000 times and was able to repro this in 22 of them.  After the fix, I could no longer repro it.

(There is still an even more rare but expected race that can occur if the block is in the process of consuming the item from one of its sources and the block being marked as completed, but that's no different than a race between it being marked as completed and another thread adding to the block and is the nature of using these components concurrently.)

Fixes https://github.com/dotnet/corefx/issues/7244
cc: @mellinoe, @AlfredoMS