### PR TITLE
Make "@echo off" configurable.

### DIFF
--- a/build-packages.cmd
+++ b/build-packages.cmd
@@ -1,4 +1,4 @@
-@echo off
+@if "%_echo%" neq "on" echo off
 setlocal
 
 set packagesLog=build-packages.log

--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,4 @@
-@echo off
+@if "%_echo%" neq "on" echo off
 setlocal
 
 :: Note: We've disabled node reuse because it causes file locking issues.

--- a/clean.cmd
+++ b/clean.cmd
@@ -1,4 +1,4 @@
-@echo off
+@if "%_echo%" neq "on" echo off
 setlocal
 
 set cleanlog=%~dp0clean.log

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -1,4 +1,4 @@
-@echo off
+@if "%_echo%" neq "on" echo off
 setlocal
 
 REM Workaround https://github.com/dotnet/coreclr/issues/2153

--- a/run-test.cmd
+++ b/run-test.cmd
@@ -1,4 +1,4 @@
-@echo off
+@if "%_echo%" neq "on" echo off
 
 :: To run tests outside of MSBuild.exe
 :: %1 is the path to the tests\<OSConfig> folder

--- a/src/Native/Windows/build-native.cmd
+++ b/src/Native/Windows/build-native.cmd
@@ -1,4 +1,4 @@
-@echo off
+@if "%_echo%" neq "on" echo off
 setlocal
 
 :SetupArgs

--- a/src/Native/Windows/gen-buildsys-win.bat
+++ b/src/Native/Windows/gen-buildsys-win.bat
@@ -1,4 +1,4 @@
-@echo off
+@if "%_echo%" neq "on" echo off
 rem
 rem This file invokes cmake and generates the build system for windows.
 set argC=0

--- a/sync.cmd
+++ b/sync.cmd
@@ -1,4 +1,4 @@
-@echo off
+@if "%_echo%" neq "on" echo off
 setlocal
 
 set synclog=sync.log


### PR DESCRIPTION
Echo is unconditionally turned off in batch files making it hard to debug
issues.  This change provides a way to leave echo on by setting the _echo
environment var to on.