### PR TITLE
Fixes to the dev workflow scripts for OSX

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -19,6 +19,7 @@ case $OSName in
     Darwin)
         OS=OSX
         __DOTNET_PKG=dotnet-osx-x64
+        ulimit -n 2048
         ;;
 
     Linux)

--- a/sync.sh
+++ b/sync.sh
@@ -51,7 +51,7 @@ $working_tree_root/init-tools.sh
 
 if [ "$sync_src" == true ]; then
     echo "Fetching git database from remote repos..."
-    git fetch --all -p -v &>> $sync_log
+    git fetch --all -p -v >> $sync_log
     if [ $? -ne 0 ]; then
         echo -e "\ngit fetch failed. Aborting sync." >> $sync_log
         echo "ERROR: An error occurred while fetching remote source code; see $sync_log for more details."


### PR DESCRIPTION
sync.sh was not marked as executable and had a syntax error.

cc: @naamunds @weshaggard @joperezr