### PR TITLE
Temporarily disable Console.Title test on Windows

### DIFF
--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -102,6 +102,7 @@ public class WindowAndCursorProps
 
     [Fact]
     [PlatformSpecific(PlatformID.Windows)]
+    [ActiveIssue(6223)]
     public static void Title()
     {
         Assert.NotNull(Console.Title);


### PR DESCRIPTION
It's failing in all Win10 outerloop runs.

cc: @pallavit