### PR TITLE
Lazily allocate ChannelBinding in CurlHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlTransportContext.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlTransportContext.cs
@@ -2,36 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Security.Authentication.ExtendedProtection;
+using System.Threading;
 
 namespace System.Net.Http
 {
-    internal class CurlTransportContext : TransportContext
+    internal sealed class CurlTransportContext : TransportContext
     {
-        private CurlChannelBinding _channelBinding = new CurlChannelBinding();
+        private CurlChannelBinding _channelBinding;
 
-        internal CurlChannelBinding CurlChannelBinding
-        {
-            get
-            {
-                return _channelBinding;
-            }
-        }
+        internal CurlChannelBinding CurlChannelBinding => LazyInitializer.EnsureInitialized(ref _channelBinding);
 
-        internal CurlTransportContext()
-        {
-        }
-
-        public override ChannelBinding GetChannelBinding(ChannelBindingKind kind)
-        {
+        public override ChannelBinding GetChannelBinding(ChannelBindingKind kind) =>
+            kind == ChannelBindingKind.Endpoint ? CurlChannelBinding : null;
             // Parity with WinHTTP : CurHandler only supports retrieval of ChannelBindingKind.Endpoint for CBT.
-            if (kind == ChannelBindingKind.Endpoint)
-            {
-                return _channelBinding;
-            }
-
-            return null;
-        }
     }
 }


### PR DESCRIPTION
This SafeHandle is only used by HttpContent-derived types that care about TransportContext, which is not a common case, and it's only used by the implementation when doing something custom with certificates and when there is request content.  Lazily allocate it.

Just as an example, before this change, it was being allocated during ~50 tests.  After this change, it's allocated just once, in the test explicitly verifying the binding.

cc: @ericeil, @kapilash, @davidsh