### PR TITLE
Improve performance of BitConverter.ToString

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/BitConverter.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
+using System.Text;
 using Xunit;
 
 namespace System.Tests
@@ -207,7 +209,20 @@ namespace System.Tests
             Assert.Equal("12-34-56-78-9A", BitConverter.ToString(bytes));
             Assert.Equal("56-78-9A", BitConverter.ToString(bytes, 2));
             Assert.Equal("56", BitConverter.ToString(bytes, 2, 1));
-            Assert.Equal(String.Empty, BitConverter.ToString(new byte[0]));
+
+            Assert.Same(string.Empty, BitConverter.ToString(new byte[0]));
+            Assert.Same(string.Empty, BitConverter.ToString(new byte[3], 1, 0));
+        }
+
+        [Fact]
+        public static void ToString_ByteArray_Long()
+        {
+            byte[] bytes = Enumerable.Range(0, 256 * 4).Select(i => (byte)i).ToArray();
+
+            string expected = string.Join("-", bytes.Select(b => b.ToString("X2")));
+
+            Assert.Equal(expected, BitConverter.ToString(bytes));
+            Assert.Equal(expected.Substring(3, expected.Length - 6), BitConverter.ToString(bytes, 1, bytes.Length - 2));
         }
 
         [Fact]


### PR DESCRIPTION
Primary changes:
- Avoid allocating an intermediate char[] for shorter byte[]s by using stack instead of heap space.
- Use bit masking/shifting to get each nibble rather than mod/div.

For a little test program like:
```C#
using System;
using System.Diagnostics;
using System.Linq;

public class Program
{
    public static void Main()
    {
        var sw = new Stopwatch();
        var bytes = Enumerable.Range(0, 32).Select(i => (byte)i).ToArray();
        for (int iter = 0; iter < 5; iter++)
        {
            int gen0 = GC.CollectionCount(0);
            sw.Restart();
            for (int i = 0; i < 10000000; i++) BitConverter.ToString(bytes);
            sw.Stop();
            Console.WriteLine($"Time: {sw.Elapsed.TotalSeconds}\tGC0: {GC.CollectionCount(0) - gen0}");
        }
    }
}
```
Before change:
```
Time: 1.9214318 GC0: 2059
Time: 1.8662056 GC0: 2060
Time: 1.8491225 GC0: 2060
Time: 1.8419979 GC0: 2060
Time: 1.8282545 GC0: 2059
```
After change:
```
Time: 1.4348172 GC0: 1030
Time: 1.4222383 GC0: 1030
Time: 1.4204402 GC0: 1030
Time: 1.4265846 GC0: 1030
Time: 1.4241592 GC0: 1030
```

cc: @bartonjs, @mellinoe