### PR TITLE
Remove unnecessary branches in UrlDecoder

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -625,11 +625,9 @@ namespace System.Net
 
             private void FlushBytes()
             {
-                if (_numBytes > 0)
-                {
-                    _numChars += _encoding.GetChars(_byteBuffer, 0, _numBytes, _charBuffer, _numChars);
-                    _numBytes = 0;
-                }
+                Debug.Assert(_numBytes > 0);
+                _numChars += _encoding.GetChars(_byteBuffer, 0, _numBytes, _charBuffer, _numChars);
+                _numBytes = 0;
             }
 
             internal UrlDecoder(int bufferSize, Encoding encoding)


### PR DESCRIPTION
FlushBytes already checks for if _numBytes > 0 so we can remove this check at the call site

I renamed FlushBytes to FlushBytesIfNeeded to convey this semantic at the call site

/cc @stephentoub @jamesqo 