### PR TITLE
Add JapaneseLunisolarCalendar and UmAlQuraCalendar tests

### DIFF
--- a/src/System.Globalization.Calendars/tests/CalendarHelpers.cs
+++ b/src/System.Globalization.Calendars/tests/CalendarHelpers.cs
@@ -34,7 +34,9 @@ namespace System.Globalization.Tests
             new TaiwanLunisolarCalendar(),
             new ChineseLunisolarCalendar(),
             new KoreanLunisolarCalendar(),
-            new PersianCalendar()
+            new PersianCalendar(),
+            new JapaneseLunisolarCalendar(),
+            new UmAlQuraCalendar()
         };
 
         private static int MinEra(Calendar calendar) => calendar.GetEra(calendar.MinSupportedDateTime);


### PR DESCRIPTION
Now that the bugs in these calendars has been fixed in coreclr, we can
test them (and make sure no bugs regress)

/cc @tarekgh @stephentoub