### PR TITLE
Ensure CurlHandler sets CBT even on fast verification path

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -6,11 +6,12 @@ using System.Collections.Generic;
 using System.Net.Security;
 using System.Net.Test.Common;
 using System.Runtime.InteropServices;
+using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.Net.Http.Tests
+namespace System.Net.Http.Functional.Tests
 {
     public class HttpClientHandler_ServerCertificates_Test
     {
@@ -208,6 +209,54 @@ namespace System.Net.Http.Tests
             using (var client = new HttpClient(handler))
             {
                 await Assert.ThrowsAsync<PlatformNotSupportedException>(() => client.GetAsync(HttpTestServers.SecureRemoteEchoServer));
+            }
+        }
+
+        [Fact]
+        public async Task PostAsync_Post_ChannelBinding_ConfiguredCorrectly()
+        {
+            var content = new ChannelBindingAwareContent("Test contest");
+            using (var client = new HttpClient())
+            using (HttpResponseMessage response = await client.PostAsync(HttpTestServers.SecureRemoteEchoServer, content))
+            {
+                // Validate status.
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                // Validate the ChannelBinding object exists.
+                ChannelBinding channelBinding = content.ChannelBinding;
+                Assert.NotNull(channelBinding);
+
+                // Validate the ChannelBinding's validity.
+                if (BackendSupportsCustomCertificateHandling)
+                {
+                    Assert.False(channelBinding.IsInvalid, "Expected valid binding");
+                    Assert.NotEqual(IntPtr.Zero, channelBinding.DangerousGetHandle());
+
+                    // Validate the ChannelBinding's description.
+                    string channelBindingDescription = channelBinding.ToString();
+                    Assert.NotNull(channelBindingDescription);
+                    Assert.NotEmpty(channelBindingDescription);
+                    Assert.True((channelBindingDescription.Length + 1) % 3 == 0, $"Unexpected length {channelBindingDescription.Length}");
+                    for (int i = 0; i < channelBindingDescription.Length; i++)
+                    {
+                        char c = channelBindingDescription[i];
+                        if (i % 3 == 2)
+                        {
+                            Assert.Equal(' ', c);
+                        }
+                        else
+                        {
+                            Assert.True((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F'), $"Expected hex, got {c}");
+                        }
+                    }
+                }
+                else
+                {
+                    // Backend doesn't support getting the details to create the CBT.
+                    Assert.True(channelBinding.IsInvalid, "Expected invalid binding");
+                    Assert.Equal(IntPtr.Zero, channelBinding.DangerousGetHandle());
+                    Assert.Null(channelBinding.ToString());
+                }
             }
         }
 


### PR DESCRIPTION
When we get called back by libcurl to verify the server's certificate, we try to take a fast path where we use OpenSSL's certificate verification rather than doing our own, which is more comprehensive but also slower.  However, when we added that fast path, we inadvertently ended up not setting the Channel Binding Token in that case, only doing so in the fallback path.  This fixes that, moving the configuring of the CBT up to before we ask OpenSSL to verify the cert.

(I'd recommend reviewing the src changes with the whitespace-ignored view: https://github.com/dotnet/corefx/pull/7282/files?w=1)

cc: @bartonjs, @kapilash, @davidsh