### PR TITLE
Make a few perf tweaks in OpenSsslX509CertificateReader

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -100,13 +100,15 @@ namespace Internal.Cryptography.Pal
         {
             get
             {
-                SafeSharedAsn1IntegerHandle serialNumber = Interop.Crypto.X509GetSerialNumber(_cert);
-                byte[] serial = Interop.Crypto.GetAsn1IntegerBytes(serialNumber);
+                using (SafeSharedAsn1IntegerHandle serialNumber = Interop.Crypto.X509GetSerialNumber(_cert))
+                {
+                    byte[] serial = Interop.Crypto.GetAsn1IntegerBytes(serialNumber);
 
-                // Windows returns this in BigInteger Little-Endian,
-                // OpenSSL returns this in BigInteger Big-Endian.
-                Array.Reverse(serial);
-                return serial;
+                    // Windows returns this in BigInteger Little-Endian,
+                    // OpenSSL returns this in BigInteger Big-Endian.
+                    Array.Reverse(serial);
+                    return serial;
+                }
             }
         }
 
@@ -140,8 +142,8 @@ namespace Internal.Cryptography.Pal
             get
             {
                 return Interop.Crypto.OpenSslEncode(
-                    Interop.Crypto.GetX509DerSize,
-                    Interop.Crypto.EncodeX509,
+                    x => Interop.Crypto.GetX509DerSize(x),
+                    (x, buf) => Interop.Crypto.EncodeX509(x, buf),
                     _cert);
             }
         }


### PR DESCRIPTION
- Dispose of a SafeHandle that's being left for finalization in SerialNumber
- Enable the compiler to cache two delegates currently being allocated on each call to RawData

cc: @bartonjs