### PR TITLE
Avoid string.Split allocations in FrameworkName

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Runtime/Versioning/FrameworkName.cs
+++ b/src/System.Runtime.Extensions/src/System/Runtime/Versioning/FrameworkName.cs
@@ -132,7 +132,7 @@ namespace System.Runtime.Versioning
             identifier = identifier.Trim();
             if (identifier.Length == 0)
             {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, "identifier"), nameof(identifier));
+                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(identifier)), nameof(identifier));
             }
             if (version == null)
             {
@@ -173,7 +173,7 @@ namespace System.Runtime.Versioning
             }
             if (frameworkName.Length == 0)
             {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, "frameworkName"), nameof(frameworkName));
+                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(frameworkName)), nameof(frameworkName));
             }
 
             string[] components = frameworkName.Split(c_componentSeparator);
@@ -203,16 +203,17 @@ namespace System.Runtime.Versioning
             for (int i = 1; i < components.Length; i++)
             {
                 // Get the key/value pair separated by '='
-                string[] keyValuePair = components[i].Split(c_keyValueSeparator);
+                string component = components[i];
+                int separatorIndex = component.IndexOf(c_keyValueSeparator);
 
-                if (keyValuePair.Length != 2)
+                if (separatorIndex == -1 || separatorIndex != component.LastIndexOf(c_keyValueSeparator))
                 {
                     throw new ArgumentException(SR.Argument_FrameworkNameInvalid, nameof(frameworkName));
                 }
 
                 // Get the key and value, trimming any whitespace
-                string key = keyValuePair[0].Trim();
-                string value = keyValuePair[1].Trim();
+                string key = component.Substring(0, separatorIndex).Trim();
+                string value = component.Substring(separatorIndex + 1).Trim();
 
                 //
                 // 2) Parse the required "Version" key value

--- a/src/System.Runtime.Extensions/tests/System/Runtime/Versioning/FrameworkName.cs
+++ b/src/System.Runtime.Extensions/tests/System/Runtime/Versioning/FrameworkName.cs
@@ -12,8 +12,8 @@ namespace System.Runtime.Versioning.Tests
         private const string TestProfile = "TestProfile";
 
         private static readonly Version s_testVersion = new Version(1, 2, 3, 4);
-        private static readonly string s_testNameString = string.Format("{0},Version=v{1},Profile={2}", TestIdentifier, s_testVersion, TestProfile);
-        private static readonly string s_testNameNoProfileString = string.Format("{0},Version=v{1}", TestIdentifier, s_testVersion);
+        private static readonly string s_testNameString = $"{TestIdentifier},Version=v{s_testVersion},Profile={TestProfile}";
+        private static readonly string s_testNameNoProfileString = $"{TestIdentifier},Version=v{s_testVersion}";
         private static readonly FrameworkName s_testName = new FrameworkName(s_testNameString);
         private static readonly FrameworkName s_testNameNoProfile = new FrameworkName(s_testNameNoProfileString);
 
@@ -50,6 +50,9 @@ namespace System.Runtime.Versioning.Tests
             Assert.Throws<ArgumentException>(() => new FrameworkName("A,Version=1.z.0.0,Profile=C"));
             Assert.Throws<ArgumentException>(() => new FrameworkName("A,Something=1.z.0.0,Profile=C"));
             Assert.Throws<ArgumentException>(() => new FrameworkName("A,Profile=C"));
+            Assert.Throws<ArgumentException>(() => new FrameworkName("A,======"));
+            Assert.Throws<ArgumentException>(() => new FrameworkName("A,    =B="));
+            Assert.Throws<ArgumentException>(() => new FrameworkName("A,1  =2=3"));
         }
 
         [Fact]


### PR DESCRIPTION
When parsing the input in the `FrameworkName` constructor, we're expecting it to look something like this:

```
Foo=Bar,Baz=Quux
```

The way we handle this is by calling `input.Split(',')`, and then splitting each of the individual components again via `component.Split('=')`. This is less than optimal, since calling `Split` makes 3 unneeded allocations:

- one for the `params` array
- one for an `int[]` that contains the separator indices
- one for the returned `string[]`

This PR replaces such use of `Split` with the following snippet, eliminating these allocations:

```cs
int separatorIndex = component.IndexOf('=');
if (separatorIndex == -1 || separatorIndex != component.LastIndexOf('='))
{
    throw;
}

string key = component.Substring(0, separatorIndex);
string value = component.Substring(separatorIndex + 1);
```

Other changes:

- Added tests for multiple `=` signs.
- Replaced some magic strings -> `nameof`.
- Replaced `string.Format` -> string interpolation.

Related CoreCLR PR: dotnet/coreclr#3949

cc @AlexGhiondea @JonHanna  @stephentoub 