### PR TITLE
Use nameof in Common

### DIFF
--- a/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
@@ -16,7 +16,7 @@ namespace System.Net
         {
             if (GlobalLog.IsEnabled)
             {
-                GlobalLog.Enter("EnumerateSecurityPackages");
+                GlobalLog.Enter(nameof(EnumerateSecurityPackages));
             }
 
             if (secModule.SecurityPackages == null)
@@ -66,7 +66,7 @@ namespace System.Net
 
             if (GlobalLog.IsEnabled)
             {
-                GlobalLog.Leave("EnumerateSecurityPackages");
+                GlobalLog.Leave(nameof(EnumerateSecurityPackages));
             }
             return secModule.SecurityPackages;
         }
@@ -255,7 +255,7 @@ namespace System.Net
 
             if (SecurityEventSource.Log.IsEnabled())
             {
-                SecurityEventSource.Log.SecurityContextInputBuffer("InitializeSecurityContext", (inputBuffer == null ? 0 : inputBuffer.size), outputBuffer.size, (Interop.SecurityStatus)errorCode);
+                SecurityEventSource.Log.SecurityContextInputBuffer(nameof(InitializeSecurityContext), (inputBuffer == null ? 0 : inputBuffer.size), outputBuffer.size, (Interop.SecurityStatus)errorCode);
             }
 
             return errorCode;
@@ -275,7 +275,7 @@ namespace System.Net
 
             if (SecurityEventSource.Log.IsEnabled())
             {
-                SecurityEventSource.Log.SecurityContextInputBuffers("InitializeSecurityContext", (inputBuffers == null ? 0 : inputBuffers.Length), outputBuffer.size, (Interop.SecurityStatus)errorCode);
+                SecurityEventSource.Log.SecurityContextInputBuffers(nameof(InitializeSecurityContext), (inputBuffers == null ? 0 : inputBuffers.Length), outputBuffer.size, (Interop.SecurityStatus)errorCode);
             }
 
             return errorCode;
@@ -292,7 +292,7 @@ namespace System.Net
 
             if (SecurityEventSource.Log.IsEnabled())
             {
-                SecurityEventSource.Log.SecurityContextInputBuffer("AcceptSecurityContext", (inputBuffer == null ? 0 : inputBuffer.size), outputBuffer.size, (Interop.SecurityStatus)errorCode);
+                SecurityEventSource.Log.SecurityContextInputBuffer(nameof(AcceptSecurityContext), (inputBuffer == null ? 0 : inputBuffer.size), outputBuffer.size, (Interop.SecurityStatus)errorCode);
             }
 
             return errorCode;
@@ -309,7 +309,7 @@ namespace System.Net
 
             if (SecurityEventSource.Log.IsEnabled())
             {
-                SecurityEventSource.Log.SecurityContextInputBuffers("AcceptSecurityContext", (inputBuffers == null ? 0 : inputBuffers.Length), outputBuffer.size, (Interop.SecurityStatus)errorCode);
+                SecurityEventSource.Log.SecurityContextInputBuffers(nameof(AcceptSecurityContext), (inputBuffers == null ? 0 : inputBuffers.Length), outputBuffer.size, (Interop.SecurityStatus)errorCode);
             }
 
             return errorCode;
@@ -522,7 +522,7 @@ namespace System.Net
         {
             if (GlobalLog.IsEnabled)
             {
-                GlobalLog.Enter("QueryContextChannelBinding", contextAttribute.ToString());
+                GlobalLog.Enter(nameof(QueryContextChannelBinding), contextAttribute.ToString());
             }
 
             SafeFreeContextBufferChannelBinding result;
@@ -531,14 +531,14 @@ namespace System.Net
             {
                 if (GlobalLog.IsEnabled)
                 {
-                    GlobalLog.Leave("QueryContextChannelBinding", "ERROR = " + ErrorDescription(errorCode));
+                    GlobalLog.Leave(nameof(QueryContextChannelBinding), "ERROR = " + ErrorDescription(errorCode));
                 }
                 return null;
             }
 
             if (GlobalLog.IsEnabled)
             {
-                GlobalLog.Leave("QueryContextChannelBinding", LoggingHash.HashString(result));
+                GlobalLog.Leave(nameof(QueryContextChannelBinding), LoggingHash.HashString(result));
             }
             return result;
         }
@@ -553,7 +553,7 @@ namespace System.Net
         {
             if (GlobalLog.IsEnabled)
             {
-                GlobalLog.Enter("QueryContextAttributes", contextAttribute.ToString());
+                GlobalLog.Enter(nameof(QueryContextAttributes), contextAttribute.ToString());
             }
 
             int nativeBlockSize = IntPtr.Size;
@@ -603,7 +603,7 @@ namespace System.Net
                     break;
 
                 default:
-                    throw new ArgumentException(SR.Format(SR.net_invalid_enum, "ContextAttribute"), nameof(contextAttribute));
+                    throw new ArgumentException(SR.Format(SR.net_invalid_enum, nameof(contextAttribute)), nameof(contextAttribute));
             }
 
             SafeHandle sspiHandle = null;
@@ -684,7 +684,7 @@ namespace System.Net
 
             if (GlobalLog.IsEnabled)
             {
-                GlobalLog.Leave("QueryContextAttributes", LoggingHash.ObjectToString(attribute));
+                GlobalLog.Leave(nameof(QueryContextAttributes), LoggingHash.ObjectToString(attribute));
             }
 
             return attribute;

--- a/src/Common/src/System/Globalization/IdnMapping.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.cs
@@ -76,7 +76,7 @@ namespace System.Globalization
             if (index < 0 || count < 0)
                 throw new ArgumentOutOfRangeException((index < 0) ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
             if (index > unicode.Length)
-                throw new ArgumentOutOfRangeException("byteIndex", SR.ArgumentOutOfRange_Index);
+                throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
             if (index > unicode.Length - count)
                 throw new ArgumentOutOfRangeException(nameof(unicode), SR.ArgumentOutOfRange_IndexCountBuffer);
             Contract.EndContractBlock();
@@ -117,7 +117,7 @@ namespace System.Globalization
             if (index < 0 || count < 0)
                 throw new ArgumentOutOfRangeException((index < 0) ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
             if (index > ascii.Length)
-                throw new ArgumentOutOfRangeException("byteIndex", SR.ArgumentOutOfRange_Index);
+                throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
             if (index > ascii.Length - count)
                 throw new ArgumentOutOfRangeException(nameof(ascii), SR.ArgumentOutOfRange_IndexCountBuffer);
 

--- a/src/Common/src/System/Runtime/InteropServices/SafeHeapHandle.cs
+++ b/src/Common/src/System/Runtime/InteropServices/SafeHeapHandle.cs
@@ -33,7 +33,7 @@ namespace System.Runtime.InteropServices
         /// <exception cref="ArgumentOutOfRangeException">Thrown if size is greater than the maximum memory size.</exception>
         public void Resize(ulong byteLength)
         {
-            if (IsClosed) throw new ObjectDisposedException("SafeHeapHandle");
+            if (IsClosed) throw new ObjectDisposedException(nameof(SafeHeapHandle));
 
             ulong originalLength = 0;
             if (handle == IntPtr.Zero)

--- a/src/Common/src/System/Xml/Schema/XmlUntypedConverter.cs
+++ b/src/Common/src/System/Xml/Schema/XmlUntypedConverter.cs
@@ -270,7 +270,7 @@ namespace System.Xml.Schema
         private static short Int32ToInt16(int value)
         {
             if (value < (int)Int16.MinValue || value > (int)Int16.MaxValue)
-                throw new OverflowException(SR.Format(SR.XmlConvert_Overflow, new string[] { XmlConvert.ToString(value), "Int16" }));
+                throw new OverflowException(SR.Format(SR.XmlConvert_Overflow, new string[] { XmlConvert.ToString(value), nameof(Int16) }));
 
             return (short)value;
         }
@@ -278,7 +278,7 @@ namespace System.Xml.Schema
         private static byte Int32ToByte(int value)
         {
             if (value < (int)Byte.MinValue || value > (int)Byte.MaxValue)
-                throw new OverflowException(SR.Format(SR.XmlConvert_Overflow, new string[] { XmlConvert.ToString(value), "Byte" }));
+                throw new OverflowException(SR.Format(SR.XmlConvert_Overflow, new string[] { XmlConvert.ToString(value), nameof(Byte) }));
 
             return (byte)value;
         }
@@ -286,7 +286,7 @@ namespace System.Xml.Schema
         private static ulong DecimalToUInt64(decimal value)
         {
             if (value < (decimal)UInt64.MinValue || value > (decimal)UInt64.MaxValue)
-                throw new OverflowException(SR.Format(SR.XmlConvert_Overflow, new string[] { XmlConvert.ToString(value), "UInt64" }));
+                throw new OverflowException(SR.Format(SR.XmlConvert_Overflow, new string[] { XmlConvert.ToString(value), nameof(UInt64) }));
 
             return (ulong)value;
         }
@@ -294,7 +294,7 @@ namespace System.Xml.Schema
         private static sbyte Int32ToSByte(int value)
         {
             if (value < (int)SByte.MinValue || value > (int)SByte.MaxValue)
-                throw new OverflowException(SR.Format(SR.XmlConvert_Overflow, new string[] { XmlConvert.ToString(value), "SByte" }));
+                throw new OverflowException(SR.Format(SR.XmlConvert_Overflow, new string[] { XmlConvert.ToString(value), nameof(SByte) }));
 
             return (sbyte)value;
         }
@@ -336,7 +336,7 @@ namespace System.Xml.Schema
         private static ushort Int32ToUInt16(int value)
         {
             if (value < (int)UInt16.MinValue || value > (int)UInt16.MaxValue)
-                throw new OverflowException(SR.Format(SR.XmlConvert_Overflow, new string[] { XmlConvert.ToString(value), "UInt16" }));
+                throw new OverflowException(SR.Format(SR.XmlConvert_Overflow, new string[] { XmlConvert.ToString(value), nameof(UInt16) }));
 
             return (ushort)value;
         }
@@ -344,7 +344,7 @@ namespace System.Xml.Schema
         private static uint Int64ToUInt32(long value)
         {
             if (value < (long)UInt32.MinValue || value > (long)UInt32.MaxValue)
-                throw new OverflowException(SR.Format(SR.XmlConvert_Overflow, new string[] { XmlConvert.ToString(value), "UInt32" }));
+                throw new OverflowException(SR.Format(SR.XmlConvert_Overflow, new string[] { XmlConvert.ToString(value), nameof(UInt32) }));
 
             return (uint)value;
         }

--- a/src/Common/src/System/Xml/XmlConvertEx.cs
+++ b/src/Common/src/System/Xml/XmlConvertEx.cs
@@ -72,13 +72,13 @@ namespace System.Xml
                 s = TrimString(s);
                 if (s.Length == 0 || s.IndexOf("##", StringComparison.Ordinal) != -1)
                 {
-                    throw new FormatException(SR.Format(SR.XmlConvert_BadFormat, s, "Uri"));
+                    throw new FormatException(SR.Format(SR.XmlConvert_BadFormat, s, nameof(Uri)));
                 }
             }
             Uri uri;
             if (!Uri.TryCreate(s, UriKind.RelativeOrAbsolute, out uri))
             {
-                throw new FormatException(SR.Format(SR.XmlConvert_BadFormat, s, "Uri"));
+                throw new FormatException(SR.Format(SR.XmlConvert_BadFormat, s, nameof(Uri)));
             }
             return uri;
         }


### PR DESCRIPTION
Follows up on #7290 by replacing some of the magic strings in `Common` with `nameof`.

cc @stephentoub