### PR TITLE
Use nameof in System.Collections.*

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -1784,7 +1784,7 @@ nameof(collections), SR.BlockingCollection_ValidateCollectionsArray_DispElems);
         {
             if (_isDisposed)
             {
-                throw new ObjectDisposedException("BlockingCollection", SR.BlockingCollection_Disposed);
+                throw new ObjectDisposedException(nameof(BlockingCollection<T>), SR.BlockingCollection_Disposed);
             }
         }
     }

--- a/src/System.Collections.NonGeneric/src/System/Collections/ArrayList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/ArrayList.cs
@@ -66,7 +66,7 @@ namespace System.Collections
         // 
         public ArrayList(int capacity)
         {
-            if (capacity < 0) throw new ArgumentOutOfRangeException(nameof(capacity), SR.Format(SR.ArgumentOutOfRange_MustBeNonNegNum, "capacity"));
+            if (capacity < 0) throw new ArgumentOutOfRangeException(nameof(capacity), SR.Format(SR.ArgumentOutOfRange_MustBeNonNegNum, nameof(capacity)));
             Contract.EndContractBlock();
 
             if (capacity == 0)
@@ -584,7 +584,7 @@ namespace System.Collections
         public virtual int LastIndexOf(Object value, int startIndex, int count)
         {
             if (Count != 0 && (startIndex < 0 || count < 0))
-                throw new ArgumentOutOfRangeException((startIndex < 0 ? "startIndex" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException(startIndex < 0 ? nameof(startIndex) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
             Contract.Ensures(Contract.Result<int>() < Count);
             Contract.EndContractBlock();
 
@@ -592,7 +592,7 @@ namespace System.Collections
                 return -1;
 
             if (startIndex >= _size || count > startIndex + 1)
-                throw new ArgumentOutOfRangeException((startIndex >= _size ? "startIndex" : "count"), SR.ArgumentOutOfRange_BiggerThanCollection);
+                throw new ArgumentOutOfRangeException(startIndex >= _size ? nameof(startIndex) : nameof(count), SR.ArgumentOutOfRange_BiggerThanCollection);
 
             return Array.LastIndexOf((Array)_items, value, startIndex, count);
         }
@@ -743,7 +743,7 @@ namespace System.Collections
         public virtual ArrayList GetRange(int index, int count)
         {
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
             if (_size - index < count)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
             Contract.Ensures(Contract.Result<ArrayList>() != null);
@@ -932,7 +932,7 @@ namespace System.Collections
             public override int BinarySearch(int index, int count, Object value, IComparer comparer)
             {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 if (Count - index < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
                 Contract.EndContractBlock();
@@ -993,7 +993,7 @@ namespace System.Collections
                 if (array == null)
                     throw new ArgumentNullException(nameof(array));
                 if (index < 0 || arrayIndex < 0)
-                    throw new ArgumentOutOfRangeException((index < 0) ? "index" : "arrayIndex", SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(arrayIndex), SR.ArgumentOutOfRange_NeedNonNegNum);
                 if (count < 0)
                     throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 if (array.Length - arrayIndex < count)
@@ -1017,7 +1017,7 @@ namespace System.Collections
             public override IEnumerator GetEnumerator(int index, int count)
             {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 Contract.EndContractBlock();
                 if (_list.Count - index < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
@@ -1147,7 +1147,7 @@ namespace System.Collections
             public override void RemoveRange(int index, int count)
             {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 Contract.EndContractBlock();
                 if (_list.Count - index < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
@@ -1165,7 +1165,7 @@ namespace System.Collections
             public override void Reverse(int index, int count)
             {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 Contract.EndContractBlock();
                 if (_list.Count - index < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
@@ -1208,7 +1208,7 @@ namespace System.Collections
             public override ArrayList GetRange(int index, int count)
             {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 Contract.EndContractBlock();
                 if (_list.Count - index < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
@@ -1218,7 +1218,7 @@ namespace System.Collections
             public override void Sort(int index, int count, IComparer comparer)
             {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 Contract.EndContractBlock();
                 if (_list.Count - index < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
@@ -2074,7 +2074,7 @@ namespace System.Collections
             public override ArrayList GetRange(int index, int count)
             {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 if (Count - index < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
                 Contract.EndContractBlock();
@@ -2385,7 +2385,7 @@ namespace System.Collections
             public override ArrayList GetRange(int index, int count)
             {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 if (Count - index < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
                 Contract.EndContractBlock();
@@ -2543,7 +2543,7 @@ namespace System.Collections
             public override int BinarySearch(int index, int count, Object value, IComparer comparer)
             {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 if (_baseSize - index < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
                 Contract.EndContractBlock();
@@ -2630,7 +2630,7 @@ namespace System.Collections
                 if (array.Rank != 1)
                     throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 if (array.Length - arrayIndex < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
                 if (_baseSize - index < count)
@@ -2673,7 +2673,7 @@ namespace System.Collections
             public override IEnumerator GetEnumerator(int index, int count)
             {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 if (_baseSize - index < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
                 Contract.EndContractBlock();
@@ -2685,7 +2685,7 @@ namespace System.Collections
             public override ArrayList GetRange(int index, int count)
             {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 if (_baseSize - index < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
                 Contract.EndContractBlock();
@@ -2817,7 +2817,7 @@ namespace System.Collections
             public override void RemoveRange(int index, int count)
             {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 if (_baseSize - index < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
                 Contract.EndContractBlock();
@@ -2836,7 +2836,7 @@ namespace System.Collections
             public override void Reverse(int index, int count)
             {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 if (_baseSize - index < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
                 Contract.EndContractBlock();
@@ -2861,7 +2861,7 @@ namespace System.Collections
             public override void Sort(int index, int count, IComparer comparer)
             {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), SR.ArgumentOutOfRange_NeedNonNegNum);
+                    throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 if (_baseSize - index < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
                 Contract.EndContractBlock();

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/BitVector32.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/BitVector32.cs
@@ -168,7 +168,7 @@ namespace System.Collections.Specialized
         {
             if (maxValue < 1)
             {
-                throw new ArgumentException(SR.Format(SR.Argument_InvalidValue, "maxValue", 1), nameof(maxValue));
+                throw new ArgumentException(SR.Format(SR.Argument_InvalidValue, nameof(maxValue), 1), nameof(maxValue));
             }
 
             short offset = (short)(priorOffset + CountBitsSet(priorMask));


### PR DESCRIPTION
Replaces the hardcoded strings in `System.Collections.*` with `nameof`.
Contributes to #7290 

/cc @stephentoub @jamesqo