### PR TITLE
Improve memory usage of HttpClient's StreamToStreamCopy

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs
@@ -25,9 +25,7 @@ namespace System.Net.Http
             _offset = 0;
             _count = content.Length;
             
-#if NETNative
             SetBuffer(_content, _offset, _count);
-#endif
         }
 
         public ByteArrayContent(byte[] content, int offset, int count)
@@ -49,9 +47,7 @@ namespace System.Net.Http
             _offset = offset;
             _count = count;
             
-#if NETNative
             SetBuffer(_content, _offset, _count);
-#endif
         }
 
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)

--- a/src/System.Net.Http/src/System/Net/Http/DelegatingStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/DelegatingStream.cs
@@ -132,6 +132,11 @@ namespace System.Net.Http
         {
             return _innerStream.WriteAsync(buffer, offset, count, cancellationToken);
         }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            return _innerStream.CopyToAsync(destination, bufferSize, cancellationToken);
+        }
         #endregion Write
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/StreamToStreamCopy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamToStreamCopy.cs
@@ -2,59 +2,275 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.Contracts;
+using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    // This helper class is used to copy the content of a source stream to a destination stream.
-    // The type verifies if the source and/or destination stream are MemoryStreams (or derived types). If so, sync
-    // read/write is used on the MemoryStream to avoid context switches.
+    /// <summary>
+    /// Helper class is used to copy the content of a source stream to a destination stream,
+    /// with optimizations based on expected usage within HttpClient and with the ability
+    /// to dispose of the source stream when the copy has completed.
+    /// </summary>
     internal static class StreamToStreamCopy
     {
-        public static async Task CopyAsync(Stream source, Stream destination, int bufferSize, bool disposeSource)
+        /// <summary>Copies the source stream from its current position to the destination stream at its current position.</summary>
+        /// <param name="source">The source stream from which to copy.</param>
+        /// <param name="destination">The destination stream to which to copy.</param>
+        /// <param name="bufferSize">The size of the buffer to allocate if one needs to be allocated.</param>
+        /// <param name="disposeSource">Whether to dispose of the source stream after the copy has finished successfully.</param>
+        public static Task CopyAsync(Stream source, Stream destination, int bufferSize, bool disposeSource)
         {
-            Contract.Requires(source != null);
-            Contract.Requires(destination != null);
-            Contract.Requires(bufferSize > 0);
-
-            byte[] buffer = new byte[bufferSize];
-
-            // If both streams are MemoryStreams, just copy the whole content at once to avoid context switches.
-            // This will not block since it will just result in a memcopy.
-            if (source is MemoryStream && destination is MemoryStream)
-            {
-                for (; ;)
-                {
-                    int bytesRead = source.Read(buffer, 0, bufferSize);
-                    if (bytesRead == 0)
-                        break;
-                    destination.Write(buffer, 0, bytesRead);
-                }
-            }
-            else
-            {
-                for (; ;)
-                {
-                    int bytesRead = await source.ReadAsync(buffer, 0, bufferSize).ConfigureAwait(false);
-                    if (bytesRead == 0)
-                        break;
-                    await destination.WriteAsync(buffer, 0, bytesRead).ConfigureAwait(false);
-                }
-            }
+            Debug.Assert(source != null);
+            Debug.Assert(destination != null);
+            Debug.Assert(bufferSize > 0);
 
             try
             {
-                if (disposeSource)
+                // If the source is a MemoryStream from which we can extract the internal buffer,
+                // then we can perform the copy in a single write operation.
+                ArraySegment<byte> sourceBuffer;
+                MemoryStream sourceMemoryStream = source as MemoryStream;
+                if (sourceMemoryStream != null && sourceMemoryStream.TryGetBuffer(out sourceBuffer))
                 {
-                    source.Dispose();
+                    // It's possible source derives from MemoryStream but has a bad override of Position.
+                    // If we get back a value that doesn't make sense, don't take the optimized path.
+                    long pos = source.CanSeek ? source.Position : -1;
+                    if (pos >= 0 && pos < sourceBuffer.Count)
+                    {
+                        // We need to copy from the current position, so if necessary update the buffer
+                        // based on the position of the stream.
+                        if (pos != 0)
+                        {
+                            sourceBuffer = new ArraySegment<byte>(
+                                sourceBuffer.Array, 
+                                (int)checked(sourceBuffer.Offset + pos),
+                                (int)checked(sourceBuffer.Count - pos));
+                        }
+
+                        // Update position to simulate reading all the data
+                        source.Position += sourceBuffer.Count; 
+
+                        // Now write the buffer to the destination stream. This will complete synchronously if the 
+                        // destination's WriteAsync completes synchronously, such as if destination is also a MemoryStream.  
+                        // Thus we don't need to special case it.
+                        return WriteToAnyStreamAsync(sourceBuffer, source, destination, disposeSource);
+                    }
                 }
+
+                // The source is not a MemoryStream whose buffer we can use directly, but the destination might be our special 
+                // LimitMemoryStream, in which case if it's been pre-sized with a capacity, we can optimize the copy 
+                // by giving its buffer to the source directly, avoiding the need for an intermediate buffer.
+                HttpContent.LimitMemoryStream destinationLimitStream = destination as HttpContent.LimitMemoryStream;
+                if (destinationLimitStream != null)
+                {
+                    // We primarily care about the case where the stream has been presized based on a Content-Length.
+                    // If capacity is 0, we have no buffer to copy to, so we skip.  If capacity is <= the max size allowed,
+                    // then we can fill the capacity that's there, and if it's not enough (which should be very rare), 
+                    // we'll just fall back to continuing with a read/write loop for any additional data.  If the capacity 
+                    // is greater than the max size, we don't want to copy to it, as if we use all of the capacity, we'll 
+                    // end up exceeding the max, so we skip the optimization for that case.  That case could happen if
+                    // there's no Content-Length, and the stream is written to by something before it's given to us, in which 
+                    // case the growth-algorithm inside the MemoryStream could cause its capacity to grow beyond the MaxSize; 
+                    // that case should also be extremely rare, and we don't care about it from an optimization perspective.
+                    int capacity = destinationLimitStream.Capacity;
+                    if (capacity > 0 && capacity <= destinationLimitStream.MaxSize)
+                    {
+                        return CopyAsyncToPreSizedLimitMemoryStream(source, destinationLimitStream, bufferSize, disposeSource);
+                    }
+                }
+
+                // If the source is a MemoryStream, at this point we know we can't get its buffer.  But, since
+                // we're about to allocate a new byte[] of length bufferSize, if the MemoryStream's Length is
+                // no larger than that and we're at the beginning of the stream, we can just ask it for its array 
+                // and still do a single write to the target.
+                if (sourceMemoryStream != null && 
+                    sourceMemoryStream.CanSeek &&
+                    sourceMemoryStream.Position == 0 &&
+                    sourceMemoryStream.Length <= bufferSize)
+                {
+                    var buffer = new ArraySegment<byte>(sourceMemoryStream.ToArray());
+                    sourceMemoryStream.Position = buffer.Count; // Update position to simulate reading all the data
+                    return WriteToAnyStreamAsync(buffer, sourceMemoryStream, destination, disposeSource);
+                }
+
+                // No special-stream cases worked, so we need to fall back to doing a normal copy, involving
+                // allocating a byte[] of length bufferSize. However, if we don't need to dispose of the source, 
+                // then there's no work to be performed after the copy operation finishes, and we can simply delegate 
+                // to the source's CopyToAsync implementation to provide the best implementation the source can muster. 
+                // If we do need to dispose of the source, then using CopyToAsync would result in needing an extra
+                // async method wrapper and its potential allocations, so we fall back to our own read/write loop that 
+                // does the copy and the disposal in a single async method.
+                return disposeSource ?
+                    CopyAsyncAnyStreamToAnyStreamCore(source, destination, bufferSize, disposeSource) :
+                    source.CopyToAsync(destination, bufferSize);
+            }
+            catch (Exception e)
+            {
+                // For compatibility with the previous implementation, catch everything (including arg exceptions) and
+                // store errors into the task rather than letting them propagate to the synchronous caller.
+                return Task.FromException(e);
+            }
+        }
+
+        /// <summary>Writes the array segment to the destination stream.</summary>
+        /// <param name="buffer">The array segment to write.</param>
+        /// <param name="source">The source stream with which <paramref name="buffer"/> is associated.</param>
+        /// <param name="destination">The destination stream to which to write.</param>
+        /// <param name="disposeSource">Whether to dispose of the source stream after the copy has finished successfully.</param>
+        private static async Task WriteToAnyStreamAsync(ArraySegment<byte> buffer, Stream source, Stream destination, bool disposeSource)
+        {
+            await destination.WriteAsync(buffer.Array, buffer.Offset, buffer.Count).ConfigureAwait(false);
+            DisposeSource(disposeSource, source);
+        }
+
+        /// <summary>Copies a source stream to a LimitMemoryStream by writing directly to the LimitMemoryStream's buffer.</summary>
+        /// <param name="source">The source stream from which to copy.</param>
+        /// <param name="destination">The destination LimitMemoryStream to write to.</param>
+        /// <param name="bufferSize">The size of the buffer to allocate if one needs to be allocated.</param>
+        /// <param name="disposeSource">Whether to dispose of the source stream after the copy has finished successfully.</param>
+        private static async Task CopyAsyncToPreSizedLimitMemoryStream(Stream source, HttpContent.LimitMemoryStream destination, int bufferSize, bool disposeSource)
+        {
+            // When a LimitMemoryStream is constructed to represent a response with a particular ContentLength, its
+            // Capacity is set to that amount in order to pre-size it.  We can take advantage of that in this copy
+            // by handing the destination's pre-sized underlying byte[] to the source stream for it to read into
+            // rather than creating a temporary buffer, copying from the source into that, and then copying again
+            // from the buffer into the LimitMemoryStream.
+            long capacity = destination.Capacity;
+            Debug.Assert(capacity > 0, "Caller should have checked that there's capacity");
+
+            // Get the initial length of the stream.  When the length of a LimitMemoryStream is increased, the newly available
+            // space is zero-filled, either due to allocating a new array or due to an explicit clear.  As a result, we can't
+            // write into the array directly and then increase the length to the right size afterward, as doing so will overwrite
+            // all of the data newly written.  Instead, we need to increase the length to the capacity, write in our data, and
+            // then subsequently trim back the length to the end of the written data.
+            long startingLength = destination.Length;
+            if (startingLength < capacity)
+            {
+                destination.SetLength(capacity);
+            }
+
+            int bytesRead;
+            try
+            {
+                // Get the LimitMemoryStream's buffer.
+                ArraySegment<byte> entireBuffer;
+                bool gotBuffer = destination.TryGetBuffer(out entireBuffer);
+                Debug.Assert(gotBuffer, "Should only be in CopyAsyncToMemoryStream if we were able to get the buffer");
+                Debug.Assert(entireBuffer.Offset == 0, "LimitMemoryStream's are only constructed with a 0-offset");
+                Debug.Assert(entireBuffer.Count == entireBuffer.Array.Length, $"LimitMemoryStream's buffer count {entireBuffer.Count} should be the same as its length {entireBuffer.Array.Length}");
+
+                // While there's space remaining in the destination buffer, do another read to try to fill it.
+                // Each time we read successfully, we update the position of the destination stream to be
+                // at the end of the data read.
+                int spaceRemaining = (int)(entireBuffer.Array.Length - destination.Position);
+                while (spaceRemaining > 0)
+                {
+                    // Read into the buffer
+                    bytesRead = await source.ReadAsync(entireBuffer.Array, (int)destination.Position, spaceRemaining).ConfigureAwait(false);
+                    if (bytesRead == 0)
+                    {
+                        DisposeSource(disposeSource, source);
+                        return;
+                    }
+                    destination.Position += bytesRead;
+                    spaceRemaining -= bytesRead;
+                }
+            }
+            finally
+            {
+                // Now that we're done reading directly into the buffer, if we previously increased the length
+                // of the stream, set it be at the end of the data read.
+                if (startingLength < capacity)
+                {
+                    destination.SetLength(destination.Position);
+                }
+            }
+
+            // A typical case will be that we read exactly the amount requested.  This means that the next
+            // read will likely return 0 bytes, but we need to try to do the read to know that, which means
+            // we need a buffer to read into.  Use a cached single-byte array to do a read for 1-byte.
+            // Ideally this read returns 0, and we're done.
+            byte[] singleByteArray = RentCachedSingleByteArray();
+            bytesRead = await source.ReadAsync(singleByteArray, 0, 1).ConfigureAwait(false);
+            if (bytesRead == 0)
+            {
+                ReturnCachedSingleByteArray(singleByteArray);
+                DisposeSource(disposeSource, source);
+                return;
+            }
+
+            // The read actually returned data, which means there was more data available then
+            // the capacity of the LimitMemoryStream.  This is likely an error condition, but
+            // regardless we need to finish the copy.  First, we write out the byte we read...
+            await destination.WriteAsync(singleByteArray, 0, 1).ConfigureAwait(false);
+            ReturnCachedSingleByteArray(singleByteArray);
+
+            // ...then we fall back to doing the normal read/write loop.
+            await CopyAsyncAnyStreamToAnyStreamCore(source, destination, bufferSize, disposeSource).ConfigureAwait(false);
+        }
+
+        /// <summary>Copies a source stream to a destination stream via a standard read/write loop.</summary>
+        /// <param name="source">The source stream from which to copy.</param>
+        /// <param name="destination">The destination stream to which to copy.</param>
+        /// <param name="bufferSize">The size of the buffer to allocate if one needs to be allocated.</param>
+        /// <param name="disposeSource">Whether to dispose of the source stream after the copy has finished successfully.</param>
+        private static async Task CopyAsyncAnyStreamToAnyStreamCore(Stream source, Stream destination, int bufferSize, bool disposeSource)
+        {
+            var buffer = new byte[bufferSize];
+
+            int bytesRead;
+            while ((bytesRead = await source.ReadAsync(buffer, 0, bufferSize).ConfigureAwait(false)) > 0)
+            {
+                await destination.WriteAsync(buffer, 0, bytesRead).ConfigureAwait(false);
+            }
+
+            DisposeSource(disposeSource, source);
+        }
+
+        /// <summary>A cached byte[1] array.</summary>
+        [ThreadStatic]
+        private static byte[] t_singleByteArray;
+
+        /// <summary>Gets a byte[1] array, either taking a cached one or allocating one a new.</summary>
+        private static byte[] RentCachedSingleByteArray()
+        {
+            byte[] singleByteArray = t_singleByteArray;
+            if (singleByteArray != null)
+            {
+                // This will be used across async points, so we need to ensure no one else can use
+                // the array while it's in use.
+                t_singleByteArray = null;
+                return singleByteArray;
+            }
+            else
+            {
+                return new byte[1];
+            }
+        }
+
+        private static void ReturnCachedSingleByteArray(byte[] singleByteArray)
+        {
+            t_singleByteArray = singleByteArray; // ok if we overwrite one already there
+        }
+
+        /// <summary>Disposes the source stream if <paramref name="disposeSource"/> is true.</summary>
+        private static void DisposeSource(bool disposeSource, Stream source)
+        {
+            if (!disposeSource) return;
+
+            try
+            {
+                source.Dispose();
             }
             catch (Exception e)
             {
                 // Dispose() should never throw, but since we're on an async codepath, make sure to catch the exception.
-                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exception(NetEventSource.ComponentType.Http, null, "CopyAsync", e);
+                if (NetEventSource.Log.IsEnabled())
+                {
+                    NetEventSource.Exception(NetEventSource.ComponentType.Http, null, nameof(CopyAsync), e);
+                }
             }
         }
     }

--- a/src/System.Net.Http/tests/FunctionalTests/ChannelBindingAwareContent.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ChannelBindingAwareContent.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
 using System.Security.Authentication.ExtendedProtection;
 using System.Text;
@@ -10,10 +9,13 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public sealed class ChannelBindingAwareContent : StringContent
+    internal sealed class ChannelBindingAwareContent : HttpContent
     {
-        public ChannelBindingAwareContent(string content) : base(content)
+        private readonly byte[] _content;
+
+        public ChannelBindingAwareContent(string content)
         {
+            _content = Encoding.UTF8.GetBytes(content);
         }
         
         public ChannelBinding ChannelBinding { get ; private set; }
@@ -21,8 +23,18 @@ namespace System.Net.Http.Functional.Tests
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
             ChannelBinding = context.GetChannelBinding(ChannelBindingKind.Endpoint);
-            
-            return base.SerializeToStreamAsync(stream, context);
+            return stream.WriteAsync(_content, 0, _content.Length);
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = _content.Length;
+            return true;
+        }
+
+        protected override Task<Stream> CreateContentReadStreamAsync()
+        {
+            return Task.FromResult<Stream>(new MemoryStream(_content, 0, _content.Length, writable: false));
         }
     }
 }

--- a/src/System.Net.Http/tests/UnitTests/HttpContentTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpContentTest.cs
@@ -4,7 +4,7 @@
 
 using System.IO;
 using System.Reflection;
-
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Net.Http.Tests
@@ -30,6 +30,51 @@ namespace System.Net.Http.Tests
 
             // The following line will throw an ObjectDisposedException if the buffered-stream was correctly disposed.
             Assert.Throws<ObjectDisposedException>(() => { string str = bufferedContentStream.Length.ToString(); });
+        }
+
+        [Theory]
+        [InlineData(1, 100, 99, 1)]
+        [InlineData(1, 100, 50, 99)]
+        [InlineData(1, 100, 98, 98)]
+        [InlineData(1, 100, 99, 99)]
+        [InlineData(1, 100, 99, 98)]
+        [InlineData(3, 50, 100, 149)]
+        [InlineData(3, 50, 149, 149)]
+        public async Task LoadIntoBufferAsync_ContentLengthSmallerThanActualData_ActualDataLargerThanMaxSize_ThrowsException(
+            int numberOfWrites, int sizeOfEachWrite, int reportedLength, int maxSize)
+        {
+            Assert.InRange(maxSize, 1, (numberOfWrites * sizeOfEachWrite) - 1);
+
+            LieAboutLengthContent c = new LieAboutLengthContent(numberOfWrites, sizeOfEachWrite, reportedLength);
+            Task t = c.LoadIntoBufferAsync(maxSize);
+            await Assert.ThrowsAsync<HttpRequestException>(() => t);
+        }
+
+        private sealed class LieAboutLengthContent : HttpContent
+        {
+            private readonly int _numberOfWrites, _sizeOfEachWrite, _reportedLength;
+
+            public LieAboutLengthContent(int numberOfWrites, int sizeOfEachWrite, int reportedLength)
+            {
+                _numberOfWrites = numberOfWrites;
+                _sizeOfEachWrite = sizeOfEachWrite;
+                _reportedLength = reportedLength;
+            }
+
+            protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                byte[] bytes = new byte[_sizeOfEachWrite];
+                for (int i = 0; i < _numberOfWrites; i++)
+                {
+                    await stream.WriteAsync(bytes, 0, bytes.Length).ConfigureAwait(false);
+                }
+            }
+
+            protected internal override bool TryComputeLength(out long length)
+            {
+                length = _reportedLength;
+                return true;
+            }
         }
     }
 }

--- a/src/System.Net.Http/tests/UnitTests/StreamToStreamCopyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/StreamToStreamCopyTest.cs
@@ -1,0 +1,351 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Http.Tests
+{
+    public class StreamToStreamCopyTest
+    {
+        [Theory]
+        [MemberData(nameof(TwoBooleansWithAdditionalArg), new object[] { new object[] { 256, 8192, 8231 } })]
+        public async Task MemoryStream_To_MemoryStream(bool sourceIsExposable, bool disposeSource, int inputSize)
+        {
+            byte[] input = CreateByteArray(inputSize);
+            MemoryStream source = CreateSourceMemoryStream(sourceIsExposable, input);
+            var destination = new MemoryStream();
+
+            await StreamToStreamCopy.CopyAsync(source, destination, 4096, disposeSource);
+
+            Assert.NotEqual(disposeSource, source.CanRead);
+            if (!disposeSource)
+            {
+                Assert.Equal(input.Length, source.Position);
+            }
+
+            Assert.Equal(input, destination.ToArray());
+            Assert.Equal(input.Length, destination.Position);
+            Assert.Equal(input.Length, destination.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(TwoBooleans))]
+        public async Task NonSeekableMemoryStream_To_MemoryStream(bool sourceIsExposable, bool disposeSource)
+        {
+            byte[] input = CreateByteArray(8192);
+            var source = new NonSeekableMemoryStream(input, sourceIsExposable);
+            var destination = new MemoryStream();
+
+            await StreamToStreamCopy.CopyAsync(source, destination, 4096, disposeSource);
+
+            Assert.NotEqual(disposeSource, source.CanRead);
+            if (!disposeSource)
+            {
+                Assert.Equal(input.Length, source.Position);
+            }
+
+            Assert.Equal(input, destination.ToArray());
+            Assert.Equal(input.Length, destination.Position);
+            Assert.Equal(input.Length, destination.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(TwoBooleans))]
+        public async Task MemoryStream_NonZeroPosition_To_MemoryStream(bool sourceIsExposable, bool disposeSource)
+        {
+            byte[] input = CreateByteArray(8192);
+            MemoryStream source = CreateSourceMemoryStream(sourceIsExposable, input);
+            const int StartingPosition = 1024;
+            source.Position = StartingPosition;
+
+            var destination = new HttpContent.LimitMemoryStream(int.MaxValue, 0);
+
+            await StreamToStreamCopy.CopyAsync(source, destination, 4096, disposeSource);
+
+            Assert.NotEqual(disposeSource, source.CanRead);
+            if (!disposeSource)
+            {
+                Assert.Equal(input.Length, source.Position);
+            }
+
+            Assert.Equal(input.Skip(StartingPosition), destination.ToArray());
+            Assert.Equal(input.Length - StartingPosition, destination.Position);
+            Assert.Equal(input.Length - StartingPosition, destination.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(TwoBooleans))]
+        public async Task MemoryStream_PositionAtEnd_To_MemoryStream(bool sourceIsExposable, bool disposeSource)
+        {
+            byte[] input = CreateByteArray(8192);
+            MemoryStream source = CreateSourceMemoryStream(sourceIsExposable, input);
+            int StartingPosition = input.Length;
+            source.Position = StartingPosition;
+
+            var destination = new HttpContent.LimitMemoryStream(int.MaxValue, 0);
+
+            await StreamToStreamCopy.CopyAsync(source, destination, 4096, disposeSource);
+
+            Assert.NotEqual(disposeSource, source.CanRead);
+            if (!disposeSource)
+            {
+                Assert.Equal(input.Length, source.Position);
+            }
+
+            Assert.Equal(input.Skip(StartingPosition), destination.ToArray());
+            Assert.Equal(input.Length - StartingPosition, destination.Position);
+            Assert.Equal(input.Length - StartingPosition, destination.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(TwoBooleans))]
+        public async Task MemoryStream_To_LimitMemoryStream_NoCapacity(bool sourceIsExposable, bool disposeSource)
+        {
+            byte[] input = CreateByteArray(8192);
+            MemoryStream source = CreateSourceMemoryStream(sourceIsExposable, input);
+            var destination = new HttpContent.LimitMemoryStream(int.MaxValue, 0);
+
+            await StreamToStreamCopy.CopyAsync(source, destination, 4096, disposeSource);
+
+            Assert.NotEqual(disposeSource, source.CanRead);
+            if (!disposeSource)
+            {
+                Assert.Equal(input.Length, source.Position);
+            }
+
+            Assert.Equal(input, destination.ToArray());
+            Assert.Equal(input.Length, destination.Position);
+            Assert.Equal(input.Length, destination.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(TwoBooleans))]
+        public async Task MemoryStream_To_LimitMemoryStream_EqualCapacity(bool sourceIsExposable, bool disposeSource)
+        {
+            byte[] input = CreateByteArray(8192);
+            MemoryStream source = CreateSourceMemoryStream(sourceIsExposable, input);
+            var destination = new HttpContent.LimitMemoryStream(int.MaxValue, input.Length);
+
+            await StreamToStreamCopy.CopyAsync(source, destination, 4096, disposeSource);
+
+            Assert.NotEqual(disposeSource, source.CanRead);
+            if (!disposeSource)
+            {
+                Assert.Equal(input.Length, source.Position);
+            }
+
+            Assert.Equal(input, destination.ToArray());
+            Assert.Equal(input.Length, destination.Position);
+            Assert.Equal(input.Length, destination.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(TwoBooleans))]
+        public async Task MemoryStream_To_LimitMemoryStream_BiggerCapacity(bool sourceIsExposable, bool disposeSource)
+        {
+            byte[] input = CreateByteArray(8192);
+            MemoryStream source = CreateSourceMemoryStream(sourceIsExposable, input);
+            var destination = new HttpContent.LimitMemoryStream(int.MaxValue, input.Length * 2);
+
+            await StreamToStreamCopy.CopyAsync(source, destination, 4096, disposeSource);
+
+            Assert.NotEqual(disposeSource, source.CanRead);
+            if (!disposeSource)
+            {
+                Assert.Equal(input.Length, source.Position);
+            }
+
+            Assert.Equal(input, destination.ToArray());
+            Assert.Equal(input.Length, destination.Position);
+            Assert.Equal(input.Length, destination.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(TwoBooleans))]
+        public async Task MemoryStream_To_LimitMemoryStream_SmallerCapacity(bool sourceIsExposable, bool disposeSource)
+        {
+            byte[] input = CreateByteArray(8192);
+            MemoryStream source = CreateSourceMemoryStream(sourceIsExposable, input);
+            var destination = new HttpContent.LimitMemoryStream(int.MaxValue, 1024);
+
+            await StreamToStreamCopy.CopyAsync(source, destination, 4096, disposeSource);
+
+            Assert.NotEqual(disposeSource, source.CanRead);
+            if (!disposeSource)
+            {
+                Assert.Equal(input.Length, source.Position);
+            }
+
+            Assert.Equal(input, destination.ToArray());
+            Assert.Equal(input.Length, destination.Position);
+            Assert.Equal(input.Length, destination.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(TwoBooleans))]
+        public async Task MemoryStream_To_LimitMemoryStream_BiggerLength(bool sourceIsExposable, bool disposeSource)
+        {
+            byte[] input = CreateByteArray(8192);
+            MemoryStream source = CreateSourceMemoryStream(sourceIsExposable, input);
+            var destination = new HttpContent.LimitMemoryStream(int.MaxValue, 0);
+            destination.SetLength(input.Length * 2);
+
+            await StreamToStreamCopy.CopyAsync(source, destination, 4096, disposeSource);
+
+            Assert.NotEqual(disposeSource, source.CanRead);
+            if (!disposeSource)
+            {
+                Assert.Equal(input.Length, source.Position);
+            }
+
+            Assert.Equal(input.Concat(new byte[input.Length]), destination.ToArray());
+            Assert.Equal(input.Length, destination.Position);
+            Assert.Equal(input.Length * 2, destination.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(TwoBooleans))]
+        public async Task NonMemoryStream_To_MemoryStream(bool sourceIsExposable, bool disposeSource)
+        {
+            byte[] input = CreateByteArray(8192);
+            var source = new WrapperStream(CreateSourceMemoryStream(sourceIsExposable, input));
+            var destination = new MemoryStream();
+
+            await StreamToStreamCopy.CopyAsync(source, destination, 4096, disposeSource);
+
+            Assert.NotEqual(disposeSource, source.CanRead);
+            if (!disposeSource)
+            {
+                Assert.Equal(input.Length, source.Position);
+            }
+
+            Assert.Equal(input, destination.ToArray());
+            Assert.Equal(input.Length, destination.Position);
+            Assert.Equal(input.Length, destination.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(TwoBooleans))]
+        public async Task NonMemoryStream_To_LimitMemoryStream_NoCapacity(bool sourceIsExposable, bool disposeSource)
+        {
+            byte[] input = CreateByteArray(8192);
+            var source = new WrapperStream(CreateSourceMemoryStream(sourceIsExposable, input));
+            var destination = new HttpContent.LimitMemoryStream(int.MaxValue, 0);
+
+            await StreamToStreamCopy.CopyAsync(source, destination, 4096, disposeSource);
+
+            Assert.NotEqual(disposeSource, source.CanRead);
+            if (!disposeSource)
+            {
+                Assert.Equal(input.Length, source.Position);
+            }
+
+            Assert.Equal(input, destination.ToArray());
+            Assert.Equal(input.Length, destination.Position);
+            Assert.Equal(input.Length, destination.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(TwoBooleans))]
+        public async Task NonMemoryStream_To_LimitMemoryStream_EqualCapacity(bool sourceIsExposable, bool disposeSource)
+        {
+            byte[] input = CreateByteArray(8192);
+            var source = new WrapperStream(CreateSourceMemoryStream(sourceIsExposable, input));
+            var destination = new HttpContent.LimitMemoryStream(int.MaxValue, input.Length);
+
+            await StreamToStreamCopy.CopyAsync(source, destination, 4096, disposeSource);
+
+            Assert.NotEqual(disposeSource, source.CanRead);
+            if (!disposeSource)
+            {
+                Assert.Equal(input.Length, source.Position);
+            }
+
+            Assert.Equal(input, destination.ToArray());
+            Assert.Equal(input.Length, destination.Position);
+            Assert.Equal(input.Length, destination.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(TwoBooleans))]
+        public async Task NonMemoryStream_To_NonMemoryStream(bool sourceIsExposable, bool disposeSource)
+        {
+            byte[] input = CreateByteArray(8192);
+            var source = new WrapperStream(CreateSourceMemoryStream(sourceIsExposable, input));
+
+            var underlyingDestination = new MemoryStream();
+            var destination = new WrapperStream(underlyingDestination);
+
+            await StreamToStreamCopy.CopyAsync(source, destination, 4096, disposeSource);
+
+            Assert.NotEqual(disposeSource, source.CanRead);
+            if (!disposeSource)
+            {
+                Assert.Equal(input.Length, source.Position);
+            }
+
+            Assert.Equal(input, underlyingDestination.ToArray());
+            Assert.Equal(input.Length, destination.Position);
+            Assert.Equal(input.Length, destination.Length);
+        }
+
+        private static MemoryStream CreateSourceMemoryStream(bool sourceIsExposable, byte[] input)
+        {
+            MemoryStream source;
+            if (sourceIsExposable)
+            {
+                source = new MemoryStream();
+                source.Write(input, 0, input.Length);
+                source.Position = 0;
+            }
+            else
+            {
+                source = new MemoryStream(input);
+            }
+            return source;
+        }
+
+        private static byte[] CreateByteArray(int length)
+        {
+            byte[] data = new byte[length];
+            new Random(1).NextBytes(data);
+            return data;
+        }
+
+        public static IEnumerable<object[]> TwoBooleans = new object[][]
+        {
+            new object[] { false, false },
+            new object[] { false, true },
+            new object[] { true, false },
+            new object[] { true, true },
+        };
+
+        public static IEnumerable<object[]> TwoBooleansWithAdditionalArg(object[] args)
+        {
+            bool[] bools = new[] { true, false };
+            foreach (object arg in args)
+                foreach (bool b1 in bools)
+                    foreach (bool b2 in bools)
+                        yield return new object[] { b1, b2, arg };
+        }
+
+        private sealed class WrapperStream : DelegatingStream
+        {
+            public WrapperStream(Stream wrapped) : base(wrapped) { }
+        }
+
+        private sealed class NonSeekableMemoryStream : MemoryStream
+        {
+            public NonSeekableMemoryStream(byte[] input, bool sourceIsExposable) : base(input, 0, input.Length, true, sourceIsExposable)
+            {
+            }
+
+            public override bool CanSeek => false;
+        }
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -344,6 +344,7 @@
     <Compile Include="HttpContentTest.cs" />
     <Compile Include="HttpRuleParserTest.cs" />
     <Compile Include="MockContent.cs" />
+    <Compile Include="StreamToStreamCopyTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />


### PR DESCRIPTION
Copying between streams represents one of the larger sources of memory allocations and copying in HttpClient. HttpClient has its own stream-to-stream copy implementation, but there are ways we can significantly improve it based on typical usage within HttpClient.  

This commit does the following:
- Previously it would special case when both the source and destination stream were MemoryStreams, but even in that case it would allocate a temporary buffer and do a Read/Write loop to copy between them, and even then it's relatively rare to copy from a MemoryStream to a MemoryStream.  Instead, if the source stream is a MemoryStream and we can get its buffer, we can do a single write to the destination (regardless of what kind of stream it is), avoiding the need for multiple read/writes and for the temporary buffer.  If we can't get its buffer but its length is known to be less than or equal to the requested buffer size and it's positioned at the beginning, we can simply ToArray the source and still do a single write to the target.
- If the destination is the special LimitMemoryStream, used for buffering output, and if that LimitMemoryStream was pre-sized based on the response having a Content-Length, then rather than allocating a temporary buffer and repeatedly copying from the source stream into that buffer and copying from the buffer into the memory stream, we can instead give the destination's buffer directly to be read into by the source, avoiding the temporary buffer and the extra copies.  This is a very common case.
- If the source does not need to be disposed after the copy, rather than doing our own copy loop, we can instead ask the source to use its CopyToAsync implementation to copy to the destination stream.  Worst case this will be exactly what we were previously doing, but best case the source has its own CopyToAsync override that's more efficient.
- When constructing a LimitMemoryStream, if the Content-Length isn't known, we were explicitly passing a 0 capacity to the base, which causes it to allocate a new zero-length array; I've added a ctor to avoid that.

As a small example, with this short test:
```C#
var uri = new Uri("http://httpbin.org/get");
var c = new HttpClient();
for (int i = 0; i < 100; i++)
    c.GetAsync(uri).GetAwaiter().GetResult().Dispose();
```
before the change it allocated 1,411,714 bytes, and after the change, it allocated 1,003,702, for an ~30% reduction.  That drop is almost entirely in avoiding needing byte[]s:

I'd appreciate some extra scrutiny on this.
cc: @davidsh, @cipop, @ericeil, @kapilash, @bartonjs, @ianhays