### PR TITLE
Add default CMake installation path to probe script.

### DIFF
--- a/build-packages.cmd
+++ b/build-packages.cmd
@@ -7,6 +7,10 @@ echo Running build-packages.cmd %* > %packagesLog%
 if /I [%1] == [/?] goto Usage
 if /I [%1] == [/help] goto Usage
 
+REM ensure that msbuild is available
+echo Running init-tools.cmd
+call %~dp0init-tools.cmd
+
 echo msbuild.exe %~dp0src\packages.builds %* /nologo /v:minimal /flp:v=detailed;Append;LogFile=%packagesLog% >> %packagesLog%
 call msbuild.exe %~dp0src\packages.builds %* /nologo /v:minimal /flp:v=detailed;Append;LogFile=%packagesLog%
 if NOT [%ERRORLEVEL%]==[0] (

--- a/build-packages.sh
+++ b/build-packages.sh
@@ -14,9 +14,13 @@ arguments="$@"
 echo -e "Running build-packages.sh $arguments" > $build_packages_log
 
 # Parse arguments
-if [ $arguments == "-h" ] || [ $arguments == "--help" ]; then
+if [ "$arguments" == "-h" ] || [ "$arguments" == "--help" ]; then
     usage
 fi
+
+# Ensure that MSBuild is available
+echo "Running init-tools.sh"
+$working_tree_root/init-tools.sh
 
 echo -e "\n$working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/packages.builds $arguments /nologo /v:minimal /flp:v=detailed;Append;LogFile=$build_packages_log" >> $build_packages_log
 $working_tree_root/Tools/corerun $working_tree_root/Tools/MSBuild.exe $working_tree_root/src/packages.builds $arguments /nologo /v:minimal "/flp:v=detailed;Append;LogFile=$build_packages_log"

--- a/src/Native/Windows/probe-win.ps1
+++ b/src/Native/Windows/probe-win.ps1
@@ -11,6 +11,7 @@ function GetCMakeVersions
 
 function GetCMakeInfo($regKey)
 {
+  # This no longer works for versions 3.5+
   try {
     $version = [System.Version] $regKey.PSChildName.Split(' ')[1]
   }
@@ -31,6 +32,11 @@ function LocateCMake
   $inPathPath = (get-command cmake.exe -ErrorAction SilentlyContinue).Path
   if ($inPathPath -ne $null) {
     return $inPathPath
+  }
+  # Check the default installation directory
+  $inDefaultDir = [System.IO.Path]::Combine(${Env:ProgramFiles(x86)}, "CMake\bin\cmake.exe")
+  if ([System.IO.File]::Exists($inDefaultDir)) {
+    return $inDefaultDir
   }
   # Let us hope that CMake keep using their current version scheme
   $validVersions = @()


### PR DESCRIPTION
CMake 3.5+ MSI-based installations no longer write the installation
directory to the registry.  To work around this I have added the default
installation directory to the probing logic.
Fix syntax errors in build-packages.sh and run init-tools.sh if tools haven't
been restored.