### PR TITLE
Add BaseDirectory tests to System.AppContext

### DIFF
--- a/src/System.AppContext/tests/AppContext.BaseDirectory.cs
+++ b/src/System.AppContext/tests/AppContext.BaseDirectory.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Xunit;
+
+namespace System.Tests
+{
+    public partial class AppContextTests
+    {
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void DefaultMatchesGetModuleFileName()
+        {
+            Assert.Equal(GetMainModuleDirectory(), AppContext.BaseDirectory.TrimEnd('\\'));
+        }
+
+        private static string GetMainModuleDirectory()
+        {
+            StringBuilder path = new StringBuilder(260);
+            int size = GetModuleFileNameOrThrow(IntPtr.Zero, path, path.Capacity);
+
+            while (size == path.Capacity)
+            {
+                path.Length = 0;
+                path.Capacity *= 2;
+                size = GetModuleFileNameOrThrow(IntPtr.Zero, path, path.Capacity);
+            }
+
+            // Assume that the host environment for running tests has the default
+            // behaviour of using the main module directory as its base directory
+            string modulePath = Path.GetDirectoryName(path.ToString()).TrimEnd('\\');
+
+            // The above assumption is not true for the NetCoreForCoreCLR enviornment.
+            // In order to execute in a UAP environment we had to create a shim.  This
+            // shim lives in a CoreRuntime directory and gets renamed to the same name
+            // as the app executable.  When running this way we need to just strip off 
+            // the CoreRuntime directory before we do the compare.
+            if (Path.GetFileName(modulePath) == "CoreRuntime")
+            {
+                modulePath = Path.GetDirectoryName(modulePath);
+            }
+
+            return modulePath;
+        }
+
+        private static int GetModuleFileNameOrThrow(IntPtr module, StringBuilder path, int capacity)
+        {
+            int size = GetModuleFileNameW(IntPtr.Zero, path, capacity);
+
+            if (size == 0)
+            {
+                throw new InvalidOperationException("GetModuleFileName failed. Win32 error: " + Marshal.GetLastWin32Error());
+            }
+
+            return size;
+        }
+
+        [DllImport("api-ms-win-core-libraryloader-l1-1-0.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern int GetModuleFileNameW(IntPtr module, StringBuilder path, int capacity);
+    }
+}

--- a/src/System.AppContext/tests/AppContext.BaseDirectory.cs
+++ b/src/System.AppContext/tests/AppContext.BaseDirectory.cs
@@ -16,7 +16,7 @@ namespace System.Tests
         [Fact]
         public void DefaultMatchesGetModuleFileName()
         {
-            Assert.Equal(GetMainModuleDirectory(), AppContext.BaseDirectory.TrimEnd('\\'));
+            Assert.Equal(GetMainModuleDirectory(), AppContext.BaseDirectory.TrimEnd(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar));
         }
 
         private static string GetMainModuleDirectory()
@@ -25,7 +25,7 @@ namespace System.Tests
 
             // Assume that the host environment for running tests has the default
             // behaviour of using the main module directory as its base directory
-            string modulePath = Path.GetDirectoryName(path.ToString()).TrimEnd('\\');
+            string modulePath = Path.GetDirectoryName(path.ToString()).TrimEnd(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
 
             // The above assumption is not true for the NetCoreForCoreCLR enviornment.
             // In order to execute in a UAP environment we had to create a shim.  This

--- a/src/System.AppContext/tests/AppContext.BaseDirectory.cs
+++ b/src/System.AppContext/tests/AppContext.BaseDirectory.cs
@@ -14,6 +14,7 @@ namespace System.Tests
     public partial class AppContextTests
     {
         [Fact]
+        [ActiveIssue(6677, PlatformID.OSX)]
         public void DefaultMatchesGetModuleFileName()
         {
             Assert.Equal(GetMainModuleDirectory(), AppContext.BaseDirectory.TrimEnd(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar));

--- a/src/System.AppContext/tests/System.AppContext.Tests.csproj
+++ b/src/System.AppContext/tests/System.AppContext.Tests.csproj
@@ -12,6 +12,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="AppContext.BaseDirectory.cs" />
     <Compile Include="AppContext.Switch.cs" />
     <Compile Include="AppContext.Switch.Validation.cs" />
   </ItemGroup>

--- a/src/System.AppContext/tests/project.json
+++ b/src/System.AppContext/tests/project.json
@@ -5,6 +5,7 @@
     "System.Linq.Expressions": "4.0.11-rc3-23925-00",
     "System.ObjectModel": "4.0.12-rc3-23925-00",
     "System.Runtime": "4.1.0-rc3-23925-00",
+    "System.Diagnostics.Process": "4.1.0-rc3-23925-00",
     "System.Text.RegularExpressions": "4.0.12-rc3-23925-00",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00187"


### PR DESCRIPTION
Port ToF tests for System.AppContext missing from CoreFX.

resolves #6416

@stephentoub 