### PR TITLE
Redirect 'git fetch' output to log

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -51,7 +51,7 @@ $working_tree_root/init-tools.sh
 
 if [ "$sync_src" == true ]; then
     echo "Fetching git database from remote repos..."
-    git fetch --all -p -v >> $sync_log
+    git fetch --all -p -v >> $sync_log 2>&1
     if [ $? -ne 0 ]; then
         echo -e "\ngit fetch failed. Aborting sync." >> $sync_log
         echo "ERROR: An error occurred while fetching remote source code; see $sync_log for more details."


### PR DESCRIPTION
Much of the output from 'git fetch' is to stderr, so it should also be
redirected to the log file.  The original implementation using &>> was
added to Bash in version 4, so to ensure that this script works on OS X,
an alternative syntax is used.

cc: @maririos @joperezr