### PR TITLE
Unix NegotiateStream: Addressing PR feedback

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.GssApi.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.GssApi.cs
@@ -79,7 +79,6 @@ internal static partial class Interop
             Interop.NetSecurityNative.GssBuffer encryptedBuffer = default(Interop.NetSecurityNative.GssBuffer);
             try
             {
-
                 NetSecurityNative.Status minorStatus;
                 NetSecurityNative.Status status = NetSecurityNative.WrapBuffer(out minorStatus, context, encrypt, buffer, offset, count, ref encryptedBuffer);
                 if (status != NetSecurityNative.Status.GSS_S_COMPLETE)

--- a/src/Common/src/System/Collections/Generic/BidirectionalDictionary.cs
+++ b/src/Common/src/System/Collections/Generic/BidirectionalDictionary.cs
@@ -17,6 +17,15 @@ namespace System.Collections.Generic
             _backward = new Dictionary<T2, T1>(capacity);
         }
 
+        public int Count
+        {
+            get
+            {
+                Debug.Assert(_forward.Count == _backward.Count, "both the dictionaries must have the same number of elements");
+                return _forward.Count;
+            }
+        }
+
         public void Add(T1 item1, T2 item2)
         {
             Debug.Assert(!_backward.ContainsKey(item2), "No added item1 should ever have existing item2");

--- a/src/Native/System.Net.Security.Native/CMakeLists.txt
+++ b/src/Native/System.Net.Security.Native/CMakeLists.txt
@@ -6,12 +6,14 @@ add_definitions(-DPIC=1)
 
 if (HAVE_GSSFW_HEADERS)
    find_library(LIBGSS NAMES GSS)
+   if(LIBGSS STREQUAL LIBGSS-NOTFOUND)
+      message(FATAL_ERROR "Cannot find GSS.Framework and System.Net.Security.Native cannot build without it. Try installing GSS.Framework (or the appropriate package for your platform)")
+   endif()
 else()
    find_library(LIBGSS NAMES gssapi_krb5)
-endif()
-
-if(LIBGSS STREQUAL LIBGSS-NOTFOUND)
-    message(FATAL_ERROR "Cannot find libgssapi_krb5 and System.Net.Security.Native cannot build without it. Try installing libkrb5-dev (or the appropriate package for your platform)")
+   if(LIBGSS STREQUAL LIBGSS-NOTFOUND)
+      message(FATAL_ERROR "Cannot find libgssapi_krb5 and System.Net.Security.Native cannot build without it. Try installing libkrb5-dev (or the appropriate package for your platform)")
+   endif()
 endif()
 
 set(NATIVEGSS_SOURCES

--- a/src/Native/System.Net.Security.Native/pal_gssapi.cpp
+++ b/src/Native/System.Net.Security.Native/pal_gssapi.cpp
@@ -35,6 +35,7 @@ static_assert(PAL_GSS_CONTINUE_NEEDED == GSS_S_CONTINUE_NEEDED, "");
 
 #if !HAVE_GSS_SPNEGO_MECHANISM
 static char gss_spnego_oid_value[] = "\x2b\x06\x01\x05\x05\x02"; // Binary representation of SPNEGO Oid (RFC 4178)
+static gss_OID_desc gss_mech_spnego_OID_desc = {.length = 6, .elements = static_cast<void*>(gss_spnego_oid_value)};
 #endif
 
 // transfers ownership of the underlying data from gssBuffer to PAL_GssBuffer
@@ -59,7 +60,6 @@ static uint32_t NetSecurityNative_AcquireCredSpNego(uint32_t* minorStatus,
 #if HAVE_GSS_SPNEGO_MECHANISM
     gss_OID_set_desc gss_mech_spnego_OID_set_desc = {.count = 1, .elements = GSS_SPNEGO_MECHANISM};
 #else
-    gss_OID_desc gss_mech_spnego_OID_desc = {.length = 6, .elements = static_cast<void*>(gss_spnego_oid_value)};
     gss_OID_set_desc gss_mech_spnego_OID_set_desc = {.count = 1, .elements = &gss_mech_spnego_OID_desc};
 #endif
     return gss_acquire_cred(
@@ -164,7 +164,6 @@ extern "C" uint32_t NetSecurityNative_InitSecContext(uint32_t* minorStatus,
     assert(!isNtlm && "NTLM is not supported by MIT libgssapi_krb5");
     (void)isNtlm; // unused
 
-    gss_OID_desc gss_mech_spnego_OID_desc = {.length = 6, .elements = static_cast<void*>(gss_spnego_oid_value)};
     gss_OID desiredMech = &gss_mech_spnego_OID_desc;
 #endif
 

--- a/src/System.Net.Security/src/System/Net/SecurityStatusAdapterPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/SecurityStatusAdapterPal.Windows.cs
@@ -8,7 +8,16 @@ namespace System.Net
 {
     internal static class SecurityStatusAdapterPal
     {
-        private static readonly BidirectionalDictionary<Interop.SecurityStatus, SecurityStatusPalErrorCode> s_statusDictionary = new BidirectionalDictionary<Interop.SecurityStatus, SecurityStatusPalErrorCode>(39)
+        private const int StatusDictionarySize = 39;
+
+#if DEBUG
+        static SecurityStatusAdapterPal()
+        {
+            Debug.Assert(s_statusDictionary.Count == StatusDictionarySize, $"Expected size {StatusDictionarySize}, got size {s_statusDictionary.Count}");
+        }
+#endif
+
+        private static readonly BidirectionalDictionary<Interop.SecurityStatus, SecurityStatusPalErrorCode> s_statusDictionary = new BidirectionalDictionary<Interop.SecurityStatus, SecurityStatusPalErrorCode>(StatusDictionarySize)
         {
             { Interop.SecurityStatus.AlgorithmMismatch, SecurityStatusPalErrorCode.AlgorithmMismatch },
             { Interop.SecurityStatus.BadBinding, SecurityStatusPalErrorCode.BadBinding },


### PR DESCRIPTION
#7031 listed out the places in NegotiateStream that needed fix.

This PR addresses those of the comments where the scope is limited to NegotiateStream functionality.

Specifically, 

- the tests are cleaned up to remove boilerplate code.
- ```SecurityStatusAdapterPal ``` is changed to include a static constructor in the Debug mode.
- Constants in pal_gssapi.cpp are defined at a single location.
- CMakeLists.txt is modified to give proper, OS-specific error message