### PR TITLE
Fix System.Text.Encoding test helper.

### DIFF
--- a/src/System.Text.Encoding/tests/EncodingTestHelpers.cs
+++ b/src/System.Text.Encoding/tests/EncodingTestHelpers.cs
@@ -32,7 +32,7 @@ namespace System.Text.Tests
 
             // Use GetBytes(char[], int, int, byte[], int)
             byte[] charArrayBytes = (byte[])bytes.Clone();
-            int charArrayResult = encoding.GetBytes(source, index, count, charArrayBytes, byteIndex);
+            int charArrayResult = encoding.GetBytes(source.ToCharArray(), index, count, charArrayBytes, byteIndex);
             Assert.Equal(expected, charArrayResult);
         }
 


### PR DESCRIPTION
A test helper in System.Text.Encoding had a typo that was causing the GetBytes(char[],...) methods to not be tested for positive validation.

resolves #6924