### PR TITLE
Add tests for CodePages with duplicate names.

### DIFF
--- a/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
+++ b/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
@@ -280,6 +280,7 @@ namespace System.Text.Tests
             yield return new object[] { 20924, "ibm00924", "ccsid00924" };
             yield return new object[] { 20924, "ibm00924", "cp00924" };
             yield return new object[] { 20924, "ibm00924", "ebcdic-latin9--euro" };
+            yield return new object[] { 20932, "euc-jp", "euc-jp" };
             yield return new object[] { 20936, "x-cp20936", "x-cp20936" };
             yield return new object[] { 20949, "x-cp20949", "x-cp20949" };
             yield return new object[] { 21025, "cp1025", "cp1025" };
@@ -355,6 +356,7 @@ namespace System.Text.Tests
             yield return new object[] { 38598, "iso-8859-8-i", "iso-8859-8-i" };
             yield return new object[] { 50220, "iso-2022-jp", "iso-2022-jp" };
             yield return new object[] { 50221, "csiso2022jp", "csiso2022jp" };
+            yield return new object[] { 50222, "iso-2022-jp", "iso-2022-jp" };
             yield return new object[] { 50225, "iso-2022-kr", "iso-2022-kr" };
             yield return new object[] { 50225, "iso-2022-kr", "csiso2022kr" };
             yield return new object[] { 50225, "iso-2022-kr", "iso-2022-kr-7" };
@@ -525,19 +527,41 @@ namespace System.Text.Tests
         [MemberData(nameof(CodePageInfo))]
         public static void TestCodepageEncoding(int codePage, string webName, string queryString)
         {
-            Encoding encoding = CodePagesEncodingProvider.Instance.GetEncoding(queryString);
-            Assert.NotNull(encoding);
-            Assert.Equal(codePage, encoding.CodePage);
-            Assert.Equal(encoding, CodePagesEncodingProvider.Instance.GetEncoding(codePage));
-            Assert.Equal(webName, encoding.WebName);
-            Assert.Equal(encoding, CodePagesEncodingProvider.Instance.GetEncoding(webName));
+            // There are two names that have duplicate associated CodePages. For those two names,
+            // we have to test with the expectation that querying the name will always return the
+            // same codepage.
+            if (codePage != 20932 && codePage != 50222)
+            {
+                Encoding encoding = CodePagesEncodingProvider.Instance.GetEncoding(queryString);
+                Assert.NotNull(encoding);
+                Assert.Equal(codePage, encoding.CodePage);
+                Assert.Equal(encoding, CodePagesEncodingProvider.Instance.GetEncoding(codePage));
+                Assert.Equal(webName, encoding.WebName);
+                Assert.Equal(encoding, CodePagesEncodingProvider.Instance.GetEncoding(webName));
 
-            // Small round-trip for ASCII alphanumeric range (some code pages use different punctuation!)
-            // Start with space.
-            string asciiPrintable = " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+                // Small round-trip for ASCII alphanumeric range (some code pages use different punctuation!)
+                // Start with space.
+                string asciiPrintable = " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
-            char[] traveled = encoding.GetChars(encoding.GetBytes(asciiPrintable));
-            Assert.Equal(asciiPrintable.ToCharArray(), traveled);
+                char[] traveled = encoding.GetChars(encoding.GetBytes(asciiPrintable));
+                Assert.Equal(asciiPrintable.ToCharArray(), traveled);
+            }
+            else
+            {
+                Encoding encoding = CodePagesEncodingProvider.Instance.GetEncoding(codePage);
+                Assert.NotNull(encoding);
+                Assert.Equal(codePage, encoding.CodePage);
+                Assert.Equal(webName, encoding.WebName);
+                Assert.NotEqual(encoding, CodePagesEncodingProvider.Instance.GetEncoding(queryString));
+                Assert.NotEqual(encoding, CodePagesEncodingProvider.Instance.GetEncoding(webName));
+
+                // Small round-trip for ASCII alphanumeric range (some code pages use different punctuation!)
+                // Start with space.
+                string asciiPrintable = " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+                char[] traveled = encoding.GetChars(encoding.GetBytes(asciiPrintable));
+                Assert.Equal(asciiPrintable.ToCharArray(), traveled);
+            }
         }
 
         [Theory]

--- a/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
+++ b/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
@@ -527,41 +527,32 @@ namespace System.Text.Tests
         [MemberData(nameof(CodePageInfo))]
         public static void TestCodepageEncoding(int codePage, string webName, string queryString)
         {
+            Encoding encoding;
             // There are two names that have duplicate associated CodePages. For those two names,
             // we have to test with the expectation that querying the name will always return the
             // same codepage.
             if (codePage != 20932 && codePage != 50222)
             {
-                Encoding encoding = CodePagesEncodingProvider.Instance.GetEncoding(queryString);
-                Assert.NotNull(encoding);
-                Assert.Equal(codePage, encoding.CodePage);
+                encoding = CodePagesEncodingProvider.Instance.GetEncoding(queryString);
                 Assert.Equal(encoding, CodePagesEncodingProvider.Instance.GetEncoding(codePage));
-                Assert.Equal(webName, encoding.WebName);
                 Assert.Equal(encoding, CodePagesEncodingProvider.Instance.GetEncoding(webName));
-
-                // Small round-trip for ASCII alphanumeric range (some code pages use different punctuation!)
-                // Start with space.
-                string asciiPrintable = " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-
-                char[] traveled = encoding.GetChars(encoding.GetBytes(asciiPrintable));
-                Assert.Equal(asciiPrintable.ToCharArray(), traveled);
             }
             else
             {
-                Encoding encoding = CodePagesEncodingProvider.Instance.GetEncoding(codePage);
-                Assert.NotNull(encoding);
-                Assert.Equal(codePage, encoding.CodePage);
-                Assert.Equal(webName, encoding.WebName);
+                encoding = CodePagesEncodingProvider.Instance.GetEncoding(codePage);
                 Assert.NotEqual(encoding, CodePagesEncodingProvider.Instance.GetEncoding(queryString));
                 Assert.NotEqual(encoding, CodePagesEncodingProvider.Instance.GetEncoding(webName));
-
-                // Small round-trip for ASCII alphanumeric range (some code pages use different punctuation!)
-                // Start with space.
-                string asciiPrintable = " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-
-                char[] traveled = encoding.GetChars(encoding.GetBytes(asciiPrintable));
-                Assert.Equal(asciiPrintable.ToCharArray(), traveled);
             }
+
+            Assert.NotNull(encoding);
+            Assert.Equal(codePage, encoding.CodePage);
+            Assert.Equal(webName, encoding.WebName);
+
+            // Small round-trip for ASCII alphanumeric range (some code pages use different punctuation!)
+            // Start with space.
+            string asciiPrintable = " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+            char[] traveled = encoding.GetChars(encoding.GetBytes(asciiPrintable));
+            Assert.Equal(asciiPrintable.ToCharArray(), traveled);
         }
 
         [Theory]


### PR DESCRIPTION
There are two names that have duplicate associated CodePages. For those two names, we have to test with the expectation that querying the name will always return the same codepage.

resolves #6456