### PR TITLE
Add Tracing test to filter an event with a higher EventLevel

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestFilter.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestFilter.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Diagnostics.Tracing;
+using Xunit;
+
+namespace BasicEventSourceTests
+{
+    public class TestFilter
+    {
+        /// <summary>
+        /// Tests that Events with a level lower than the logging level will be filtered
+        /// </summary>
+        [Fact]
+        public static void TestFilterEvent()
+        {
+            using (EventCountListener listener = new EventCountListener())
+            using (TestSource log = new TestSource())
+            {
+                listener.EnableEvents(log, EventLevel.Error);
+
+                /* This call should be filtered since it is at WarningLevel and we are logging Error */
+                log.WarningEventWithArgs(1, 2, 3, false);
+
+                /* This call should be filtered since it is at Verbose and we are logging Error */
+                log.VerboseEvent();
+
+                Assert.Equal(0, listener.EventCount);
+            }
+        }
+    }
+
+    /// <summary>
+    /// EventListener that keeps track of the number of events that have been written.
+    /// </summary>
+    public class EventCountListener : EventListener
+    {
+        public int EventCount = 0;
+
+        protected override void OnEventWritten(EventWrittenEventArgs e)
+        {
+            EventCount++;
+        }
+    }
+
+    public class TestSource : EventSource
+    {
+        [Event(9000, Level = EventLevel.Warning)]
+        public void WarningEventWithArgs(int i, int j, int k, bool b)
+        {
+            WriteEvent(9000, i, j, k, b);
+        }
+
+        [Event(9001, Level = EventLevel.Verbose)]
+        public void VerboseEvent()
+        {
+            WriteEvent(9001);
+        }
+    }
+}

--- a/src/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
+++ b/src/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="BasicEventSourceTest\FuzzyTests.cs" />
     <Compile Include="BasicEventSourceTest\Harness\Listeners.cs" />
     <Compile Include="BasicEventSourceTest\TestEventCounter.cs" />
+    <Compile Include="BasicEventSourceTest\TestFilter.cs" />
     <Compile Include="BasicEventSourceTest\TestShutdown.cs" />
     <Compile Include="BasicEventSourceTest\TestsEventSourceLifetime.cs" />
     <Compile Include="BasicEventSourceTest\TestsManifestGeneration.cs" />


### PR DESCRIPTION
We didn't have any tests that filtered events with a higher event level than being listened to. This adds one (adapted from a ToF test) and resolves #6428.