### PR TITLE
Fill coverage gaps for Collections.Concurrent

### DIFF
--- a/src/System.Collections.Concurrent/tests/ConcurrentBagTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentBagTests.cs
@@ -16,6 +16,7 @@ namespace System.Collections.Concurrent.Tests
         public static void TestBasicScenarios()
         {
             ConcurrentBag<int> cb = new ConcurrentBag<int>();
+            Assert.True(cb.IsEmpty);
             Task[] tks = new Task[2];
             tks[0] = Task.Run(() =>
                 {

--- a/src/System.Collections.Concurrent/tests/ConcurrentDictionaryTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentDictionaryTests.cs
@@ -799,6 +799,7 @@ namespace System.Collections.Concurrent.Tests
             Assert.True(dictionary.IsEmpty, "TestClear: FAILED.  IsEmpty returned false after Clear");
         }
 
+        [Fact]
         public static void TestTryUpdate()
         {
             var dictionary = new ConcurrentDictionary<string, int>();


### PR DESCRIPTION
One test supplied most of the missing coverage but simply wasn't decorated as a fact. Most other missing coverage bits were the result of the same test taking different code paths from execution to execution (e.g. race conditions)

resolves #6417