### PR TITLE
Add more tests for HttpClient

### DIFF
--- a/src/Common/tests/System/Net/HttpTestServers.cs
+++ b/src/Common/tests/System/Net/HttpTestServers.cs
@@ -20,8 +20,6 @@ namespace System.Net.Test.Common
         public const string SelfSignedCertRemoteServer = "https://self-signed.badssl.com/";
         public const string RevokedCertRemoteServer = "https://revoked.grc.com/";
 
-        public static string DelayResponseServer(int seconds) => $"http://httpbin.org/delay/{seconds}";
-
         private const string HttpScheme = "http";
         private const string HttpsScheme = "https";
 

--- a/src/Common/tests/System/Net/HttpTestServers.cs
+++ b/src/Common/tests/System/Net/HttpTestServers.cs
@@ -20,6 +20,8 @@ namespace System.Net.Test.Common
         public const string SelfSignedCertRemoteServer = "https://self-signed.badssl.com/";
         public const string RevokedCertRemoteServer = "https://revoked.grc.com/";
 
+        public static string DelayResponseServer(int seconds) => $"http://httpbin.org/delay/{seconds}";
+
         private const string HttpScheme = "http";
         private const string HttpsScheme = "https";
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -2,22 +2,301 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
-using System.Net;
-using System.Net.Http;
+using System.IO;
+using System.Linq;
 using System.Net.Test.Common;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;
-using Xunit.Abstractions;
 
 namespace System.Net.Http.Functional.Tests
 {
     public class HttpClientTest
     {
+        [Fact]
+        public void DefaultRequestHeaders_Idempotent()
+        {
+            using (var client = new HttpClient())
+            {
+                Assert.NotNull(client.DefaultRequestHeaders);
+                Assert.Same(client.DefaultRequestHeaders, client.DefaultRequestHeaders);
+            }
+        }
+
+        [Fact]
+        public void BaseAddress_Roundtrip_Equal()
+        {
+            using (var client = new HttpClient())
+            {
+                Assert.Null(client.BaseAddress);
+
+                client.BaseAddress = HttpTestServers.RemoteEchoServer;
+                Assert.Equal(HttpTestServers.RemoteEchoServer, client.BaseAddress);
+
+                client.BaseAddress = null;
+                Assert.Null(client.BaseAddress);
+            }
+        }
+
+        [Fact]
+        public void BaseAddress_InvalidUri_Throws()
+        {
+            using (var client = new HttpClient())
+            {
+                Assert.Throws<ArgumentException>("value", () => client.BaseAddress = new Uri("ftp://onlyhttpsupported"));
+                Assert.Throws<ArgumentException>("value", () => client.BaseAddress = new Uri("/onlyabsolutesupported", UriKind.Relative));
+            }
+        }
+
+        [Fact]
+        public void Timeout_Roundtrip_Equal()
+        {
+            using (var client = new HttpClient())
+            {
+                client.Timeout = Timeout.InfiniteTimeSpan;
+                Assert.Equal(Timeout.InfiniteTimeSpan, client.Timeout);
+
+                client.Timeout = TimeSpan.FromSeconds(1);
+                Assert.Equal(TimeSpan.FromSeconds(1), client.Timeout);
+            }
+        }
+
+        [Fact]
+        public void Timeout_OutOfRange_Throws()
+        {
+            using (var client = new HttpClient())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => client.Timeout = TimeSpan.FromSeconds(-2));
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => client.Timeout = TimeSpan.FromSeconds(0));
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => client.Timeout = TimeSpan.FromSeconds(int.MaxValue));
+            }
+        }
+
+        [Fact]
+        public void MaxResponseContentBufferSize_Roundtrip_Equal()
+        {
+            using (var client = new HttpClient())
+            {
+                client.MaxResponseContentBufferSize = 1;
+                Assert.Equal(1, client.MaxResponseContentBufferSize);
+
+                client.MaxResponseContentBufferSize = int.MaxValue;
+                Assert.Equal(int.MaxValue, client.MaxResponseContentBufferSize);
+            }
+        }
+
+        [Fact]
+        public void MaxResponseContentBufferSize_OutOfRange_Throws()
+        {
+            using (var client = new HttpClient())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => client.MaxResponseContentBufferSize = -1);
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => client.MaxResponseContentBufferSize = 0);
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => client.MaxResponseContentBufferSize = 1 + (long)int.MaxValue);
+            }
+        }
+
+        [Fact]
+        public async Task MaxResponseContentBufferSize_TooSmallForContent_Throws()
+        {
+            using (var client = new HttpClient())
+            {
+                client.MaxResponseContentBufferSize = 1;
+                await Assert.ThrowsAsync<HttpRequestException>(() => client.GetStringAsync(HttpTestServers.RemoteEchoServer));
+            }
+        }
+
+        [Fact]
+        public async Task Properties_CantChangeAfterOperation_Throws()
+        {
+            using (var client = new HttpClient())
+            {
+                (await client.GetAsync(HttpTestServers.RemoteEchoServer)).Dispose();
+                Assert.Throws<InvalidOperationException>(() => client.BaseAddress = null);
+                Assert.Throws<InvalidOperationException>(() => client.Timeout = TimeSpan.FromSeconds(1));
+                Assert.Throws<InvalidOperationException>(() => client.MaxResponseContentBufferSize = 1);
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("/something.html")]
+        public void GetAsync_NoBaseAddress_InvalidUri_ThrowsException(string uri)
+        {
+            using (var client = new HttpClient())
+            {
+                Assert.Throws<InvalidOperationException>(() => { client.GetAsync(uri == null ? null : new Uri(uri, UriKind.RelativeOrAbsolute)); });
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("/")]
+        public async Task GetAsync_BaseAddress_ValidUri_Success(string uri)
+        {
+            using (var client = new HttpClient())
+            {
+                client.BaseAddress = new Uri($"http://{HttpTestServers.Host}");
+                using (HttpResponseMessage response = await client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead))
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GetContentAsync_ErrorStatusCode_ExpectedExceptionThrown()
+        {
+            using (var client = new HttpClient())
+            {
+                const int statusCode = 418;
+                string url = HttpTestServers.StatusCodeUri(false, statusCode).ToString();
+
+                await Assert.ThrowsAsync<HttpRequestException>(() => client.GetStringAsync(url));
+                await Assert.ThrowsAsync<HttpRequestException>(() => client.GetByteArrayAsync(url));
+                await Assert.ThrowsAsync<HttpRequestException>(() => client.GetStreamAsync(url));
+            }
+        }
+
+        [Fact]
+        public async Task GetContentAsync_NullResponse_Throws()
+        {
+            using (var client = new HttpClient(new CustomResponseHandler { Response = null }))
+            {
+                await Assert.ThrowsAnyAsync<InvalidOperationException>(() => client.GetStringAsync(HttpTestServers.RemoteEchoServer));
+            }
+        }
+
+        [Fact]
+        public async Task GetContentAsync_NullResponseContent_ReturnsDefaultValue()
+        {
+            using (var client = new HttpClient(new CustomResponseHandler { Response = new HttpResponseMessage() { Content = null } }))
+            {
+                Assert.Same(string.Empty, await client.GetStringAsync(HttpTestServers.RemoteEchoServer));
+                Assert.Same(Array.Empty<byte>(), await client.GetByteArrayAsync(HttpTestServers.RemoteEchoServer));
+                Assert.Same(Stream.Null, await client.GetStreamAsync(HttpTestServers.RemoteEchoServer));
+            }
+        }
+
+        [Fact]
+        public async Task GetAsync_InvalidUrl_ExpectedExceptionThrown()
+        {
+            using (var client = new HttpClient())
+            {
+                string url = "http://" + Guid.NewGuid().ToString("N");
+                await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url));
+                await Assert.ThrowsAsync<HttpRequestException>(() => client.GetStringAsync(url));
+            }
+        }
+
+        [Fact]
+        public async Task GetPutPostAsync_Canceled_Throws()
+        {
+            using (var client = new HttpClient())
+            {
+                string delayUri = HttpTestServers.DelayResponseServer(60).ToString();
+                var content = new ByteArrayContent(new byte[1]);
+                var cts = new CancellationTokenSource();
+
+                Task t1 = client.GetAsync(delayUri, cts.Token);
+                Task t2 = client.GetAsync(delayUri, HttpCompletionOption.ResponseContentRead, cts.Token);
+                Task t3 = client.PostAsync(delayUri, content, cts.Token);
+                Task t4 = client.PutAsync(delayUri, content, cts.Token);
+
+                cts.Cancel();
+
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t1);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t2);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t3);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t4);
+            }
+        }
+
+        [Fact]
+        public void SendAsync_NullRequest_ThrowsException()
+        {
+            using (var client = new HttpClient())
+            {
+                Assert.Throws<ArgumentNullException>("request", () => { client.SendAsync(null); });
+            }
+        }
+
+        [Fact]
+        public async Task SendAsync_DuplicateRequest_ThrowsException()
+        {
+            using (var client = new HttpClient())
+            using (var request = new HttpRequestMessage(HttpMethod.Get, HttpTestServers.RemoteEchoServer))
+            {
+                (await client.SendAsync(request)).Dispose();
+                Assert.Throws<InvalidOperationException>(() => { client.SendAsync(request); });
+            }
+        }
+
+        [Fact]
+        public void Dispose_UseAfterDispose_Throws()
+        {
+            var client = new HttpClient();
+            client.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => client.BaseAddress = null);
+            Assert.Throws<ObjectDisposedException>(() => client.CancelPendingRequests());
+            Assert.Throws<ObjectDisposedException>(() => { client.DeleteAsync(HttpTestServers.RemoteEchoServer); });
+            Assert.Throws<ObjectDisposedException>(() => { client.GetAsync(HttpTestServers.RemoteEchoServer); });
+            Assert.Throws<ObjectDisposedException>(() => { client.GetByteArrayAsync(HttpTestServers.RemoteEchoServer); });
+            Assert.Throws<ObjectDisposedException>(() => { client.GetStreamAsync(HttpTestServers.RemoteEchoServer); });
+            Assert.Throws<ObjectDisposedException>(() => { client.GetStringAsync(HttpTestServers.RemoteEchoServer); });
+            Assert.Throws<ObjectDisposedException>(() => { client.PostAsync(HttpTestServers.RemoteEchoServer, new ByteArrayContent(new byte[1])); });
+            Assert.Throws<ObjectDisposedException>(() => { client.PutAsync(HttpTestServers.RemoteEchoServer, new ByteArrayContent(new byte[1])); });
+            Assert.Throws<ObjectDisposedException>(() => { client.SendAsync(new HttpRequestMessage(HttpMethod.Get, HttpTestServers.RemoteEchoServer)); });
+            Assert.Throws<ObjectDisposedException>(() => { client.Timeout = TimeSpan.FromSeconds(1); });
+        }
+
+        [Fact]
+        public async Task DeleteAsync_NotDeletable_NoExceptionThrown()
+        {
+            using (var client = new HttpClient())
+            {
+                string url = HttpTestServers.RemoteEchoServer.ToString();
+
+                using (HttpResponseMessage response = await client.DeleteAsync(url))
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
+
+                using (HttpResponseMessage response = await client.DeleteAsync(url, CancellationToken.None))
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
+            }
+        }
+
+        [Fact]
+        public void CancelAllPending_AllPendingOperationsCanceled()
+        {
+            using (var client = new HttpClient())
+            {
+                string url = HttpTestServers.DelayResponseServer(60);
+                Task<HttpResponseMessage>[] tasks = Enumerable.Range(0, 3).Select(_ => client.GetAsync(url)).ToArray();
+                client.CancelPendingRequests();
+                Assert.All(tasks, task => Assert.ThrowsAny<OperationCanceledException>(() => task.GetAwaiter().GetResult()));
+            }
+        }
+
+        [Fact]
+        public void Timeout_TooShort_AllPendingOperationsCanceled()
+        {
+            using (var client = new HttpClient())
+            {
+                client.Timeout = TimeSpan.FromMilliseconds(1);
+                string url = HttpTestServers.DelayResponseServer(60);
+                Task<HttpResponseMessage>[] tasks = Enumerable.Range(0, 3).Select(_ => client.GetAsync(url)).ToArray();
+                Assert.All(tasks, task => Assert.ThrowsAny<OperationCanceledException>(() => task.GetAwaiter().GetResult()));
+            }
+        }
+
         [Fact]
         [OuterLoop]
         public void Timeout_SetTo60AndGetResponseFromServerWhichTakes40_Success()
@@ -143,6 +422,16 @@ namespace System.Net.Http.Functional.Tests
             Assert.IsAssignableFrom<T>(propertyValue);
 
             return (T)propertyValue;
+        }
+
+        private sealed class CustomResponseHandler : HttpMessageHandler
+        {
+            public HttpResponseMessage Response;
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return Task.FromResult<HttpResponseMessage>(Response);
+            }
         }
     }
 }


### PR DESCRIPTION
To have more confidence while refactoring (https://github.com/dotnet/corefx/pull/7315), added more HttpClient coverage, in particular of error paths.  Brings HttpClient line coverage from 64.7% to 98.3%, and branch coverage from 42.3% to 78.7%.

cc: @davidsh, @cipop, @ericeil, @kapilash