### PR TITLE
Optimise System.Dynamic.Utils.CollectionExtensions.ListEquals

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/CollectionExtensions.cs
+++ b/src/Common/src/System/Dynamic/Utils/CollectionExtensions.cs
@@ -57,24 +57,29 @@ namespace System.Dynamic.Utils
         }
 
         [Pure]
-        public static bool ListEquals<T>(this ICollection<T> first, ICollection<T> second)
+        public static bool ListEquals<T>(this ReadOnlyCollection<T> first, ReadOnlyCollection<T> second)
         {
-            if (first.Count != second.Count)
+            if (first == second)
+            {
+                return true;
+            }
+
+            int count = first.Count;
+
+            if (count != second.Count)
             {
                 return false;
             }
-            var cmp = EqualityComparer<T>.Default;
-            var f = first.GetEnumerator();
-            var s = second.GetEnumerator();
-            while (f.MoveNext())
-            {
-                s.MoveNext();
 
-                if (!cmp.Equals(f.Current, s.Current))
+            var cmp = EqualityComparer<T>.Default;
+            for(int i = 0; i != count; ++i)
+            {
+                if (!cmp.Equals(first[i], second[i]))
                 {
                     return false;
                 }
             }
+
             return true;
         }
 

--- a/src/System.Dynamic.Runtime/tests/CallInfoTests.cs
+++ b/src/System.Dynamic.Runtime/tests/CallInfoTests.cs
@@ -1,0 +1,84 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Dynamic.Runtime.Tests
+{
+    public class CallInfoTests
+    {
+        [Fact]
+        public void NullNames()
+        {
+            Assert.Throws<ArgumentNullException>("argNames", () => new CallInfo(0, default(string[])));
+            Assert.Throws<ArgumentNullException>("argNames", () => new CallInfo(0, default(IEnumerable<string>)));
+        }
+
+        [Fact]
+        public void ArgCountTooLow()
+        {
+            Assert.Throws<ArgumentException>(null, () => new CallInfo(1, "a", "b"));
+        }
+
+        [Fact]
+        public void NullName()
+        {
+            Assert.Throws<ArgumentNullException>("argNames[1]", () => new CallInfo(3, "a", null, "c"));
+        }
+
+        [Fact]
+        public void ArgCountRetained()
+        {
+            Assert.Equal(0, new CallInfo(0).ArgumentCount);
+            Assert.Equal(4, new CallInfo(4).ArgumentCount);
+            Assert.Equal(3, new CallInfo(3, "a", "b", "c").ArgumentCount);
+        }
+
+        [Fact]
+        public void ArgNamesRetained()
+        {
+            Assert.Equal(new[] { "a", "b", "c" }, new CallInfo(3, "a", "b", "c").ArgumentNames);
+            // Having a singleton for empty name lists isn't required by the spec,
+            // (any empty ReadOnlyCollection<string> will fulfill that),
+            // but consider the impact (possibly breaking, possibly less performant)
+            // before changing this.
+            Assert.Same(new CallInfo(0).ArgumentNames, new CallInfo(1).ArgumentNames);
+        }
+
+        [Fact]
+        public void Equality()
+        {
+            CallInfo a = new CallInfo(5, "a", "b");
+            CallInfo b = new CallInfo(5, "a", "b");
+            CallInfo c = new CallInfo(5, a.ArgumentNames);
+            CallInfo d = new CallInfo(5, "b", "a");
+            CallInfo e = new CallInfo(4, "a", "b");
+            CallInfo f = new CallInfo(5, "a");
+            CallInfo x = new CallInfo(3);
+            CallInfo y = new CallInfo(3);
+            CallInfo z = new CallInfo(2);
+
+            Assert.Equal(a, a);
+            Assert.Equal(a, b);
+            Assert.Equal(a, c);
+            Assert.NotEqual(a, d);
+            Assert.NotEqual(a, e);
+            Assert.NotEqual(a, f);
+            Assert.Equal(x, y);
+            Assert.NotEqual(x, z);
+
+            var dict = new Dictionary<CallInfo, int> { { a, 1 }, { x, 2 } };
+
+            Assert.Equal(1, dict[a]);
+            Assert.Equal(1, dict[b]);
+            Assert.Equal(1, dict[c]);
+            Assert.False(dict.ContainsKey(d));
+            Assert.False(dict.ContainsKey(e));
+            Assert.False(dict.ContainsKey(f));
+            Assert.Equal(2, dict[y]);
+            Assert.False(dict.ContainsKey(z));
+        }
+    }
+}

--- a/src/System.Dynamic.Runtime/tests/System.Dynamic.Runtime.Tests.csproj
+++ b/src/System.Dynamic.Runtime/tests/System.Dynamic.Runtime.Tests.csproj
@@ -20,6 +20,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CallInfoTests.cs" />
     <Compile Include="Dynamic.Context\Conformance.dynamic.context.attribute.cs" />
     <Compile Include="Dynamic.Context\Conformance.dynamic.context.delegateEvent.delegate.cs" />
     <Compile Include="Dynamic.Context\Conformance.dynamic.context.ExplicitImple.basic.cs" />


### PR DESCRIPTION
Shortcut on identity (in practice covers comparisons of `CallInfo` with no names or one constructed from information from another). Restrict to `ReadOnlyCollection<T>` (only type it is used with) and index through it rather than enumerate (half as many interface calls).

Include tests on `CallInfo` beyond enough to cover this code.