### PR TITLE
Use cast where result is not checked later

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -910,7 +910,7 @@ namespace System.Data.SqlClient
             }
             // does not require GC.KeepAlive(this) because of OnStateChange
 
-            var tdsInnerConnection = (InnerConnection as SqlInternalConnectionTds);
+            var tdsInnerConnection = (SqlInternalConnectionTds)InnerConnection;
             Debug.Assert(tdsInnerConnection.Parser != null, "Where's the parser?");
 
             if (!tdsInnerConnection.ConnectionOptions.Pooling)


### PR DESCRIPTION
`as` is abused here - the later code relies on a successful cast.

This resolves https://github.com/dotnet/corefx/issues/5415