### PR TITLE
Constrain ReferenceEqualityComparer to use with reference types only.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/ReferenceEqualityComparer.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/ReferenceEqualityComparer.cs
@@ -7,20 +7,14 @@ using System.Runtime.CompilerServices;
 
 namespace System.Dynamic.Utils
 {
-    internal sealed class ReferenceEqualityComparer<T> : IEqualityComparer<T>
+    internal sealed class ReferenceEqualityComparer<T> : IEqualityComparer<T> where T : class
     {
         internal static readonly ReferenceEqualityComparer<T> Instance = new ReferenceEqualityComparer<T>();
 
         private ReferenceEqualityComparer() { }
 
-        public bool Equals(T x, T y)
-        {
-            return object.ReferenceEquals(x, y);
-        }
+        public bool Equals(T x, T y) => ReferenceEquals(x, y);
 
-        public int GetHashCode(T obj)
-        {
-            return RuntimeHelpers.GetHashCode(obj);
-        }
+        public int GetHashCode(T obj) => RuntimeHelpers.GetHashCode(obj);
     }
 }


### PR DESCRIPTION
Only makes sense with such types; attempts to use it otherwise would always rebox resulting in nothing being equal to anything, including itself.

Change single-expression methods to expression syntax while I'm at it.