### PR TITLE
Use empty array in MemoryStream ctor for 0 capacity

### DIFF
--- a/src/System.IO/src/System/IO/MemoryStream.cs
+++ b/src/System.IO/src/System/IO/MemoryStream.cs
@@ -48,7 +48,7 @@ namespace System.IO
                 throw new ArgumentOutOfRangeException(nameof(capacity), SR.ArgumentOutOfRange_NegativeCapacity);
             }
 
-            _buffer = new byte[capacity];
+            _buffer = capacity != 0 ? new byte[capacity] : Array.Empty<byte>();
             _capacity = capacity;
             _expandable = true;
             _writable = true;


### PR DESCRIPTION
```new MemoryStream()``` allocates an empty array.  This fixes it for both MemoryStream.ctor() and MemoryStream.ctor(0) to use Array.Empty instead.

Port of https://github.com/dotnet/coreclr/pull/3967

cc: @bartonjs, @ianhays