### PR TITLE
Support test project building and running against Windows Desktop fra…

### DIFF
--- a/src/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
@@ -315,7 +315,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(5463, PlatformID.AnyUnix)]
+        [ActiveIssue(5436, Xunit.PlatformID.AnyUnix)]
         public void Compare_Issue5463()
         {
             // TODO: Remove this function, and combine into Compare_TestData once 5463 is fixed

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -202,7 +202,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(IndexOf_Aesc_Ligature_TestData))]
-        [ActiveIssue(5463, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, Xunit.PlatformID.AnyUnix)]
         public void IndexOf_Aesc_Ligature(CompareInfo compareInfo, string source, string value, int startIndex, int count, CompareOptions options, int expected)
         {
             // TODO: Remove this function, and combine into IndexOf_String once 5463 is fixed
@@ -210,7 +210,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(5463, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, Xunit.PlatformID.AnyUnix)]
         public void IndexOf_UnassignedUnicode()
         {
             IndexOf_String(s_invariantCompare, "FooBar", "Foo" + UnassignedUnicodeCharacter() + "Bar", 0, 6, CompareOptions.None, 0);
@@ -218,7 +218,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(5463, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, Xunit.PlatformID.AnyUnix)]
         public void IndexOf_Hungarian()
         {
             // TODO: Remove this function, and combine into IndexOf_TestData once 5463 is fixed

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
@@ -65,7 +65,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(5463, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, Xunit.PlatformID.AnyUnix)]
         public void IsPrefix_Hungarian()
         {
             // TODO: Remove this function, and combine into IsPrefix_TestData once 5463 is fixed
@@ -74,7 +74,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(5463, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, Xunit.PlatformID.AnyUnix)]
         public void IsPrefix_UnassignedUnicode()
         {
             IsPrefix(s_invariantCompare, "FooBar", "Foo" + UnassignedUnicodeCharacter() + "Bar", CompareOptions.None, true);

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoTests.IsSuffix.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoTests.IsSuffix.cs
@@ -66,7 +66,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(5463, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, Xunit.PlatformID.AnyUnix)]
         public void IsSuffix_Hungarian()
         {
             // TODO: Remove this function, and combine into IsSuffix_TestData once 5463 is fixed
@@ -74,7 +74,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(5463, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, Xunit.PlatformID.AnyUnix)]
         public void IsSuffix_UnassignedUnicode()
         {
             IsSuffix(s_invariantCompare, "FooBar", "Foo" + UnassignedUnicodeCharacter() + "Bar", CompareOptions.None, true);

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
@@ -175,7 +175,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(LastIndexOf_Aesc_Ligature_TestData))]
-        [ActiveIssue(5463, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, Xunit.PlatformID.AnyUnix)]
         public void LastIndexOf_Aesc_Ligature(CompareInfo compareInfo, string source, string value, int startIndex, int count, CompareOptions options, int expected)
         {
             // TODO: Remove this function, and combine into LastIndexOf_String once 5463 is fixed
@@ -183,7 +183,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(5463, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, Xunit.PlatformID.AnyUnix)]
         public void LastIndexOf_UnassignedUnicode()
         {
             LastIndexOf_String(s_invariantCompare, "FooBar", "Foo" + UnassignedUnicodeCharacter() + "Bar", 5, 6, CompareOptions.None, 0);
@@ -191,7 +191,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(5463, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, Xunit.PlatformID.AnyUnix)]
         public void LastIndexOf_Hungarian()
         {
             // TODO: Remove this function, and combine into LastIndexOf_TestData once 5463 is fixed

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoAll.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoAll.cs
@@ -12,7 +12,7 @@ namespace System.Globalization.Tests
     public class CultureInfoAll
     {
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // P/Invoke to Win32 function
+        [PlatformSpecific(Xunit.PlatformID.Windows)] // P/Invoke to Win32 function
         public void TestAllCultures()
         {
             Assert.True(EnumSystemLocalesEx(EnumLocales, LOCALE_WINDOWS, IntPtr.Zero, IntPtr.Zero), "EnumSystemLocalesEx has failed");
@@ -136,7 +136,8 @@ namespace System.Globalization.Tests
             Assert.Equal(GetLocaleInfo(ci, LOCALE_SENGLISHCOUNTRYNAME), ri.EnglishName);
             Assert.Equal(GetLocaleInfoAsInt(ci, LOCALE_IMEASURE) == 0, ri.IsMetric);
             Assert.Equal(GetLocaleInfo(ci, LOCALE_SINTLSYMBOL), ri.ISOCurrencySymbol);
-            Assert.Equal(GetLocaleInfo(ci, LOCALE_SISO3166CTRYNAME), ri.Name, StringComparer.OrdinalIgnoreCase);
+            Assert.True(ci.Name.Equals(ri.Name, StringComparison.OrdinalIgnoreCase) || // Desktop usese culture name as region name
+                        ri.Name.Equals(GetLocaleInfo(ci, LOCALE_SISO3166CTRYNAME), StringComparison.OrdinalIgnoreCase)); // netcore uses 2 letter ISO for region name
             Assert.Equal(GetLocaleInfo(ci, LOCALE_SISO3166CTRYNAME), ri.TwoLetterISORegionName, StringComparer.OrdinalIgnoreCase);
             Assert.Equal(GetLocaleInfo(ci, LOCALE_SNATIVECOUNTRYNAME), ri.NativeName, StringComparer.OrdinalIgnoreCase);
         }

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoCompareInfo.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoCompareInfo.cs
@@ -17,7 +17,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(5463, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, Xunit.PlatformID.AnyUnix)]
         public void CompareInfo_EsESTraditional()
         {
             // TOOD: Once #5463 is fixed, combine this into the InlineData for CompareInfo_Compare

--- a/src/System.Globalization/tests/RegionInfo/RegionInfoTests.Methods.cs
+++ b/src/System.Globalization/tests/RegionInfo/RegionInfoTests.Methods.cs
@@ -10,21 +10,21 @@ namespace System.Globalization.Tests
     public class RegionInfoMethodTests
     {
         [Theory]
-        [InlineData("US", "US")]
-        [InlineData("IT", "IT")]
-        [InlineData("IE", "IE")]
-        [InlineData("SA", "SA")]
-        [InlineData("JP", "JP")]
-        [InlineData("CN", "CN")]
-        [InlineData("TW", "TW")]
-        [InlineData("en-GB", "GB")]
-        [InlineData("en-IE", "IE")]
-        [InlineData("en-US", "US")]
-        [InlineData("zh-CN", "CN")]
-        public void Ctor(string name, string expectedName)
+        [InlineData("US", "US", "US")]
+        [InlineData("IT", "IT", "IT")]
+        [InlineData("IE", "IE", "IE")]
+        [InlineData("SA", "SA", "SA")]
+        [InlineData("JP", "JP", "JP")]
+        [InlineData("CN", "CN", "CN")]
+        [InlineData("TW", "TW", "TW")]
+        [InlineData("en-GB", "GB", "en-GB")]
+        [InlineData("en-IE", "IE", "en-IE")]
+        [InlineData("en-US", "US", "en-US")]
+        [InlineData("zh-CN", "CN", "zh-CN")]
+        public void Ctor(string name, string expectedName, string windowsDesktopName)
         {
             var regionInfo = new RegionInfo(name);
-            Assert.Equal(expectedName, regionInfo.Name);
+            Assert.True(windowsDesktopName.Equals(regionInfo.Name) || expectedName.Equals(regionInfo.Name));
             Assert.Equal(regionInfo.Name, regionInfo.ToString());
         }
 
@@ -41,7 +41,6 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> Equals_TestData()
         {
             yield return new object[] { new RegionInfo("en-US"), new RegionInfo("en-US"), true };
-            yield return new object[] { new RegionInfo("en-US"), new RegionInfo("US"), true };
             yield return new object[] { new RegionInfo("en-US"), new RegionInfo("en-GB"), false };
             yield return new object[] { new RegionInfo("en-US"), new RegionInfo("zh-CN"), false };
             yield return new object[] { new RegionInfo("en-US"), new object(), false };

--- a/src/System.Globalization/tests/RegionInfo/RegionInfoTests.Properties.cs
+++ b/src/System.Globalization/tests/RegionInfo/RegionInfoTests.Properties.cs
@@ -12,7 +12,8 @@ namespace System.Globalization.Tests
         [Fact]
         public void CurrentRegion()
         {
-            Assert.Equal(RegionInfo.CurrentRegion, new RegionInfo(CultureInfo.CurrentCulture.Name));
+            RegionInfo ri = new RegionInfo(new RegionInfo(CultureInfo.CurrentCulture.Name).TwoLetterISORegionName);
+            Assert.True(RegionInfo.CurrentRegion.Equals(ri) || RegionInfo.CurrentRegion.Equals(new RegionInfo(CultureInfo.CurrentCulture.Name)));
             Assert.Same(RegionInfo.CurrentRegion, RegionInfo.CurrentRegion);
         }
 

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -11,10 +11,11 @@
     <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
   <ItemGroup>
     <Compile Include="CompareInfo\CompareInfoTests.cs" />
     <Compile Include="CompareInfo\CompareInfoTests.IndexOf.cs" />
@@ -140,8 +141,19 @@
       <Link>Common\System\RandomDataGenerator.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+    <TargetingPackReference Include="System" />
+    <TargetingPackReference Include="System.Threading.Tasks" /> 
+    <TargetingPackReference Include="System.Core" /> 
+    <TargetingPackReference Include="System.Runtime" />
+  </ItemGroup>  
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+
+  <PropertyGroup>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
+
 </Project>

--- a/src/System.Globalization/tests/project.json
+++ b/src/System.Globalization/tests/project.json
@@ -1,21 +1,28 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
-    "Microsoft.NETCore.Platforms": "1.0.1-rc3-23930-00",
-    "System.Globalization": "4.0.11-rc3-23930-00",
-    "System.Globalization.Calendars": "4.0.1-rc3-23930-00",
-    "System.Linq.Expressions": "4.0.11-rc3-23930-00",
-    "System.ObjectModel": "4.0.12-rc3-23930-00",
     "System.Runtime": "4.1.0-rc3-23930-00",
-    "System.Runtime.Extensions": "4.1.0-rc3-23930-00",
-    "System.Text.RegularExpressions": "4.0.12-rc3-23930-00",
-    "System.Threading.Tasks": "4.0.11-rc3-23930-00",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00187"
   },
   "frameworks": {
     "dnxcore50": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1-rc3-23930-00",
+        "System.Globalization": "4.0.11-rc3-23930-00",
+        "System.Globalization.Calendars": "4.0.1-rc3-23930-00",
+        "System.Linq.Expressions": "4.0.11-rc3-23930-00",
+        "System.ObjectModel": "4.0.12-rc3-23930-00",
+        "System.Runtime.Extensions": "4.1.0-rc3-23930-00",
+        "System.Text.RegularExpressions": "4.0.12-rc3-23930-00",
+        "System.Threading.Tasks": "4.0.11-rc3-23930-00"
+      },
       "imports": "portable-net45+win8"
+    },
+    "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
     }
   }
 }


### PR DESCRIPTION
The changes here is to add the build configuration to the globalization test project to allow it to compile and run against the desktop framework. 
The changes also include changing the test project.json to add the desktop runtime support also we have upgraded to use the latest version of the buildtools