### PR TITLE
Add tests for System.Runtime.

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Convert.BoxedObjectCheck.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.BoxedObjectCheck.cs
@@ -62,7 +62,8 @@ namespace System.Tests
                     object converted = ((IConvertible)testValue).ToType(input[0].GetType(), null);
                     Assert.NotSame(testValue, converted);
                 }
-                catch (Exception) { }
+                catch (InvalidCastException) { }
+                catch (OverflowException) { }
             });
         }
 

--- a/src/System.Runtime.Extensions/tests/System/Convert.BoxedObjectCheck.cs
+++ b/src/System.Runtime.Extensions/tests/System/Convert.BoxedObjectCheck.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Xunit;
 
@@ -9,33 +10,69 @@ namespace System.Tests
 {
     public class ConvertBoxedObjectCheckTests
     {
-        [Fact]
-        public static void ChangeTypeIdentity()
+        public static IEnumerable<object[]> DefaultToTypeValues()
         {
-            object[] testValues =
-            {
-            true, false,
-            Byte.MinValue, Byte.MaxValue,
-            SByte.MinValue,SByte.MaxValue, (SByte)0,
-            Int16.MinValue, Int16.MaxValue, (Int16)0,
-            UInt16.MinValue, UInt16.MaxValue,
-            Int32.MinValue, Int32.MaxValue, (Int32)0,
-            UInt32.MinValue, UInt32.MaxValue,
-            Int64.MinValue, Int64.MaxValue, (Int64)0,
-            UInt64.MinValue, UInt64.MaxValue,
-            Char.MinValue, Char.MaxValue, (Char)0,
-            Double.MinValue, Double.MaxValue, (Double)0,
-            Single.MinValue, Single.MaxValue, (Single)0,
-            Decimal.MinValue, Decimal.MaxValue, (Decimal)0,
-            DateTime.MinValue, DateTime.Now, DateTime.MaxValue
-        };
+            yield return new object[] { true };
+            yield return new object[] { false };
+            yield return new object[] { Byte.MinValue };
+            yield return new object[] { Byte.MaxValue };
+            yield return new object[] { SByte.MinValue };
+            yield return new object[] { SByte.MaxValue };
+            yield return new object[] { (SByte)0 };
+            yield return new object[] { Int16.MinValue };
+            yield return new object[] { Int16.MaxValue };
+            yield return new object[] { (Int16)0 };
+            yield return new object[] { UInt16.MinValue };
+            yield return new object[] { UInt16.MaxValue };
+            yield return new object[] { Int32.MinValue };
+            yield return new object[] { Int32.MaxValue };
+            yield return new object[] { (Int32)0 };
+            yield return new object[] { UInt32.MinValue };
+            yield return new object[] { UInt32.MaxValue };
+            yield return new object[] { Int64.MinValue };
+            yield return new object[] { Int64.MaxValue };
+            yield return new object[] { (Int64)0 };
+            yield return new object[] { UInt64.MinValue };
+            yield return new object[] { UInt64.MaxValue };
+            yield return new object[] { Char.MinValue };
+            yield return new object[] { Char.MaxValue };
+            yield return new object[] { (Char)0 };
+            yield return new object[] { Double.MinValue };
+            yield return new object[] { Double.MaxValue };
+            yield return new object[] { (Double)0 };
+            yield return new object[] { Single.MinValue };
+            yield return new object[] { Single.MaxValue };
+            yield return new object[] { (Single)0 };
+            yield return new object[] { Decimal.MinValue };
+            yield return new object[] { Decimal.MaxValue };
+            yield return new object[] { (Decimal)0 };
+            yield return new object[] { DateTime.MinValue };
+            yield return new object[] { DateTime.Now };
+            yield return new object[] { DateTime.MaxValue };
+        }
 
-            foreach (object obj in testValues)
+        [Theory]
+        [MemberData(nameof(DefaultToTypeValues))]
+        public static void TestConvertedCopies(object testValue)
+        {
+            Assert.All(DefaultToTypeValues(), input =>
             {
-                object copy = GetBoxedCopy(obj);
-                Assert.NotSame(obj, copy);
-                Assert.Equal(obj, copy);
-            }
+                try
+                {
+                    object converted = ((IConvertible)testValue).ToType(input[0].GetType(), null);
+                    Assert.NotSame(testValue, converted);
+                }
+                catch (Exception) { }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultToTypeValues))]
+        public static void ChangeTypeIdentity(object testValue)
+        {
+            object copy = GetBoxedCopy(testValue);
+            Assert.NotSame(testValue, copy);
+            Assert.Equal(testValue, copy);
         }
 
         public static object GetBoxedCopy(object obj)

--- a/src/System.Runtime/tests/System/Char.cs
+++ b/src/System.Runtime/tests/System/Char.cs
@@ -192,6 +192,10 @@ public static class CharTests
         Assert.Equal(Char.GetNumericValue("9", 0), 9);
         Assert.Equal(Char.GetNumericValue("Test 7", 5), 7);
         Assert.Equal(Char.GetNumericValue("T", 0), -1);
+
+        Assert.Throws<ArgumentNullException>(() => char.GetNumericValue(null, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => char.IsControl("abc", -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => char.IsControl("abc", 4));
     }
 
     [Fact]
@@ -641,6 +645,14 @@ public static class CharTests
         foreach (char hs in s_highSurrogates)
             foreach (char ls in s_nonSurrogates)
                 Assert.False(Char.IsSurrogatePair(hs.ToString() + ls, 0));
+
+        Assert.Throws<ArgumentNullException>(() => char.IsSurrogatePair(null, 0));
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => char.IsSurrogatePair("abc", -1));
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => char.IsSurrogatePair("abc", 4));
+
+        Assert.False(char.IsSurrogatePair("abc", 2)); // index + 1 < s.length always returns false.
     }
 
     [Fact]

--- a/src/System.Runtime/tests/System/Char.cs
+++ b/src/System.Runtime/tests/System/Char.cs
@@ -652,7 +652,7 @@ public static class CharTests
 
         Assert.Throws<ArgumentOutOfRangeException>(() => char.IsSurrogatePair("abc", 4));
 
-        Assert.False(char.IsSurrogatePair("abc", 2)); // index + 1 < s.length always returns false.
+        Assert.False(char.IsSurrogatePair("abc", 2)); // index + 1 == s.length always returns false.
     }
 
     [Fact]

--- a/src/System.Runtime/tests/System/String.cs
+++ b/src/System.Runtime/tests/System/String.cs
@@ -1228,7 +1228,7 @@ public static class StringTests
         Assert.Equal(expected, s.Insert(startIndex, value));
     }
 
-    [InlineData]
+    [Fact]
     public static void TestInsert_Invalid()
     {
         Assert.Throws<ArgumentNullException>("value", () => "Hello".Insert(0, null)); // Value is null

--- a/src/System.Runtime/tests/System/Tuple.cs
+++ b/src/System.Runtime/tests/System/Tuple.cs
@@ -187,6 +187,11 @@ public class TupleTests
                 Assert.True(Tuple.Equals(other.Tuple));
                 Assert.Equal(Tuple.GetHashCode(), other.Tuple.GetHashCode());
             }
+            else
+            {
+                Assert.False(Tuple.Equals(other.Tuple));
+                Assert.NotEqual(Tuple.GetHashCode(), other.Tuple.GetHashCode());
+            }
 
             if (expectStructuallyEqual)
             {
@@ -195,8 +200,16 @@ public class TupleTests
                 Assert.True(equatable.Equals(other.Tuple, TestEqualityComparer.Instance));
                 Assert.Equal(equatable.GetHashCode(TestEqualityComparer.Instance), otherEquatable.GetHashCode(TestEqualityComparer.Instance));
             }
+            else
+            {
+                var equatable = ((IStructuralEquatable)Tuple);
+                var otherEquatable = ((IStructuralEquatable)other.Tuple);
+                Assert.False(equatable.Equals(other.Tuple, TestEqualityComparer.Instance));
+                Assert.NotEqual(equatable.GetHashCode(TestEqualityComparer.Instance), otherEquatable.GetHashCode(TestEqualityComparer.Instance));
+            }
 
             Assert.False(Tuple.Equals(null));
+            Assert.False(((IStructuralEquatable)Tuple).Equals(null));
         }
 
         public void TestCompareTo(TupleTestDriver<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> other, int expectedResult, int expectedStructuralResult)
@@ -291,49 +304,63 @@ public class TupleTests
     [Fact]
     public static void TestEquals_GetHashCode()
     {
-        TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan> tupleDriverA, tupleDriverB, tupleDriverC;
+        TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan> tupleDriverA, tupleDriverB, tupleDriverC, tupleDriverD;
         //Tuple-1
         tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MaxValue);
         tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MaxValue);
         tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MinValue);
+        tupleDriverD = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MaxValue, int.MaxValue);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverB, true, true);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverC, false, false);
+        tupleDriverA.TestEquals_GetHashCode(tupleDriverD, false, false);
         //Tuple-2
         tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MinValue, int.MaxValue);
         tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MinValue, int.MaxValue);
         tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MinValue, int.MinValue);
+        tupleDriverD = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), long.MinValue);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverB, true, true);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverC, false, false);
+        tupleDriverA.TestEquals_GetHashCode(tupleDriverD, false, false);
         //Tuple-3
         tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)0, (int)0, long.MaxValue);
         tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)0, (int)0, long.MaxValue);
         tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), long.MinValue);
+        tupleDriverD = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "this");
         tupleDriverA.TestEquals_GetHashCode(tupleDriverB, true, true);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverC, false, false);
+        tupleDriverA.TestEquals_GetHashCode(tupleDriverD, false, false);
         //Tuple-4
         tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "This");
         tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "This");
         tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "this");
+        tupleDriverD = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)0, (int)0, (long)1, "IS", 'a');
         tupleDriverA.TestEquals_GetHashCode(tupleDriverB, true, true);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverC, false, false);
+        tupleDriverA.TestEquals_GetHashCode(tupleDriverD, false, false);
         //Tuple-5
         tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), (long)0, "is", 'A');
         tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), (long)0, "is", 'A');
         tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)0, (int)0, (long)1, "IS", 'a');
+        tupleDriverD = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MinValue);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverB, true, true);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverC, false, false);
+        tupleDriverA.TestEquals_GetHashCode(tupleDriverD, false, false);
         //Tuple-6
         tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MaxValue);
         tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MaxValue);
         tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MinValue);
+        tupleDriverD = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-101), (int)(-1001), (long)(-2), "tuples", ' ', Single.MinValue, (Double)0.0);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverB, true, true);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverC, false, false);
+        tupleDriverA.TestEquals_GetHashCode(tupleDriverD, false, false);
         //Tuple-7
         tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-100), (int)(-1000), (long)(-1), "Tuples", ' ', Single.MinValue, Double.MaxValue);
         tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-100), (int)(-1000), (long)(-1), "Tuples", ' ', Single.MinValue, Double.MaxValue);
         tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-101), (int)(-1001), (long)(-2), "tuples", ' ', Single.MinValue, (Double)0.0);
+        tupleDriverD = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10001, (int)1000001, (long)10000001, "2008?7?3?", '1', (Single)0.0002, (Double)0.0000002, DateTime.Now.AddMilliseconds(1));
         tupleDriverA.TestEquals_GetHashCode(tupleDriverB, true, true);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverC, false, false);
+        tupleDriverA.TestEquals_GetHashCode(tupleDriverD, false, false);
 
         object myObj = new object();
         //Tuple-10


### PR DESCRIPTION
Add tests to cover all coverage gaps in System.Runtime and System.Runtime.Extensions with the exception of the URI tests which still need to be ported.

resolves #6445.