### PR TITLE
Fix compilation failure in System.Linq.Expressions tests on Unix

### DIFF
--- a/src/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -276,14 +276,14 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckUnsignedEnumInObjectCastEnum(bool useInterpreter)
         {
-            foreach (Eu value in new[] { Eu.Bagahi, Eu.Laca, Eu.Bachahé, (Eu)uint.MaxValue })
+            foreach (Eu value in new[] { Eu.Bagahi, Eu.Laca, Eu.Bachahe, (Eu)uint.MaxValue })
                 VerifyUnsignedEnumInObjectCastEnum(value, useInterpreter);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckUnsignedEnumCastEnum(bool useInterpreter)
         {
-            foreach (Eu value in new[] { Eu.Bagahi, Eu.Laca, Eu.Bachahé, (Eu)uint.MaxValue })
+            foreach (Eu value in new[] { Eu.Bagahi, Eu.Laca, Eu.Bachahe, (Eu)uint.MaxValue })
                 VerifyUnsignedEnumCastEnum(value, useInterpreter);
         }
 

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -89,7 +89,7 @@ namespace System.Linq.Expressions.Tests
     {
         Bagahi,
         Laca,
-        Bachahé
+        Bachahe
     }
 
     public struct S : IEquatable<S>


### PR DESCRIPTION
```
HelperTypes.cs(92,15): error CS1056: Unexpected character '�' [/mnt/j/workspace/dotnet_corefx/outerloop_ubuntu14.04_debug/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj]
14:22:05 Cast/CastTests.cs(279,71): error CS1056: Unexpected character '�' [/mnt/j/workspace/dotnet_corefx/outerloop_ubuntu14.04_debug/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj]
14:22:05 Cast/CastTests.cs(286,71): error CS1056: Unexpected character '�' [/mnt/j/workspace/dotnet_corefx/outerloop_ubuntu14.04_debug/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj]
```
cc: @VSadov, @JonHanna