### PR TITLE
Add a test for X509Chain.Build with X509RevocationMode.Online

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -697,7 +697,10 @@ namespace Internal.Cryptography.Pal
                         Interop.Crypto.X509VerifyStatusCode errorCode = Interop.Crypto.X509StoreCtxGetError(storeCtx);
                         int errorDepth = Interop.Crypto.X509StoreCtxGetErrorDepth(storeCtx);
 
-                        if (errorCode != Interop.Crypto.X509VerifyStatusCode.X509_V_OK)
+                        // We don't report "OK" as an error.
+                        // For compatibility with Windows / .NET Framework, do not report X509_V_CRL_NOT_YET_VALID.
+                        if (errorCode != Interop.Crypto.X509VerifyStatusCode.X509_V_OK &&
+                            errorCode != Interop.Crypto.X509VerifyStatusCode.X509_V_ERR_CRL_NOT_YET_VALID)
                         {
                             while (Errors.Count <= errorDepth)
                             {

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
@@ -63,15 +63,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 valid = chain.Build(microsoftDotComIssuer);
                 Assert.True(valid, "Chain should build validly now");
                 Assert.Equal(initialErrorCount, chain.ChainStatus.Length);
-
-                // Rewind one second, the CRL is not "not yet valid"
-                chain.ChainPolicy.VerificationTime = chain.ChainPolicy.VerificationTime.Subtract(TimeSpan.FromSeconds(1));
-
-                valid = chain.Build(microsoftDotComIssuer);
-                Assert.False(valid, "Chain should not build validly, CRL is not yet valid");
-
-                Assert.Equal(initialErrorCount + 1, chain.ChainStatus.Length);
-                Assert.Equal(X509ChainStatusFlags.RevocationStatusUnknown, chain.ChainStatus[0].Status);
             }
         }
 


### PR DESCRIPTION
This was identified as a coverage delta from ToF (#6454).  During the development of the test it discovered an inconsistency in X509Chain between Windows and Unix regarding not-yet-valid CRLs.  Since that inconsistency resulted in X509Chain.Build returning `true` (success) on Windows but `false` (failure) on Unix for the same inputs it is also changed in this PR.

cc: @stephentoub @AtsushiKan @morganbr 

### Add an Online revocation mode test

This test may result in contacting the network to download a CRL, or
intermediate certificates, so it is being confined to OuterLoop.

This doesn't test that revocation actually works.  Unfortunately that is hard to
build into a unit test due to the non-constant nature of time: once a certificate
has gone out of validity a CA has no obligation (other than their own policy)
to keep a revoked certificate on the CRL.

The best way to write such a test is to use a live source of truth for a revoked
certificate; but the notion of "live" is subject to change.

An alternate mechanism would be to create a private CA with an
unfathomably large expiration time, issue and subsequently revoke a
certificate, and use that certificate, CA, and published CDP as a controlled
portion of the test.  Such an infrastructure dependency is beyond the scope
of this change (and would still fail for very old snapshots given enough time).

### Make Unix X509Chain match Windows behaviors on NotYetValid CRLs

Windows X509Chain reports no error when the cached-or-downloaded CRL
has a thisUpdate value in the future (as compared to the VerificationTime value).
Unix X509Chain did report this as an error, because OpenSSL emits it as a chain
processing error.

The solution is simply to ignore X509_V_CRL_NOT_YET_VALID, and let other
potential issues continue to be raised.