### PR TITLE
Change test variable names to be more culturally neutral

### DIFF
--- a/src/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -276,14 +276,14 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckUnsignedEnumInObjectCastEnum(bool useInterpreter)
         {
-            foreach (Eu value in new[] { Eu.Bagahi, Eu.Laca, Eu.Bachahe, (Eu)uint.MaxValue })
+            foreach (Eu value in new[] { Eu.Foo, Eu.Bar, Eu.Baz, (Eu)uint.MaxValue })
                 VerifyUnsignedEnumInObjectCastEnum(value, useInterpreter);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckUnsignedEnumCastEnum(bool useInterpreter)
         {
-            foreach (Eu value in new[] { Eu.Bagahi, Eu.Laca, Eu.Bachahe, (Eu)uint.MaxValue })
+            foreach (Eu value in new[] { Eu.Foo, Eu.Bar, Eu.Baz, (Eu)uint.MaxValue })
                 VerifyUnsignedEnumCastEnum(value, useInterpreter);
         }
 

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -87,9 +87,9 @@ namespace System.Linq.Expressions.Tests
 
     public enum Eu : uint
     {
-        Bagahi,
-        Laca,
-        Bachahe
+        Foo,
+        Bar,
+        Baz
     }
 
     public struct S : IEquatable<S>


### PR DESCRIPTION
Using something with a religious origin was not appropriate. Bad thinking in the wee hours.