### PR TITLE
Refactor MultipartContent to use async/await

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/MultipartContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/MultipartContent.cs
@@ -27,13 +27,8 @@ namespace System.Net.Http
         private static readonly int s_colonSpaceLength = GetEncodedLength(": ");
         private static readonly int s_commaSpaceLength = GetEncodedLength(", ");
 
-        private List<HttpContent> _nestedContent;
-        private string _boundary;
-
-        // Temp context for serialization.
-        private int _nextContentIndex;
-        private Stream _outputStream;
-        private TaskCompletionSource<Object> _tcs;
+        private readonly List<HttpContent> _nestedContent;
+        private readonly string _boundary;
 
         #endregion Fields
 
@@ -96,14 +91,14 @@ namespace System.Net.Http
             }
             Contract.EndContractBlock();
 
-            string allowedMarks = @"'()+_,-./:=? ";
+            const string AllowedMarks = @"'()+_,-./:=? ";
 
             foreach (char ch in boundary)
             {
                 if (('0' <= ch && ch <= '9') || // Digit.
                     ('a' <= ch && ch <= 'z') || // alpha.
                     ('A' <= ch && ch <= 'Z') || // ALPHA.
-                    (allowedMarks.IndexOf(ch) >= 0)) // Marks.
+                    (AllowedMarks.IndexOf(ch) >= 0)) // Marks.
                 {
                     // Valid.
                 }
@@ -177,122 +172,57 @@ namespace System.Net.Http
         // write "--" + boundary + "--"
         // Can't be canceled directly by the user.  If the overall request is canceled 
         // then the stream will be closed an exception thrown.
-        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
             Debug.Assert(stream != null);
-            Debug.Assert(_outputStream == null, "Operation already in progress");
-            Debug.Assert(_tcs == null, "Operation already in progress");
-            Debug.Assert(_nextContentIndex == 0, "Operation already in progress");
-
-            // Keep a local copy in case the operation completes and cleans up synchronously.
-            TaskCompletionSource<Object> localTcs = new TaskCompletionSource<Object>();
-            _tcs = localTcs;
-            _outputStream = stream;
-            _nextContentIndex = 0;
-
-            // Start Boundary, chain everything else.
-            EncodeStringToStreamAsync(_outputStream, "--" + _boundary + CrLf)
-                .ContinueWithStandard(WriteNextContentHeadersAsync);
-
-            return localTcs.Task;
-        }
-
-        private void WriteNextContentHeadersAsync(Task task)
-        {
-            if (task.IsFaulted)
-            {
-                HandleAsyncException("WriteNextContentHeadersAsync", task.Exception.GetBaseException());
-                return;
-            }
-
             try
             {
-                // Base case, no more content, finish.
-                if (_nextContentIndex >= _nestedContent.Count)
-                {
-                    WriteTerminatingBoundaryAsync();
-                    return;
-                }
+                // Write start boundary
+                await EncodeStringToStreamAsync(stream, "--" + _boundary + CrLf).ConfigureAwait(false);
 
-                StringBuilder output = new StringBuilder();
-                if (_nextContentIndex != 0) // First time, don't write dividing boundary.
+                // Write each nested content
+                var output = new StringBuilder();
+                for (int contentIndex = 0; contentIndex < _nestedContent.Count; contentIndex++)
                 {
-                    output.Append(CrLf + "--"); // const strings
-                    output.Append(_boundary);
-                    output.Append(CrLf);
-                }
+                    output.Clear();
+                    HttpContent content = _nestedContent[contentIndex];
 
-                HttpContent content = _nestedContent[_nextContentIndex];
-
-                // Headers
-                foreach (KeyValuePair<string, IEnumerable<string>> headerPair in content.Headers)
-                {
-                    output.Append(headerPair.Key);
-                    output.Append(": ");
-                    string delim = string.Empty;
-                    foreach (string value in headerPair.Value)
+                    // Add divider
+                    if (contentIndex != 0) // Write divider for all but the first content
                     {
-                        output.Append(delim);
-                        output.Append(value);
-                        delim = ", ";
+                        output.Append(CrLf + "--"); // const strings
+                        output.Append(_boundary);
+                        output.Append(CrLf);
                     }
-                    output.Append(CrLf);
+
+                    // Add headers
+                    foreach (KeyValuePair<string, IEnumerable<string>> headerPair in content.Headers)
+                    {
+                        output.Append(headerPair.Key);
+                        output.Append(": ");
+                        string delim = string.Empty;
+                        foreach (string value in headerPair.Value)
+                        {
+                            output.Append(delim);
+                            output.Append(value);
+                            delim = ", ";
+                        }
+                        output.Append(CrLf);
+                    }
+                    output.Append(CrLf); // Extra CRLF to end headers (even if there are no headers).
+
+                    // Write divider, headers, and content
+                    await EncodeStringToStreamAsync(stream, output.ToString()).ConfigureAwait(false);
+                    await content.CopyToAsync(stream).ConfigureAwait(false);
                 }
 
-                output.Append(CrLf); // Extra CRLF to end headers (even if there are no headers).
-
-                EncodeStringToStreamAsync(_outputStream, output.ToString())
-                    .ContinueWithStandard(WriteNextContentAsync);
+                // Write footer boundary
+                await EncodeStringToStreamAsync(stream, CrLf + "--" + _boundary + "--" + CrLf).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                HandleAsyncException("WriteNextContentHeadersAsync", ex);
-            }
-        }
-
-        private void WriteNextContentAsync(Task task)
-        {
-            if (task.IsFaulted)
-            {
-                HandleAsyncException("WriteNextContentAsync", task.Exception.GetBaseException());
-                return;
-            }
-
-            try
-            {
-                HttpContent content = _nestedContent[_nextContentIndex];
-                _nextContentIndex++; // Next call will operate on the next content object.
-
-                content.CopyToAsync(_outputStream)
-                    .ContinueWithStandard(WriteNextContentHeadersAsync);
-            }
-            catch (Exception ex)
-            {
-                HandleAsyncException("WriteNextContentAsync", ex);
-            }
-        }
-
-        // Final step, write the footer boundary.
-        private void WriteTerminatingBoundaryAsync()
-        {
-            try
-            {
-                EncodeStringToStreamAsync(_outputStream, CrLf + "--" + _boundary + "--" + CrLf)
-                    .ContinueWithStandard(task =>
-                    {
-                        if (task.IsFaulted)
-                        {
-                            HandleAsyncException("WriteTerminatingBoundaryAsync", task.Exception.GetBaseException());
-                            return;
-                        }
-
-                        TaskCompletionSource<object> lastTcs = CleanupAsync();
-                        lastTcs.TrySetResult(null); // This was the final operation.
-                    });
-            }
-            catch (Exception ex)
-            {
-                HandleAsyncException("WriteTerminatingBoundaryAsync", ex);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exception(NetEventSource.ComponentType.Http, this, nameof(SerializeToStreamAsync), ex);
+                throw;
             }
         }
 
@@ -300,23 +230,6 @@ namespace System.Net.Http
         {
             byte[] buffer = HttpRuleParser.DefaultHttpEncoding.GetBytes(input);
             return stream.WriteAsync(buffer, 0, buffer.Length);
-        }
-
-        private TaskCompletionSource<object> CleanupAsync()
-        {
-            Contract.Requires(_tcs != null, "Operation already cleaned up");
-            TaskCompletionSource<object> toReturn = _tcs;
-            _outputStream = null;
-            _nextContentIndex = 0;
-            _tcs = null;
-            return toReturn;
-        }
-
-        private void HandleAsyncException(string method, Exception ex)
-        {
-            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exception(NetEventSource.ComponentType.Http, this, method, ex);
-            TaskCompletionSource<object> lastTcs = CleanupAsync();
-            lastTcs.TrySetException(ex);
         }
 
         protected internal override bool TryComputeLength(out long length)

--- a/src/System.Net.Http/src/System/Net/Http/MultipartContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/MultipartContent.cs
@@ -177,25 +177,25 @@ namespace System.Net.Http
             Debug.Assert(stream != null);
             try
             {
-                // Write start boundary
+                // Write start boundary.
                 await EncodeStringToStreamAsync(stream, "--" + _boundary + CrLf).ConfigureAwait(false);
 
-                // Write each nested content
+                // Write each nested content.
                 var output = new StringBuilder();
                 for (int contentIndex = 0; contentIndex < _nestedContent.Count; contentIndex++)
                 {
                     output.Clear();
                     HttpContent content = _nestedContent[contentIndex];
 
-                    // Add divider
-                    if (contentIndex != 0) // Write divider for all but the first content
+                    // Add divider.
+                    if (contentIndex != 0) // Write divider for all but the first content.
                     {
                         output.Append(CrLf + "--"); // const strings
                         output.Append(_boundary);
                         output.Append(CrLf);
                     }
 
-                    // Add headers
+                    // Add headers.
                     foreach (KeyValuePair<string, IEnumerable<string>> headerPair in content.Headers)
                     {
                         output.Append(headerPair.Key);
@@ -211,17 +211,20 @@ namespace System.Net.Http
                     }
                     output.Append(CrLf); // Extra CRLF to end headers (even if there are no headers).
 
-                    // Write divider, headers, and content
+                    // Write divider, headers, and content.
                     await EncodeStringToStreamAsync(stream, output.ToString()).ConfigureAwait(false);
                     await content.CopyToAsync(stream).ConfigureAwait(false);
                 }
 
-                // Write footer boundary
+                // Write footer boundary.
                 await EncodeStringToStreamAsync(stream, CrLf + "--" + _boundary + "--" + CrLf).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exception(NetEventSource.ComponentType.Http, this, nameof(SerializeToStreamAsync), ex);
+                if (NetEventSource.Log.IsEnabled())
+                {
+                    NetEventSource.Exception(NetEventSource.ComponentType.Http, this, nameof(SerializeToStreamAsync), ex);
+                }
                 throw;
             }
         }


### PR DESCRIPTION
Currently serialization of MultipartContent is split across multiple Task-based methods that each ContinueWith to each other.    We can instead just write the code naturally in an async method. In addition to being simpler, it also helps with performance, especially when serializing to a memory stream and the whole operation can actually run synchronously.  For example, with this little snippet:
```C#
var c = new HttpClient();
var url = new Uri("http://httpbin.org/post");
for (int i = 0; i < 100; i++)
{
    var mc = new MultipartContent("someSubtype", "theBoundary");
    mc.Add(new ByteArrayContent(Encoding.UTF8.GetBytes("This is a ByteArrayContent")));
    mc.Add(new StringContent("This is a StringContent"));
    await c.PostAsync(url, mc);
}
````
the number of allocations drops nicely:
![image](https://cloud.githubusercontent.com/assets/2642209/14164603/e51fe004-f6ce-11e5-893e-9c1d10480102.png)

cc: @davidsh, @cipop, @ericeil, @kapilash