### PR TITLE
Disable padded warnings in ARM32 environment

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.GssBuffer.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.GssBuffer.cs
@@ -62,6 +62,15 @@ internal static partial class Interop
 
                 _length = 0;
             }
+
+#if DEBUG
+            static GssBuffer()
+            {
+                // Verify managed size on both 32-bit and 64-bit matches the PAL_GssBuffer 
+                // native struct size, which is also padded on 32-bit.
+                Debug.Assert(Marshal.SizeOf<GssBuffer>() == 16);
+            }
+#endif
         }
     }
 }

--- a/src/Native/System.Net.Security.Native/pal_gssapi.h
+++ b/src/Native/System.Net.Security.Native/pal_gssapi.h
@@ -39,11 +39,18 @@ enum PAL_GssFlags : uint32_t
     PAL_GSS_C_DELEG_POLICY_FLAG = 0x8000
 };
 
+/*
+Issue: #7342
+Disable padded warning which occurs in case of 32-bit builds
+*/
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpadded"
 struct PAL_GssBuffer
 {
     uint64_t length;
     uint8_t* data;
 };
+#pragma clang diagnostic pop
 
 /*
 Shims the gss_release_buffer method.


### PR DESCRIPTION
Tracking issue: #7342

8-byte alignment expectation throws up -Wpadded warning in ARM32.
Disable this using clang pragmas only for ARM32 environment.

Signed-off-by: Prajwal A N <an.prajwal@samsung.com>