### PR TITLE
Actually test GetBytes and GetChars in System.Text.Encoding

### DIFF
--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetByteCount.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetByteCount.cs
@@ -28,13 +28,7 @@ namespace System.Text.Tests
         [MemberData(nameof(GetByteCount_TestData))]
         private void GetByteCount(string chars, int index, int count, int expected)
         {
-            char[] charArray = chars.ToCharArray();
-            if (index == 0 && count == chars.Length)
-            {
-                Assert.Equal(expected, new ASCIIEncoding().GetByteCount(chars));
-                Assert.Equal(expected, new ASCIIEncoding().GetByteCount(charArray));
-            }
-            Assert.Equal(expected, new ASCIIEncoding().GetByteCount(charArray, index, count));
+            EncodingHelpers.GetByteCount(new ASCIIEncoding(), chars, index, count, expected);
         }
     }
 }

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetBytes.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetBytes.cs
@@ -35,44 +35,20 @@ namespace System.Text.Tests
         [MemberData(nameof(GetBytes_TestData))]
         public void GetBytes(string source, int index, int count, byte[] bytes, int byteIndex)
         {
-            // Use GetBytes(string, int, int, byte[], int)
-            byte[] stringBytes = (byte[])bytes.Clone();
-            int stringResult = new ASCIIEncoding().GetBytes(source, index, count, stringBytes, byteIndex);
-            VerifyGetBytes(source, index, count, stringBytes, byteIndex, stringResult);
-
-            // Use GetBytes(char[], int, int, byte[], int)
-            byte[] charArrayBytes = (byte[])bytes.Clone();
-            int charArrayResult = new ASCIIEncoding().GetBytes(source, index, count, charArrayBytes, byteIndex);
-            VerifyGetBytes(source, index, count, charArrayBytes, byteIndex, charArrayResult);
-        }
-
-        private void VerifyGetBytes(string source, int charIndex, int count, byte[] bytes, int byteIndex, int result)
-        {
-            if (source.Length == 0)
+            byte[] expectedBytes = new byte[count];
+            for (int i = 0; i < expectedBytes.Length; i++)
             {
-                Assert.Equal(0, result);
-                return;
-            }
-
-            int currentCharIndex;
-            int currentByteIndex;
-            int charEndIndex = charIndex + count - 1;
-
-            for (currentCharIndex = charIndex, currentByteIndex = byteIndex; currentCharIndex <= charEndIndex; ++currentCharIndex)
-            {
-                if (source[currentCharIndex] <= MaxASCIIChar && source[currentCharIndex] >= MinASCIIChar)
+                if (source[i] >= 0x0 && source[i] <= 0x7f)
                 {
-                    // Verify normal ASCII encoding character
-                    Assert.Equal(source[currentCharIndex], (char)bytes[currentByteIndex]);
-                    ++currentByteIndex;
+                    expectedBytes[i] = (byte)source[i + index];
                 }
                 else
                 {
-                    // Verify ASCII encoder replacement fallback
-                    ++currentByteIndex;
+                    // Verify the fallback character for non-ASCII chars
+                    expectedBytes[i] = 63;
                 }
             }
-            Assert.Equal(currentByteIndex - byteIndex, result);
+            EncodingHelpers.GetBytes(new ASCIIEncoding(), source, index, count, bytes, byteIndex, expectedBytes);
         }
     }
 }

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetBytes.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetBytes.cs
@@ -12,23 +12,19 @@ namespace System.Text.Tests
         private const int MinStringLength = 2;
         private const int MaxStringLength = 260;
 
-        private const char MinASCIIChar = (char)0x0;
-        private const char MaxASCIIChar = (char)0x7f;
-
         private static readonly RandomDataGenerator s_randomDataGenerator = new RandomDataGenerator();
 
         public static IEnumerable<object[]> GetBytes_TestData()
         {
             yield return new object[] { string.Empty, 0, 0, new byte[0], 0 };
 
-            string randomString = s_randomDataGenerator.GetString(-55, false, MinStringLength, MaxStringLength);
-            int randomIndex = s_randomDataGenerator.GetInt32(-55) % randomString.Length;
-            int randomCount = s_randomDataGenerator.GetInt32(-55) % (randomString.Length - randomIndex) + 1;
-            int minLength = new ASCIIEncoding().GetByteCount(randomString.Substring(randomIndex, randomCount));
-            int randomBytesLength = minLength + s_randomDataGenerator.GetInt32(-55) % (short.MaxValue - minLength);
-            byte[] bytes = new byte[randomBytesLength];
-            int randomByteIndex = s_randomDataGenerator.GetInt32(-55) % (bytes.Length - minLength + 1);
-            yield return new object[] { randomString, randomIndex, randomCount, bytes, randomByteIndex };
+            string testString = "Hello World";
+            yield return new object[] { testString, 0, testString.Length, new byte[testString.Length], 0 };
+            yield return new object[] { testString, 0, testString.Length, new byte[testString.Length + 1], 1 };
+            yield return new object[] { testString, 4, 5, new byte[5], 0 };
+
+            string unicodeString = "a\u1234\u2345b";
+            yield return new object[] { unicodeString, 0, unicodeString.Length, new byte[unicodeString.Length], 0 };
         }
         
         [Theory]
@@ -45,7 +41,7 @@ namespace System.Text.Tests
                 else
                 {
                     // Verify the fallback character for non-ASCII chars
-                    expectedBytes[i] = 63;
+                    expectedBytes[i] = (byte)'?';
                 }
             }
             EncodingHelpers.GetBytes(new ASCIIEncoding(), source, index, count, bytes, byteIndex, expectedBytes);

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetCharCount.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetCharCount.cs
@@ -28,11 +28,7 @@ namespace System.Text.Tests
         [MemberData(nameof(GetCharCount_TestData))]
         public void GetCharCount(byte[] bytes, int index, int count, int expected)
         {
-            if (index == 0 && count == bytes.Length)
-            {
-                Assert.Equal(expected, new ASCIIEncoding().GetCharCount(bytes));
-            }
-            Assert.Equal(expected, new ASCIIEncoding().GetCharCount(bytes, index, count));
+            EncodingHelpers.GetCharCount(new ASCIIEncoding(), bytes, index, count, expected);
         }
     }
 }

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetChars.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingGetChars.cs
@@ -34,20 +34,12 @@ namespace System.Text.Tests
         [MemberData(nameof(GetChars_TestData))]
         public void GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
         {
-            int result = new ASCIIEncoding().GetChars(bytes, byteIndex, byteCount, chars, charIndex);
-            VerifyGetChars(bytes, byteIndex, byteCount, chars, charIndex, result);
-        }
-
-        private void VerifyGetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex, int result)
-        {
-            Assert.Equal(result, byteCount);
-
-            // Assume that the character array has enough capacity to accommodate the resulting characters
-            // i current index of byte array, j current index of character array
-            for (int byteEnd = byteIndex + byteCount, i = byteIndex, j = charIndex; i < byteEnd; i++, j++)
+            char[] expectedChars = new char[byteCount];
+            for (int i = 0; i < byteCount; i++)
             {
-                Assert.Equal(bytes[i], (byte)chars[j]);
+                expectedChars[i] = (char)bytes[i + byteIndex]; 
             }
+            EncodingHelpers.GetChars(new ASCIIEncoding(), bytes, byteIndex, byteCount, chars, charIndex, expectedChars);
         }
     }
 }

--- a/src/System.Text.Encoding/tests/EncodingTestHelpers.cs
+++ b/src/System.Text.Encoding/tests/EncodingTestHelpers.cs
@@ -67,7 +67,7 @@ namespace System.Text.Tests
             }
             for (int i = byteIndex + byteCount; i < bytes.Length; i++)
             {
-                // Chars outside the range should be ignored
+                // Bytes outside the range should be ignored
                 Assert.Equal(originalBytes[i], bytes[i]);
             }
         }
@@ -93,7 +93,7 @@ namespace System.Text.Tests
                 char[] resultBasic = encoding.GetChars(bytes);
                 VerifyGetChars(resultBasic, 0, resultBasic.Length, originalChars, expectedChars);
             }
-            // Use GetChars(byte[], int int)
+            // Use GetChars(byte[], int, int)
             char[] resultAdvanced = encoding.GetChars(bytes, byteIndex, byteCount);
             VerifyGetChars(resultAdvanced, 0, resultAdvanced.Length, originalChars, expectedChars);
 

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetBytes.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetBytes.cs
@@ -11,20 +11,22 @@ namespace System.Text.Tests
     {
         public static IEnumerable<object[]> GetBytes_TestData()
         {
-            string randomString = EncodingHelpers.GetRandomString(10);
-            yield return new object[] { randomString, 0, randomString.Length, new byte[30], 5, 20 };
-            yield return new object[] { randomString, 0, 1, new byte[30], 0, 2 };
-            yield return new object[] { randomString, 0, 0, new byte[20], 20, 0 };
-            yield return new object[] { randomString, randomString.Length, 0, new byte[20], 20, 0 };
+            string testString = "Hello World";
+            byte[] testStringBytes = new byte[] { 72, 0, 101, 0, 108, 0, 108, 0, 111, 0, 32, 0, 87, 0, 111, 0, 114, 0, 108, 0, 100, 0 };
 
-            yield return new object[] { string.Empty, 0, 0, new byte[0], 0, 0 };
+            yield return new object[] { testString, 0, testString.Length, new byte[30], 5, testStringBytes };
+            yield return new object[] { testString, 0, 1, new byte[30], 0, new byte[] { 72, 0 } };
+            yield return new object[] { testString, 0, 0, new byte[20], 20, new byte[0] };
+            yield return new object[] { testString, testString.Length, 0, new byte[20], 20, new byte[0] };
+
+            yield return new object[] { string.Empty, 0, 0, new byte[0], 0, new byte[0] };
         }
 
         [Theory]
         [MemberData(nameof(GetBytes_TestData))]
-        public void GetBytes(string source, int index, int count, byte[] bytes, int byteIndex, int expected)
+        public void GetBytes(string source, int index, int count, byte[] bytes, int byteIndex, byte[] expectedBytes)
         {
-            EncodingHelpers.GetBytes(new UnicodeEncoding(), source, index, count, bytes, byteIndex, expected);
+            EncodingHelpers.GetBytes(new UnicodeEncoding(), source, index, count, bytes, byteIndex, expectedBytes);
         }
     }
 }

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetBytes.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetBytes.cs
@@ -19,7 +19,13 @@ namespace System.Text.Tests
             yield return new object[] { testString, 0, 0, new byte[20], 20, new byte[0] };
             yield return new object[] { testString, testString.Length, 0, new byte[20], 20, new byte[0] };
 
+            byte[] allBytes = new byte[256];
+            for (int i = 0; i <= byte.MaxValue; i++)
+            {
+                allBytes[i] = (byte)i;
+            }
             yield return new object[] { string.Empty, 0, 0, new byte[0], 0, new byte[0] };
+            yield return new object[] { string.Empty, 0, 0, allBytes, 0, new byte[0] };
         }
 
         [Theory]

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetChars.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingGetChars.cs
@@ -16,22 +16,22 @@ namespace System.Text.Tests
             string randomString = EncodingHelpers.GetRandomString(10);
             byte[] randomBytesBasic = new UnicodeEncoding().GetBytes(randomString);
 
-            yield return new object[] { randomBytesBasic, 0, randomBytesBasic.Length, new char[randomString.Length], 0, randomBytesBasic.Length / 2 };
+            yield return new object[] { randomBytesBasic, 0, randomBytesBasic.Length, new char[randomString.Length], 0, randomString.ToCharArray() };
 
             int randomByteCount = s_randomDataGenerator.GetInt16(-55) % randomString.Length + 1;
             byte[] randomBytesAdvanced = new UnicodeEncoding().GetBytes(randomString.ToCharArray());
-            yield return new object[] { randomBytesAdvanced, 0, randomByteCount * 2, new char[randomString.Length], 0, randomByteCount };
+            yield return new object[] { randomBytesAdvanced, 0, randomByteCount * 2, new char[randomString.Length], 0, randomString.ToCharArray(0, randomByteCount) };
+            
+            yield return new object[] { randomBytesBasic, 0, 0, new char[randomString.Length], randomString.Length, new char[0] };
 
-            yield return new object[] { randomBytesBasic, 0, 0, new char[randomString.Length], randomString.Length, 0 };
-
-            yield return new object[] { randomBytesBasic, 20, 0, new char[randomString.Length], randomString.Length, 0 };
+            yield return new object[] { randomBytesBasic, 20, 0, new char[randomString.Length], randomString.Length, new char[0] };
         }
 
         [Theory]
         [MemberData(nameof(GetChars_TestData))]
-        public void GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex, int expected)
+        public void GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex, char[] expectedChars)
         {
-            EncodingHelpers.GetChars(new UnicodeEncoding(), bytes, byteIndex, byteCount, chars, charIndex, expected);
+            EncodingHelpers.GetChars(new UnicodeEncoding(), bytes, byteIndex, byteCount, chars, charIndex, expectedChars);
         }
     }
 }


### PR DESCRIPTION
- Previous tests for GetBytes and GetChars did not test anything apart
from the return value: the method could've created any byte[] or char[]
result and we wouldn't have verified it.
- Also adds more coverage by testing more overloads of GetBytes and
GetChars