### PR TITLE
Fix generation of IS.PInvoke contract

### DIFF
--- a/src/System.Runtime.InteropServices.PInvoke/pkg/System.Runtime.InteropServices.PInvoke.pkgproj
+++ b/src/System.Runtime.InteropServices.PInvoke/pkg/System.Runtime.InteropServices.PInvoke.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Runtime.InteropServices.PInvoke.csproj">
-      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
+      <SupportedFramework>net462;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.InteropServices.PInvoke.builds" />
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/System.Runtime.InteropServices.PInvoke/ref/System.Runtime.InteropServices.PInvoke.csproj
+++ b/src/System.Runtime.InteropServices.PInvoke/ref/System.Runtime.InteropServices.PInvoke.csproj
@@ -8,8 +8,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.5</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Runtime.InteropServices.PInvoke.cs" />

--- a/src/System.Runtime.InteropServices.PInvoke/src/System.Runtime.InteropServices.PInvoke.builds
+++ b/src/System.Runtime.InteropServices.PInvoke/src/System.Runtime.InteropServices.PInvoke.builds
@@ -4,11 +4,12 @@
   <ItemGroup>
     <Project Include="System.Runtime.InteropServices.PInvoke.csproj"/>
     <Project Include="System.Runtime.InteropServices.PInvoke.csproj">
-      <TargetGroup>net46</TargetGroup>
+      <TargetGroup>net462</TargetGroup>
     </Project>
+    <!-- Due to shared library we cannot currently support PINvoke on NETCore50
     <Project Include="System.Runtime.InteropServices.PInvoke.csproj">
       <TargetGroup>netcore50aot</TargetGroup>
-    </Project>
+    </Project> -->
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime.InteropServices.PInvoke/src/System.Runtime.InteropServices.PInvoke.csproj
+++ b/src/System.Runtime.InteropServices.PInvoke/src/System.Runtime.InteropServices.PInvoke.csproj
@@ -9,16 +9,16 @@
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <!-- Force string resources to be excluded for full facades. -->
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' != ''">None</ResourcesSourceOutputDirectory>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.5</PackageTargetFramework>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.5</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462_Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System\Runtime\InteropServices\PInvokeMarshal.cs" />
   </ItemGroup>
@@ -30,7 +30,7 @@
   <ItemGroup Condition="'$(TargetGroup)' != 'netcore50aot'">
     <TargetingPackReference Include="mscorlib" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'net462'">
     <TargetingPackReference Include="System.Core" />
     <TargetingPackReference Include="System" />
   </ItemGroup>

--- a/src/System.Runtime.InteropServices.PInvoke/src/project.json
+++ b/src/System.Runtime.InteropServices.PInvoke/src/project.json
@@ -1,6 +1,6 @@
 {
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.5": {
       "dependencies": {
         "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23931-00"
       },
@@ -13,7 +13,7 @@
         "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23931-00"
       }
     },
-    "net46": {
+    "net462": {
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }

--- a/src/System.Runtime.InteropServices/src/System.Runtime.InteropServices.csproj
+++ b/src/System.Runtime.InteropServices/src/System.Runtime.InteropServices.csproj
@@ -46,7 +46,6 @@
     <None Include="project.json" />
     <ProjectReference Include="../../System.Runtime.InteropServices.PInvoke/src/System.Runtime.InteropServices.PInvoke.csproj">
       <Private>false</Private>
-      <TargetGroup Condition="'$(TargetGroup)' == 'net462'">net46</TargetGroup>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
Right now the new version of IS that typeforwards to this is NS1.5
this must also be NS1.5 to avoid type collisions.

As a seperate follow up issue we need to come up with a strategy to
oob this contract all the way back to NS1.1 so that we don't have COM
as part of NETStandard.Library.

Fixes https://github.com/dotnet/corefx/issues/7274