### PR TITLE
Add Globalization tests

### DIFF
--- a/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -2,35 +2,32 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Globalization.Tests
 {
-    public class DateTimeFormatInfoCurrentCultureTests
+    public class DateTimeFormatInfoCurrentCultureTests : RemoteExecutorTestBase
     {
         [Fact]
         public void CurrentCulture()
         {
-            // Run all tests in one method to avoid multi-threading issues
-            CultureInfo defaultCulture = CultureInfo.CurrentCulture;
-            Assert.NotEqual(CultureInfo.InvariantCulture, defaultCulture);
-
-            CultureInfo newCulture = new CultureInfo(defaultCulture.Name.Equals("ja-JP", StringComparison.OrdinalIgnoreCase) ? "ar-SA" : "ja-JP");
-            CultureInfo.CurrentCulture = newCulture;
-            try
+            RemoteInvoke(() =>
             {
+                CultureInfo newCulture = new CultureInfo(CultureInfo.CurrentCulture.Name.Equals("ja-JP", StringComparison.OrdinalIgnoreCase) ? "ar-SA" : "ja-JP");
+                CultureInfo.CurrentCulture = newCulture;
+
                 Assert.Equal(CultureInfo.CurrentCulture, newCulture);
 
                 newCulture = new CultureInfo("de-DE_phoneb");
                 CultureInfo.CurrentCulture = newCulture;
+
                 Assert.Equal(CultureInfo.CurrentCulture, newCulture);
                 Assert.Equal("de-DE_phoneb", newCulture.CompareInfo.Name);
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = defaultCulture;
-            }
-            Assert.Equal(CultureInfo.CurrentCulture, defaultCulture);
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
@@ -42,26 +39,58 @@ namespace System.Globalization.Tests
         [Fact]
         public void CurrentUICulture()
         {
-            // Run all tests in one method to avoid multi-threading issues
-            CultureInfo defaultUICulture = CultureInfo.CurrentUICulture;
-            Assert.NotEqual(CultureInfo.InvariantCulture, defaultUICulture);
-
-            CultureInfo newUICulture = new CultureInfo(defaultUICulture.Name.Equals("ja-JP", StringComparison.OrdinalIgnoreCase) ? "ar-SA" : "ja-JP");
-            CultureInfo.CurrentUICulture = newUICulture;
-            try
+            RemoteInvoke(() =>
             {
+                CultureInfo newUICulture = new CultureInfo(CultureInfo.CurrentUICulture.Name.Equals("ja-JP", StringComparison.OrdinalIgnoreCase) ? "ar-SA" : "ja-JP");
+                CultureInfo.CurrentUICulture = newUICulture;
+
                 Assert.Equal(CultureInfo.CurrentUICulture, newUICulture);
 
                 newUICulture = new CultureInfo("de-DE_phoneb");
                 CultureInfo.CurrentUICulture = newUICulture;
+
                 Assert.Equal(CultureInfo.CurrentUICulture, newUICulture);
                 Assert.Equal("de-DE_phoneb", newUICulture.CompareInfo.Name);
-            }
-            finally
+                return SuccessExitCode;
+            }).Dispose();
+        }
+
+        [Fact]
+        public void DefaultThreadCurrentCulture()
+        {
+            RemoteInvoke(() =>
             {
-                CultureInfo.CurrentUICulture = defaultUICulture;
-            }
-            Assert.Equal(CultureInfo.CurrentUICulture, defaultUICulture);
+                CultureInfo newCulture = new CultureInfo(CultureInfo.DefaultThreadCurrentCulture == null || CultureInfo.DefaultThreadCurrentCulture.Name.Equals("ja-JP", StringComparison.OrdinalIgnoreCase) ? "ar-SA" : "ja-JP");
+                CultureInfo.DefaultThreadCurrentCulture = newCulture;
+
+                Task task = Task.Run(() =>
+                {
+                    Assert.Equal(CultureInfo.CurrentCulture, newCulture);
+                });
+                ((IAsyncResult)task).AsyncWaitHandle.WaitOne();
+                task.Wait();
+
+                return SuccessExitCode;
+            }).Dispose();
+        }
+
+        [Fact]
+        public void DefaultThreadCurrentUICulture()
+        {
+            RemoteInvoke(() =>
+            {
+                CultureInfo newUICulture = new CultureInfo(CultureInfo.DefaultThreadCurrentUICulture == null || CultureInfo.DefaultThreadCurrentUICulture.Name.Equals("ja-JP", StringComparison.OrdinalIgnoreCase) ? "ar-SA" : "ja-JP");
+                CultureInfo.DefaultThreadCurrentUICulture = newUICulture;
+
+                Task task = Task.Run(() =>
+                {
+                    Assert.Equal(CultureInfo.CurrentUICulture, newUICulture);
+                });
+                ((IAsyncResult)task).AsyncWaitHandle.WaitOne();
+                task.Wait();
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
@@ -3,11 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Globalization.Tests
 {
-    public class CultureInfoDateTimeFormat
+    public class CultureInfoDateTimeFormat : RemoteExecutorTestBase
     {
         public static IEnumerable<object[]> DateTimeFormatInfo_Set_TestData()
         {
@@ -29,6 +30,20 @@ namespace System.Globalization.Tests
             CultureInfo culture = new CultureInfo(name);
             culture.DateTimeFormat = newDateTimeFormatInfo;
             Assert.Equal(newDateTimeFormatInfo, culture.DateTimeFormat);
+        }
+
+        [Fact]
+        public void TestSettingThreadCultures()
+        {
+            RemoteInvoke(() =>
+            {
+                CultureInfo culture = new CultureInfo("ja-JP");
+                CultureInfo.CurrentCulture = culture;
+                DateTime dt = new DateTime(2014, 3, 14, 3, 14, 0);
+                Assert.Equal(dt.ToString(), dt.ToString(culture));
+                Assert.Equal(dt.ToString(), dt.ToString(culture.DateTimeFormat));
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrentInfo.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrentInfo.cs
@@ -3,11 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Globalization.Tests
 {
-    public class NumberFormatInfoCurrentInfo
+    public class NumberFormatInfoCurrentInfo : RemoteExecutorTestBase
     {
         public static IEnumerable<object[]> CurrentInfo_CustomCulture_TestData()
         {
@@ -20,46 +21,37 @@ namespace System.Globalization.Tests
         [MemberData(nameof(CurrentInfo_CustomCulture_TestData))]
         public void CurrentInfo_CustomCulture(CultureInfo newCurrentCulture)
         {
-            CultureInfo oldCurrentCulture = CultureInfo.CurrentCulture;
-            try
+            RemoteInvoke((cultureName) =>
             {
-                CultureInfo.CurrentCulture = newCurrentCulture;
-                Assert.Same(newCurrentCulture.NumberFormat, NumberFormatInfo.CurrentInfo);
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = oldCurrentCulture;
-            }
+                if (cultureName.Equals("EmptyString"))
+                    cultureName = string.Empty;
+                CultureInfo newCulture = new CultureInfo(cultureName);
+                CultureInfo.CurrentCulture = newCulture;
+                Assert.Same(newCulture.NumberFormat, NumberFormatInfo.CurrentInfo);
+                return SuccessExitCode;
+            }, newCurrentCulture.Name.Length > 0 ? newCurrentCulture.Name : "EmptyString").Dispose();
         }
 
         [Fact]
         public void CurrentInfo_Subclass_OverridesGetFormat()
         {
-            CultureInfo oldCurrentCulture = CultureInfo.CurrentCulture;
-            try
+            RemoteInvoke(() =>
             {
                 CultureInfo.CurrentCulture = new CultureInfoSubclassOverridesGetFormat("en-US");
                 Assert.Same(CultureInfoSubclassOverridesGetFormat.CustomFormat, NumberFormatInfo.CurrentInfo);
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = oldCurrentCulture;
-            }
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void CurrentInfo_Subclass_OverridesNumberFormat()
         {
-            CultureInfo oldCurrentCulture = CultureInfo.CurrentCulture;
-            try
+            RemoteInvoke(() =>
             {
                 CultureInfo.CurrentCulture = new CultureInfoSubclassOverridesNumberFormat("en-US");
                 Assert.Same(CultureInfoSubclassOverridesNumberFormat.CustomFormat, NumberFormatInfo.CurrentInfo);
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = oldCurrentCulture;
-            }
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         private class CultureInfoSubclassOverridesGetFormat : CultureInfo

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -136,12 +136,23 @@
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>
     </Compile>
+    <!-- Helpers -->
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs">
       <Link>Common\System\RandomDataGenerator.cs</Link>
-    </Compile>  
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorTestBase.cs">
+      <Link>Common\System\Diagnostics\RemoteExecutorTestBase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
+      <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
+    </Compile>
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
     <TargetingPackReference Include="System" />

--- a/src/System.Globalization/tests/project.json
+++ b/src/System.Globalization/tests/project.json
@@ -9,6 +9,7 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
+        "System.Diagnostics.Process": "4.0.1-rc3-24008-00",
         "System.Globalization": "4.0.11-rc3-24008-00",
         "System.Globalization.Calendars": "4.0.1-rc3-24008-00",
         "System.Linq.Expressions": "4.0.11-rc3-24008-00",


### PR DESCRIPTION
Adds new globalization tests and modified existing tests where the CultureInfo of the process is modified. All tests that modify the process state were moved to execute in their own process.

replaces #7323.

resolves #6429