### PR TITLE
Further reduce Task allocations in GetString/ByteArrayAsync

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -159,110 +159,84 @@ namespace System.Net.Http
         public Task<string> ReadAsStringAsync()
         {
             CheckDisposed();
+            return WaitAndReturnAsync(LoadIntoBufferAsync(), this, s => s.ReadBufferedContentAsString());
+        }
 
-            var tcs = new TaskCompletionSource<string>(this);
+        internal string ReadBufferedContentAsString()
+        {
+            Debug.Assert(IsBuffered);
 
-            LoadIntoBufferAsync().ContinueWithStandard(tcs, (task, state) =>
+            if (_bufferedContent.Length == 0)
             {
-                var innerTcs = (TaskCompletionSource<string>)state;
-                var innerThis = (HttpContent)innerTcs.Task.AsyncState;
-                if (HttpUtilities.HandleFaultsAndCancelation(task, innerTcs))
-                {
-                    return;
-                }
+                return string.Empty;
+            }
 
-                if (innerThis._bufferedContent.Length == 0)
-                {
-                    innerTcs.TrySetResult(string.Empty);
-                    return;
-                }
+            // We don't validate the Content-Encoding header: If the content was encoded, it's the caller's 
+            // responsibility to make sure to only call ReadAsString() on already decoded content. E.g. if the 
+            // Content-Encoding is 'gzip' the user should set HttpClientHandler.AutomaticDecompression to get a 
+            // decoded response stream.
 
-                // We don't validate the Content-Encoding header: If the content was encoded, it's the caller's 
-                // responsibility to make sure to only call ReadAsString() on already decoded content. E.g. if the 
-                // Content-Encoding is 'gzip' the user should set HttpClientHandler.AutomaticDecompression to get a 
-                // decoded response stream.
+            Encoding encoding = null;
+            int bomLength = -1;
 
-                Encoding encoding = null;
-                int bomLength = -1;
+            ArraySegment<byte> buffer;
+            if (!TryGetBuffer(out buffer))
+            {
+                buffer = new ArraySegment<byte>(_bufferedContent.ToArray());
+            }
 
-                ArraySegment<byte> buffer;
-                if (!innerThis.TryGetBuffer(out buffer))
-                {
-                    buffer = new ArraySegment<byte>(innerThis._bufferedContent.ToArray());
-                }
-
-                // If we do have encoding information in the 'Content-Type' header, use that information to convert
-                // the content to a string.
-                if ((innerThis.Headers.ContentType != null) && (innerThis.Headers.ContentType.CharSet != null))
-                {
-                    try
-                    {
-                        encoding = Encoding.GetEncoding(innerThis.Headers.ContentType.CharSet);
-
-                        // Byte-order-mark (BOM) characters may be present even if a charset was specified.
-                        bomLength = GetPreambleLength(buffer, encoding);
-                    }
-                    catch (ArgumentException e)
-                    {
-                        innerTcs.TrySetException(new InvalidOperationException(SR.net_http_content_invalid_charset, e));
-                        return;
-                    }
-                }
-
-                // If no content encoding is listed in the ContentType HTTP header, or no Content-Type header present, 
-                // then check for a BOM in the data to figure out the encoding.
-                if (encoding == null)
-                {
-                    if (!TryDetectEncoding(buffer, out encoding, out bomLength))
-                    {
-                        // Use the default encoding (UTF8) if we couldn't detect one.
-                        encoding = DefaultStringEncoding;
-
-                        // We already checked to see if the data had a UTF8 BOM in TryDetectEncoding
-                        // and DefaultStringEncoding is UTF8, so the bomLength is 0.
-                        bomLength = 0;
-                    }
-                }
-
+            // If we do have encoding information in the 'Content-Type' header, use that information to convert
+            // the content to a string.
+            if ((Headers.ContentType != null) && (Headers.ContentType.CharSet != null))
+            {
                 try
                 {
-                    // Drop the BOM when decoding the data.
-                    string result = encoding.GetString(buffer.Array, buffer.Offset + bomLength, buffer.Count - bomLength);
-                    innerTcs.TrySetResult(result);
-                }
-                catch (Exception ex)
-                {
-                    innerTcs.TrySetException(ex);
-                }
-            });
+                    encoding = Encoding.GetEncoding(Headers.ContentType.CharSet);
 
-            return tcs.Task;
+                    // Byte-order-mark (BOM) characters may be present even if a charset was specified.
+                    bomLength = GetPreambleLength(buffer, encoding);
+                }
+                catch (ArgumentException e)
+                {
+                    throw new InvalidOperationException(SR.net_http_content_invalid_charset, e);
+                }
+            }
+
+            // If no content encoding is listed in the ContentType HTTP header, or no Content-Type header present, 
+            // then check for a BOM in the data to figure out the encoding.
+            if (encoding == null)
+            {
+                if (!TryDetectEncoding(buffer, out encoding, out bomLength))
+                {
+                    // Use the default encoding (UTF8) if we couldn't detect one.
+                    encoding = DefaultStringEncoding;
+
+                    // We already checked to see if the data had a UTF8 BOM in TryDetectEncoding
+                    // and DefaultStringEncoding is UTF8, so the bomLength is 0.
+                    bomLength = 0;
+                }
+            }
+
+            // Drop the BOM when decoding the data.
+            return encoding.GetString(buffer.Array, buffer.Offset + bomLength, buffer.Count - bomLength);
         }
 
         public Task<byte[]> ReadAsByteArrayAsync()
         {
             CheckDisposed();
+            return WaitAndReturnAsync(LoadIntoBufferAsync(), this, s => s.ReadBufferedContentAsByteArray());
+        }
 
-            var tcs = new TaskCompletionSource<byte[]>(this);
-
-            LoadIntoBufferAsync().ContinueWithStandard(tcs, (task, state) =>
-            {
-                var innerTcs = (TaskCompletionSource<byte[]>)state;
-                var innerThis = (HttpContent)innerTcs.Task.AsyncState;
-                if (!HttpUtilities.HandleFaultsAndCancelation(task, innerTcs))
-                {
-                    innerTcs.TrySetResult(innerThis._bufferedContent.ToArray());
-                }
-            });
-
-            return tcs.Task;
+        internal byte[] ReadBufferedContentAsByteArray()
+        {
+            // The returned array is exposed out of the library, so use ToArray rather 
+            // than TryGetBuffer in order to make a copy.
+            return _bufferedContent.ToArray(); 
         }
 
         public Task<Stream> ReadAsStreamAsync()
         {
             CheckDisposed();
-
-            TaskCompletionSource<Stream> tcs = new TaskCompletionSource<Stream>(this);
 
             ArraySegment<byte> buffer;
             if (_contentReadStream == null && TryGetBuffer(out buffer))
@@ -270,11 +244,14 @@ namespace System.Net.Http
                 _contentReadStream = new MemoryStream(buffer.Array, buffer.Offset, buffer.Count, writable: false);
             }
 
-            if (_contentReadStream != null)
-            {
-                tcs.TrySetResult(_contentReadStream);
-                return tcs.Task;
-            }
+            return _contentReadStream != null ?
+                Task.FromResult(_contentReadStream) :
+                ReadAsStreamAsyncCore();
+        }
+
+        private Task<Stream> ReadAsStreamAsyncCore()
+        {
+            TaskCompletionSource<Stream> tcs = new TaskCompletionSource<Stream>(this);
 
             CreateContentReadStreamAsync().ContinueWithStandard(tcs, (task, state) =>
             {
@@ -690,6 +667,12 @@ namespace System.Net.Http
         }
 
         #endregion Helpers
+
+        private static async Task<TResult> WaitAndReturnAsync<TState, TResult>(Task waitTask, TState state, Func<TState, TResult> returnFunc)
+        {
+            await waitTask.ConfigureAwait(false);
+            return returnFunc(state);
+        }
 
         internal sealed class LimitMemoryStream : MemoryStream
         {


### PR DESCRIPTION
The HttpContent ReadAsStringAsync and ReadAsByteArrayAsync methods ensure that the data is loaded into the buffer, via an async operation, and then process that buffer synchronously.  This refactors that synchronous processing into its own method, and changes ReadAs methods to use a simple async method that does the await on LoadIntoBufferAsync and then calls these methods.  This avoids any task-related allocations if the data is already buffered.  It also makes those synchronous methods callable from the GetString/ByteArrayAsync directly, such that these methods can avoid an extra layer of continuations, as they already do their own buffering. 

I will separately follow-up on converting the rest of HttpContent to use async/await where it makes sense.

cc: @davidsh, @cipop, @ericeil, @kapilash