### PR TITLE
Add Byte, Int16, Int32, Int64, SByte, UInt16, UInt32 and UInt64 tests

### DIFF
--- a/src/System.Runtime/tests/System/Byte.cs
+++ b/src/System.Runtime/tests/System/Byte.cs
@@ -5,24 +5,22 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Runtime.Tests.Common;
-
 using Xunit;
 
 public static class ByteTests
 {
     [Fact]
-    public static void TestCtorEmpty()
+    public static void TestCtor_Empty()
     {
-        byte i = new byte();
-        Assert.Equal(0, i);
+        var b = new byte();
+        Assert.Equal(0, b);
     }
-    
+
     [Fact]
-    public static void TestCtorValue()
+    public static void TestCtor_Value()
     {
-        byte i = 41;
-        Assert.Equal(41, i);
+        byte b = 41;
+        Assert.Equal(41, b);
     }
 
     [Fact]
@@ -38,238 +36,226 @@ public static class ByteTests
     }
 
     [Theory]
-    [InlineData((byte)234, 0)]
-    [InlineData(byte.MinValue, 1)]
-    [InlineData((byte)0, 1)]
-    [InlineData((byte)45, 1)]
-    [InlineData((byte)123, 1)]
-    [InlineData((byte)235, -1)]
-    [InlineData(byte.MaxValue, -1)]
-    public static void TestCompareTo(byte value, int expected)
+    [InlineData((byte)234, (byte)234, 0)]
+    [InlineData((byte)234, byte.MinValue, 1)]
+    [InlineData((byte)234, (byte)0, 1)]
+    [InlineData((byte)234, (byte)123, 1)]
+    [InlineData((byte)234, (byte)235, -1)]
+    [InlineData((byte)234, byte.MaxValue, -1)]
+    [InlineData((byte)234, null, 1)]
+    public static void TestCompareTo(byte b, object value, int expected)
     {
-        byte i = 234;
-        int result = CompareHelper.NormalizeCompare(i.CompareTo(value));
-        Assert.Equal(expected, result);
+        if (value is byte)
+        {
+            Assert.Equal(expected, Math.Sign(b.CompareTo((byte)value)));
+        }
+        IComparable comparable = b;
+        Assert.Equal(expected, Math.Sign(comparable.CompareTo(value)));
     }
 
-    [Theory]
-    [InlineData(null, 1)]
-    [InlineData((byte)234, 0)]
-    [InlineData(byte.MinValue, 1)]
-    [InlineData((byte)0, 1)]
-    [InlineData((byte)45, 1)]
-    [InlineData((byte)123, 1)]
-    [InlineData((byte)235, -1)]
-    [InlineData(byte.MaxValue, -1)]
-    public static void TestCompareToObject(object obj, int expected)
+    [Fact]
+    public static void TestCompareTo_Invalid()
     {
         IComparable comparable = (byte)234;
-        int i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
-        Assert.Equal(expected, i);
-    }
-
-    [Fact]
-    public static void TestCompareToObjectInvalid()
-    {
-        IComparable comparable = (byte)234;
-        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a byte
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); // Obj is not a byte
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo(234)); // Obj is not a byte
     }
 
     [Theory]
-    [InlineData((byte)78, true)]
-    [InlineData((byte)0, false)]
-    public static void TestEqualsObject(object obj, bool expected)
+    [InlineData((byte)78, (byte)78, true)]
+    [InlineData((byte)78, (byte)0, false)]
+    [InlineData((byte)0, (byte)0, true)]
+    [InlineData((byte)78, null, false)]
+    [InlineData((byte)78, "78", false)]
+    [InlineData((byte)78, 78, false)]
+    public static void TestEquals(byte b, object obj, bool expected)
     {
-        byte i = 78;
-        Assert.Equal(expected, i.Equals(obj));
+        if (obj is byte)
+        {
+            byte b2 = (byte)obj;
+            Assert.Equal(expected, b.Equals(b2));
+            Assert.Equal(expected, b.GetHashCode().Equals(b2.GetHashCode()));
+            Assert.Equal(b, b.GetHashCode());
+        }
+        Assert.Equal(expected, b.Equals(obj));
+    }
+
+    public static IEnumerable<object[]> ToString_TestData()
+    {
+        NumberFormatInfo emptyFormat = NumberFormatInfo.CurrentInfo;
+        yield return new object[] { (byte)0, "G", emptyFormat, "0" };
+        yield return new object[] { (byte)123, "G", emptyFormat, "123" };
+        yield return new object[] { byte.MaxValue, "G", emptyFormat, "255" };
+
+        yield return new object[] { (byte)0x24, "x", emptyFormat, "24" };
+        yield return new object[] { (byte)24, "N", emptyFormat, string.Format("{0:N}", 24.00) };
+
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.NegativeSign = "#";
+        customFormat.NumberDecimalSeparator = "~";
+        customFormat.NumberGroupSeparator = "*";
+        yield return new object[] { (byte)24, "N", customFormat, "24~00" };
     }
 
     [Theory]
-    [InlineData((byte)78, true)]
-    [InlineData((byte)0, false)]
-    public static void TestEquals(byte i2, bool expected)
+    [MemberData(nameof(ToString_TestData))]
+    public static void TestToString(byte b, string format, IFormatProvider provider, string expected)
     {
-        byte i = 78;
-        Assert.Equal(expected, i.Equals(i2));
+        // Format is case insensitive
+        string upperFormat = format.ToUpperInvariant();
+        string lowerFormat = format.ToLowerInvariant();
+
+        string upperExpected = expected.ToUpperInvariant();
+        string lowerExpected = expected.ToLowerInvariant();
+
+        bool isDefaultProvider = (provider == null || provider == NumberFormatInfo.CurrentInfo);
+        if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")
+        {
+            if (isDefaultProvider)
+            {
+                Assert.Equal(upperExpected, b.ToString());
+                Assert.Equal(upperExpected, b.ToString((IFormatProvider)null));
+            }
+            Assert.Equal(upperExpected, b.ToString(provider));
+        }
+        if (isDefaultProvider)
+        {
+            Assert.Equal(upperExpected, b.ToString(upperFormat));
+            Assert.Equal(lowerExpected, b.ToString(lowerFormat));
+            Assert.Equal(upperExpected, b.ToString(upperFormat, null));
+            Assert.Equal(lowerExpected, b.ToString(lowerFormat, null));
+        }
+        Assert.Equal(upperExpected, b.ToString(upperFormat, provider));
+        Assert.Equal(lowerExpected, b.ToString(lowerFormat, provider));
     }
 
     [Fact]
-    public static void TestGetHashCode()
+    public static void TestToString_Invalid()
     {
-        byte i1 = 123;
-        byte i2 = 65;
-
-        Assert.NotEqual(0, i1.GetHashCode());
-        Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
+        byte b = 123;
+        Assert.Throws<FormatException>(() => b.ToString("Y")); // Invalid format
+        Assert.Throws<FormatException>(() => b.ToString("Y", null)); // Invalid format
     }
 
-    [Fact]
-    public static void TestToString()
+    public static IEnumerable<object[]> Parse_Valid_TestData()
     {
-        byte i1 = 63;
-        Assert.Equal("63", i1.ToString());
-    }
-
-    [Fact]
-    public static void TestToStringFormatProvider()
-    {
-        var numberFormat = new NumberFormatInfo();
-
-        byte i1 = 63;
-        Assert.Equal("63", i1.ToString(numberFormat));
-    }
-
-    [Fact]
-    public static void TestToStringFormat()
-    {
-        byte i1 = 63;
-        Assert.Equal("63", i1.ToString("G"));
-
-        byte i2 = 82;
-        Assert.Equal("82", i2.ToString("g"));
-
-        byte i3 = 246;
-        Assert.Equal(string.Format("{0:N}", 246.00), i3.ToString("N"));
-
-        byte i4 = 0x24;
-        Assert.Equal("24", i4.ToString("x"));
-    }
-
-    [Fact]
-    public static void TestToStringFormatFormatProvider()
-    {
-        var numberFormat = new NumberFormatInfo();
-
-        byte i1 = 63;
-        Assert.Equal("63", i1.ToString("G", numberFormat));
-
-        byte i2 = 82;
-        Assert.Equal("82", i2.ToString("g", numberFormat));
-
-        numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
-        numberFormat.NumberGroupSeparator = "*";
-        numberFormat.NumberNegativePattern = 0;
-        numberFormat.NumberDecimalSeparator = ".";
-        byte i3 = 24;
-        Assert.Equal("24.00", i3.ToString("N", numberFormat));
-    }
-
-    public static IEnumerable<object[]> ParseValidData()
-    {
-        NumberFormatInfo defaultFormat = null;
+        NumberFormatInfo nullFormat = null;
         NumberStyles defaultStyle = NumberStyles.Integer;
-        var emptyNfi = new NumberFormatInfo();
+        NumberFormatInfo emptyFormat = new NumberFormatInfo();
 
-        var testNfi = new NumberFormatInfo();
-        testNfi.CurrencySymbol = "$";
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.CurrencySymbol = "$";
 
-        yield return new object[] { "0", defaultStyle, defaultFormat, (byte)0 };
-        yield return new object[] { "123", defaultStyle, defaultFormat, (byte)123 };
-        yield return new object[] { "  123  ", defaultStyle, defaultFormat, (byte)123 };
-        yield return new object[] { "255", defaultStyle, defaultFormat, (byte)255 };
+        yield return new object[] { "0", defaultStyle, nullFormat, (byte)0 };
+        yield return new object[] { "123", defaultStyle, nullFormat, (byte)123 };
+        yield return new object[] { "  123  ", defaultStyle, nullFormat, (byte)123 };
+        yield return new object[] { "255", defaultStyle, nullFormat, (byte)255 };
 
-        yield return new object[] { "12", NumberStyles.HexNumber, defaultFormat, (byte)0x12 };
-        yield return new object[] { "10", NumberStyles.AllowThousands, defaultFormat, (byte)10 };
+        yield return new object[] { "12", NumberStyles.HexNumber, nullFormat, (byte)0x12 };
+        yield return new object[] { "10", NumberStyles.AllowThousands, nullFormat, (byte)10 };
 
-        yield return new object[] { "123", defaultStyle, emptyNfi, (byte)123 };
+        yield return new object[] { "123", defaultStyle, emptyFormat, (byte)123 };
 
-        yield return new object[] { "123", NumberStyles.Any, emptyNfi, (byte)123 };
-        yield return new object[] { "12", NumberStyles.HexNumber, emptyNfi, (byte)0x12 };
-        yield return new object[] { "ab", NumberStyles.HexNumber, emptyNfi, (byte)0xab };
-        yield return new object[] { "$100", NumberStyles.Currency, testNfi, (byte)100 };
+        yield return new object[] { "123", NumberStyles.Any, emptyFormat, (byte)123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, emptyFormat, (byte)0x12 };
+        yield return new object[] { "ab", NumberStyles.HexNumber, emptyFormat, (byte)0xab };
+        yield return new object[] { "$100", NumberStyles.Currency, customFormat, (byte)100 };
     }
 
-    public static IEnumerable<object[]> ParseInvalidData()
+    [Theory]
+    [MemberData(nameof(Parse_Valid_TestData))]
+    public static void TestParse(string value, NumberStyles style, IFormatProvider provider, byte expected)
     {
-        NumberFormatInfo defaultFormat = null;
-        NumberStyles defaultStyle = NumberStyles.Integer;
-        var emptyNfi = new NumberFormatInfo();
-
-        var testNfi = new NumberFormatInfo();
-        testNfi.CurrencySymbol = "$";
-        testNfi.NumberDecimalSeparator = ".";
-
-        yield return new object[] { null, defaultStyle, defaultFormat, typeof(ArgumentNullException) };
-        yield return new object[] { "", defaultStyle, defaultFormat, typeof(FormatException) };
-        yield return new object[] { " ", defaultStyle, defaultFormat, typeof(FormatException) };
-        yield return new object[] { "Garbage", defaultStyle, defaultFormat, typeof(FormatException) };
-
-        yield return new object[] { "ab", defaultStyle, defaultFormat, typeof(FormatException) }; // Hex value
-        yield return new object[] { "1E23", defaultStyle, defaultFormat, typeof(FormatException) }; // Exponent
-        yield return new object[] { "(123)", defaultStyle, defaultFormat, typeof(FormatException) }; // Parentheses
-        yield return new object[] { 100.ToString("C0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Currency
-        yield return new object[] { 1000.ToString("N0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Thousands
-        yield return new object[] { 67.90.ToString("F2"), defaultStyle, defaultFormat, typeof(FormatException) }; //Decimal
-
-        yield return new object[] { "ab", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Negative hex value
-        yield return new object[] { "  123  ", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Trailing and leading whitespace
-
-        yield return new object[] { "67.90", defaultStyle, testNfi, typeof(FormatException) }; // Decimal
-
-        yield return new object[] { "-1", defaultStyle, defaultFormat, typeof(OverflowException) }; // < min value
-        yield return new object[] { "256", defaultStyle, defaultFormat, typeof(OverflowException) }; // > max value
-        yield return new object[] { "(123)", NumberStyles.AllowParentheses, defaultFormat, typeof(OverflowException) }; // Parentheses = negative
-    }
-
-    [Theory, MemberData(nameof(ParseValidData))]
-    public static void TestParse(string value, NumberStyles style, NumberFormatInfo nfi, byte expected)
-    {
-        byte i;
-        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        byte result;
+        // If no style is specified, use the (String) or (String, IFormatProvider) overload
         if (style == NumberStyles.Integer)
         {
-            Assert.Equal(true, byte.TryParse(value, out i));
-            Assert.Equal(expected, i);
+            Assert.True(byte.TryParse(value, out result));
+            Assert.Equal(expected, result);
 
             Assert.Equal(expected, byte.Parse(value));
-            
-            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-            if (nfi != null)
+
+            // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (provider != null)
             {
-                Assert.Equal(expected, byte.Parse(value, nfi));
+                Assert.Equal(expected, byte.Parse(value, provider));
             }
         }
 
         // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-        Assert.Equal(true, byte.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
-        Assert.Equal(expected, i);
+        Assert.True(byte.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
+        Assert.Equal(expected, result);
 
-        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
-        if (nfi == null)
+        // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (provider == null)
         {
             Assert.Equal(expected, byte.Parse(value, style));
         }
-        Assert.Equal(expected, byte.Parse(value, style, nfi ?? new NumberFormatInfo()));
+        Assert.Equal(expected, byte.Parse(value, style, provider ?? new NumberFormatInfo()));
     }
 
-    [Theory, MemberData(nameof(ParseInvalidData))]
-    public static void TestParseInvalid(string value, NumberStyles style, NumberFormatInfo nfi, Type exceptionType)
+    public static IEnumerable<object[]> Parse_Invalid_TestData()
     {
-        byte i;
-        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        NumberFormatInfo nullFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.CurrencySymbol = "$";
+        customFormat.NumberDecimalSeparator = ".";
+
+        yield return new object[] { null, defaultStyle, nullFormat, typeof(ArgumentNullException) };
+        yield return new object[] { "", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { " ", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, nullFormat, typeof(FormatException) };
+
+        yield return new object[] { "ab", defaultStyle, nullFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, nullFormat, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, nullFormat, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 100.ToString("C0"), defaultStyle, nullFormat, typeof(FormatException) }; // Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, nullFormat, typeof(FormatException) }; // Thousands
+        yield return new object[] { 67.90.ToString("F2"), defaultStyle, nullFormat, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "ab", NumberStyles.None, nullFormat, typeof(FormatException) }; // Negative hex value
+        yield return new object[] { "  123  ", NumberStyles.None, nullFormat, typeof(FormatException) }; // Trailing and leading whitespace
+
+        yield return new object[] { "67.90", defaultStyle, customFormat, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "-1", defaultStyle, nullFormat, typeof(OverflowException) }; // < min value
+        yield return new object[] { "256", defaultStyle, nullFormat, typeof(OverflowException) }; // > max value
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, nullFormat, typeof(OverflowException) }; // Parentheses = negative
+
+        yield return new object[] { "2147483648", defaultStyle, nullFormat, typeof(OverflowException) }; // Internally, Parse pretends we are inputting an Int32, so this overflows
+    }
+
+    [Theory]
+    [MemberData(nameof(Parse_Invalid_TestData))]
+    public static void TestParse_Invalid(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
+    {
+        byte result;
+        // If no style is specified, use the (String) or (String, IFormatProvider) overload
         if (style == NumberStyles.Integer)
         {
-            Assert.Equal(false, byte.TryParse(value, out i));
-            Assert.Equal(default(byte), i);
-            
+            Assert.False(byte.TryParse(value, out result));
+            Assert.Equal(default(byte), result);
+
             Assert.Throws(exceptionType, () => byte.Parse(value));
 
-            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-            if (nfi != null)
+            // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (provider != null)
             {
-                Assert.Throws(exceptionType, () => byte.Parse(value, nfi));
+                Assert.Throws(exceptionType, () => byte.Parse(value, provider));
             }
         }
 
         // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-        Assert.Equal(false, byte.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
-        Assert.Equal(default(byte), i);
+        Assert.False(byte.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
+        Assert.Equal(default(byte), result);
 
-        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
-        if (nfi == null)
+        // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (provider == null)
         {
             Assert.Throws(exceptionType, () => byte.Parse(value, style));
         }
-        Assert.Throws(exceptionType, () => byte.Parse(value, style, nfi ?? new NumberFormatInfo()));
+        Assert.Throws(exceptionType, () => byte.Parse(value, style, provider ?? new NumberFormatInfo()));
     }
 }

--- a/src/System.Runtime/tests/System/Decimal.cs
+++ b/src/System.Runtime/tests/System/Decimal.cs
@@ -627,7 +627,7 @@ public static class DecimalTests
         yield return new object[] { "123.456   ", NumberStyles.None, nullFormat, typeof(FormatException) }; // Leading space
         yield return new object[] { "1E23", NumberStyles.None, nullFormat, typeof(FormatException) }; // Exponent
 
-        yield return new object[] { "ab", NumberStyles.None, nullFormat, typeof(FormatException) }; // Negative hex value
+        yield return new object[] { "ab", NumberStyles.None, nullFormat, typeof(FormatException) }; // Hex value
         yield return new object[] { "  123  ", NumberStyles.None, nullFormat, typeof(FormatException) }; // Trailing and leading whitespace
     }
 

--- a/src/System.Runtime/tests/System/Int16.cs
+++ b/src/System.Runtime/tests/System/Int16.cs
@@ -5,21 +5,19 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Runtime.Tests.Common;
-
 using Xunit;
 
 public static class Int16Tests
 {
     [Fact]
-    public static void TestCtorEmpty()
+    public static void TestCtor_Empty()
     {
-        short i = new short();
+        var i = new short();
         Assert.Equal(0, i);
     }
 
     [Fact]
-    public static void TestCtorValue()
+    public static void TestCtor_Value()
     {
         short i = 41;
         Assert.Equal(41, i);
@@ -38,258 +36,237 @@ public static class Int16Tests
     }
 
     [Theory]
-    [InlineData((short)234, 0)]
-    [InlineData(short.MinValue, 1)]
-    [InlineData((short)(-123), 1)]
-    [InlineData((short)0, 1)]
-    [InlineData((short)45, 1)]
-    [InlineData((short)123, 1)]
-    [InlineData((short)456, -1)]
-    [InlineData(short.MaxValue, -1)]
-    public static void TestCompareTo(short value, int expected)
+    [InlineData((short)234, (short)234, 0)]
+    [InlineData((short)234, short.MinValue, 1)]
+    [InlineData((short)234, (short)-123, 1)]
+    [InlineData((short)234, (short)0, 1)]
+    [InlineData((short)234, (short)123, 1)]
+    [InlineData((short)234, (short)456, -1)]
+    [InlineData((short)234, short.MaxValue, -1)]
+    [InlineData((short)234, null, 1)]
+    public static void TestCompareTo(short i, object obj, int expected)
     {
-        short i = 234;
-        int result = CompareHelper.NormalizeCompare(i.CompareTo(value));
-        Assert.Equal(expected, result);
+        if (obj is short)
+        {
+            Assert.Equal(expected, Math.Sign(i.CompareTo((short)obj)));
+        }
+        IComparable comparable = i;
+        Assert.Equal(expected, Math.Sign(comparable.CompareTo(obj)));
     }
 
-    [Theory]
-    [InlineData(null, 1)]
-    [InlineData((short)234, 0)]
-    [InlineData(short.MinValue, 1)]
-    [InlineData((short)(-123), 1)]
-    [InlineData((short)0, 1)]
-    [InlineData((short)45, 1)]
-    [InlineData((short)123, 1)]
-    [InlineData((short)456, -1)]
-    [InlineData(short.MaxValue, -1)]
-    public static void TestCompareToObject(object obj, int expected)
+    [Fact]
+    public static void TestCompareTo_Invalid()
     {
         IComparable comparable = (short)234;
-        int i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
-        Assert.Equal(expected, i);
-    }
-
-    [Fact]
-    public static void TestCompareToObjectInvalid()
-    {
-        IComparable comparable = (short)234;
-        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a short
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); // Obj is not a short
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo(234)); // Obj is not a short
     }
 
     [Theory]
-    [InlineData((short)789, true)]
-    [InlineData((short)(-789), false)]
-    [InlineData((short)0, false)]
-    public static void TestEqualsObject(object obj, bool expected)
+    [InlineData((short)789, (short)789, true)]
+    [InlineData((short)789, (short)-789, false)]
+    [InlineData((short)789, (short)0, false)]
+    [InlineData((short)0, (short)0, true)]
+    [InlineData((short)789, null, false)]
+    [InlineData((short)789, "789", false)]
+    [InlineData((short)789, 789, false)]
+    public static void TestEquals(short i1, object obj, bool expected)
     {
-        short i = 789;
-        Assert.Equal(expected, i.Equals(obj));
+        if (obj is short)
+        {
+            short i2 = (short)obj;
+            Assert.Equal(expected, i1.Equals(i2));
+            Assert.Equal(expected, i1.GetHashCode().Equals(i2.GetHashCode()));
+        }
+        Assert.Equal(expected, i1.Equals(obj));
+    }
+
+    public static IEnumerable<object[]> ToString_TestData()
+    {
+        NumberFormatInfo emptyFormat = NumberFormatInfo.CurrentInfo;
+        yield return new object[] { short.MinValue, "G", emptyFormat, "-32768" };
+        yield return new object[] { (short)-4567, "G", emptyFormat, "-4567" };
+        yield return new object[] { (short)0, "G", emptyFormat, "0" };
+        yield return new object[] { (short)4567, "G", emptyFormat, "4567" };
+        yield return new object[] { short.MaxValue, "G", emptyFormat, "32767" };
+
+        yield return new object[] { (short)0x2468, "x", emptyFormat, "2468" };
+        yield return new object[] { (short)-0x2468, "x", emptyFormat, "DB98" };
+
+        yield return new object[] { (short)2468, "N", emptyFormat, string.Format("{0:N}", 2468.00) };
+
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.NegativeSign = "#";
+        customFormat.NumberDecimalSeparator = "~";
+        customFormat.NumberGroupSeparator = "*";
+        yield return new object[] { (short)-2468, "N", customFormat, "#2*468~00" };
+        yield return new object[] { (short)2468, "N", customFormat, "2*468~00" };
     }
 
     [Theory]
-    [InlineData((short)789, true)]
-    [InlineData((short)(-789), false)]
-    [InlineData((short)0, false)]
-    public static void TestEquals(short i2, bool expected)
+    [MemberData(nameof(ToString_TestData))]
+    public static void TestToString(short i, string format, IFormatProvider provider, string expected)
     {
-        short i = 789;
-        Assert.Equal(expected, i.Equals(i2));
+        // Format is case insensitive
+        string upperFormat = format.ToUpperInvariant();
+        string lowerFormat = format.ToLowerInvariant();
+
+        string upperExpected = expected.ToUpperInvariant();
+        string lowerExpected = expected.ToLowerInvariant();
+
+        bool isDefaultProvider = (provider == null || provider == NumberFormatInfo.CurrentInfo);
+        if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")
+        {
+            if (isDefaultProvider)
+            {
+                Assert.Equal(upperExpected, i.ToString());
+                Assert.Equal(upperExpected, i.ToString((IFormatProvider)null));
+            }
+            Assert.Equal(upperExpected, i.ToString(provider));
+        }
+        if (isDefaultProvider)
+        {
+            Assert.Equal(upperExpected, i.ToString(upperFormat));
+            Assert.Equal(lowerExpected, i.ToString(lowerFormat));
+            Assert.Equal(upperExpected, i.ToString(upperFormat, null));
+            Assert.Equal(lowerExpected, i.ToString(lowerFormat, null));
+        }
+        Assert.Equal(upperExpected, i.ToString(upperFormat, provider));
+        Assert.Equal(lowerExpected, i.ToString(lowerFormat, provider));
     }
 
     [Fact]
-    public static void TestGetHashCode()
+    public static void TestToString_Invalid()
     {
-        short i1 = 123;
-        short i2 = 654;
-
-        Assert.NotEqual(0, i1.GetHashCode());
-        Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
+        short i = 123;
+        Assert.Throws<FormatException>(() => i.ToString("Y")); // Invalid format
+        Assert.Throws<FormatException>(() => i.ToString("Y", null)); // Invalid format
     }
 
-    [Fact]
-    public static void TestToString()
+    public static IEnumerable<object[]> Parse_Valid_TestData()
     {
-        short i1 = 6310;
-        Assert.Equal("6310", i1.ToString());
-
-        short i2 = -8249;
-        Assert.Equal("-8249", i2.ToString());
-    }
-
-    [Fact]
-    public static void TestToStringFormatProvider()
-    {
-        var numberFormat = new NumberFormatInfo();
-
-        short i1 = 6310;
-        Assert.Equal("6310", i1.ToString(numberFormat));
-
-        short i2 = -8249;
-        Assert.Equal("-8249", i2.ToString(numberFormat));
-
-        short i3 = -2468;
-
-        // Changing the negative pattern doesn't do anything without also passing in a format string
-        numberFormat.NumberNegativePattern = 0;
-        Assert.Equal("-2468", i3.ToString(numberFormat));
-    }
-
-    [Fact]
-    public static void TestToStringFormat()
-    {
-        short i1 = 6310;
-        Assert.Equal("6310", i1.ToString("G"));
-
-        short i2 = -8249;
-        Assert.Equal("-8249", i2.ToString("g"));
-
-        short i3 = -2468;
-        Assert.Equal(string.Format("{0:N}", -2468.00), i3.ToString("N"));
-
-        short i4 = 0x248;
-        Assert.Equal("248", i4.ToString("x"));
-    }
-
-    [Fact]
-    public static void TestToStringFormatFormatProvider()
-    {
-        var numberFormat = new NumberFormatInfo();
-
-        short i1 = 6310;
-        Assert.Equal("6310", i1.ToString("G", numberFormat));
-
-        short i2 = -8249;
-        Assert.Equal("-8249", i2.ToString("g", numberFormat));
-
-        numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
-        numberFormat.NumberGroupSeparator = "*";
-        numberFormat.NumberNegativePattern = 0;
-        short i3 = -2468;
-        Assert.Equal("(2*468.00)", i3.ToString("N", numberFormat));
-
-        short i4 = -10;
-        Assert.Equal("FFF6", i4.ToString("X", numberFormat));
-    }
-
-    public static IEnumerable<object[]> ParseValidData()
-    {
-        NumberFormatInfo defaultFormat = null;
+        NumberFormatInfo nullFormat = null;
         NumberStyles defaultStyle = NumberStyles.Integer;
-        var emptyNfi = new NumberFormatInfo();
+        NumberFormatInfo emptyFormat = new NumberFormatInfo();
 
-        var testNfi = new NumberFormatInfo();
-        testNfi.CurrencySymbol = "$";
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.CurrencySymbol = "$";
 
-        yield return new object[] { "-32768", defaultStyle, defaultFormat, (short)-32768 };
-        yield return new object[] { "-123", defaultStyle, defaultFormat, (short)-123 };
-        yield return new object[] { "0", defaultStyle, defaultFormat, (short)0 };
-        yield return new object[] { "123", defaultStyle, defaultFormat, (short)123 };
-        yield return new object[] { "  123  ", defaultStyle, defaultFormat, (short)123 };
-        yield return new object[] { "32767", defaultStyle, defaultFormat, (short)32767 };
+        yield return new object[] { "-32768", defaultStyle, nullFormat, (short)-32768 };
+        yield return new object[] { "-123", defaultStyle, nullFormat, (short)-123 };
+        yield return new object[] { "0", defaultStyle, nullFormat, (short)0 };
+        yield return new object[] { "123", defaultStyle, nullFormat, (short)123 };
+        yield return new object[] { "  123  ", defaultStyle, nullFormat, (short)123 };
+        yield return new object[] { "32767", defaultStyle, nullFormat, (short)32767 };
 
-        yield return new object[] { "123", NumberStyles.HexNumber, defaultFormat, (short )0x123 };
-        yield return new object[] { "abc", NumberStyles.HexNumber, defaultFormat, (short)0xabc };
-        yield return new object[] { "1000", NumberStyles.AllowThousands, defaultFormat, (short)1000 };
-        yield return new object[] { "(123)", NumberStyles.AllowParentheses, defaultFormat, (short)-123 }; // Parentheses = negative
+        yield return new object[] { "123", NumberStyles.HexNumber, nullFormat, (short)0x123 };
+        yield return new object[] { "abc", NumberStyles.HexNumber, nullFormat, (short)0xabc };
+        yield return new object[] { "1000", NumberStyles.AllowThousands, nullFormat, (short)1000 };
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, nullFormat, (short)-123 }; // Parentheses = negative
 
-        yield return new object[] { "123", defaultStyle, emptyNfi, (short)123 };
+        yield return new object[] { "123", defaultStyle, emptyFormat, (short)123 };
 
-        yield return new object[] { "123", NumberStyles.Any, emptyNfi, (short)123 };
-        yield return new object[] { "12", NumberStyles.HexNumber, emptyNfi, (short)0x12 };
-        yield return new object[] { "$1,000", NumberStyles.Currency, testNfi, (short)1000 };
+        yield return new object[] { "123", NumberStyles.Any, emptyFormat, (short)123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, emptyFormat, (short)0x12 };
+        yield return new object[] { "$1,000", NumberStyles.Currency, customFormat, (short)1000 };
     }
 
-    public static IEnumerable<object[]> ParseInvalidData()
+    [Theory]
+    [MemberData(nameof(Parse_Valid_TestData))]
+    public static void TestParse(string value, NumberStyles style, IFormatProvider provider, short expected)
     {
-        NumberFormatInfo defaultFormat = null;
-        NumberStyles defaultStyle = NumberStyles.Integer;
-        var emptyNfi = new NumberFormatInfo();
-
-        var testNfi = new NumberFormatInfo();
-        testNfi.CurrencySymbol = "$";
-        testNfi.NumberDecimalSeparator = ".";
-
-        yield return new object[] { null, defaultStyle, defaultFormat, typeof(ArgumentNullException) };
-        yield return new object[] { "", defaultStyle, defaultFormat, typeof(FormatException) };
-        yield return new object[] { " ", defaultStyle, defaultFormat, typeof(FormatException) };
-        yield return new object[] { "Garbage", defaultStyle, defaultFormat, typeof(FormatException) };
-
-        yield return new object[] { "abc", defaultStyle, defaultFormat, typeof(FormatException) }; // Hex value
-        yield return new object[] { "1E23", defaultStyle, defaultFormat, typeof(FormatException) }; // Exponent
-        yield return new object[] { "(123)", defaultStyle, defaultFormat, typeof(FormatException) }; // Parentheses
-        yield return new object[] { 1000.ToString("C0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Currency
-        yield return new object[] { 1000.ToString("N0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Thousands
-        yield return new object[] { 678.90.ToString("F2"), defaultStyle, defaultFormat, typeof(FormatException) }; //Decimal
-
-        yield return new object[] { "abc", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Negative hex value
-        yield return new object[] { "  123  ", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Trailing and leading whitespace
-
-        yield return new object[] { "67.90", defaultStyle, testNfi, typeof(FormatException) }; // Decimal
-        
-        yield return new object[] { "-32769", defaultStyle, defaultFormat, typeof(OverflowException) }; // < min value
-        yield return new object[] { "32768", defaultStyle, defaultFormat, typeof(OverflowException) }; // > max value
-    }
-
-    [Theory, MemberData(nameof(ParseValidData))]
-    public static void TestParse(string value, NumberStyles style, NumberFormatInfo nfi, short expected)
-    {
-        short i;
-        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        short result;
+        // If no style is specified, use the (String) or (String, IFormatProvider) overload
         if (style == NumberStyles.Integer)
         {
-            Assert.Equal(true, short.TryParse(value, out i));
-            Assert.Equal(expected, i);
+            Assert.True(short.TryParse(value, out result));
+            Assert.Equal(expected, result);
 
             Assert.Equal(expected, short.Parse(value));
 
-            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-            if (nfi != null)
+            // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (provider != null)
             {
-                Assert.Equal(expected, short.Parse(value, nfi));
+                Assert.Equal(expected, short.Parse(value, provider));
             }
         }
 
         // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-        Assert.Equal(true, short.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
-        Assert.Equal(expected, i);
+        Assert.True(short.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
+        Assert.Equal(expected, result);
 
-        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
-        if (nfi == null)
+        // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (provider == null)
         {
             Assert.Equal(expected, short.Parse(value, style));
         }
-        Assert.Equal(expected, short.Parse(value, style, nfi ?? new NumberFormatInfo()));
+        Assert.Equal(expected, short.Parse(value, style, provider ?? new NumberFormatInfo()));
     }
 
-    [Theory, MemberData(nameof(ParseInvalidData))]
-    public static void TestParseInvalid(string value, NumberStyles style, NumberFormatInfo nfi, Type exceptionType)
+    public static IEnumerable<object[]> Parse_Invalid_TestData()
     {
-        short i;
-        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        NumberFormatInfo nullFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.CurrencySymbol = "$";
+        customFormat.NumberDecimalSeparator = ".";
+
+        yield return new object[] { null, defaultStyle, nullFormat, typeof(ArgumentNullException) };
+        yield return new object[] { "", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { " ", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, nullFormat, typeof(FormatException) };
+
+        yield return new object[] { "abc", defaultStyle, nullFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, nullFormat, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, nullFormat, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 1000.ToString("C0"), defaultStyle, nullFormat, typeof(FormatException) }; // Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, nullFormat, typeof(FormatException) }; // Thousands
+        yield return new object[] { 678.90.ToString("F2"), defaultStyle, nullFormat, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "abc", NumberStyles.None, nullFormat, typeof(FormatException) }; // Negative hex value
+        yield return new object[] { "  123  ", NumberStyles.None, nullFormat, typeof(FormatException) }; // Trailing and leading whitespace
+
+        yield return new object[] { "67.90", defaultStyle, customFormat, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "-32769", defaultStyle, nullFormat, typeof(OverflowException) }; // < min value
+        yield return new object[] { "32768", defaultStyle, nullFormat, typeof(OverflowException) }; // > max value
+
+        yield return new object[] { "2147483648", defaultStyle, nullFormat, typeof(OverflowException) }; // Internally, Parse pretends we are inputting an Int32, so this overflows
+
+        yield return new object[] { "FFFFFFFF", NumberStyles.HexNumber, nullFormat, typeof(OverflowException) }; // Hex number < 0
+        yield return new object[] { "10000", NumberStyles.HexNumber, nullFormat, typeof(OverflowException) }; // Hex number > max value
+    }
+
+    [Theory]
+    [MemberData(nameof(Parse_Invalid_TestData))]
+    public static void TestParse_Invalid(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
+    {
+        short result;
+        // If no style is specified, use the (String) or (String, IFormatProvider) overload
         if (style == NumberStyles.Integer)
         {
-            Assert.Equal(false, short.TryParse(value, out i));
-            Assert.Equal(default(short), i);
+            Assert.False(short.TryParse(value, out result));
+            Assert.Equal(default(short), result);
 
             Assert.Throws(exceptionType, () => short.Parse(value));
 
-            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-            if (nfi != null)
+            // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (provider != null)
             {
-                Assert.Throws(exceptionType, () => short.Parse(value, nfi));
+                Assert.Throws(exceptionType, () => short.Parse(value, provider));
             }
         }
 
         // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-        Assert.Equal(false, short.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
-        Assert.Equal(default(short), i);
+        Assert.False(short.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
+        Assert.Equal(default(short), result);
 
-        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
-        if (nfi == null)
+        // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (provider == null)
         {
             Assert.Throws(exceptionType, () => short.Parse(value, style));
         }
-        Assert.Throws(exceptionType, () => short.Parse(value, style, nfi ?? new NumberFormatInfo()));
+        Assert.Throws(exceptionType, () => short.Parse(value, style, provider ?? new NumberFormatInfo()));
     }
 }

--- a/src/System.Runtime/tests/System/Int32.cs
+++ b/src/System.Runtime/tests/System/Int32.cs
@@ -5,21 +5,19 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Runtime.Tests.Common;
-
 using Xunit;
 
 public static class Int32Tests
 {
     [Fact]
-    public static void TestCtorEmpty()
+    public static void TestCtor_Empty()
     {
-        int i = new int();
+        var i = new int();
         Assert.Equal(0, i);
     }
 
     [Fact]
-    public static void TestCtorValue()
+    public static void TestCtor_Value()
     {
         int i = 41;
         Assert.Equal(41, i);
@@ -38,254 +36,230 @@ public static class Int32Tests
     }
 
     [Theory]
-    [InlineData(234, 0)]
-    [InlineData(int.MinValue, 1)]
-    [InlineData(-123, 1)]
-    [InlineData(0, 1)]
-    [InlineData(45, 1)]
-    [InlineData(123, 1)]
-    [InlineData(456, -1)]
-    [InlineData(int.MaxValue, -1)]
-    public static void TestCompareTo(int value, int expected)
+    [InlineData(234, 234, 0)]
+    [InlineData(234, int.MinValue, 1)]
+    [InlineData(234, -123, 1)]
+    [InlineData(234, 0, 1)]
+    [InlineData(234, 123, 1)]
+    [InlineData(234, 456, -1)]
+    [InlineData(234, int.MaxValue, -1)]
+    [InlineData(234, null, 1)]
+    public static void TestCompareTo(int i, object value, int expected)
     {
-        int i = 234;
-        int result = CompareHelper.NormalizeCompare(i.CompareTo(value));
-        Assert.Equal(expected, result);
+        if (value is int)
+        {
+            Assert.Equal(expected, Math.Sign(i.CompareTo((int)value)));
+        }
+        IComparable comparable = i;
+        Assert.Equal(expected, Math.Sign(comparable.CompareTo(value)));
     }
 
-    [Theory]
-    [InlineData(null, 1)]
-    [InlineData(234, 0)]
-    [InlineData(int.MinValue, 1)]
-    [InlineData(-123, 1)]
-    [InlineData(0, 1)]
-    [InlineData(45, 1)]
-    [InlineData(123, 1)]
-    [InlineData(456, -1)]
-    [InlineData(int.MaxValue, -1)]
-    public static void TestCompareToObject(object obj, int expected)
+    [Fact]
+    public static void TestCompareTo_Invalid()
     {
         IComparable comparable = 234;
-        int i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
-        Assert.Equal(expected, i);
-    }
-
-    [Fact]
-    public static void TestCompareToObjectInvalid()
-    {
-        IComparable comparable = 234;
-        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a int
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); // Obj is not an int
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo((long)234)); // Obj is not an int
     }
 
     [Theory]
-    [InlineData(789, true)]
-    [InlineData(-789, false)]
-    [InlineData(0, false)]
-    public static void TestEqualsObject(object obj, bool expected)
+    [InlineData(789, 789, true)]
+    [InlineData(789, -789, false)]
+    [InlineData(789, 0, false)]
+    [InlineData(0, 0, true)]
+    [InlineData(789, null, false)]
+    [InlineData(789, "789", false)]
+    [InlineData(789, (long)789, false)]
+    public static void TestEquals(int i1, object obj, bool expected)
     {
-        int i = 789;
-        Assert.Equal(expected, i.Equals(obj));
+        if (obj is int)
+        {
+            int i2 = (int)obj;
+            Assert.Equal(expected, i1.Equals(i2));
+            Assert.Equal(expected, i1.GetHashCode().Equals(i2.GetHashCode()));
+        }
+        Assert.Equal(expected, i1.Equals(obj));
+    }
+
+    public static IEnumerable<object[]> ToString_TestData()
+    {
+        NumberFormatInfo emptyFormat = NumberFormatInfo.CurrentInfo;
+        yield return new object[] { int.MinValue, "G", emptyFormat, "-2147483648" };
+        yield return new object[] { -4567, "G", emptyFormat, "-4567" };
+        yield return new object[] { 0, "G", emptyFormat, "0" };
+        yield return new object[] { 4567, "G", emptyFormat, "4567" };
+        yield return new object[] { int.MaxValue, "G", emptyFormat, "2147483647" };
+
+        yield return new object[] { 0x2468, "x", emptyFormat, "2468" };
+        yield return new object[] { 2468, "N", emptyFormat, string.Format("{0:N}", 2468.00) };
+
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.NegativeSign = "#";
+        customFormat.NumberDecimalSeparator = "~";
+        customFormat.NumberGroupSeparator = "*";
+        yield return new object[] { -2468, "N", customFormat, "#2*468~00" };
+        yield return new object[] { 2468, "N", customFormat, "2*468~00" };
     }
 
     [Theory]
-    [InlineData(789, true)]
-    [InlineData(-789, false)]
-    [InlineData(0, false)]
-    public static void TestEquals(int i2, bool expected)
+    [MemberData(nameof(ToString_TestData))]
+    public static void TestToString(int i, string format, IFormatProvider provider, string expected)
     {
-        int i = 789;
-        Assert.Equal(expected, i.Equals(i2));
+        // Format is case insensitive
+        string upperFormat = format.ToUpperInvariant();
+        string lowerFormat = format.ToLowerInvariant();
+
+        string upperExpected = expected.ToUpperInvariant();
+        string lowerExpected = expected.ToLowerInvariant();
+
+        bool isDefaultProvider = (provider == null || provider == NumberFormatInfo.CurrentInfo);
+        if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")
+        {
+            if (isDefaultProvider)
+            {
+                Assert.Equal(upperExpected, i.ToString());
+                Assert.Equal(upperExpected, i.ToString((IFormatProvider)null));
+            }
+            Assert.Equal(upperExpected, i.ToString(provider));
+        }
+        if (isDefaultProvider)
+        {
+            Assert.Equal(upperExpected, i.ToString(upperFormat));
+            Assert.Equal(lowerExpected, i.ToString(lowerFormat));
+            Assert.Equal(upperExpected, i.ToString(upperFormat, null));
+            Assert.Equal(lowerExpected, i.ToString(lowerFormat, null));
+        }
+        Assert.Equal(upperExpected, i.ToString(upperFormat, provider));
+        Assert.Equal(lowerExpected, i.ToString(lowerFormat, provider));
     }
 
     [Fact]
-    public static void TestGetHashCode()
+    public static void TestToString_Invalid()
     {
-        int i1 = 123;
-        int i2 = 654;
-
-        Assert.NotEqual(0, i1.GetHashCode());
-        Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
+        int i = 123;
+        Assert.Throws<FormatException>(() => i.ToString("Y")); // Invalid format
+        Assert.Throws<FormatException>(() => i.ToString("Y", null)); // Invalid format
     }
 
-    [Fact]
-    public static void TestToString()
+    public static IEnumerable<object[]> Parse_Valid_TestData()
     {
-        int i1 = 6310;
-        Assert.Equal("6310", i1.ToString());
-
-        int i2 = -8249;
-        Assert.Equal("-8249", i2.ToString());
-    }
-
-    [Fact]
-    public static void TestToStringFormatProvider()
-    {
-        var numberFormat = new NumberFormatInfo();
-
-        int i1 = 6310;
-        Assert.Equal("6310", i1.ToString(numberFormat));
-
-        int i2 = -8249;
-        Assert.Equal("-8249", i2.ToString(numberFormat));
-
-        int i3 = -2468;
-
-        // Changing the negative pattern doesn't do anything without also passing in a format string
-        numberFormat.NumberNegativePattern = 0;
-        Assert.Equal("-2468", i3.ToString(numberFormat));
-    }
-
-    [Fact]
-    public static void TestToStringFormat()
-    {
-        int i1 = 6310;
-        Assert.Equal("6310", i1.ToString("G"));
-
-        int i2 = -8249;
-        Assert.Equal("-8249", i2.ToString("g"));
-
-        int i3 = -2468;
-        Assert.Equal(string.Format("{0:N}", -2468.00), i3.ToString("N"));
-
-        int i4 = 0x248;
-        Assert.Equal("248", i4.ToString("x"));
-    }
-
-    [Fact]
-    public static void TestToStringFormatFormatProvider()
-    {
-        var numberFormat = new NumberFormatInfo();
-
-        int i1 = 6310;
-        Assert.Equal("6310", i1.ToString("G", numberFormat));
-
-        int i2 = -8249;
-        Assert.Equal("-8249", i2.ToString("g", numberFormat));
-
-        numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
-        numberFormat.NumberGroupSeparator = "*";
-        numberFormat.NumberNegativePattern = 0;
-        int i3 = -2468;
-        Assert.Equal("(2*468.00)", i3.ToString("N", numberFormat));
-    }
-
-    public static IEnumerable<object[]> ParseValidData()
-    {
-        NumberFormatInfo defaultFormat = null;
+        NumberFormatInfo nullFormat = null;
         NumberStyles defaultStyle = NumberStyles.Integer;
-        var emptyNfi = new NumberFormatInfo();
+        NumberFormatInfo emptyFormat = new NumberFormatInfo();
 
-        var testNfi = new NumberFormatInfo();
-        testNfi.CurrencySymbol = "$";
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.CurrencySymbol = "$";
 
-        yield return new object[] { "-2147483648", defaultStyle, defaultFormat, -2147483648 };
-        yield return new object[] { "0", defaultStyle, defaultFormat, 0 };
-        yield return new object[] { "123", defaultStyle, defaultFormat, 123 };
-        yield return new object[] { "  123  ", defaultStyle, defaultFormat, 123 };
-        yield return new object[] { "2147483647", defaultStyle, defaultFormat, 2147483647 };
+        yield return new object[] { "-2147483648", defaultStyle, nullFormat, -2147483648 };
+        yield return new object[] { "-123", defaultStyle, nullFormat, -123 };
+        yield return new object[] { "0", defaultStyle, nullFormat, 0 };
+        yield return new object[] { "123", defaultStyle, nullFormat, 123 };
+        yield return new object[] { "  123  ", defaultStyle, nullFormat, 123 };
+        yield return new object[] { "2147483647", defaultStyle, nullFormat, 2147483647 };
 
-        yield return new object[] { "123", NumberStyles.HexNumber, defaultFormat, 0x123 };
-        yield return new object[] { "abc", NumberStyles.HexNumber, defaultFormat, 0xabc };
-        yield return new object[] { "1000", NumberStyles.AllowThousands, defaultFormat, 1000 };
-        yield return new object[] { "(123)", NumberStyles.AllowParentheses, defaultFormat, -123 }; // Parentheses = negative
+        yield return new object[] { "123", NumberStyles.HexNumber, nullFormat, 0x123 };
+        yield return new object[] { "abc", NumberStyles.HexNumber, nullFormat, 0xabc };
+        yield return new object[] { "1000", NumberStyles.AllowThousands, nullFormat, 1000 };
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, nullFormat, -123 }; // Parentheses = negative
 
-        yield return new object[] { "123", defaultStyle, emptyNfi, 123 };
+        yield return new object[] { "123", defaultStyle, emptyFormat, 123 };
 
-        yield return new object[] { "123", NumberStyles.Any, emptyNfi, 123 };
-        yield return new object[] { "12", NumberStyles.HexNumber, emptyNfi, 0x12 };
-        yield return new object[] { "$1,000", NumberStyles.Currency, testNfi, 1000 };
+        yield return new object[] { "123", NumberStyles.Any, emptyFormat, 123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, emptyFormat, 0x12 };
+        yield return new object[] { "$1,000", NumberStyles.Currency, customFormat, 1000 };
     }
 
-    public static IEnumerable<object[]> ParseInvalidData()
+    [Theory]
+    [MemberData(nameof(Parse_Valid_TestData))]
+    public static void TestParse(string value, NumberStyles style, IFormatProvider provider, int expected)
     {
-        NumberFormatInfo defaultFormat = null;
-        NumberStyles defaultStyle = NumberStyles.Integer;
-        var emptyNfi = new NumberFormatInfo();
-
-        var testNfi = new NumberFormatInfo();
-        testNfi.CurrencySymbol = "$";
-        testNfi.NumberDecimalSeparator = ".";
-
-        yield return new object[] { null, defaultStyle, defaultFormat, typeof(ArgumentNullException) };
-        yield return new object[] { "", defaultStyle, defaultFormat, typeof(FormatException) };
-        yield return new object[] { " ", defaultStyle, defaultFormat, typeof(FormatException) };
-        yield return new object[] { "Garbage", defaultStyle, defaultFormat, typeof(FormatException) };
-
-        yield return new object[] { "abc", defaultStyle, defaultFormat, typeof(FormatException) }; // Hex value
-        yield return new object[] { "1E23", defaultStyle, defaultFormat, typeof(FormatException) }; // Exponent
-        yield return new object[] { "(123)", defaultStyle, defaultFormat, typeof(FormatException) }; // Parentheses
-        yield return new object[] { 1000.ToString("C0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Currency
-        yield return new object[] { 1000.ToString("N0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Thousands
-        yield return new object[] { 678.90.ToString("F2"), defaultStyle, defaultFormat, typeof(FormatException) }; //Decimal
-
-        yield return new object[] { "abc", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Negative hex value
-        yield return new object[] { "  123  ", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Trailing and leading whitespace
-
-        yield return new object[] { "67.90", defaultStyle, testNfi, typeof(FormatException) }; // Decimal
-        
-        yield return new object[] { "-2147483649", defaultStyle, defaultFormat, typeof(OverflowException) }; // > max value
-        yield return new object[] { "2147483648", defaultStyle, defaultFormat, typeof(OverflowException) }; // < min value
-    }
-
-    [Theory, MemberData(nameof(ParseValidData))]
-    public static void TestParse(string value, NumberStyles style, NumberFormatInfo nfi, int expected)
-    {
-        int i;
-        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        int result;
+        // If no style is specified, use the (String) or (String, IFormatProvider) overload
         if (style == NumberStyles.Integer)
         {
-            Assert.Equal(true, int.TryParse(value, out i));
-            Assert.Equal(expected, i);
+            Assert.True(int.TryParse(value, out result));
+            Assert.Equal(expected, result);
 
             Assert.Equal(expected, int.Parse(value));
 
-            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-            if (nfi != null)
+            // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (provider != null)
             {
-                Assert.Equal(expected, int.Parse(value, nfi));
+                Assert.Equal(expected, int.Parse(value, provider));
             }
         }
 
         // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-        Assert.Equal(true, int.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
-        Assert.Equal(expected, i);
+        Assert.True(int.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
+        Assert.Equal(expected, result);
 
-        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
-        if (nfi == null)
+        // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (provider == null)
         {
             Assert.Equal(expected, int.Parse(value, style));
         }
-        Assert.Equal(expected, int.Parse(value, style, nfi ?? new NumberFormatInfo()));
+        Assert.Equal(expected, int.Parse(value, style, provider ?? new NumberFormatInfo()));
     }
 
-    [Theory, MemberData(nameof(ParseInvalidData))]
-    public static void TestParseInvalid(string value, NumberStyles style, NumberFormatInfo nfi, Type exceptionType)
+    public static IEnumerable<object[]> Parse_Invalid_TestData()
     {
-        int i;
-        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        NumberFormatInfo nullFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.CurrencySymbol = "$";
+        customFormat.NumberDecimalSeparator = ".";
+
+        yield return new object[] { null, defaultStyle, nullFormat, typeof(ArgumentNullException) };
+        yield return new object[] { "", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { " ", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, nullFormat, typeof(FormatException) };
+
+        yield return new object[] { "abc", defaultStyle, nullFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, nullFormat, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, nullFormat, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 1000.ToString("C0"), defaultStyle, nullFormat, typeof(FormatException) }; // Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, nullFormat, typeof(FormatException) }; // Thousands
+        yield return new object[] { 678.90.ToString("F2"), defaultStyle, nullFormat, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "abc", NumberStyles.None, nullFormat, typeof(FormatException) }; // Negative hex value
+        yield return new object[] { "  123  ", NumberStyles.None, nullFormat, typeof(FormatException) }; // Trailing and leading whitespace
+
+        yield return new object[] { "67.90", defaultStyle, customFormat, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "-2147483649", defaultStyle, nullFormat, typeof(OverflowException) }; // > max value
+        yield return new object[] { "2147483648", defaultStyle, nullFormat, typeof(OverflowException) }; // < min value
+    }
+
+    [Theory]
+    [MemberData(nameof(Parse_Invalid_TestData))]
+    public static void TestParse_Invalid(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
+    {
+        int result;
+        // If no style is specified, use the (String) or (String, IFormatProvider) overload
         if (style == NumberStyles.Integer)
         {
-            Assert.Equal(false, int.TryParse(value, out i));
-            Assert.Equal(default(int), i);
+            Assert.False(int.TryParse(value, out result));
+            Assert.Equal(default(int), result);
 
             Assert.Throws(exceptionType, () => int.Parse(value));
 
-            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-            if (nfi != null)
+            // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (provider != null)
             {
-                Assert.Throws(exceptionType, () => int.Parse(value, nfi));
+                Assert.Throws(exceptionType, () => int.Parse(value, provider));
             }
         }
 
         // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-        Assert.Equal(false, int.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
-        Assert.Equal(default(int), i);
+        Assert.False(int.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
+        Assert.Equal(default(int), result);
 
-        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
-        if (nfi == null)
+        // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (provider == null)
         {
             Assert.Throws(exceptionType, () => int.Parse(value, style));
         }
-        Assert.Throws(exceptionType, () => int.Parse(value, style, nfi ?? new NumberFormatInfo()));
+        Assert.Throws(exceptionType, () => int.Parse(value, style, provider ?? new NumberFormatInfo()));
     }
 }

--- a/src/System.Runtime/tests/System/Int64.cs
+++ b/src/System.Runtime/tests/System/Int64.cs
@@ -5,21 +5,19 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Runtime.Tests.Common;
-
 using Xunit;
 
 public static class Int64Tests
 {
     [Fact]
-    public static void TestCtorEmpty()
+    public static void TestCtor_Empty()
     {
-        long i = new long();
+        var i = new long();
         Assert.Equal(0, i);
     }
 
     [Fact]
-    public static void TestCtorValue()
+    public static void TestCtor_Value()
     {
         long i = 41;
         Assert.Equal(41, i);
@@ -38,261 +36,230 @@ public static class Int64Tests
     }
 
     [Theory]
-    [InlineData((long)234, 0)]
-    [InlineData(long.MinValue, 1)]
-    [InlineData((long)(-123), 1)]
-    [InlineData((long)0, 1)]
-    [InlineData((long)45, 1)]
-    [InlineData((long)123, 1)]
-    [InlineData((long)456, -1)]
-    [InlineData(long.MaxValue, -1)]
-    public static void TestCompareTo(long value, long expected)
+    [InlineData((long)234, (long)234, 0)]
+    [InlineData((long)234, long.MinValue, 1)]
+    [InlineData((long)234, (long)-123, 1)]
+    [InlineData((long)234, (long)0, 1)]
+    [InlineData((long)234, (long)123, 1)]
+    [InlineData((long)234, (long)456, -1)]
+    [InlineData((long)234, long.MaxValue, -1)]
+    [InlineData((long)234, null, 1)]
+    public static void TestCompareTo(long i, object value, long expected)
     {
-        long i = 234;
-        long result = CompareHelper.NormalizeCompare(i.CompareTo(value));
-        Assert.Equal(expected, result);
+        if (value is long)
+        {
+            Assert.Equal(expected, Math.Sign(i.CompareTo((long)value)));
+        }
+        IComparable comparable = i;
+        Assert.Equal(expected, Math.Sign(comparable.CompareTo(value)));
     }
 
-    [Theory]
-    [InlineData(null, 1)]
-    [InlineData((long)234, 0)]
-    [InlineData(long.MinValue, 1)]
-    [InlineData((long)(-123), 1)]
-    [InlineData((long)0, 1)]
-    [InlineData((long)45, 1)]
-    [InlineData((long)123, 1)]
-    [InlineData((long)456, -1)]
-    [InlineData(long.MaxValue, -1)]
-    public static void TestCompareToObject(object obj, long expected)
+    [Fact]
+    public static void TestCompareTo_Invalid()
     {
         IComparable comparable = (long)234;
-        long i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
-        Assert.Equal(expected, i);
-    }
-
-    [Fact]
-    public static void TestCompareToObjectInvalid()
-    {
-        IComparable comparable = (long)234;
-        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a long
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); // Obj is not a long
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo(234)); // Obj is not a long
     }
 
     [Theory]
-    [InlineData((long)789, true)]
-    [InlineData((long)(-789), false)]
-    [InlineData((long)0, false)]
-    public static void TestEqualsObject(object obj, bool expected)
+    [InlineData((long)789, (long)789, true)]
+    [InlineData((long)789, (long)-789, false)]
+    [InlineData((long)789, (long)0, false)]
+    [InlineData((long)0, (long)0, true)]
+    [InlineData((long)789, null, false)]
+    [InlineData((long)789, "789", false)]
+    [InlineData((long)789, 789, false)]
+    public static void TestEquals(long i1, object obj, bool expected)
     {
-        long i = 789;
-        Assert.Equal(expected, i.Equals(obj));
+        if (obj is long)
+        {
+            long i2 = (long)obj;
+            Assert.Equal(expected, i1.Equals(i2));
+            Assert.Equal(expected, i1.GetHashCode().Equals(i2.GetHashCode()));
+        }
+        Assert.Equal(expected, i1.Equals(obj));
+    }
+
+    public static IEnumerable<object[]> ToString_TestData()
+    {
+        NumberFormatInfo emptyFormat = NumberFormatInfo.CurrentInfo;
+        yield return new object[] { long.MinValue, "G", emptyFormat, "-9223372036854775808" };
+        yield return new object[] { (long)-4567, "G", emptyFormat, "-4567" };
+        yield return new object[] { (long)0, "G", emptyFormat, "0" };
+        yield return new object[] { (long)4567, "G", emptyFormat, "4567" };
+        yield return new object[] { long.MaxValue, "G", emptyFormat, "9223372036854775807" };
+
+        yield return new object[] { (long)0x2468, "x", emptyFormat, "2468" };
+        yield return new object[] { (long)2468, "N", emptyFormat, string.Format("{0:N}", 2468.00) };
+
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.NegativeSign = "#";
+        customFormat.NumberDecimalSeparator = "~";
+        customFormat.NumberGroupSeparator = "*";
+        yield return new object[] { (long)-2468, "N", customFormat, "#2*468~00" };
+        yield return new object[] { (long)2468, "N", customFormat, "2*468~00" };
     }
 
     [Theory]
-    [InlineData((long)789, true)]
-    [InlineData((long)(-789), false)]
-    [InlineData((long)0, false)]
-    public static void TestEquals(long i2, bool expected)
+    [MemberData(nameof(ToString_TestData))]
+    public static void TestToString(long i, string format, IFormatProvider provider, string expected)
     {
-        long i = 789;
-        Assert.Equal(expected, i.Equals(i2));
+        // Format is case insensitive
+        string upperFormat = format.ToUpperInvariant();
+        string lowerFormat = format.ToLowerInvariant();
+
+        string upperExpected = expected.ToUpperInvariant();
+        string lowerExpected = expected.ToLowerInvariant();
+
+        bool isDefaultProvider = (provider == null || provider == NumberFormatInfo.CurrentInfo);
+        if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")
+        {
+            if (isDefaultProvider)
+            {
+                Assert.Equal(upperExpected, i.ToString());
+                Assert.Equal(upperExpected, i.ToString((IFormatProvider)null));
+            }
+            Assert.Equal(upperExpected, i.ToString(provider));
+        }
+        if (isDefaultProvider)
+        {
+            Assert.Equal(upperExpected, i.ToString(upperFormat));
+            Assert.Equal(lowerExpected, i.ToString(lowerFormat));
+            Assert.Equal(upperExpected, i.ToString(upperFormat, null));
+            Assert.Equal(lowerExpected, i.ToString(lowerFormat, null));
+        }
+        Assert.Equal(upperExpected, i.ToString(upperFormat, provider));
+        Assert.Equal(lowerExpected, i.ToString(lowerFormat, provider));
     }
 
     [Fact]
-    public static void TestGetHashCode()
+    public static void TestToString_Invalid()
     {
-        long i1 = 123;
-        long i2 = 654;
-
-        Assert.NotEqual(0, i1.GetHashCode());
-        Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
+        long i = 123;
+        Assert.Throws<FormatException>(() => i.ToString("Y")); // Invalid format
+        Assert.Throws<FormatException>(() => i.ToString("Y", null)); // Invalid format
     }
 
-    [Fact]
-    public static void TestToString()
+    public static IEnumerable<object[]> Parse_Valid_TestData()
     {
-        long i1 = 6310;
-        Assert.Equal("6310", i1.ToString());
-
-        long i2 = -8249;
-        Assert.Equal("-8249", i2.ToString());
-
-        Assert.Equal(long.MaxValue.ToString(), "9223372036854775807");
-        Assert.Equal(long.MinValue.ToString(), "-9223372036854775808");
-    }
-
-    [Fact]
-    public static void TestToStringFormatProvider()
-    {
-        var numberFormat = new NumberFormatInfo();
-
-        long i1 = 6310;
-        Assert.Equal("6310", i1.ToString(numberFormat));
-
-        long i2 = -8249;
-        Assert.Equal("-8249", i2.ToString(numberFormat));
-
-        long i3 = -2468;
-
-        // Changing the negative pattern doesn't do anything without also passing in a format string
-        numberFormat.NumberNegativePattern = 0;
-        Assert.Equal("-2468", i3.ToString(numberFormat));
-    }
-
-    [Fact]
-    public static void TestToStringFormat()
-    {
-        long i1 = 6310;
-        Assert.Equal("6310", i1.ToString("G"));
-
-        long i2 = -8249;
-        Assert.Equal("-8249", i2.ToString("g"));
-
-        long i3 = -2468;
-        Assert.Equal(string.Format("{0:N}", -2468.00), i3.ToString("N"));
-
-        long i4 = 0x248;
-        Assert.Equal("248", i4.ToString("x"));
-
-        Assert.Equal(long.MinValue.ToString("X"), "8000000000000000");
-        Assert.Equal(long.MaxValue.ToString("X"), "7FFFFFFFFFFFFFFF");
-    }
-
-    [Fact]
-    public static void TestToStringFormatFormatProvider()
-    {
-        var numberFormat = new NumberFormatInfo();
-
-        long i1 = 6310;
-        Assert.Equal("6310", i1.ToString("G", numberFormat));
-
-        long i2 = -8249;
-        Assert.Equal("-8249", i2.ToString("g", numberFormat));
-
-        numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
-        numberFormat.NumberGroupSeparator = "*";
-        numberFormat.NumberNegativePattern = 0;
-        long i3 = -2468;
-        Assert.Equal("(2*468.00)", i3.ToString("N", numberFormat));
-    }
-
-    public static IEnumerable<object[]> ParseValidData()
-    {
-        NumberFormatInfo defaultFormat = null;
+        NumberFormatInfo nullFormat = null;
         NumberStyles defaultStyle = NumberStyles.Integer;
-        var emptyNfi = new NumberFormatInfo();
+        NumberFormatInfo emptyFormat = new NumberFormatInfo();
 
-        var testNfi = new NumberFormatInfo();
-        testNfi.CurrencySymbol = "$";
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.CurrencySymbol = "$";
 
-        yield return new object[] { "-9223372036854775808", defaultStyle, defaultFormat, -9223372036854775808 };
-        yield return new object[] { "-123", defaultStyle, defaultFormat, (long)-123 };
-        yield return new object[] { "0", defaultStyle, defaultFormat, (long)0 };
-        yield return new object[] { "123", defaultStyle, defaultFormat, (long)123 };
-        yield return new object[] { "  123  ", defaultStyle, defaultFormat, (long)123 };
-        yield return new object[] { "9223372036854775807", defaultStyle, defaultFormat, 9223372036854775807 };
+        yield return new object[] { "-9223372036854775808", defaultStyle, nullFormat, -9223372036854775808 };
+        yield return new object[] { "-123", defaultStyle, nullFormat, (long)-123 };
+        yield return new object[] { "0", defaultStyle, nullFormat, (long)0 };
+        yield return new object[] { "123", defaultStyle, nullFormat, (long)123 };
+        yield return new object[] { "  123  ", defaultStyle, nullFormat, (long)123 };
+        yield return new object[] { "9223372036854775807", defaultStyle, nullFormat, 9223372036854775807 };
 
-        yield return new object[] { "123", NumberStyles.HexNumber, defaultFormat, (long)0x123 };
-        yield return new object[] { "abc", NumberStyles.HexNumber, defaultFormat, (long)0xabc };
-        yield return new object[] { "1000", NumberStyles.AllowThousands, defaultFormat, (long)1000 };
-        yield return new object[] { "(123)", NumberStyles.AllowParentheses, defaultFormat, (long)-123 }; // Parentheses = negative
+        yield return new object[] { "123", NumberStyles.HexNumber, nullFormat, (long)0x123 };
+        yield return new object[] { "abc", NumberStyles.HexNumber, nullFormat, (long)0xabc };
+        yield return new object[] { "1000", NumberStyles.AllowThousands, nullFormat, (long)1000 };
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, nullFormat, (long)-123 }; // Parentheses = negative
 
-        yield return new object[] { "123", defaultStyle, emptyNfi, (long)123 };
+        yield return new object[] { "123", defaultStyle, emptyFormat, (long)123 };
 
-        yield return new object[] { "123", NumberStyles.Any, emptyNfi, (long)123 };
-        yield return new object[] { "12", NumberStyles.HexNumber, emptyNfi, (long)0x12 };
-        yield return new object[] { "$1,000", NumberStyles.Currency, testNfi, (long)1000 };
+        yield return new object[] { "123", NumberStyles.Any, emptyFormat, (long)123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, emptyFormat, (long)0x12 };
+        yield return new object[] { "$1,000", NumberStyles.Currency, customFormat, (long)1000 };
     }
 
-    public static IEnumerable<object[]> ParseInvalidData()
+    [Theory]
+    [MemberData(nameof(Parse_Valid_TestData))]
+    public static void TestParse(string value, NumberStyles style, IFormatProvider provider, long expected)
     {
-        NumberFormatInfo defaultFormat = null;
-        NumberStyles defaultStyle = NumberStyles.Integer;
-        var emptyNfi = new NumberFormatInfo();
-
-        var testNfi = new NumberFormatInfo();
-        testNfi.CurrencySymbol = "$";
-        testNfi.NumberDecimalSeparator = ".";
-
-        yield return new object[] { null, defaultStyle, defaultFormat, typeof(ArgumentNullException) };
-        yield return new object[] { "", defaultStyle, defaultFormat, typeof(FormatException) };
-        yield return new object[] { " ", defaultStyle, defaultFormat, typeof(FormatException) };
-        yield return new object[] { "Garbage", defaultStyle, defaultFormat, typeof(FormatException) };
-
-        yield return new object[] { "abc", defaultStyle, defaultFormat, typeof(FormatException) }; // Hex value
-        yield return new object[] { "1E23", defaultStyle, defaultFormat, typeof(FormatException) }; // Exponent
-        yield return new object[] { "(123)", defaultStyle, defaultFormat, typeof(FormatException) }; // Parentheses
-        yield return new object[] { 1000.ToString("C0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Currency
-        yield return new object[] { 1000.ToString("N0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Thousands
-        yield return new object[] { 678.90.ToString("F2"), defaultStyle, defaultFormat, typeof(FormatException) }; //Decimal
-
-        yield return new object[] { "abc", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Negative hex value
-        yield return new object[] { "  123  ", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Trailing and leading whitespace
-
-        yield return new object[] { "67.90", defaultStyle, testNfi, typeof(FormatException) }; // Decimal
-        
-        yield return new object[] { "-9223372036854775809", defaultStyle, defaultFormat, typeof(OverflowException) }; // < min value
-        yield return new object[] { "9223372036854775808", defaultStyle, defaultFormat, typeof(OverflowException) }; // > max value
-    }
-
-    [Theory, MemberData(nameof(ParseValidData))]
-    public static void TestParse(string value, NumberStyles style, NumberFormatInfo nfi, long expected)
-    {
-        long i;
-        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        long result;
+        // If no style is specified, use the (String) or (String, IFormatProvider) overload
         if (style == NumberStyles.Integer)
         {
-            Assert.Equal(true, long.TryParse(value, out i));
-            Assert.Equal(expected, i);
+            Assert.True(long.TryParse(value, out result));
+            Assert.Equal(expected, result);
 
             Assert.Equal(expected, long.Parse(value));
 
-            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-            if (nfi != null)
+            // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (provider != null)
             {
-                Assert.Equal(expected, long.Parse(value, nfi));
+                Assert.Equal(expected, long.Parse(value, provider));
             }
         }
 
         // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-        Assert.Equal(true, long.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
-        Assert.Equal(expected, i);
+        Assert.True(long.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
+        Assert.Equal(expected, result);
 
-        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
-        if (nfi == null)
+        // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (provider == null)
         {
             Assert.Equal(expected, long.Parse(value, style));
         }
-        Assert.Equal(expected, long.Parse(value, style, nfi ?? new NumberFormatInfo()));
+        Assert.Equal(expected, long.Parse(value, style, provider ?? new NumberFormatInfo()));
     }
 
-    [Theory, MemberData(nameof(ParseInvalidData))]
-    public static void TestParseInvalid(string value, NumberStyles style, NumberFormatInfo nfi, Type exceptionType)
+    public static IEnumerable<object[]> Parse_Invalid_TestData()
     {
-        long i;
-        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        NumberFormatInfo nullFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.CurrencySymbol = "$";
+        customFormat.NumberDecimalSeparator = ".";
+
+        yield return new object[] { null, defaultStyle, nullFormat, typeof(ArgumentNullException) };
+        yield return new object[] { "", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { " ", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, nullFormat, typeof(FormatException) };
+
+        yield return new object[] { "abc", defaultStyle, nullFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, nullFormat, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, nullFormat, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 1000.ToString("C0"), defaultStyle, nullFormat, typeof(FormatException) }; // Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, nullFormat, typeof(FormatException) }; // Thousands
+        yield return new object[] { 678.90.ToString("F2"), defaultStyle, nullFormat, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "abc", NumberStyles.None, nullFormat, typeof(FormatException) }; // Negative hex value
+        yield return new object[] { "  123  ", NumberStyles.None, nullFormat, typeof(FormatException) }; // Trailing and leading whitespace
+
+        yield return new object[] { "67.90", defaultStyle, customFormat, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "-9223372036854775809", defaultStyle, nullFormat, typeof(OverflowException) }; // < min value
+        yield return new object[] { "9223372036854775808", defaultStyle, nullFormat, typeof(OverflowException) }; // > max value
+    }
+
+    [Theory]
+    [MemberData(nameof(Parse_Invalid_TestData))]
+    public static void TestParse_Invalid(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
+    {
+        long result;
+        // If no style is specified, use the (String) or (String, IFormatProvider) overload
         if (style == NumberStyles.Integer)
         {
-            Assert.Equal(false, long.TryParse(value, out i));
-            Assert.Equal(default(long), i);
+            Assert.False(long.TryParse(value, out result));
+            Assert.Equal(default(long), result);
 
             Assert.Throws(exceptionType, () => long.Parse(value));
 
-            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-            if (nfi != null)
+            // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (provider != null)
             {
-                Assert.Throws(exceptionType, () => long.Parse(value, nfi));
+                Assert.Throws(exceptionType, () => long.Parse(value, provider));
             }
         }
 
         // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-        Assert.Equal(false, long.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
-        Assert.Equal(default(long), i);
+        Assert.False(long.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
+        Assert.Equal(default(long), result);
 
-        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
-        if (nfi == null)
+        // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (provider == null)
         {
             Assert.Throws(exceptionType, () => long.Parse(value, style));
         }
-        Assert.Throws(exceptionType, () => long.Parse(value, style, nfi ?? new NumberFormatInfo()));
+        Assert.Throws(exceptionType, () => long.Parse(value, style, provider ?? new NumberFormatInfo()));
     }
 }

--- a/src/System.Runtime/tests/System/SByte.cs
+++ b/src/System.Runtime/tests/System/SByte.cs
@@ -5,21 +5,19 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Runtime.Tests.Common;
-
 using Xunit;
 
 public static class SByteTests
 {
     [Fact]
-    public static void TestCtorEmpty()
+    public static void TestCtor_Empty()
     {
-        sbyte i = new sbyte();
+        var i = new sbyte();
         Assert.Equal(0, i);
     }
 
     [Fact]
-    public static void TestCtorValue()
+    public static void TestCtor_Value()
     {
         sbyte i = 41;
         Assert.Equal(41, i);
@@ -36,108 +34,107 @@ public static class SByteTests
     {
         Assert.Equal(-0x80, sbyte.MinValue);
     }
-    
-    [Theory]
-    [InlineData((sbyte)114, 0)]
-    [InlineData(sbyte.MinValue, 1)]
-    [InlineData((sbyte)0, 1)]
-    [InlineData((sbyte)45, 1)]
-    [InlineData((sbyte)123, -1)]
-    [InlineData(sbyte.MaxValue, -1)]
-    public static void TestCompareTo(sbyte value, int expected)
-    {
-        sbyte i = 114;
-        int result = CompareHelper.NormalizeCompare(i.CompareTo(value));
-        Assert.Equal(expected, result);
-    }
 
     [Theory]
-    [InlineData(null, 1)]
-    [InlineData((sbyte)114, 0)]
-    [InlineData(sbyte.MinValue, 1)]
-    [InlineData((sbyte)(-23), 1)]
-    [InlineData((sbyte)0, 1)]
-    [InlineData((sbyte)45, 1)]
-    [InlineData((sbyte)123, -1)]
-    [InlineData(sbyte.MaxValue, -1)]
-    public static void TestCompareToObject(object obj, int expected)
+    [InlineData((sbyte)114, (sbyte)114, 0)]
+    [InlineData((sbyte)114, sbyte.MinValue, 1)]
+    [InlineData((sbyte)114, (sbyte)-123, 1)]
+    [InlineData((sbyte)114, (sbyte)0, 1)]
+    [InlineData((sbyte)114, (sbyte)123, -1)]
+    [InlineData((sbyte)114, sbyte.MaxValue, -1)]
+    [InlineData((sbyte)114, null, 1)]
+    public static void TestCompareTo(sbyte i, object value, int expected)
+    {
+        if (value is sbyte)
+        {
+            Assert.Equal(expected, Math.Sign(i.CompareTo((sbyte)value)));
+        }
+
+        IComparable comparable = i;
+        Assert.Equal(expected, Math.Sign(comparable.CompareTo(value)));
+    }
+
+    [Fact]
+    public static void TestCompareTo_Invalid()
     {
         IComparable comparable = (sbyte)114;
-        int i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
-        Assert.Equal(expected, i);
-    }
-
-    [Fact]
-    public static void TestCompareToObjectInvalid()
-    {
-        IComparable comparable = (sbyte)114;
-        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a sbyte
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); // Obj is not a sbyte
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo(234)); // Obj is not a sbyte
     }
 
     [Theory]
-    [InlineData((sbyte)78, true)]
-    [InlineData((sbyte)(-78), false)]
-    [InlineData((sbyte)0, false)]
-    public static void TestEqualsObject(object obj, bool expected)
+    [InlineData((sbyte)78, (sbyte)78, true)]
+    [InlineData((sbyte)78, (sbyte)-78, false)]
+    [InlineData((sbyte)78, (sbyte)0, false)]
+    [InlineData((sbyte)0, (sbyte)0, true)]
+    [InlineData((sbyte)78, null, false)]
+    [InlineData((sbyte)78, "78", false)]
+    [InlineData((sbyte)78, 78, false)]
+    public static void TestEquals(sbyte i1, object obj, bool expected)
     {
-        sbyte i = 78;
-        Assert.Equal(expected, i.Equals(obj));
+        if (obj is sbyte)
+        {
+            sbyte i2 = (sbyte)obj;
+            Assert.Equal(expected, i1.Equals(i2));
+            Assert.Equal(expected, i1.GetHashCode().Equals(i2.GetHashCode()));
+        }
+        Assert.Equal(expected, i1.Equals(obj));
+    }
+
+    public static IEnumerable<object[]> ToString_TestData()
+    {
+        NumberFormatInfo emptyFormat = NumberFormatInfo.CurrentInfo;
+        yield return new object[] { sbyte.MinValue, "G", emptyFormat, "-128" };
+        yield return new object[] { (sbyte)-123, "G", emptyFormat, "-123" };
+        yield return new object[] { (sbyte)0, "G", emptyFormat, "0" };
+        yield return new object[] { (sbyte)123, "G", emptyFormat, "123" };
+        yield return new object[] { sbyte.MaxValue, "G", emptyFormat, "127" };
+
+        yield return new object[] { (sbyte)0x24, "x", emptyFormat, "24" };
+        yield return new object[] { (sbyte)24, "N", emptyFormat, string.Format("{0:N}", 24.00) };
+
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.NegativeSign = "#";
+        customFormat.NumberDecimalSeparator = "~";
+        customFormat.NumberGroupSeparator = "*";
+        yield return new object[] { (sbyte)-24, "N", customFormat, "#24~00" };
+        yield return new object[] { (sbyte)24, "N", customFormat, "24~00" };
     }
 
     [Theory]
-    [InlineData((sbyte)78, true)]
-    [InlineData((sbyte)(-78), false)]
-    [InlineData((sbyte)0, false)]
-    public static void TestEqualsObject(sbyte i2, bool expected)
+    [MemberData(nameof(ToString_TestData))]
+    public static void TestToString(sbyte i, string format, IFormatProvider provider, string expected)
     {
-        sbyte i = 78;
-        Assert.Equal(expected, i.Equals(i2));
+        // Format is case insensitive
+        string upperFormat = format.ToUpperInvariant();
+        string lowerFormat = format.ToLowerInvariant();
+
+        string upperExpected = expected.ToUpperInvariant();
+        string lowerExpected = expected.ToLowerInvariant();
+
+        bool isDefaultProvider = (provider == null || provider == NumberFormatInfo.CurrentInfo);
+        if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")
+        {
+            if (isDefaultProvider)
+            {
+                Assert.Equal(upperExpected, i.ToString());
+                Assert.Equal(upperExpected, i.ToString((IFormatProvider)null));
+            }
+            Assert.Equal(upperExpected, i.ToString(provider));
+        }
+        if (isDefaultProvider)
+        {
+            Assert.Equal(upperExpected, i.ToString(upperFormat));
+            Assert.Equal(lowerExpected, i.ToString(lowerFormat));
+            Assert.Equal(upperExpected, i.ToString(upperFormat, null));
+            Assert.Equal(lowerExpected, i.ToString(lowerFormat, null));
+        }
+        Assert.Equal(upperExpected, i.ToString(upperFormat, provider));
+        Assert.Equal(lowerExpected, i.ToString(lowerFormat, provider));
     }
 
     [Fact]
-    public static void TestGetHashCode()
-    {
-        sbyte i1 = 123;
-        sbyte i2 = 65;
-
-        Assert.NotEqual(0, i1.GetHashCode());
-        Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
-    }
-
-    [Fact]
-    public static void TestToString()
-    {
-        sbyte i1 = 63;
-        Assert.Equal("63", i1.ToString());
-    }
-
-    [Fact]
-    public static void TestToStringFormatProvider()
-    {
-        var numberFormat = new NumberFormatInfo();
-
-        sbyte i1 = 63;
-        Assert.Equal("63", i1.ToString(numberFormat));
-    }
-
-    [Fact]
-    public static void TestToStringFormat()
-    {
-        sbyte i1 = 63;
-        Assert.Equal("63", i1.ToString("G"));
-
-        sbyte i2 = 82;
-        Assert.Equal("82", i2.ToString("g"));
-
-        sbyte i3 = 46;
-        Assert.Equal(string.Format("{0:N}", 46.00), i3.ToString("N"));
-
-        sbyte i4 = 0x24;
-        Assert.Equal("24", i4.ToString("x"));
-    }
-
-    [Fact]
-    public static void TestToStringFormatFormatProvider()
+    public static void TestToString_Invalid()
     {
         var numberFormat = new NumberFormatInfo();
 
@@ -184,96 +181,123 @@ public static class SByteTests
         yield return new object[] { "$100", NumberStyles.Currency, testNfi, (sbyte)100 };
     }
 
-    public static IEnumerable<object[]> ParseInvalidData()
+    public static IEnumerable<object[]> Parse_Valid_TestData()
     {
-        NumberFormatInfo defaultFormat = null;
+        NumberFormatInfo nullFormat = null;
         NumberStyles defaultStyle = NumberStyles.Integer;
-        var emptyNfi = new NumberFormatInfo();
+        NumberFormatInfo emptyFormat = new NumberFormatInfo();
 
-        var testNfi = new NumberFormatInfo();
-        testNfi.CurrencySymbol = "$";
-        testNfi.NumberDecimalSeparator = ".";
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.CurrencySymbol = "$";
 
-        yield return new object[] { null, defaultStyle, defaultFormat, typeof(ArgumentNullException) };
-        yield return new object[] { "", defaultStyle, defaultFormat, typeof(FormatException) };
-        yield return new object[] { " ", defaultStyle, defaultFormat, typeof(FormatException) };
-        yield return new object[] { "Garbage", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { "-123", defaultStyle, nullFormat, (sbyte)-123 };
+        yield return new object[] { "0", defaultStyle, nullFormat, (sbyte)0 };
+        yield return new object[] { "123", defaultStyle, nullFormat, (sbyte)123 };
+        yield return new object[] { "  123  ", defaultStyle, nullFormat, (sbyte)123 };
+        yield return new object[] { "127", defaultStyle, nullFormat, (sbyte)127 };
 
-        yield return new object[] { "ab", defaultStyle, defaultFormat, typeof(FormatException) }; // Hex value
-        yield return new object[] { "1E23", defaultStyle, defaultFormat, typeof(FormatException) }; // Exponent
-        yield return new object[] { "(123)", defaultStyle, defaultFormat, typeof(FormatException) }; // Parentheses
-        yield return new object[] { 100.ToString("C0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Currency
-        yield return new object[] { 1000.ToString("N0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Thousands
-        yield return new object[] { 67.90.ToString("F2"), defaultStyle, defaultFormat, typeof(FormatException) }; //Decimal
+        yield return new object[] { "12", NumberStyles.HexNumber, nullFormat, (sbyte)0x12 };
+        yield return new object[] { "10", NumberStyles.AllowThousands, nullFormat, (sbyte)10 };
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, nullFormat, (sbyte)-123 }; // Parentheses = negative
 
-        yield return new object[] { "ab", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Hex value
-        yield return new object[] { "  123  ", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Trailing and leading whitespace
+        yield return new object[] { "123", defaultStyle, emptyFormat, (sbyte)123 };
 
-        yield return new object[] { "67.90", defaultStyle, testNfi, typeof(FormatException) }; // Decimal
-
-        yield return new object[] { "-129", defaultStyle, defaultFormat, typeof(OverflowException) }; // < min value
-        yield return new object[] { "128", defaultStyle, defaultFormat, typeof(OverflowException) }; // > max value
+        yield return new object[] { "123", NumberStyles.Any, emptyFormat, (sbyte)123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, emptyFormat, (sbyte)0x12 };
+        yield return new object[] { "$100", NumberStyles.Currency, customFormat, (sbyte)100 };
     }
 
-    [Theory, MemberData(nameof(ParseValidData))]
-    public static void TestParse(string value, NumberStyles style, NumberFormatInfo nfi, sbyte expected)
+    [Theory]
+    [MemberData(nameof(Parse_Valid_TestData))]
+    public static void TestParse(string value, NumberStyles style, IFormatProvider provider, sbyte expected)
     {
-        sbyte i;
-        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        sbyte result;
+        // If no style is specified, use the (String) or (String, IFormatProvider) overload
         if (style == NumberStyles.Integer)
         {
-            Assert.Equal(true, sbyte.TryParse(value, out i));
-            Assert.Equal(expected, i);
+            Assert.True(sbyte.TryParse(value, out result));
+            Assert.Equal(expected, result);
 
             Assert.Equal(expected, sbyte.Parse(value));
 
-            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-            if (nfi != null)
+            // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (provider != null)
             {
-                Assert.Equal(expected, sbyte.Parse(value, nfi));
+                Assert.Equal(expected, sbyte.Parse(value, provider));
             }
         }
 
         // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-        Assert.Equal(true, sbyte.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
-        Assert.Equal(expected, i);
+        Assert.True(sbyte.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
+        Assert.Equal(expected, result);
 
-        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
-        if (nfi == null)
+        // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (provider == null)
         {
             Assert.Equal(expected, sbyte.Parse(value, style));
         }
-        Assert.Equal(expected, sbyte.Parse(value, style, nfi ?? new NumberFormatInfo()));
+        Assert.Equal(expected, sbyte.Parse(value, style, provider ?? new NumberFormatInfo()));
     }
 
-    [Theory, MemberData(nameof(ParseInvalidData))]
-    public static void TestParseInvalid(string value, NumberStyles style, NumberFormatInfo nfi, Type exceptionType)
+    public static IEnumerable<object[]> Parse_Invalid_TestData()
     {
-        sbyte i;
-        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        NumberFormatInfo nullFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.CurrencySymbol = "$";
+        customFormat.NumberDecimalSeparator = ".";
+
+        yield return new object[] { null, defaultStyle, nullFormat, typeof(ArgumentNullException) };
+        yield return new object[] { "", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { " ", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, nullFormat, typeof(FormatException) };
+
+        yield return new object[] { "ab", defaultStyle, nullFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, nullFormat, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, nullFormat, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 100.ToString("C0"), defaultStyle, nullFormat, typeof(FormatException) }; // Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, nullFormat, typeof(FormatException) }; // Thousands
+        yield return new object[] { 67.90.ToString("F2"), defaultStyle, nullFormat, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "ab", NumberStyles.None, nullFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "  123  ", NumberStyles.None, nullFormat, typeof(FormatException) }; // Trailing and leading whitespace
+
+        yield return new object[] { "67.90", defaultStyle, customFormat, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "-129", defaultStyle, nullFormat, typeof(OverflowException) }; // < min value
+        yield return new object[] { "128", defaultStyle, nullFormat, typeof(OverflowException) }; // > max value
+    }
+
+    [Theory]
+    [MemberData(nameof(Parse_Invalid_TestData))]
+    public static void TestParse_Invalid(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
+    {
+        sbyte result;
+        // If no style is specified, use the (String) or (String, IFormatProvider) overload
         if (style == NumberStyles.Integer)
         {
-            Assert.Equal(false, sbyte.TryParse(value, out i));
-            Assert.Equal(default(sbyte), i);
+            Assert.False(sbyte.TryParse(value, out result));
+            Assert.Equal(default(sbyte), result);
 
             Assert.Throws(exceptionType, () => sbyte.Parse(value));
 
-            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-            if (nfi != null)
+            // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (provider != null)
             {
-                Assert.Throws(exceptionType, () => sbyte.Parse(value, nfi));
+                Assert.Throws(exceptionType, () => sbyte.Parse(value, provider));
             }
         }
 
         // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-        Assert.Equal(false, sbyte.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
-        Assert.Equal(default(sbyte), i);
+        Assert.False(sbyte.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
+        Assert.Equal(default(sbyte), result);
 
-        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
-        if (nfi == null)
+        // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (provider == null)
         {
             Assert.Throws(exceptionType, () => sbyte.Parse(value, style));
         }
-        Assert.Throws(exceptionType, () => sbyte.Parse(value, style, nfi ?? new NumberFormatInfo()));
+        Assert.Throws(exceptionType, () => sbyte.Parse(value, style, provider ?? new NumberFormatInfo()));
     }
 }

--- a/src/System.Runtime/tests/System/UInt16.cs
+++ b/src/System.Runtime/tests/System/UInt16.cs
@@ -5,21 +5,19 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Runtime.Tests.Common;
-
 using Xunit;
 
 public static class UInt16Tests
 {
     [Fact]
-    public static void TestCtorEmpty()
+    public static void TestCtor_Empty()
     {
-        ushort i = new ushort();
+        var i = new ushort();
         Assert.Equal(0, i);
     }
 
     [Fact]
-    public static void TestCtorValue()
+    public static void TestCtor_Value()
     {
         ushort i = 41;
         Assert.Equal(41, i);
@@ -38,237 +36,223 @@ public static class UInt16Tests
     }
 
     [Theory]
-    [InlineData((ushort)234, 0)]
-    [InlineData(ushort.MinValue, 1)]
-    [InlineData((ushort)0, 1)]
-    [InlineData((ushort)45, 1)]
-    [InlineData((ushort)123, 1)]
-    [InlineData((ushort)456, -1)]
-    [InlineData(ushort.MaxValue, -1)]
-    public static void TestCompareTo(ushort value, int expected)
+    [InlineData((ushort)234, (ushort)234, 0)]
+    [InlineData((ushort)234, ushort.MinValue, 1)]
+    [InlineData((ushort)234, (ushort)0, 1)]
+    [InlineData((ushort)234, (ushort)123, 1)]
+    [InlineData((ushort)234, (ushort)456, -1)]
+    [InlineData((ushort)234, ushort.MaxValue, -1)]
+    [InlineData((ushort)234, null, 1)]
+    public static void TestCompareTo(ushort i, object value, int expected)
     {
-        ushort i = 234;
-        int result = CompareHelper.NormalizeCompare(i.CompareTo(value));
-        Assert.Equal(expected, result);
+        if (value is ushort)
+        {
+            Assert.Equal(expected, Math.Sign(i.CompareTo((ushort)value)));
+        }
+        IComparable comparable = i;
+        Assert.Equal(expected, Math.Sign(comparable.CompareTo(value)));
     }
 
-    [Theory]
-    [InlineData(null, 1)]
-    [InlineData((ushort)234, 0)]
-    [InlineData(ushort.MinValue, 1)]
-    [InlineData((ushort)0, 1)]
-    [InlineData((ushort)45, 1)]
-    [InlineData((ushort)123, 1)]
-    [InlineData((ushort)456, -1)]
-    [InlineData(ushort.MaxValue, -1)]
-    public static void TestCompareToObject(object obj, int expected)
+    [Fact]
+    public static void TestCompareTo_Invalid()
     {
         IComparable comparable = (ushort)234;
-        int i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
-        Assert.Equal(expected, i);
-    }
-
-    [Fact]
-    public static void TestCompareToObjectInvalid()
-    {
-        IComparable comparable = (ushort)234;
-        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a ushort
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); // Obj is not a ushort
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo(234)); // Obj is not a ushort
     }
 
     [Theory]
-    [InlineData((ushort)789, true)]
-    [InlineData((ushort)0, false)]
-    public static void TestEqualsObject(object obj, bool expected)
+    [InlineData((ushort)789, (ushort)789, true)]
+    [InlineData((ushort)788, (ushort)0, false)]
+    [InlineData((ushort)0, (ushort)0, true)]
+    [InlineData((ushort)789, null, false)]
+    [InlineData((ushort)789, "789", false)]
+    [InlineData((ushort)789, 789, false)]
+    public static void TestEquals(ushort i1, object obj, bool expected)
     {
-        ushort i = 789;
-        Assert.Equal(expected, i.Equals(obj));
+        if (obj is ushort)
+        {
+            Assert.Equal(expected, i1.Equals((ushort)obj));
+            Assert.Equal(expected, i1.GetHashCode().Equals(((ushort)obj).GetHashCode()));
+            Assert.Equal(i1, i1.GetHashCode());
+        }
+        Assert.Equal(expected, i1.Equals(obj));
+    }
+
+    public static IEnumerable<object[]> ToString_TestData()
+    {
+        NumberFormatInfo emptyFormat = NumberFormatInfo.CurrentInfo;
+        yield return new object[] { (ushort)0, "G", emptyFormat, "0" };
+        yield return new object[] { (ushort)4567, "G", emptyFormat, "4567" };
+        yield return new object[] { ushort.MaxValue, "G", emptyFormat, "65535" };
+
+        yield return new object[] { (ushort)0x2468, "x", emptyFormat, "2468" };
+        yield return new object[] { (ushort)2468, "N", emptyFormat, string.Format("{0:N}", 2468.00) };
+
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.NegativeSign = "#";
+        customFormat.NumberDecimalSeparator = "~";
+        customFormat.NumberGroupSeparator = "*";
+        yield return new object[] { (ushort)2468, "N", customFormat, "2*468~00" };
     }
 
     [Theory]
-    [InlineData((ushort)789, true)]
-    [InlineData((ushort)0, false)]
-    public static void TestEquals(ushort i2, bool expected)
+    [MemberData(nameof(ToString_TestData))]
+    public static void TestToString(ushort i, string format, IFormatProvider provider, string expected)
     {
-        ushort i = 789;
-        Assert.Equal(expected, i.Equals(i2));
+        // Format should be case insensitive
+        string upperFormat = format.ToUpperInvariant();
+        string lowerFormat = format.ToLowerInvariant();
+
+        string upperExpected = expected.ToUpperInvariant();
+        string lowerExpected = expected.ToLowerInvariant();
+
+        bool isDefaultProvider = (provider == null || provider == NumberFormatInfo.CurrentInfo);
+        if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")
+        {
+            if (isDefaultProvider)
+            {
+                Assert.Equal(upperExpected, i.ToString());
+                Assert.Equal(upperExpected, i.ToString((IFormatProvider)null));
+            }
+            Assert.Equal(upperExpected, i.ToString(provider));
+        }
+        if (isDefaultProvider)
+        {
+            Assert.Equal(upperExpected, i.ToString(upperFormat));
+            Assert.Equal(lowerExpected, i.ToString(lowerFormat));
+            Assert.Equal(upperExpected, i.ToString(upperFormat, null));
+            Assert.Equal(lowerExpected, i.ToString(lowerFormat, null));
+        }
+        Assert.Equal(upperExpected, i.ToString(upperFormat, provider));
+        Assert.Equal(lowerExpected, i.ToString(lowerFormat, provider));
     }
 
     [Fact]
-    public static void TestGetHashCode()
+    public static void TestToString_Invalid()
     {
-        ushort i1 = 123;
-        ushort i2 = 654;
-
-        Assert.NotEqual(0, i1.GetHashCode());
-        Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
+        ushort i = 123;
+        Assert.Throws<FormatException>(() => i.ToString("Y")); // Invalid format
+        Assert.Throws<FormatException>(() => i.ToString("Y", null)); // Invalid format
     }
 
-    [Fact]
-    public static void TestToString()
+    public static IEnumerable<object[]> Parse_Valid_TestData()
     {
-        ushort i1 = 6310;
-        Assert.Equal("6310", i1.ToString());
-    }
-
-    [Fact]
-    public static void TestToStringFormatProvider()
-    {
-        var numberFormat = new NumberFormatInfo();
-
-        ushort i1 = 6310;
-        Assert.Equal("6310", i1.ToString(numberFormat));
-    }
-
-    [Fact]
-    public static void TestToStringFormat()
-    {
-        ushort i1 = 6310;
-        Assert.Equal("6310", i1.ToString("G"));
-
-        ushort i2 = 8249;
-        Assert.Equal("8249", i2.ToString("g"));
-
-        ushort i3 = 2468;
-        Assert.Equal(string.Format("{0:N}", 2468.00), i3.ToString("N"));
-
-        ushort i4 = 0x248;
-        Assert.Equal("248", i4.ToString("x"));
-    }
-
-    [Fact]
-    public static void TestToStringFormatFormatProvider()
-    {
-        var numberFormat = new NumberFormatInfo();
-
-        ushort i1 = 6310;
-        Assert.Equal("6310", i1.ToString("G", numberFormat));
-
-        ushort i2 = 8249;
-        Assert.Equal("8249", i2.ToString("g", numberFormat));
-
-        numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
-        numberFormat.NumberGroupSeparator = "*";
-        numberFormat.NumberNegativePattern = 0;
-        ushort i3 = 2468;
-        Assert.Equal("2*468.00", i3.ToString("N", numberFormat));
-    }
-
-    public static IEnumerable<object[]> ParseValidData()
-    {
-        NumberFormatInfo defaultFormat = null;
+        NumberFormatInfo nullFormat = null;
         NumberStyles defaultStyle = NumberStyles.Integer;
-        var emptyNfi = new NumberFormatInfo();
+        NumberFormatInfo emptyFormat = new NumberFormatInfo();
 
-        var testNfi = new NumberFormatInfo();
-        testNfi.CurrencySymbol = "$";
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.CurrencySymbol = "$";
 
-        yield return new object[] { "0", defaultStyle, defaultFormat, (ushort)0 };
-        yield return new object[] { "123", defaultStyle, defaultFormat, (ushort)123 };
-        yield return new object[] { "  123  ", defaultStyle, defaultFormat, (ushort)123 };
-        yield return new object[] { "65535", defaultStyle, defaultFormat, (ushort)65535 };
+        yield return new object[] { "0", defaultStyle, nullFormat, (ushort)0 };
+        yield return new object[] { "123", defaultStyle, nullFormat, (ushort)123 };
+        yield return new object[] { "  123  ", defaultStyle, nullFormat, (ushort)123 };
+        yield return new object[] { "65535", defaultStyle, nullFormat, (ushort)65535 };
 
-        yield return new object[] { "12", NumberStyles.HexNumber, defaultFormat, (ushort)0x12 };
-        yield return new object[] { "1000", NumberStyles.AllowThousands, defaultFormat, (ushort)1000 };
+        yield return new object[] { "12", NumberStyles.HexNumber, nullFormat, (ushort)0x12 };
+        yield return new object[] { "1000", NumberStyles.AllowThousands, nullFormat, (ushort)1000 };
 
-        yield return new object[] { "123", defaultStyle, emptyNfi, (ushort)123 };
+        yield return new object[] { "123", defaultStyle, emptyFormat, (ushort)123 };
 
-        yield return new object[] { "123", NumberStyles.Any, emptyNfi, (ushort)123 };
-        yield return new object[] { "12", NumberStyles.HexNumber, emptyNfi, (ushort)0x12 };
-        yield return new object[] { "abc", NumberStyles.HexNumber, emptyNfi, (ushort)0xabc };
-        yield return new object[] { "$1,000", NumberStyles.Currency, testNfi, (ushort)1000 };
+        yield return new object[] { "123", NumberStyles.Any, emptyFormat, (ushort)123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, emptyFormat, (ushort)0x12 };
+        yield return new object[] { "abc", NumberStyles.HexNumber, emptyFormat, (ushort)0xabc };
+        yield return new object[] { "$1,000", NumberStyles.Currency, customFormat, (ushort)1000 };
     }
 
-    public static IEnumerable<object[]> ParseInvalidData()
+    [Theory]
+    [MemberData(nameof(Parse_Valid_TestData))]
+    public static void TestParse(string value, NumberStyles style, IFormatProvider provider, ushort expected)
     {
-        NumberFormatInfo defaultFormat = null;
-        NumberStyles defaultStyle = NumberStyles.Integer;
-        var emptyNfi = new NumberFormatInfo();
-
-        var testNfi = new NumberFormatInfo();
-        testNfi.CurrencySymbol = "$";
-        testNfi.NumberDecimalSeparator = ".";
-
-        yield return new object[] { null, defaultStyle, defaultFormat, typeof(ArgumentNullException) };
-        yield return new object[] { "", defaultStyle, defaultFormat, typeof(FormatException) };
-        yield return new object[] { " ", defaultStyle, defaultFormat, typeof(FormatException) };
-        yield return new object[] { "Garbage", defaultStyle, defaultFormat, typeof(FormatException) };
-
-        yield return new object[] { "abc", defaultStyle, defaultFormat, typeof(FormatException) }; // Hex value
-        yield return new object[] { "1E23", defaultStyle, defaultFormat, typeof(FormatException) }; // Exponent
-        yield return new object[] { "(123)", defaultStyle, defaultFormat, typeof(FormatException) }; // Parentheses
-        yield return new object[] { 100.ToString("C0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Currency
-        yield return new object[] { 1000.ToString("N0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Thousands
-        yield return new object[] { 678.90.ToString("F2"), defaultStyle, defaultFormat, typeof(FormatException) }; //Decimal
-
-        yield return new object[] { "abc", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Negative hex value
-        yield return new object[] { "  123  ", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Trailing and leading whitespace
-
-        yield return new object[] { "678.90", defaultStyle, testNfi, typeof(FormatException) }; // Decimal
-
-        yield return new object[] { "-1", defaultStyle, defaultFormat, typeof(OverflowException) }; // < min value
-        yield return new object[] { "65536", defaultStyle, defaultFormat, typeof(OverflowException) }; // > max value
-        yield return new object[] { "(123)", NumberStyles.AllowParentheses, defaultFormat, typeof(OverflowException) }; // Parentheses = negative
-    }
-
-    [Theory, MemberData(nameof(ParseValidData))]
-    public static void TestParse(string value, NumberStyles style, NumberFormatInfo nfi, ushort expected)
-    {
-        ushort i;
-        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        ushort result;
+        // If no style is specified, use the (String) or (String, IFormatProvider) overload
         if (style == NumberStyles.Integer)
         {
-            Assert.Equal(true, ushort.TryParse(value, out i));
-            Assert.Equal(expected, i);
+            Assert.True(ushort.TryParse(value, out result));
+            Assert.Equal(expected, result);
 
             Assert.Equal(expected, ushort.Parse(value));
 
-            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-            if (nfi != null)
+            // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (provider != null)
             {
-                Assert.Equal(expected, ushort.Parse(value, nfi));
+                Assert.Equal(expected, ushort.Parse(value, provider));
             }
         }
 
         // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-        Assert.Equal(true, ushort.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
-        Assert.Equal(expected, i);
+        Assert.True(ushort.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
+        Assert.Equal(expected, result);
 
-        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
-        if (nfi == null)
+        // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (provider == null)
         {
             Assert.Equal(expected, ushort.Parse(value, style));
         }
-        Assert.Equal(expected, ushort.Parse(value, style, nfi ?? new NumberFormatInfo()));
+        Assert.Equal(expected, ushort.Parse(value, style, provider ?? new NumberFormatInfo()));
     }
 
-    [Theory, MemberData(nameof(ParseInvalidData))]
-    public static void TestParseInvalid(string value, NumberStyles style, NumberFormatInfo nfi, Type exceptionType)
+    public static IEnumerable<object[]> Parse_Invalid_TestData()
     {
-        ushort i;
-        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        NumberFormatInfo nullFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.CurrencySymbol = "$";
+        customFormat.NumberDecimalSeparator = ".";
+
+        yield return new object[] { null, defaultStyle, nullFormat, typeof(ArgumentNullException) };
+        yield return new object[] { "", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { " ", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, nullFormat, typeof(FormatException) };
+
+        yield return new object[] { "abc", defaultStyle, nullFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, nullFormat, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, nullFormat, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 100.ToString("C0"), defaultStyle, nullFormat, typeof(FormatException) }; // Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, nullFormat, typeof(FormatException) }; // Thousands
+        yield return new object[] { 678.90.ToString("F2"), defaultStyle, nullFormat, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "abc", NumberStyles.None, nullFormat, typeof(FormatException) }; // Negative hex value
+        yield return new object[] { "  123  ", NumberStyles.None, nullFormat, typeof(FormatException) }; // Trailing and leading whitespace
+
+        yield return new object[] { "678.90", defaultStyle, customFormat, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "-1", defaultStyle, nullFormat, typeof(OverflowException) }; // < min value
+        yield return new object[] { "65536", defaultStyle, nullFormat, typeof(OverflowException) }; // > max value
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, nullFormat, typeof(OverflowException) }; // Parentheses = negative
+    }
+
+    [Theory]
+    [MemberData(nameof(Parse_Invalid_TestData))]
+    public static void TestParse_Invalid(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
+    {
+        ushort result;
+        // If no style is specified, use the (String) or (String, IFormatProvider) overload
         if (style == NumberStyles.Integer)
         {
-            Assert.Equal(false, ushort.TryParse(value, out i));
-            Assert.Equal(default(ushort), i);
+            Assert.False(ushort.TryParse(value, out result));
+            Assert.Equal(default(ushort), result);
 
             Assert.Throws(exceptionType, () => ushort.Parse(value));
 
-            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-            if (nfi != null)
+            // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (provider != null)
             {
-                Assert.Throws(exceptionType, () => ushort.Parse(value, nfi));
+                Assert.Throws(exceptionType, () => ushort.Parse(value, provider));
             }
         }
 
         // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-        Assert.Equal(false, ushort.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
-        Assert.Equal(default(ushort), i);
+        Assert.False(ushort.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
+        Assert.Equal(default(ushort), result);
 
-        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
-        if (nfi == null)
+        // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (provider == null)
         {
             Assert.Throws(exceptionType, () => ushort.Parse(value, style));
         }
-        Assert.Throws(exceptionType, () => ushort.Parse(value, style, nfi ?? new NumberFormatInfo()));
+        Assert.Throws(exceptionType, () => ushort.Parse(value, style, provider ?? new NumberFormatInfo()));
     }
 }

--- a/src/System.Runtime/tests/System/UInt32.cs
+++ b/src/System.Runtime/tests/System/UInt32.cs
@@ -139,26 +139,27 @@ public static class UInt32Tests
 
     public static IEnumerable<object[]> Parse_Valid_TestData()
     {
-        NumberFormatInfo nullFormat = null;
         NumberStyles defaultStyle = NumberStyles.Integer;
         NumberFormatInfo emptyFormat = new NumberFormatInfo();
 
         NumberFormatInfo customFormat = new NumberFormatInfo();
         customFormat.CurrencySymbol = "$";
 
-        yield return new object[] { "0", defaultStyle, nullFormat, (uint)0 };
-        yield return new object[] { "123", defaultStyle, nullFormat, (uint)123 };
-        yield return new object[] { "  123  ", defaultStyle, nullFormat, (uint)123 };
-        yield return new object[] { "4294967295", defaultStyle, nullFormat, 4294967295 };
+        yield return new object[] { "0", defaultStyle, null, (uint)0 };
+        yield return new object[] { "123", defaultStyle, null, (uint)123 };
+        yield return new object[] { "+123", defaultStyle, null, (uint)123 };
+        yield return new object[] { "  123  ", defaultStyle, null, (uint)123 };
+        yield return new object[] { "4294967295", defaultStyle, null, 4294967295 };
 
-        yield return new object[] { "12", NumberStyles.HexNumber, nullFormat, (uint)0x12 };
-        yield return new object[] { "1000", NumberStyles.AllowThousands, nullFormat, (uint)1000 };
+        yield return new object[] { "12", NumberStyles.HexNumber, null, (uint)0x12 };
+        yield return new object[] { "1000", NumberStyles.AllowThousands, null, (uint)1000 };
 
         yield return new object[] { "123", defaultStyle, emptyFormat, (uint)123 };
 
         yield return new object[] { "123", NumberStyles.Any, emptyFormat, (uint)123 };
         yield return new object[] { "12", NumberStyles.HexNumber, emptyFormat, (uint)0x12 };
         yield return new object[] { "abc", NumberStyles.HexNumber, emptyFormat, (uint)0xabc };
+        yield return new object[] { "ABC", NumberStyles.HexNumber, emptyFormat, (uint)0xabc };
         yield return new object[] { "$1,000", NumberStyles.Currency, customFormat, (uint)1000 };
     }
 
@@ -196,33 +197,40 @@ public static class UInt32Tests
 
     public static IEnumerable<object[]> Parse_Invalid_TestData()
     {
-        NumberFormatInfo nullFormat = null;
         NumberStyles defaultStyle = NumberStyles.Integer;
 
         NumberFormatInfo customFormat = new NumberFormatInfo();
         customFormat.CurrencySymbol = "$";
         customFormat.NumberDecimalSeparator = ".";
 
-        yield return new object[] { null, defaultStyle, nullFormat, typeof(ArgumentNullException) };
-        yield return new object[] { "", defaultStyle, nullFormat, typeof(FormatException) };
-        yield return new object[] { " ", defaultStyle, nullFormat, typeof(FormatException) };
-        yield return new object[] { "Garbage", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { null, defaultStyle, null, typeof(ArgumentNullException) };
 
-        yield return new object[] { "abc", defaultStyle, nullFormat, typeof(FormatException) }; // Hex value
-        yield return new object[] { "1E23", defaultStyle, nullFormat, typeof(FormatException) }; // Exponent
-        yield return new object[] { "(123)", defaultStyle, nullFormat, typeof(FormatException) }; // Parentheses
-        yield return new object[] { 100.ToString("C0"), defaultStyle, nullFormat, typeof(FormatException) }; // Currency
-        yield return new object[] { 1000.ToString("N0"), defaultStyle, nullFormat, typeof(FormatException) }; // Thousands
-        yield return new object[] { 678.90.ToString("F2"), defaultStyle, nullFormat, typeof(FormatException) }; // Decimal
+        yield return new object[] { "", defaultStyle, null, typeof(FormatException) };
+        yield return new object[] { " \t \n \r ", defaultStyle, null, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, null, typeof(FormatException) };
 
-        yield return new object[] { "abc", NumberStyles.None, nullFormat, typeof(FormatException) }; // Negative hex value
-        yield return new object[] { "  123  ", NumberStyles.None, nullFormat, typeof(FormatException) }; // Trailing and leading whitespace
+        yield return new object[] { "abc", defaultStyle, null, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, null, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, null, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 100.ToString("C0"), defaultStyle, null, typeof(FormatException) }; // Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, null, typeof(FormatException) }; // Thousands
+        yield return new object[] { 678.90.ToString("F2"), defaultStyle, null, typeof(FormatException) }; // Decimal
+        yield return new object[] { "+-123", defaultStyle, null, typeof(FormatException) };
+        yield return new object[] { "-+123", defaultStyle, null, typeof(FormatException) };
+        yield return new object[] { "+abc", NumberStyles.HexNumber, null, typeof(FormatException) };
+        yield return new object[] { "-abc", NumberStyles.HexNumber, null, typeof(FormatException) };
+
+        yield return new object[] { "- 123", defaultStyle, null, typeof(FormatException) };
+        yield return new object[] { "+ 123", defaultStyle, null, typeof(FormatException) };
+
+        yield return new object[] { "abc", NumberStyles.None, null, typeof(FormatException) }; // Hex value
+        yield return new object[] { "  123  ", NumberStyles.None, null, typeof(FormatException) }; // Trailing and leading whitespace
 
         yield return new object[] { "678.90", defaultStyle, customFormat, typeof(FormatException) }; // Decimal
 
-        yield return new object[] { "-1", defaultStyle, nullFormat, typeof(OverflowException) }; // < min value
-        yield return new object[] { "4294967296", defaultStyle, nullFormat, typeof(OverflowException) }; // > max value
-        yield return new object[] { "(123)", NumberStyles.AllowParentheses, nullFormat, typeof(OverflowException) }; // Parentheses = negative
+        yield return new object[] { "-1", defaultStyle, null, typeof(OverflowException) }; // < min value
+        yield return new object[] { "4294967296", defaultStyle, null, typeof(OverflowException) }; // > max value
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, null, typeof(OverflowException) }; // Parentheses = negative
     }
 
     [Theory]
@@ -255,5 +263,18 @@ public static class UInt32Tests
             Assert.Throws(exceptionType, () => uint.Parse(value, style));
         }
         Assert.Throws(exceptionType, () => uint.Parse(value, style, provider ?? new NumberFormatInfo()));
+    }
+
+    [Theory]
+    [InlineData(NumberStyles.HexNumber | NumberStyles.AllowParentheses)]
+    [InlineData(unchecked((NumberStyles)0xFFFFFC00))]
+    public static void TestTryParse_InvalidNumberStyle_ThrowsArgumentException(NumberStyles style)
+    {
+        uint result = 0;
+        Assert.Throws<ArgumentException>(() => uint.TryParse("1", style, null, out result));
+        Assert.Equal(default(uint), result);
+
+        Assert.Throws<ArgumentException>(() => uint.Parse("1", style));
+        Assert.Throws<ArgumentException>(() => uint.Parse("1", style, null));
     }
 }

--- a/src/System.Runtime/tests/System/UInt32.cs
+++ b/src/System.Runtime/tests/System/UInt32.cs
@@ -5,21 +5,19 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Runtime.Tests.Common;
-
 using Xunit;
 
 public static class UInt32Tests
 {
     [Fact]
-    public static void TestCtorEmpty()
+    public static void TestCtor_Empty()
     {
-        uint i = new uint();
+        var i = new uint();
         Assert.Equal((uint)0, i);
     }
 
     [Fact]
-    public static void TestCtorValue()
+    public static void TestCtor_Value()
     {
         uint i = 41;
         Assert.Equal((uint)41, i);
@@ -38,237 +36,224 @@ public static class UInt32Tests
     }
 
     [Theory]
-    [InlineData((uint)234, 0)]
-    [InlineData(uint.MinValue, 1)]
-    [InlineData((uint)0, 1)]
-    [InlineData((uint)45, 1)]
-    [InlineData((uint)123, 1)]
-    [InlineData((uint)456, -1)]
-    [InlineData(uint.MaxValue, -1)]
-    public static void TestCompareTo(uint value, int expected)
+    [InlineData((uint)234, (uint)234, 0)]
+    [InlineData((uint)234, uint.MinValue, 1)]
+    [InlineData((uint)234, (uint)0, 1)]
+    [InlineData((uint)234, (uint)123, 1)]
+    [InlineData((uint)234, (uint)456, -1)]
+    [InlineData((uint)234, uint.MaxValue, -1)]
+    [InlineData((uint)234, null, 1)]
+    public static void TestCompareTo(uint i, object value, int expected)
     {
-        uint i = 234;
-        int result = CompareHelper.NormalizeCompare(i.CompareTo(value));
-        Assert.Equal(expected, result);
+        if (value is uint)
+        {
+            Assert.Equal(expected, Math.Sign(i.CompareTo((uint)value)));
+        }
+        IComparable comparable = i;
+        Assert.Equal(expected, Math.Sign(comparable.CompareTo(value)));
     }
 
-    [Theory]
-    [InlineData(null, 1)]
-    [InlineData((uint)234, 0)]
-    [InlineData(uint.MinValue, 1)]
-    [InlineData((uint)0, 1)]
-    [InlineData((uint)45, 1)]
-    [InlineData((uint)123, 1)]
-    [InlineData((uint)456, -1)]
-    [InlineData(uint.MaxValue, -1)]
-    public static void TestCompareToObject(object obj, int expected)
+    [Fact]
+    public static void TestCompareTo_Invalid()
     {
         IComparable comparable = (uint)234;
-        int i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
-        Assert.Equal(expected, i);
-    }
-
-    [Fact]
-    public static void TestCompareToObjectInvalid()
-    {
-        IComparable comparable = (uint)234;
-        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a byte
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); // Obj is not a uint
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo(234)); // Obj is not a uint
     }
 
     [Theory]
-    [InlineData((uint)789, true)]
-    [InlineData((uint)0, false)]
-    public static void TestEqualsObject(object obj, bool expected)
+    [InlineData((uint)789, (uint)789, true)]
+    [InlineData((uint)788, (uint)0, false)]
+    [InlineData((uint)0, (uint)0, true)]
+    [InlineData((uint)789, null, false)]
+    [InlineData((uint)789, "789", false)]
+    [InlineData((uint)789, 789, false)]
+    public static void TestEquals(uint i1, object obj, bool expected)
     {
-        uint i = 789;
-        Assert.Equal(expected, i.Equals(obj));
+        if (obj is uint)
+        {
+            uint i2 = (uint)obj;
+            Assert.Equal(expected, i1.Equals(i2));
+            Assert.Equal(expected, i1.GetHashCode().Equals(i2.GetHashCode()));
+            Assert.Equal((int)i1, i1.GetHashCode());
+        }
+        Assert.Equal(expected, i1.Equals(obj));
+    }
+
+    public static IEnumerable<object[]> ToString_TestData()
+    {
+        NumberFormatInfo emptyFormat = NumberFormatInfo.CurrentInfo;
+        yield return new object[] { (uint)0, "G", emptyFormat, "0" };
+        yield return new object[] { (uint)4567, "G", emptyFormat, "4567" };
+        yield return new object[] { uint.MaxValue, "G", emptyFormat, "4294967295" };
+
+        yield return new object[] { (uint)0x2468, "x", emptyFormat, "2468" };
+        yield return new object[] { (uint)2468, "N", emptyFormat, string.Format("{0:N}", 2468.00) };
+
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.NegativeSign = "#";
+        customFormat.NumberDecimalSeparator = "~";
+        customFormat.NumberGroupSeparator = "*";
+        yield return new object[] { (uint)2468, "N", customFormat, "2*468~00" };
     }
 
     [Theory]
-    [InlineData((uint)789, true)]
-    [InlineData((uint)0, false)]
-    public static void TestEquals(uint i2, bool expected)
+    [MemberData(nameof(ToString_TestData))]
+    public static void TestToString(uint i, string format, IFormatProvider provider, string expected)
     {
-        uint i = 789;
-        Assert.Equal(expected, i.Equals(i2));
+        // Format is case insensitive
+        string upperFormat = format.ToUpperInvariant();
+        string lowerFormat = format.ToLowerInvariant();
+
+        string upperExpected = expected.ToUpperInvariant();
+        string lowerExpected = expected.ToLowerInvariant();
+
+        bool isDefaultProvider = (provider == null || provider == NumberFormatInfo.CurrentInfo);
+        if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")
+        {
+            if (isDefaultProvider)
+            {
+                Assert.Equal(upperExpected, i.ToString());
+                Assert.Equal(upperExpected, i.ToString((IFormatProvider)null));
+            }
+            Assert.Equal(upperExpected, i.ToString(provider));
+        }
+        if (isDefaultProvider)
+        {
+            Assert.Equal(upperExpected, i.ToString(upperFormat));
+            Assert.Equal(lowerExpected, i.ToString(lowerFormat));
+            Assert.Equal(upperExpected, i.ToString(upperFormat, null));
+            Assert.Equal(lowerExpected, i.ToString(lowerFormat, null));
+        }
+        Assert.Equal(upperExpected, i.ToString(upperFormat, provider));
+        Assert.Equal(lowerExpected, i.ToString(lowerFormat, provider));
     }
 
     [Fact]
-    public static void TestGetHashCode()
+    public static void TestToString_Invalid()
     {
-        uint i1 = 123;
-        uint i2 = 654;
-
-        Assert.NotEqual(0, i1.GetHashCode());
-        Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
+        uint i = 123;
+        Assert.Throws<FormatException>(() => i.ToString("Y")); // Invalid format
+        Assert.Throws<FormatException>(() => i.ToString("Y", null)); // Invalid format
     }
 
-    [Fact]
-    public static void TestToString()
+    public static IEnumerable<object[]> Parse_Valid_TestData()
     {
-        uint i1 = 6310;
-        Assert.Equal("6310", i1.ToString());
-    }
-
-    [Fact]
-    public static void TestToStringFormatProvider()
-    {
-        var numberFormat = new NumberFormatInfo();
-
-        uint i1 = 6310;
-        Assert.Equal("6310", i1.ToString(numberFormat));
-    }
-
-    [Fact]
-    public static void TestToStringFormat()
-    {
-        uint i1 = 6310;
-        Assert.Equal("6310", i1.ToString("G"));
-
-        uint i2 = 8249;
-        Assert.Equal("8249", i2.ToString("g"));
-
-        uint i3 = 2468;
-        Assert.Equal(string.Format("{0:N}", 2468.00), i3.ToString("N"));
-
-        uint i4 = 0x248;
-        Assert.Equal("248", i4.ToString("x"));
-    }
-
-    [Fact]
-    public static void TestToStringFormatFormatProvider()
-    {
-        var numberFormat = new NumberFormatInfo();
-
-        uint i1 = 6310;
-        Assert.Equal("6310", i1.ToString("G", numberFormat));
-
-        uint i2 = 8249;
-        Assert.Equal("8249", i2.ToString("g", numberFormat));
-
-        numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
-        numberFormat.NumberGroupSeparator = "*";
-        numberFormat.NumberNegativePattern = 0;
-        uint i3 = 2468;
-        Assert.Equal("2*468.00", i3.ToString("N", numberFormat));
-    }
-
-    public static IEnumerable<object[]> ParseValidData()
-    {
-        NumberFormatInfo defaultFormat = null;
+        NumberFormatInfo nullFormat = null;
         NumberStyles defaultStyle = NumberStyles.Integer;
-        var emptyNfi = new NumberFormatInfo();
+        NumberFormatInfo emptyFormat = new NumberFormatInfo();
 
-        var testNfi = new NumberFormatInfo();
-        testNfi.CurrencySymbol = "$";
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.CurrencySymbol = "$";
 
-        yield return new object[] { "0", defaultStyle, defaultFormat, (uint)0 };
-        yield return new object[] { "123", defaultStyle, defaultFormat, (uint)123 };
-        yield return new object[] { "  123  ", defaultStyle, defaultFormat, (uint)123 };
-        yield return new object[] { "4294967295", defaultStyle, defaultFormat, (uint)4294967295 };
-        
-        yield return new object[] { "12", NumberStyles.HexNumber, defaultFormat, (uint)0x12 };
-        yield return new object[] { "1000", NumberStyles.AllowThousands, defaultFormat, (uint)1000 };
+        yield return new object[] { "0", defaultStyle, nullFormat, (uint)0 };
+        yield return new object[] { "123", defaultStyle, nullFormat, (uint)123 };
+        yield return new object[] { "  123  ", defaultStyle, nullFormat, (uint)123 };
+        yield return new object[] { "4294967295", defaultStyle, nullFormat, 4294967295 };
 
-        yield return new object[] { "123", defaultStyle, emptyNfi, (uint)123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, nullFormat, (uint)0x12 };
+        yield return new object[] { "1000", NumberStyles.AllowThousands, nullFormat, (uint)1000 };
 
-        yield return new object[] { "123", NumberStyles.Any, emptyNfi, (uint)123 };
-        yield return new object[] { "12", NumberStyles.HexNumber, emptyNfi, (uint)0x12 };
-        yield return new object[] { "abc", NumberStyles.HexNumber, emptyNfi, (uint)0xabc };
-        yield return new object[] { "$1,000", NumberStyles.Currency, testNfi, (uint)1000 };
+        yield return new object[] { "123", defaultStyle, emptyFormat, (uint)123 };
+
+        yield return new object[] { "123", NumberStyles.Any, emptyFormat, (uint)123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, emptyFormat, (uint)0x12 };
+        yield return new object[] { "abc", NumberStyles.HexNumber, emptyFormat, (uint)0xabc };
+        yield return new object[] { "$1,000", NumberStyles.Currency, customFormat, (uint)1000 };
     }
 
-    public static IEnumerable<object[]> ParseInvalidData()
+    [Theory]
+    [MemberData(nameof(Parse_Valid_TestData))]
+    public static void TestParse(string value, NumberStyles style, IFormatProvider provider, uint expected)
     {
-        NumberFormatInfo defaultFormat = null;
-        NumberStyles defaultStyle = NumberStyles.Integer;
-        var emptyNfi = new NumberFormatInfo();
-
-        var testNfi = new NumberFormatInfo();
-        testNfi.CurrencySymbol = "$";
-        testNfi.NumberDecimalSeparator = ".";
-
-        yield return new object[] { null, defaultStyle, defaultFormat, typeof(ArgumentNullException) };
-        yield return new object[] { "", defaultStyle, defaultFormat, typeof(FormatException) };
-        yield return new object[] { " ", defaultStyle, defaultFormat, typeof(FormatException) };
-        yield return new object[] { "Garbage", defaultStyle, defaultFormat, typeof(FormatException) };
-
-        yield return new object[] { "abc", defaultStyle, defaultFormat, typeof(FormatException) }; // Hex value
-        yield return new object[] { "1E23", defaultStyle, defaultFormat, typeof(FormatException) }; // Exponent
-        yield return new object[] { "(123)", defaultStyle, defaultFormat, typeof(FormatException) }; // Parentheses
-        yield return new object[] { 100.ToString("C0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Currency
-        yield return new object[] { 1000.ToString("N0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Thousands
-        yield return new object[] { 678.90.ToString("F2"), defaultStyle, defaultFormat, typeof(FormatException) }; //Decimal
-
-        yield return new object[] { "abc", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Negative hex value
-        yield return new object[] { "  123  ", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Trailing and leading whitespace
-
-        yield return new object[] { "678.90", defaultStyle, testNfi, typeof(FormatException) }; // Decimal
-        
-        yield return new object[] { "-1", defaultStyle, defaultFormat, typeof(OverflowException) }; // < min value
-        yield return new object[] { "4294967296", defaultStyle, defaultFormat, typeof(OverflowException) }; // > max value
-        yield return new object[] { "(123)", NumberStyles.AllowParentheses, defaultFormat, typeof(OverflowException) }; // Parentheses = negative
-    }
-
-    [Theory, MemberData(nameof(ParseValidData))]
-    public static void TestParse(string value, NumberStyles style, NumberFormatInfo nfi, uint expected)
-    {
-        uint i;
-        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        uint result;
+        // If no style is specified, use the (String) or (String, IFormatProvider) overload
         if (style == NumberStyles.Integer)
         {
-            Assert.Equal(true, uint.TryParse(value, out i));
-            Assert.Equal(expected, i);
+            Assert.True(uint.TryParse(value, out result));
+            Assert.Equal(expected, result);
 
             Assert.Equal(expected, uint.Parse(value));
 
-            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-            if (nfi != null)
+            // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (provider != null)
             {
-                Assert.Equal(expected, uint.Parse(value, nfi));
+                Assert.Equal(expected, uint.Parse(value, provider));
             }
         }
 
         // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-        Assert.Equal(true, uint.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
-        Assert.Equal(expected, i);
+        Assert.True(uint.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
+        Assert.Equal(expected, result);
 
-        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
-        if (nfi == null)
+        // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (provider == null)
         {
             Assert.Equal(expected, uint.Parse(value, style));
         }
-        Assert.Equal(expected, uint.Parse(value, style, nfi ?? new NumberFormatInfo()));
+        Assert.Equal(expected, uint.Parse(value, style, provider ?? new NumberFormatInfo()));
     }
 
-    [Theory, MemberData(nameof(ParseInvalidData))]
-    public static void TestParseInvalid(string value, NumberStyles style, NumberFormatInfo nfi, Type exceptionType)
+    public static IEnumerable<object[]> Parse_Invalid_TestData()
     {
-        uint i;
-        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        NumberFormatInfo nullFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.CurrencySymbol = "$";
+        customFormat.NumberDecimalSeparator = ".";
+
+        yield return new object[] { null, defaultStyle, nullFormat, typeof(ArgumentNullException) };
+        yield return new object[] { "", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { " ", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, nullFormat, typeof(FormatException) };
+
+        yield return new object[] { "abc", defaultStyle, nullFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, nullFormat, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, nullFormat, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 100.ToString("C0"), defaultStyle, nullFormat, typeof(FormatException) }; // Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, nullFormat, typeof(FormatException) }; // Thousands
+        yield return new object[] { 678.90.ToString("F2"), defaultStyle, nullFormat, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "abc", NumberStyles.None, nullFormat, typeof(FormatException) }; // Negative hex value
+        yield return new object[] { "  123  ", NumberStyles.None, nullFormat, typeof(FormatException) }; // Trailing and leading whitespace
+
+        yield return new object[] { "678.90", defaultStyle, customFormat, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "-1", defaultStyle, nullFormat, typeof(OverflowException) }; // < min value
+        yield return new object[] { "4294967296", defaultStyle, nullFormat, typeof(OverflowException) }; // > max value
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, nullFormat, typeof(OverflowException) }; // Parentheses = negative
+    }
+
+    [Theory]
+    [MemberData(nameof(Parse_Invalid_TestData))]
+    public static void TestParse_Invalid(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
+    {
+        uint result;
+        // If no style is specified, use the (String) or (String, IFormatProvider) overload
         if (style == NumberStyles.Integer)
         {
-            Assert.Equal(false, uint.TryParse(value, out i));
-            Assert.Equal(default(uint), i);
+            Assert.False(uint.TryParse(value, out result));
+            Assert.Equal(default(uint), result);
 
             Assert.Throws(exceptionType, () => uint.Parse(value));
 
-            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-            if (nfi != null)
+            // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (provider != null)
             {
-                Assert.Throws(exceptionType, () => uint.Parse(value, nfi));
+                Assert.Throws(exceptionType, () => uint.Parse(value, provider));
             }
         }
 
         // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-        Assert.Equal(false, uint.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
-        Assert.Equal(default(uint), i);
+        Assert.False(uint.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
+        Assert.Equal(default(uint), result);
 
-        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
-        if (nfi == null)
+        // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (provider == null)
         {
             Assert.Throws(exceptionType, () => uint.Parse(value, style));
         }
-        Assert.Throws(exceptionType, () => uint.Parse(value, style, nfi ?? new NumberFormatInfo()));
+        Assert.Throws(exceptionType, () => uint.Parse(value, style, provider ?? new NumberFormatInfo()));
     }
 }

--- a/src/System.Runtime/tests/System/UInt64.cs
+++ b/src/System.Runtime/tests/System/UInt64.cs
@@ -5,21 +5,19 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Runtime.Tests.Common;
-
 using Xunit;
 
 public static class UInt64Tests
 {
     [Fact]
-    public static void TestCtorEmpty()
+    public static void TestCtor_Empty()
     {
-        ulong i = new ulong();
+        var i = new ulong();
         Assert.Equal((ulong)0, i);
     }
 
     [Fact]
-    public static void TestCtorValue()
+    public static void TestCtor_Value()
     {
         ulong i = 41;
         Assert.Equal((ulong)41, i);
@@ -38,238 +36,224 @@ public static class UInt64Tests
     }
 
     [Theory]
-    [InlineData((ulong)234, 0)]
-    [InlineData(ulong.MinValue, 1)]
-    [InlineData((ulong)0, 1)]
-    [InlineData((ulong)45, 1)]
-    [InlineData((ulong)123, 1)]
-    [InlineData((ulong)456, -1)]
-    [InlineData(ulong.MaxValue, -1)]
-    public static void TestCompareTo(ulong value, int expected)
+    [InlineData((ulong)234, (ulong)234, 0)]
+    [InlineData((ulong)234, ulong.MinValue, 1)]
+    [InlineData((ulong)234, (ulong)0, 1)]
+    [InlineData((ulong)234, (ulong)123, 1)]
+    [InlineData((ulong)234, (ulong)456, -1)]
+    [InlineData((ulong)234, ulong.MaxValue, -1)]
+    [InlineData((ulong)234, null, 1)]
+    public static void TestCompareTo(ulong i, object value, int expected)
     {
-        ulong i = 234;
-        int result = CompareHelper.NormalizeCompare(i.CompareTo(value));
-        Assert.Equal(expected, result);
+        if (value is ulong)
+        {
+            Assert.Equal(expected, Math.Sign(i.CompareTo((ulong)value)));
+        }
+        IComparable comparable = i;
+        Assert.Equal(expected, Math.Sign(comparable.CompareTo(value)));
     }
 
-    [Theory]
-    [InlineData(null, 1)]
-    [InlineData((ulong)234, 0)]
-    [InlineData(ulong.MinValue, 1)]
-    [InlineData((ulong)0, 1)]
-    [InlineData((ulong)45, 1)]
-    [InlineData((ulong)123, 1)]
-    [InlineData((ulong)456, -1)]
-    [InlineData(ulong.MaxValue, -1)]
-    public static void TestCompareToObject(object obj, int expected)
+    [Fact]
+    public static void TestCompareTo_Invalid()
     {
         IComparable comparable = (ulong)234;
-        int i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
-        Assert.Equal(expected, i);
-    }
-
-    [Fact]
-    public static void TestCompareToObjectInvalid()
-    {
-        IComparable comparable = (ulong)234;
-        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a byte
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); // Obj is not a ulong
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo(234)); // Obj is not a ulong
     }
 
     [Theory]
-    [InlineData((ulong)789, true)]
-    [InlineData((ulong)0, false)]
-    public static void TestEqualsObject(object obj, bool expected)
+    [InlineData((ulong)789, (ulong)789, true)]
+    [InlineData((ulong)788, (ulong)0, false)]
+    [InlineData((ulong)0, (ulong)0, true)]
+    [InlineData((ulong)789, null, false)]
+    [InlineData((ulong)789, "789", false)]
+    [InlineData((ulong)789, 789, false)]
+    public static void TestEquals(ulong i1, object obj, bool expected)
     {
-        ulong i = 789;
-        Assert.Equal(expected, i.Equals(obj));
+        if (obj is ulong)
+        {
+            ulong i2 = (ulong)obj;
+            Assert.Equal(expected, i1.Equals(i2));
+            Assert.Equal(expected, i1.GetHashCode().Equals(i2.GetHashCode()));
+            Assert.Equal((int)i1, i1.GetHashCode());
+        }
+        Assert.Equal(expected, i1.Equals(obj));
+    }
+
+    public static IEnumerable<object[]> ToStringTestData()
+    {
+        NumberFormatInfo emptyFormat = NumberFormatInfo.CurrentInfo;
+        yield return new object[] { (ulong)0, "G", emptyFormat, "0" };
+        yield return new object[] { (ulong)4567, "G", emptyFormat, "4567" };
+        yield return new object[] { ulong.MaxValue, "G", emptyFormat, "18446744073709551615" };
+
+        yield return new object[] { (ulong)0x2468, "x", emptyFormat, "2468" };
+        yield return new object[] { (ulong)2468, "N", emptyFormat, string.Format("{0:N}", 2468.00) };
+
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.NegativeSign = "#";
+        customFormat.NumberDecimalSeparator = "~";
+        customFormat.NumberGroupSeparator = "*";
+        yield return new object[] { (ulong)2468, "N", customFormat, "2*468~00" };
     }
 
     [Theory]
-    [InlineData((ulong)789, true)]
-    [InlineData((ulong)0, false)]
-    public static void TestEquals(ulong i2, bool expected)
+    [MemberData(nameof(ToStringTestData))]
+    public static void TestToString(ulong i, string format, IFormatProvider provider, string expected)
     {
-        ulong i = 789;
-        Assert.Equal(expected, i.Equals(i2));
+        // Format is case insensitive
+        string upperFormat = format.ToUpperInvariant();
+        string lowerFormat = format.ToLowerInvariant();
+
+        string upperExpected = expected.ToUpperInvariant();
+        string lowerExpected = expected.ToLowerInvariant();
+
+        bool isDefaultProvider = (provider == null || provider == NumberFormatInfo.CurrentInfo);
+        if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")
+        {
+            if (isDefaultProvider)
+            {
+                Assert.Equal(upperExpected, i.ToString());
+                Assert.Equal(upperExpected, i.ToString((IFormatProvider)null));
+            }
+            Assert.Equal(upperExpected, i.ToString(provider));
+        }
+        if (isDefaultProvider)
+        {
+            Assert.Equal(upperExpected, i.ToString(upperFormat));
+            Assert.Equal(lowerExpected, i.ToString(lowerFormat));
+            Assert.Equal(upperExpected, i.ToString(upperFormat, null));
+            Assert.Equal(lowerExpected, i.ToString(lowerFormat, null));
+        }
+        Assert.Equal(upperExpected, i.ToString(upperFormat, provider));
+        Assert.Equal(lowerExpected, i.ToString(lowerFormat, provider));
     }
 
     [Fact]
-    public static void TestGetHashCode()
+    public static void TestToString_Invalid()
     {
-        ulong i1 = 123;
-        ulong i2 = 654;
-
-        Assert.NotEqual(0, i1.GetHashCode());
-        Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
+        ulong i = 123;
+        Assert.Throws<FormatException>(() => i.ToString("Y")); // Invalid format
+        Assert.Throws<FormatException>(() => i.ToString("Y", null)); // Invalid format
     }
 
-    [Fact]
-    public static void TestToString()
+    public static IEnumerable<object[]> Parse_Valid_TestData()
     {
-        ulong i1 = 6310;
-        Assert.Equal("6310", i1.ToString());
-    }
-
-    [Fact]
-    public static void TestToStringFormatProvider()
-    {
-        var numberFormat = new NumberFormatInfo();
-
-        ulong i1 = 6310;
-        Assert.Equal("6310", i1.ToString(numberFormat));
-    }
-
-    [Fact]
-    public static void TestToStringFormat()
-    {
-        ulong i1 = 6310;
-        Assert.Equal("6310", i1.ToString("G"));
-
-        ulong i2 = 8249;
-        Assert.Equal("8249", i2.ToString("g"));
-
-        ulong i3 = 2468;
-        Assert.Equal(string.Format("{0:N}", 2468.00), i3.ToString("N"));
-
-        ulong i4 = 0x248;
-        Assert.Equal("248", i4.ToString("x"));
-    }
-
-    [Fact]
-    public static void TestToStringFormatFormatProvider()
-    {
-        var numberFormat = new NumberFormatInfo();
-
-        ulong i1 = 6310;
-        Assert.Equal("6310", i1.ToString("G", numberFormat));
-
-        ulong i2 = 8249;
-        Assert.Equal("8249", i2.ToString("g", numberFormat));
-
-        numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
-        numberFormat.NumberGroupSeparator = "*";
-        numberFormat.NumberNegativePattern = 0;
-        ulong i3 = 2468;
-        Assert.Equal("2*468.00", i3.ToString("N", numberFormat));
-    }
-
-
-    public static IEnumerable<object[]> ParseValidData()
-    {
-        NumberFormatInfo defaultFormat = null;
+        NumberFormatInfo nullFormat = null;
         NumberStyles defaultStyle = NumberStyles.Integer;
-        var emptyNfi = new NumberFormatInfo();
+        NumberFormatInfo emptyFormat = new NumberFormatInfo();
 
-        var testNfi = new NumberFormatInfo();
-        testNfi.CurrencySymbol = "$";
-        
-        yield return new object[] { "0", defaultStyle, defaultFormat, (ulong)0 };
-        yield return new object[] { "123", defaultStyle, defaultFormat, (ulong)123 };
-        yield return new object[] { "  123  ", defaultStyle, defaultFormat, (ulong)123 };
-        yield return new object[] { "18446744073709551615", defaultStyle, defaultFormat, (ulong)18446744073709551615 };
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.CurrencySymbol = "$";
 
-        yield return new object[] { "12", NumberStyles.HexNumber, defaultFormat, (ulong)0x12 };
-        yield return new object[] { "1000", NumberStyles.AllowThousands, defaultFormat, (ulong)1000 };
+        yield return new object[] { "0", defaultStyle, nullFormat, (ulong)0 };
+        yield return new object[] { "123", defaultStyle, nullFormat, (ulong)123 };
+        yield return new object[] { "  123  ", defaultStyle, nullFormat, (ulong)123 };
+        yield return new object[] { "18446744073709551615", defaultStyle, nullFormat, 18446744073709551615 };
 
-        yield return new object[] { "123", defaultStyle, emptyNfi, (ulong)123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, nullFormat, (ulong)0x12 };
+        yield return new object[] { "1000", NumberStyles.AllowThousands, nullFormat, (ulong)1000 };
 
-        yield return new object[] { "123", NumberStyles.Any, emptyNfi, (ulong)123 };
-        yield return new object[] { "12", NumberStyles.HexNumber, emptyNfi, (ulong)0x12 };
-        yield return new object[] { "abc", NumberStyles.HexNumber, emptyNfi, (ulong)0xabc };
-        yield return new object[] { "$1,000", NumberStyles.Currency, testNfi, (ulong)1000 };
+        yield return new object[] { "123", defaultStyle, emptyFormat, (ulong)123 };
+
+        yield return new object[] { "123", NumberStyles.Any, emptyFormat, (ulong)123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, emptyFormat, (ulong)0x12 };
+        yield return new object[] { "abc", NumberStyles.HexNumber, emptyFormat, (ulong)0xabc };
+        yield return new object[] { "$1,000", NumberStyles.Currency, customFormat, (ulong)1000 };
     }
 
-    public static IEnumerable<object[]> ParseInvalidData()
+    [Theory]
+    [MemberData(nameof(Parse_Valid_TestData))]
+    public static void TestParse(string value, NumberStyles style, IFormatProvider provider, ulong expected)
     {
-        NumberFormatInfo defaultFormat = null;
-        NumberStyles defaultStyle = NumberStyles.Integer;
-        var emptyNfi = new NumberFormatInfo();
-
-        var testNfi = new NumberFormatInfo();
-        testNfi.CurrencySymbol = "$";
-        testNfi.NumberDecimalSeparator = ".";
-
-        yield return new object[] { null, defaultStyle, defaultFormat, typeof(ArgumentNullException) };
-        yield return new object[] { "", defaultStyle, defaultFormat, typeof(FormatException) };
-        yield return new object[] { " ", defaultStyle, defaultFormat, typeof(FormatException) };
-        yield return new object[] { "Garbage", defaultStyle, defaultFormat, typeof(FormatException) };
-
-        yield return new object[] { "abc", defaultStyle, defaultFormat, typeof(FormatException) }; // Hex value
-        yield return new object[] { "1E23", defaultStyle, defaultFormat, typeof(FormatException) }; // Exponent
-        yield return new object[] { "(123)", defaultStyle, defaultFormat, typeof(FormatException) }; // Parentheses
-        yield return new object[] { 100.ToString("C0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Currency
-        yield return new object[] { 1000.ToString("N0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Thousands
-        yield return new object[] { 678.90.ToString("F2"), defaultStyle, defaultFormat, typeof(FormatException) }; //Decimal
-
-        yield return new object[] { "abc", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Negative hex value
-        yield return new object[] { "  123  ", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Trailing and leading whitespace
-
-        yield return new object[] { "678.90", defaultStyle, testNfi, typeof(FormatException) }; // Decimal
-
-        yield return new object[] { "-1", defaultStyle, defaultFormat, typeof(OverflowException) }; // < min value
-        yield return new object[] { "18446744073709551616", defaultStyle, defaultFormat, typeof(OverflowException) }; // > max value
-        yield return new object[] { "(123)", NumberStyles.AllowParentheses, defaultFormat, typeof(OverflowException) }; // Parentheses = negative
-    }
-
-    [Theory, MemberData(nameof(ParseValidData))]
-    public static void TestParse(string value, NumberStyles style, NumberFormatInfo nfi, ulong expected)
-    {
-        ulong i;
-        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        ulong result;
+        // If no style is specified, use the (String) or (String, IFormatProvider) overload
         if (style == NumberStyles.Integer)
         {
-            Assert.Equal(true, ulong.TryParse(value, out i));
-            Assert.Equal(expected, i);
+            Assert.True(ulong.TryParse(value, out result));
+            Assert.Equal(expected, result);
 
             Assert.Equal(expected, ulong.Parse(value));
 
-            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-            if (nfi != null)
+            // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (provider != null)
             {
-                Assert.Equal(expected, ulong.Parse(value, nfi));
+                Assert.Equal(expected, ulong.Parse(value, provider));
             }
         }
 
         // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-        Assert.Equal(true, ulong.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
-        Assert.Equal(expected, i);
+        Assert.True(ulong.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
+        Assert.Equal(expected, result);
 
-        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
-        if (nfi == null)
+        // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (provider == null)
         {
             Assert.Equal(expected, ulong.Parse(value, style));
         }
-        Assert.Equal(expected, ulong.Parse(value, style, nfi ?? new NumberFormatInfo()));
+        Assert.Equal(expected, ulong.Parse(value, style, provider ?? new NumberFormatInfo()));
     }
 
-    [Theory, MemberData(nameof(ParseInvalidData))]
-    public static void TestParseInvalid(string value, NumberStyles style, NumberFormatInfo nfi, Type exceptionType)
+    public static IEnumerable<object[]> Parse_Invalid_TestData()
     {
-        ulong i;
-        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        NumberFormatInfo nullFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+
+        NumberFormatInfo customFormat = new NumberFormatInfo();
+        customFormat.CurrencySymbol = "$";
+        customFormat.NumberDecimalSeparator = ".";
+
+        yield return new object[] { null, defaultStyle, nullFormat, typeof(ArgumentNullException) };
+        yield return new object[] { "", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { " ", defaultStyle, nullFormat, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, nullFormat, typeof(FormatException) };
+
+        yield return new object[] { "abc", defaultStyle, nullFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, nullFormat, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, nullFormat, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 100.ToString("C0"), defaultStyle, nullFormat, typeof(FormatException) }; // Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, nullFormat, typeof(FormatException) }; // Thousands
+        yield return new object[] { 678.90.ToString("F2"), defaultStyle, nullFormat, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "abc", NumberStyles.None, nullFormat, typeof(FormatException) }; // Negative hex value
+        yield return new object[] { "  123  ", NumberStyles.None, nullFormat, typeof(FormatException) }; // Trailing and leading whitespace
+
+        yield return new object[] { "678.90", defaultStyle, customFormat, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "-1", defaultStyle, nullFormat, typeof(OverflowException) }; // < min value
+        yield return new object[] { "18446744073709551616", defaultStyle, nullFormat, typeof(OverflowException) }; // > max value
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, nullFormat, typeof(OverflowException) }; // Parentheses = negative
+    }
+
+    [Theory]
+    [MemberData(nameof(Parse_Invalid_TestData))]
+    public static void TestParse_Invalid(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
+    {
+        ulong result;
+        // If no style is specified, use the (String) or (String, IFormatProvider) overload
         if (style == NumberStyles.Integer)
         {
-            Assert.Equal(false, ulong.TryParse(value, out i));
-            Assert.Equal(default(ulong), i);
+            Assert.False(ulong.TryParse(value, out result));
+            Assert.Equal(default(ulong), result);
 
             Assert.Throws(exceptionType, () => ulong.Parse(value));
 
-            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
-            if (nfi != null)
+            // If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (provider != null)
             {
-                Assert.Throws(exceptionType, () => ulong.Parse(value, nfi));
+                Assert.Throws(exceptionType, () => ulong.Parse(value, provider));
             }
         }
 
         // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
-        Assert.Equal(false, ulong.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
-        Assert.Equal(default(ulong), i);
+        Assert.False(ulong.TryParse(value, style, provider ?? new NumberFormatInfo(), out result));
+        Assert.Equal(default(ulong), result);
 
-        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
-        if (nfi == null)
+        // If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (provider == null)
         {
             Assert.Throws(exceptionType, () => ulong.Parse(value, style));
         }
-        Assert.Throws(exceptionType, () => ulong.Parse(value, style, nfi ?? new NumberFormatInfo()));
+        Assert.Throws(exceptionType, () => ulong.Parse(value, style, provider ?? new NumberFormatInfo()));
     }
 }


### PR DESCRIPTION
- Take advantage of xunit
- Refactor and add tests for Parse and ToString

Contributes to #6286
Cherry picked from #5490
Helps test dotnet/coreclr#3995