### PR TITLE
Fix issue where product assembly metadata was not always applied

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -17,6 +17,11 @@
     <RoslynPackageName>Microsoft.Net.ToolsetCompilers</RoslynPackageName>
   </PropertyGroup>
 
+  <!-- Informs build tools to apply .NET Framework metadata if not a test project -->
+  <PropertyGroup>
+    <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
+  </PropertyGroup>
+  
   <!--
     Switching to the .NET Core version of the BuildTools tasks seems to break numerous scenarios, such as VS intellisense and resource designer
     as well as runnning the build on mono. Until we can get these sorted out we will continue using the .NET 4.5 version of the tasks.


### PR DESCRIPTION
Previous change assumed IsDotNetFrameworkProductAssembly would be set without actually setting it.  Needed for native compilation.