### PR TITLE
Fixing #7410 to fix build breaks when building on non-Windows platforms

### DIFF
--- a/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.builds
+++ b/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.builds
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <!-- Temporary workaround, VisualBasic projects cannot be built on non-Windows platforms. See issue #5230. -->
-    <Project Include="Microsoft.VisualBasic.vbproj">
+    <Project Include="Microsoft.VisualBasic.vbproj" Condition="'$(OS)'=='Windows_NT'">
       <OSGroup>Windows_NT</OSGroup>
     </Project>
   </ItemGroup>

--- a/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.builds
+++ b/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.builds
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <!-- Temporary workaround, VisualBasic projects cannot be built on non-Windows platforms. See issue #5230. -->
-    <Project Include="Microsoft.VisualBasic.Tests.csproj">
+    <Project Include="Microsoft.VisualBasic.Tests.csproj" Condition="'$(OS)'=='Windows_NT'">
       <OSGroup>Windows_NT</OSGroup>
     </Project>
   </ItemGroup>

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">$(OS)_Debug</Configuration>
+    <Configuration Condition="'$(Configuration)' == '' ">Windows_Debug</Configuration>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>


### PR DESCRIPTION
Adding the Condition to the VB projects to not even try to build on Core; also, reverting the Socket csproj to have a default of Windows_NT configuration. This fixed the build break on my machine while still having the Sockets tests pass when built and run on OS X.