### PR TITLE
Fix a bug that throws a NotSupportedException when Integrated Security keyword is used at all in SqlConnections on non-Windows platforms. It should only fail when set to true.

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
@@ -194,9 +194,6 @@ namespace System.Data.SqlClient
             ThrowUnsupportedIfKeywordSet(KEY.Context_Connection);
             ThrowUnsupportedIfKeywordSet(KEY.Enlist);
             ThrowUnsupportedIfKeywordSet(KEY.TransactionBinding);
-#if MANAGED_SNI
-            ThrowUnsupportedIfKeywordSet(KEY.Integrated_Security);
-#endif
 
             // Network Library has its own special error message
             if (ContainsKey(KEY.Network_Library))
@@ -205,6 +202,12 @@ namespace System.Data.SqlClient
             }
 
             _integratedSecurity = ConvertValueToIntegratedSecurity();
+#if MANAGED_SNI
+            if(_integratedSecurity)
+            {
+                throw SQL.UnsupportedKeyword(KEY.Integrated_Security);
+            }
+#endif
             _encrypt = ConvertValueToBoolean(KEY.Encrypt, DEFAULT.Encrypt);
             _mars = ConvertValueToBoolean(KEY.MARS, DEFAULT.MARS);
             _persistSecurityInfo = ConvertValueToBoolean(KEY.Persist_Security_Info, DEFAULT.Persist_Security_Info);

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ExceptionTest/ExceptionTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ExceptionTest/ExceptionTest.cs
@@ -19,6 +19,19 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         private const string warningInfoMessage = "Test of info messages";
         private const string orderIdQuery = "select orderid from orders where orderid < 10250";
 
+#if MANAGED_SNI
+        [Fact]
+        public static void NonWindowsIntAuthFailureTest()
+        {
+            string connectionString = DataTestClass.SQL2008_Northwind + ";Integrated Security = true";
+            Assert.Throws<NotSupportedException>(() => new SqlConnection(connectionString).Open());
+
+            // Should not receive any exception when using IntAuth=false
+            connectionString = DataTestClass.SQL2008_Northwind + ";Integrated Security = false";
+            new SqlConnection(connectionString).Open();
+        }
+#endif
+
         [Fact]
         public static void WarningTest()
         {


### PR DESCRIPTION
Fixes: https://github.com/aspnet/EntityFramework/issues/4915
Tracking bug: https://github.com/dotnet/corefx/issues/7417