### PR TITLE
Make sure Packagesdir exists before restoring packages

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -61,6 +61,8 @@
   <UsingTask TaskName="GatherDirectoriesToRestore" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <Target Name="BatchRestorePackages">
+    <MakeDir Directories="$(PackagesDir)" Condition="!Exists('$(PackagesDir)')" /> 
+
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring all packages..." />
 
     <Exec Command="$(DnuRestoreCommand) @(DnuRestoreDir->'&quot;%(Identity)&quot;', ' ')"


### PR DESCRIPTION
If there is no package folder, restoring packages fails. 
This change creates the package folder if it is not there and then it restores.

cc: @naamunds @joperezr