### PR TITLE
Enable SpinWait tests in System.Threading.

### DIFF
--- a/src/System.Threading/tests/SpinWaitTests.cs
+++ b/src/System.Threading/tests/SpinWaitTests.cs
@@ -1,18 +1,13 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using System;
-using System.Threading;
 
-namespace Test
+namespace System.Threading.Tests
 {
     public static class SpinWaitTests
     {
-        //
-        // SpinWait
-        //
         [Fact]
         public static void RunSpinWaitTests()
         {

--- a/src/System.Threading/tests/System.Threading.Tests.csproj
+++ b/src/System.Threading/tests/System.Threading.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -30,6 +30,7 @@
     <Compile Include="SemaphoreTests.cs" />
     <Compile Include="SpinLockTests.cs" />
     <Compile Include="ReaderWriterLockSlimTests.cs" />
+    <Compile Include="SpinWaitTests.cs" />
     <Compile Include="ThreadLocalTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
     <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">


### PR DESCRIPTION
SpinWait tests in System.Threading were present but the file wasn't added to the csproj.

resolves #6459