### PR TITLE
Reject `op_implicit` and `op_explicit` methods as conversion ops if arity wrong

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
@@ -95,17 +95,15 @@ namespace System.Dynamic.Utils
                 return TypeCode.Object;
         }
 
-        public static MethodInfo[] GetStaticMethods(this Type type)
+        public static IEnumerable<MethodInfo> GetStaticMethods(this Type type)
         {
-            var list = new List<MethodInfo>();
             foreach (var method in type.GetRuntimeMethods())
             {
                 if (method.IsStatic)
                 {
-                    list.Add(method);
+                    yield return method;
                 }
             }
-            return list.ToArray();
         }
 
         public static MethodInfo GetAnyStaticMethod(this Type type, string name)

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 
@@ -473,37 +474,46 @@ namespace System.Dynamic.Utils
             // check for implicit coercions first
             Type nnExprType = TypeUtils.GetNonNullableType(convertFrom);
             Type nnConvType = TypeUtils.GetNonNullableType(convertToType);
+
+            bool retryForLifted = !AreEquivalent(nnExprType, convertFrom) || !AreEquivalent(nnConvType, convertToType);
+
             // try exact match on types
-            MethodInfo[] eMethods = nnExprType.GetStaticMethods();
+            IEnumerable<MethodInfo> eMethods = nnExprType.GetStaticMethods();
+            if (retryForLifted)
+            {
+                // If this may be scanned again for a lifted match, store it in a list.
+                eMethods = new List<MethodInfo>(eMethods);
+            }
+
             MethodInfo method = FindConversionOperator(eMethods, convertFrom, convertToType, implicitOnly);
             if (method != null)
             {
                 return method;
             }
-            MethodInfo[] cMethods = nnConvType.GetStaticMethods();
+
+            IEnumerable<MethodInfo> cMethods = nnConvType.GetStaticMethods();
+            if (retryForLifted)
+            {
+                cMethods = new List<MethodInfo>(cMethods);
+            }
+
             method = FindConversionOperator(cMethods, convertFrom, convertToType, implicitOnly);
             if (method != null)
             {
                 return method;
             }
+
             // try lifted conversion
-            if (!TypeUtils.AreEquivalent(nnExprType, convertFrom) ||
-                !TypeUtils.AreEquivalent(nnConvType, convertToType))
+            if (retryForLifted)
             {
-                method = FindConversionOperator(eMethods, nnExprType, nnConvType, implicitOnly);
-                if (method == null)
-                {
-                    method = FindConversionOperator(cMethods, nnExprType, nnConvType, implicitOnly);
-                }
-                if (method != null)
-                {
-                    return method;
-                }
+                return FindConversionOperator(eMethods, nnExprType, nnConvType, implicitOnly)
+                    ?? FindConversionOperator(cMethods, nnExprType, nnConvType, implicitOnly);
             }
+
             return null;
         }
 
-        public static MethodInfo FindConversionOperator(MethodInfo[] methods, Type typeFrom, Type typeTo, bool implicitOnly)
+        private static MethodInfo FindConversionOperator(IEnumerable<MethodInfo> methods, Type typeFrom, Type typeTo, bool implicitOnly)
         {
             foreach (MethodInfo mi in methods)
             {

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -507,21 +507,19 @@ namespace System.Dynamic.Utils
         {
             foreach (MethodInfo mi in methods)
             {
-                if (mi.Name != "op_Implicit" && (implicitOnly || mi.Name != "op_Explicit"))
+                if (
+                    (mi.Name == "op_Implicit" || (!implicitOnly && mi.Name == "op_Explicit"))
+                    && AreEquivalent(mi.ReturnType, typeTo)
+                    )
                 {
-                    continue;
+                    ParameterInfo[] pis = mi.GetParametersCached();
+                    if (pis.Length == 1 && AreEquivalent(pis[0].ParameterType, typeFrom))
+                    {
+                        return mi;
+                    }
                 }
-                if (!TypeUtils.AreEquivalent(mi.ReturnType, typeTo))
-                {
-                    continue;
-                }
-                ParameterInfo[] pis = mi.GetParametersCached();
-                if (!TypeUtils.AreEquivalent(pis[0].ParameterType, typeFrom))
-                {
-                    continue;
-                }
-                return mi;
             }
+
             return null;
         }
 

--- a/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
@@ -16457,5 +16457,26 @@ namespace System.Linq.Expressions.Tests
         }
 
         #endregion
+
+        private class PerverselyNamedMembers
+        {
+            public readonly uint Field;
+
+            public PerverselyNamedMembers(uint value)
+            {
+                Field = value;
+            }
+
+            public static uint op_Implicit()
+            {
+                return 0x8BADF00D;
+            }
+        }
+
+        [Fact]
+        public static void ExplicitOpImplicit()
+        {
+            Assert.Throws<InvalidOperationException>(() => Expression.Convert(Expression.Constant(new PerverselyNamedMembers(0)), typeof(uint)));
+        }
     }
 }


### PR DESCRIPTION
Fixes #7424 

Optimisation to same path:  Don't build an array of static methods for finding operators.

If there won't be a second search for a lifted operator use, check the static methods as they are found.
If there will be, build a list for the second scan, rather than building a list just to then build an array from it.

I can either squash that second optimisation commit into the first, or discard it and leave just the fix, as people judge best.