### PR TITLE
Add AnyOS test location for Nano.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -157,6 +157,8 @@ branchList.each { branchName ->
 	                batchFile("PowerShell -command \"\"C:\\Packer\\unpacker.ps1 .\\bin\\build.pack .\\bin > .\\bin\\unpacker.log\"\"")
 	                // Run the tests
 	                batchFile("run-test.cmd .\\bin\\tests\\Windows_NT.AnyCPU.${configurationGroup}")
+                    // Run the tests
+                    batchFile("run-test.cmd .\\bin\\tests\\AnyOS.AnyCPU.${configurationGroup}")
             	}
 
             	parameters {


### PR DESCRIPTION
Non OS specific tests are dropped to AnyOS, even with explicitly specifying OSGroup. Add this location as well for Nano test discovery.