### PR TITLE
Expose EventCounters publically in the Reference assembly

### DIFF
--- a/src/System.Diagnostics.Tracing/System.Diagnostics.Tracing.sln
+++ b/src/System.Diagnostics.Tracing/System.Diagnostics.Tracing.sln
@@ -1,21 +1,47 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25115.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Tracing.Tests", "tests\System.Diagnostics.Tracing.Tests.csproj", "{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Tracing", "src\System.Diagnostics.Tracing.csproj", "{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		net462_Debug|Any CPU = net462_Debug|Any CPU
+		net462_Release|Any CPU = net462_Release|Any CPU
+		netcore50aot_Debug|Any CPU = netcore50aot_Debug|Any CPU
+		netcore50aot_Release|Any CPU = netcore50aot_Release|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.net462_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.net462_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.net462_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.net462_Release|Any CPU.Build.0 = Release|Any CPU
+		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.netcore50aot_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.netcore50aot_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.netcore50aot_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.netcore50aot_Release|Any CPU.Build.0 = Release|Any CPU
 		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E0E1B11-FF70-461E-99F7-C0AF252C0C60}.Release|Any CPU.Build.0 = Release|Any CPU
-  EndGlobalSection
+		{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}.net462_Debug|Any CPU.ActiveCfg = net462_Debug|Any CPU
+		{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}.net462_Debug|Any CPU.Build.0 = net462_Debug|Any CPU
+		{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}.net462_Release|Any CPU.ActiveCfg = net462_Release|Any CPU
+		{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}.net462_Release|Any CPU.Build.0 = net462_Release|Any CPU
+		{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}.netcore50aot_Debug|Any CPU.ActiveCfg = netcore50aot_Debug|Any CPU
+		{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}.netcore50aot_Debug|Any CPU.Build.0 = netcore50aot_Debug|Any CPU
+		{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}.netcore50aot_Release|Any CPU.ActiveCfg = netcore50aot_Release|Any CPU
+		{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}.netcore50aot_Release|Any CPU.Build.0 = netcore50aot_Release|Any CPU
+		{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
+++ b/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
@@ -54,6 +54,10 @@ namespace System.Diagnostics.Tracing
         public bool DisableEvent(int eventId) { return default(bool); }
         public bool EnableEvent(int eventId) { return default(bool); }
     }
+    public class EventCounter {
+        public EventCounter(string name, EventSource eventSource) { }
+        public void WriteMetric(float value) { }
+    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(12), Inherited = false)]
     public partial class EventDataAttribute : System.Attribute
     {

--- a/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
+++ b/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
@@ -6,20 +6,20 @@
     <ProjectGuid>{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
-    <!-- The following line needs to be removed once we have a targeting pack for 4.6.2 -->
-    <TargetingPackNugetPackageId Condition="'$(TargetGroup)'=='net462'">Microsoft.TargetingPack.NETFramework.v4.6.1</TargetingPackNugetPackageId>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.5</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.5</NuGetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)'!='netcore50aot'">
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetGroup)'=='netcore50aot'">
     <DefineConstants>$(DefineConstants);PROJECTN</DefineConstants>
     <!-- Need to remove reference to System.Reflection.TypeExtensions
     which is included transitively via System.Reflection -->
     <OmitTransitiveCompileReferences>true</OmitTransitiveCompileReferences>
   </PropertyGroup>
+
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
@@ -27,10 +27,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)'==''">
+
+  <ItemGroup> 
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
     <Compile Include="System\Diagnostics\Tracing\EventCounter.cs" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetGroup)'=='netcore50aot'">
     <Compile Include="System\Diagnostics\Tracing\ActivityTracker.cs" />
     <Compile Include="System\Diagnostics\Tracing\EventActivityOptions.cs" />
@@ -104,11 +106,14 @@
     </Compile>
     <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
+
   <ItemGroup>
     <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
   </ItemGroup>
+
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventCounter.cs
@@ -434,9 +434,10 @@ namespace System.Diagnostics.Tracing
 
     // This class a work-around because .NET V4.6.2 did not make EventSourceIndex public (it was only protected)
     // We make this helper class to get around that protection.   We want V4.6.3 to make this public at which
-    // point this class is no longer needed and can be removed. 
+    // point this class is no longer needed and can be removed.  
     internal class EventListenerHelper : EventListener {
-        public new static int EventSourceIndex(EventSource eventSource) { return EventListener.EventSourceIndex(eventSource); } 
+        public new static int EventSourceIndex(EventSource eventSource) { return EventListener.EventSourceIndex(eventSource); }
+        protected override void OnEventWritten(EventWrittenEventArgs eventData) { } // override abstact methods to keep compiler happy
     }
 
     #endregion // internal supporting classes

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventCounter.cs
@@ -269,7 +269,7 @@ namespace System.Diagnostics.Tracing
 
         internal static void AddEventCounter(EventSource eventSource, EventCounter eventCounter)
         {
-            int eventSourceIndex = EventListener.EventSourceIndex(eventSource);
+            int eventSourceIndex = EventListenerHelper.EventSourceIndex(eventSource);
 
             EventCounterGroup.EnsureEventSourceIndexAvailable(eventSourceIndex);
             EventCounterGroup eventCounterGroup = GetEventCounterGroup(eventSource);
@@ -292,7 +292,7 @@ namespace System.Diagnostics.Tracing
 
         private static EventCounterGroup GetEventCounterGroup(EventSource eventSource)
         {
-            int eventSourceIndex = EventListener.EventSourceIndex(eventSource);
+            int eventSourceIndex = EventListenerHelper.EventSourceIndex(eventSource);
             EventCounterGroup result = EventCounterGroup.s_eventCounterGroups[eventSourceIndex];
             if (result == null)
             {
@@ -430,6 +430,13 @@ namespace System.Diagnostics.Tracing
         }
 
         #endregion // Implementation of the IDisposable interface
+    }
+
+    // This class a work-around because .NET V4.6.2 did not make EventSourceIndex public (it was only protected)
+    // We make this helper class to get around that protection.   We want V4.6.3 to make this public at which
+    // point this class is no longer needed and can be removed. 
+    internal class EventListenerHelper : EventListener {
+        public new static int EventSourceIndex(EventSource eventSource) { return EventListener.EventSourceIndex(eventSource); } 
     }
 
     #endregion // internal supporting classes

--- a/src/System.Diagnostics.Tracing/src/project.json
+++ b/src/System.Diagnostics.Tracing/src/project.json
@@ -29,7 +29,7 @@
     },
     "net462": {
       "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6.1": "1.0.1"
+        "Microsoft.TargetingPack.NETFramework.v4.6.2": "1.0.1"
       }
     }
   }


### PR DESCRIPTION
When EventCounters were added to EventSource, they were not added to the Reference assembly.   
These are public APIs so the should be there. 

I have confirmed that there are no other missing APIs.   

@cshung