### PR TITLE
Increase X509 file reading coverage

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -141,14 +141,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2635)]
         public static void X509Certificate2FromPkcs7DerFile()
         {
             Assert.ThrowsAny<CryptographicException>(() => new X509Certificate2(Path.Combine("TestData", "singlecert.p7b")));
         }
 
         [Fact]
-        [ActiveIssue(2635)]
         public static void X509Certificate2FromPkcs7PemFile()
         {
             Assert.ThrowsAny<CryptographicException>(() => new X509Certificate2(Path.Combine("TestData", "singlecert.p7c")));

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionImportTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionImportTests.cs
@@ -56,7 +56,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2635)]
         public static void ImportX509PemFile()
         {
             var collection = new X509Certificate2Collection();
@@ -84,7 +83,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2635)]
         public static void ImportPkcs7DerFile_Empty()
         {
             var collection = new X509Certificate2Collection();
@@ -94,7 +92,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2635)]
         public static void ImportPkcs7PemFile_Empty()
         {
             var collection = new X509Certificate2Collection();
@@ -122,7 +119,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2635)]
         public static void ImportPkcs7DerFile_Single()
         {
             var collection = new X509Certificate2Collection();
@@ -132,7 +128,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2635)]
         public static void ImportPkcs7PemFile_Single()
         {
             var collection = new X509Certificate2Collection();
@@ -160,7 +155,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2635)]
         public static void ImportPkcs7DerFile_Chain()
         {
             var collection = new X509Certificate2Collection();
@@ -170,7 +164,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2635)]
         public static void ImportPkcs7PemFile_Chain()
         {
             var collection = new X509Certificate2Collection();

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -72,7 +72,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)System.Security.Cryptography.X509Certificates.TestData\1.0.0-prerelease\content\**\*.*" />
+    <SupplementalTestData Include="$(PackagesDir)System.Security.Cryptography.X509Certificates.TestData\1.0.1-prerelease\content\**\*.*" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.X509Certificates/tests/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/tests/project.json
@@ -12,7 +12,7 @@
     "System.Security.Cryptography.Algorithms": "4.1.0-rc3-23931-00",
     "System.Security.Cryptography.Cng": "4.1.0-rc3-23931-00",
     "System.Security.Cryptography.Encoding": "4.0.0-rc3-23931-00",
-    "System.Security.Cryptography.X509Certificates.TestData": "1.0.0-prerelease",
+    "System.Security.Cryptography.X509Certificates.TestData": "1.0.1-prerelease",
     "System.Text.RegularExpressions": "4.0.12-rc3-23931-00",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00187"


### PR DESCRIPTION
Pick up the newest X509Certificates.TestData package, which includes these
additional files, and enable the tests that were added in advance of this work.

These tests just verify that load from file works in addition to the load from
bytes tests which already were enabled.

Fixes #2635.