### PR TITLE
Avoid an extraneous copy in BlockingCollection.CopyTo

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -1578,7 +1578,22 @@ nameof(boundedCapacity), boundedCapacity,
         /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
         public void CopyTo(T[] array, int index)
         {
-            ((ICollection)this).CopyTo(array, index);
+            CheckDisposed();
+            
+            if (array == null)
+            {
+                throw new ArgumentNullException(nameof(array));
+            }
+            if (index < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), index, SR.BlockingCollection_CopyTo_NonNegative);
+            }
+            if (_collection.Count + index > array.Length)
+            {
+                throw new ArgumentException(SR.BlockingCollection_CopyTo_TooManyElems, nameof(index));
+            }
+            
+            _collection.CopyTo(array, index);
         }
 
         /// <summary>Copies all of the items in the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance 


### PR DESCRIPTION
Right now `BlockingCollection` simply forwards to the non-generic overload for `CopyTo(T[], int)`. This has several drawbacks, including extra argument validation (making sure array ranks/types are the same). It also forces us to make a copy, which will affect the caller in the case the array types don't match. I've specialized the generic overload since it's more commonly used and lets us avoid this copy.

Relevant code I glossed over while making this change:

- [Exceptions thrown by Copy in CoreRT](https://github.com/dotnet/corert/blob/e801589f7612fad6aa17d71363cdd9bdbc7ba071/src/System.Private.CoreLib/src/System/Array.cs#L250)
- [Queue's implementation of non-generic Copy](https://github.com/dotnet/corefx/blob/master/src/System.Collections/src/System/Collections/Generic/Queue.cs#L149)

cc @JonHanna @stephentoub