### PR TITLE
Fix CurlHandler Content-Length handling on redirects

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Easy.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Easy.cs
@@ -85,6 +85,7 @@ internal static partial class Interop
         // Curl options are of the format <type base> + <n>
         private const int CurlOptionLongBase = 0;
         private const int CurlOptionObjectPointBase = 10000;
+        private const int CurlOptionOffTBase = 30000;
 
         // Enum for constants defined for the enum CURLoption in curl.h
         internal enum CURLoption
@@ -119,6 +120,9 @@ internal static partial class Interop
             CURLOPT_COPYPOSTFIELDS = CurlOptionObjectPointBase + 165,
             CURLOPT_USERNAME = CurlOptionObjectPointBase + 173,
             CURLOPT_PASSWORD = CurlOptionObjectPointBase + 174,
+
+            CURLOPT_INFILESIZE_LARGE = CurlOptionOffTBase + 115,
+            CURLOPT_POSTFIELDSIZE_LARGE = CurlOptionOffTBase + 120,
         }
 
         internal enum ReadWriteFunction

--- a/src/Native/System.Net.Http.Native/pal_easy.h
+++ b/src/Native/System.Net.Http.Native/pal_easy.h
@@ -12,6 +12,7 @@ enum
 {
     CurlOptionLongBase = 0,
     CurlOptionObjectPointBase = 10000,
+    CurlOptionOffTBase = 30000,
 };
 
 enum PAL_CURLoption : int32_t
@@ -46,6 +47,9 @@ enum PAL_CURLoption : int32_t
     PAL_CURLOPT_COPYPOSTFIELDS = CurlOptionObjectPointBase + 165,
     PAL_CURLOPT_USERNAME = CurlOptionObjectPointBase + 173,
     PAL_CURLOPT_PASSWORD = CurlOptionObjectPointBase + 174,
+
+    PAL_CURLOPT_INFILESIZE_LARGE = CurlOptionOffTBase + 115,
+    PAL_CURLOPT_POSTFIELDSIZE_LARGE = CurlOptionOffTBase + 120,
 };
 
 enum class ReadWriteFunction : int32_t

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -232,15 +232,16 @@ namespace System.Net.Http
                     {
                         // Tell libcurl how much data we expect to send.
                         SetCurlOption(lengthOption, contentLength);
-                        return;
                     }
-
-                    // Similarly, tell libcurl how much data we expect to send.  However,
-                    // as the amount is larger than a 32-bit value, switch to the "_LARGE"
-                    // equivalent libcurl options.
-                    SetCurlOption(
-                        lengthOption == CURLoption.CURLOPT_INFILESIZE ? CURLoption.CURLOPT_INFILESIZE_LARGE : CURLoption.CURLOPT_POSTFIELDSIZE_LARGE,
-                        contentLength);
+                    else
+                    {
+                        // Similarly, tell libcurl how much data we expect to send.  However,
+                        // as the amount is larger than a 32-bit value, switch to the "_LARGE"
+                        // equivalent libcurl options.
+                        SetCurlOption(
+                            lengthOption == CURLoption.CURLOPT_INFILESIZE ? CURLoption.CURLOPT_INFILESIZE_LARGE : CURLoption.CURLOPT_POSTFIELDSIZE_LARGE,
+                            contentLength);
+                    }
                     return;
                 }
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -213,6 +213,40 @@ namespace System.Net.Http
                 EventSourceTrace("Max automatic redirections: {0}", _handler._maxAutomaticRedirections);
             }
 
+            private void SetContentLength(CURLoption lengthOption)
+            {
+                Debug.Assert(lengthOption == CURLoption.CURLOPT_POSTFIELDSIZE || lengthOption == CURLoption.CURLOPT_INFILESIZE);
+
+                if (_requestMessage.Content == null)
+                {
+                    // Tell libcurl there's no data to be sent.
+                    SetCurlOption(lengthOption, 0L);
+                    return;
+                }
+
+                long? contentLengthOpt = _requestMessage.Content.Headers.ContentLength;
+                if (contentLengthOpt != null)
+                {
+                    long contentLength = contentLengthOpt.GetValueOrDefault();
+                    if (contentLength <= int.MaxValue)
+                    {
+                        // Tell libcurl how much data we expect to send.
+                        SetCurlOption(lengthOption, contentLength);
+                        return;
+                    }
+
+                    // Similarly, tell libcurl how much data we expect to send.  However,
+                    // as the amount is larger than a 32-bit value, switch to the "_LARGE"
+                    // equivalent libcurl options.
+                    SetCurlOption(
+                        lengthOption == CURLoption.CURLOPT_INFILESIZE ? CURLoption.CURLOPT_INFILESIZE_LARGE : CURLoption.CURLOPT_POSTFIELDSIZE_LARGE,
+                        contentLength);
+                    return;
+                }
+
+                // There is content but we couldn't determine its size.  Don't set anything.
+            }
+
             private void SetVerb()
             {
                 EventSourceTrace<string>("Verb: {0}", _requestMessage.Method.Method);
@@ -220,10 +254,7 @@ namespace System.Net.Http
                 if (_requestMessage.Method == HttpMethod.Put)
                 {
                     SetCurlOption(CURLoption.CURLOPT_UPLOAD, 1L);
-                    if (_requestMessage.Content == null)
-                    {
-                        SetCurlOption(CURLoption.CURLOPT_INFILESIZE, 0L);
-                    }
+                    SetContentLength(CURLoption.CURLOPT_INFILESIZE);
                 }
                 else if (_requestMessage.Method == HttpMethod.Head)
                 {
@@ -232,11 +263,7 @@ namespace System.Net.Http
                 else if (_requestMessage.Method == HttpMethod.Post)
                 {
                     SetCurlOption(CURLoption.CURLOPT_POST, 1L);
-                    if (_requestMessage.Content == null)
-                    {
-                        SetCurlOption(CURLoption.CURLOPT_POSTFIELDSIZE, 0L);
-                        SetCurlOption(CURLoption.CURLOPT_COPYPOSTFIELDS, string.Empty);
-                    }
+                    SetContentLength(CURLoption.CURLOPT_POSTFIELDSIZE);
                 }
                 else if (_requestMessage.Method == HttpMethod.Trace)
                 {
@@ -249,6 +276,7 @@ namespace System.Net.Http
                     if (_requestMessage.Content != null)
                     {
                         SetCurlOption(CURLoption.CURLOPT_UPLOAD, 1L);
+                        SetContentLength(CURLoption.CURLOPT_INFILESIZE);
                     }
                 }
             }
@@ -428,56 +456,40 @@ namespace System.Net.Http
 
             internal void SetRequestHeaders()
             {
-                HttpContentHeaders contentHeaders = null;
+                var slist = new SafeCurlSListHandle();
+
+                // Add content request headers
                 if (_requestMessage.Content != null)
                 {
                     SetChunkedModeForSend(_requestMessage);
 
-                    // TODO: Content-Length header isn't getting correctly placed using ToString()
-                    // This is a bug in HttpContentHeaders that needs to be fixed.
-                    if (_requestMessage.Content.Headers.ContentLength.HasValue)
-                    {
-                        long contentLength = _requestMessage.Content.Headers.ContentLength.Value;
-                        _requestMessage.Content.Headers.ContentLength = null;
-                        _requestMessage.Content.Headers.ContentLength = contentLength;
-                    }
-                    contentHeaders = _requestMessage.Content.Headers;
-                }
+                    _requestMessage.Content.Headers.Remove(HttpKnownHeaderNames.ContentLength); // avoid overriding libcurl's handling via INFILESIZE/POSTFIELDSIZE
+                    AddRequestHeaders(_requestMessage.Content.Headers, slist);
 
-                var slist = new SafeCurlSListHandle();
-
-                // Add request and content request headers
-                if (_requestMessage.Headers != null)
-                {
-                    AddRequestHeaders(_requestMessage.Headers, slist);
-                }
-                if (contentHeaders != null)
-                {
-                    AddRequestHeaders(contentHeaders, slist);
-                    if (contentHeaders.ContentType == null)
+                    if (_requestMessage.Content.Headers.ContentType == null)
                     {
-                        if (!Interop.Http.SListAppend(slist, NoContentType))
-                        {
-                            throw CreateHttpRequestException(new CurlException((int)CURLcode.CURLE_OUT_OF_MEMORY, isMulti: false));
-                        }
+                        // Remove the Content-Type header libcurl adds by default.
+                        ThrowOOMIfFalse(Interop.Http.SListAppend(slist, NoContentType));
                     }
                 }
+
+                // Add request headers
+                AddRequestHeaders(_requestMessage.Headers, slist);
 
                 // Since libcurl always adds a Transfer-Encoding header, we need to explicitly block
                 // it if caller specifically does not want to set the header
                 if (_requestMessage.Headers.TransferEncodingChunked.HasValue &&
                     !_requestMessage.Headers.TransferEncodingChunked.Value)
                 {
-                    if (!Interop.Http.SListAppend(slist, NoTransferEncoding))
-                    {
-                        throw CreateHttpRequestException(new CurlException((int)CURLcode.CURLE_OUT_OF_MEMORY, isMulti: false));
-                    }
+                    ThrowOOMIfFalse(Interop.Http.SListAppend(slist, NoTransferEncoding));
                 }
 
                 if (!slist.IsInvalid)
                 {
+                    SafeCurlSListHandle prevList = _requestHeaders;
                     _requestHeaders = slist;
                     SetCurlOption(CURLoption.CURLOPT_HTTPHEADER, slist);
+                    prevList?.Dispose();
                 }
                 else
                 {
@@ -579,10 +591,7 @@ namespace System.Net.Http
                     string headerKeyAndValue = string.IsNullOrEmpty(headerValue) ?
                         header.Key + ";" : // semicolon used by libcurl to denote empty value that should be sent
                         header.Key + ": " + headerValue;
-                    if (!Interop.Http.SListAppend(handle, headerKeyAndValue))
-                    {
-                        throw CreateHttpRequestException(new CurlException((int)CURLcode.CURLE_OUT_OF_MEMORY, isMulti: false));
-                    }
+                    ThrowOOMIfFalse(Interop.Http.SListAppend(handle, headerKeyAndValue));
                 }
             }
 
@@ -604,6 +613,12 @@ namespace System.Net.Http
             internal void SetCurlOption(CURLoption option, SafeHandle value)
             {
                 ThrowIfCURLEError(Interop.Http.EasySetOptionPointer(_easyHandle, option, value));
+            }
+
+            private static void ThrowOOMIfFalse(bool appendResult)
+            {
+                if (!appendResult)
+                    throw CreateHttpRequestException(new CurlException((int)CURLcode.CURLE_OUT_OF_MEMORY, isMulti: false));
             }
 
             internal sealed class SendTransferState

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -641,9 +641,10 @@ namespace System.Net.Http
                             response.Content.Headers.Clear();
 
                             easy._isRedirect = easy._handler.AutomaticRedirection &&
-                                         (response.StatusCode == HttpStatusCode.Redirect ||
-                                         response.StatusCode == HttpStatusCode.RedirectKeepVerb ||
-                                         response.StatusCode == HttpStatusCode.RedirectMethod);
+                                (response.StatusCode == HttpStatusCode.Moved ||           // 301
+                                 response.StatusCode == HttpStatusCode.Redirect ||        // 302
+                                 response.StatusCode == HttpStatusCode.RedirectMethod ||  // 303
+                                 response.StatusCode == HttpStatusCode.RedirectKeepVerb); // 307
                         }
                         else
                         {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -805,8 +805,8 @@ namespace System.Net.Http.Functional.Tests
             {
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 string responseContent = await response.Content.ReadAsStringAsync();
-                Assert.False(responseContent.Contains(ContentString), "Response should not contain the content string");
-                Assert.False(responseContent.Contains("Content-Length"), "Response should not contain Content-Length");
+                Assert.DoesNotContain(ContentString, responseContent);
+                Assert.DoesNotContain("Content-Length", responseContent);
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -789,6 +789,28 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task PostAsync_Redirect_ResultingGetFormattedCorrectly(bool secure)
+        {
+            const string ContentString = "This is the content string.";
+            var content = new StringContent(ContentString);
+            Uri redirectUri = HttpTestServers.RedirectUriForDestinationUri(
+                secure, 
+                secure ? HttpTestServers.SecureRemoteEchoServer : HttpTestServers.RemoteEchoServer, 
+                1);
+
+            using (var client = new HttpClient())
+            using (HttpResponseMessage response = await client.PostAsync(redirectUri, content))
+            {
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                string responseContent = await response.Content.ReadAsStringAsync();
+                Assert.False(responseContent.Contains(ContentString), "Response should not contain the content string");
+                Assert.False(responseContent.Contains("Content-Length"), "Response should not contain Content-Length");
+            }
+        }
+
+        [Theory]
         [InlineData(HttpStatusCode.MethodNotAllowed, "Custom description")]
         [InlineData(HttpStatusCode.MethodNotAllowed, "")]
         public async Task GetAsync_CallMethod_ExpectedStatusLine(HttpStatusCode statusCode, string reasonPhrase)


### PR DESCRIPTION
CurlHandler was explicitly setting the Content-Length header, which overrides libcurl's default handling of Content-Length.  This means that  Content-Length was being sent even when it shouldn't have been, such as when redirecting a POST to a GET.  This commit changes how we handle Content-Length.  Rather than explicitly setting the header ourselves, we let libcurl do it, and we tell it the length of the input via the INFILESIZE and POSTFIELDSIZE options.

A few other issues addressed as well in the act of fixing this:
- A SafeHandle wasn't being disposed of in the case of a redirect.
- 301 wasn't being considered a redirect status code for the purposes of credential handling.
- Some code could have been a bit cleaner.

Fixes https://github.com/dotnet/corefx/issues/7440
cc: @kapilash, @ericeil, @davidsh, @cesarbs