### PR TITLE
Use ValueTuple in System.Data.SqlClient

### DIFF
--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -173,6 +173,11 @@
     <Compile Include="System\Data\SqlClient\SNI\SslOverTdsStream.cs" />
     <Compile Include="System\Data\SqlClient\SNI\SNICommon.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
+    <Compile Include="$(CommonPath)\System\ValueTuple.cs">
+      <Link>Common\System\ValueTuple.cs</Link>
+    </Compile>
+  </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System.Data" />

--- a/src/System.Data.SqlClient/src/System/Data/Locale/Locale.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Locale/Locale.cs
@@ -12,25 +12,26 @@ namespace System.Data
     internal static class Locale
     {
         // Maps between LCIDs and LocaleName+AnsiCodePages+Encodings
-        private static readonly ConcurrentDictionary<int, Tuple<string, int, Encoding>> s_cachedEncodings = new ConcurrentDictionary<int, Tuple<string, int, Encoding>>();
+        private static readonly ConcurrentDictionary<int, ValueTuple<string, int, Encoding>> s_cachedEncodings =
+            new ConcurrentDictionary<int, ValueTuple<string, int, Encoding>>();
 
         static Locale()
         {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);            
         }
 
-        private static Tuple<string, int, Encoding> GetDetailsInternal(int lcid)
+        private static ValueTuple<string, int, Encoding> GetDetailsInternal(int lcid)
         {
             string localeName = LocaleMapper.LcidToLocaleNameInternal(lcid);
             int ansiCodePage = LocaleMapper.LocaleNameToAnsiCodePage(localeName);
-            return Tuple.Create(localeName, ansiCodePage, Encoding.GetEncoding(ansiCodePage));
+            return new ValueTuple<string, int, Encoding>(localeName, ansiCodePage, Encoding.GetEncoding(ansiCodePage));
         }
 
-        private static Tuple<string, int, Encoding> GetDetailsForLcid(int lcid)
+        private static ValueTuple<string, int, Encoding> GetDetailsForLcid(int lcid)
         {
             if (lcid < 0)
             {
-                throw ADP.ArgumentOutOfRange("lcid");
+                throw ADP.ArgumentOutOfRange(nameof(lcid));
             }
             return s_cachedEncodings.GetOrAdd(lcid, GetDetailsInternal);
         }


### PR DESCRIPTION
Mostly self-explanatory; since `ValueTuple` is a struct, and this isn't being used in a closure, it's beneficial to use it rather than the built-in `Tuple` class for performance reasons.

cc @stephentoub