### PR TITLE
Avoid string.Split allocations in System.Net.Http

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Headers/ContentDispositionHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/ContentDispositionHeaderValue.cs
@@ -35,7 +35,7 @@ namespace System.Net.Http.Headers
             get { return _dispositionType; }
             set
             {
-                CheckDispositionTypeFormat(value, "value");
+                CheckDispositionTypeFormat(value, nameof(value));
                 _dispositionType = value;
             }
         }
@@ -157,7 +157,7 @@ namespace System.Net.Http.Headers
 
         public ContentDispositionHeaderValue(string dispositionType)
         {
-            CheckDispositionTypeFormat(dispositionType, "dispositionType");
+            CheckDispositionTypeFormat(dispositionType, nameof(dispositionType));
             _dispositionType = dispositionType;
         }
 
@@ -501,6 +501,7 @@ namespace System.Net.Http.Headers
             {
                 return false;
             }
+            
             string[] parts = processedInput.Split('?');
             // "=, encodingName, encodingType, encodedData, ="
             if (parts.Length != 5 || parts[0] != "\"=" || parts[4] != "=\"" || parts[2].ToLowerInvariant() != "b")
@@ -564,18 +565,27 @@ namespace System.Net.Http.Headers
         private bool TryDecode5987(string input, out string output)
         {
             output = null;
-            string[] parts = input.Split('\'');
-            if (parts.Length != 3)
+            
+            int quoteIndex = input.IndexOf('\'');
+            if (quoteIndex == -1)
             {
                 return false;
             }
+            
+            int lastQuoteIndex = input.LastIndexOf('\'');
+            if (quoteIndex == lastQuoteIndex || input.IndexOf('\'', quoteIndex + 1) != lastQuoteIndex)
+            {
+                return false;
+            }
+            
+            string encodingString = input.Substring(0, quoteIndex);
+            string dataString = input.Substring(lastQuoteIndex + 1, input.Length - (lastQuoteIndex + 1));
 
             StringBuilder decoded = new StringBuilder();
             try
             {
-                Encoding encoding = Encoding.GetEncoding(parts[0]);
+                Encoding encoding = Encoding.GetEncoding(encodingString);
 
-                string dataString = parts[2];
                 byte[] unescapedBytes = new byte[dataString.Length];
                 int unescapedBytesCount = 0;
                 for (int index = 0; index < dataString.Length; index++)

--- a/src/System.Net.Http/tests/UnitTests/Headers/ContentDispositionHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/ContentDispositionHeaderValueTest.cs
@@ -188,6 +188,24 @@ namespace System.Net.Http.Tests
             contentDisposition.Parameters.Remove(fileNameStar);
             Assert.Null(contentDisposition.FileNameStar);
         }
+        
+        [Theory]
+        [InlineData("no_quotes")]
+        [InlineData("one'quote")]
+        [InlineData(@"double""quote")]
+        [InlineData(@"two""double""quotes")]
+        [InlineData("'triple'quotes'")]
+        public void FileNameStar_NotTwoQuotes_IsNull(string value)
+        {
+            ContentDispositionHeaderValue contentDisposition = new ContentDispositionHeaderValue("inline");
+
+            // Note that uppercase letters are used. Comparison should happen case-insensitive.
+            NameValueHeaderValue fileNameStar = new NameValueHeaderValue("FILENAME*", value);
+            contentDisposition.Parameters.Add(fileNameStar);
+            Assert.Equal(1, contentDisposition.Parameters.Count);
+            Assert.Same(fileNameStar, contentDisposition.Parameters.First());
+            Assert.Null(contentDisposition.FileNameStar); // Decode failure
+        }
 
         [Fact]
         public void FileNameStar_NeedsEncoding_EncodedAndDecodedCorrectly()
@@ -213,8 +231,7 @@ namespace System.Net.Http.Tests
             NameValueHeaderValue fileNameStar = new NameValueHeaderValue("FILENAME*", "utf-99'lang'File%CZName.bat");
             contentDisposition.Parameters.Add(fileNameStar);
             Assert.Equal(1, contentDisposition.Parameters.Count);
-            Assert.Equal("FILENAME*", contentDisposition.Parameters.First().Name);
-            Assert.Equal("utf-99'lang'File%CZName.bat", contentDisposition.Parameters.First().Value);
+            Assert.Same(fileNameStar, contentDisposition.Parameters.First());
             Assert.Null(contentDisposition.FileNameStar); // Decode failure
 
             contentDisposition.FileNameStar = "new_name";

--- a/src/System.Net.Http/tests/UnitTests/Headers/ContentDispositionHeaderValueTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/ContentDispositionHeaderValueTest.cs
@@ -192,8 +192,6 @@ namespace System.Net.Http.Tests
         [Theory]
         [InlineData("no_quotes")]
         [InlineData("one'quote")]
-        [InlineData(@"double""quote")]
-        [InlineData(@"two""double""quotes")]
         [InlineData("'triple'quotes'")]
         public void FileNameStar_NotTwoQuotes_IsNull(string value)
         {


### PR DESCRIPTION
Similar changes that were made in the `FrameworkName` PR in #7288, except for System.Net.Http. Also switched a couple of places to use `nameof`.

@stephentoub and @davidsh, I found another place that could be optimized similarly to not use `string.Split` [here](https://github.com/dotnet/corefx/compare/master...jamesqo:string-split?expand=1#diff-7cb88d670b5606422fd0cabab628f90cR505). Do you think it's worth it? It would lead to a lot of boilerplate code since this is a 5-element array, but would also help us avoid a couple of `Substring` allocations in addition to the `Split` ones, since `parts[0]`, `parts[4]`, and `parts[2]` wouldn't actually have to be used.