### PR TITLE
Use `using static` in CurlHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlException.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlException.cs
@@ -19,7 +19,7 @@ namespace System.Net.Http
 
         internal static string GetCurlErrorString(int code, bool isMulti)
         {
-            IntPtr ptr = isMulti ? Interop.Http.MultiGetErrorString(code) : Interop.Http.EasyGetErrorString(code);
+            IntPtr ptr = isMulti ? MultiGetErrorString(code) : EasyGetErrorString(code);
             return Marshal.PtrToStringAnsi(ptr);
         }
     }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
@@ -181,12 +181,12 @@ namespace System.Net.Http
                     if (_remainingDataCount > 0)
                     {
                         EventSourceTrace("Pausing. Remaining bytes: {0}", _remainingDataCount);
-                        return Interop.Http.CURL_WRITEFUNC_PAUSE;
+                        return CURL_WRITEFUNC_PAUSE;
                     }
                     else if (_pendingReadRequest == null)
                     {
                         EventSourceTrace("Pausing. No pending read request");
-                        return Interop.Http.CURL_WRITEFUNC_PAUSE;
+                        return CURL_WRITEFUNC_PAUSE;
                     }
 
                     // There's no data in the buffer and there is a pending read request.  

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
@@ -11,8 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 
-using CURLcode = Interop.Http.CURLcode;
-using CURLINFO = Interop.Http.CURLINFO;
+using static Interop.Http;
 
 namespace System.Net.Http
 {
@@ -20,7 +19,7 @@ namespace System.Net.Http
     {
         private static class SslProvider
         {
-            private static readonly Interop.Http.SslCtxCallback s_sslCtxCallback = SetSslCtxVerifyCallback;
+            private static readonly SslCtxCallback s_sslCtxCallback = SetSslCtxVerifyCallback;
             private static readonly Interop.Ssl.AppVerifyCallback s_sslVerifyCallback = VerifyCertChain;
 
             internal static void SetSslOptions(EasyRequest easy, ClientCertificateOption clientCertOption)
@@ -28,7 +27,7 @@ namespace System.Net.Http
                 Debug.Assert(clientCertOption == ClientCertificateOption.Automatic || clientCertOption == ClientCertificateOption.Manual);
 
                 // Disable SSLv2/SSLv3, allow TLSv1.*
-                easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_SSLVERSION, (long)Interop.Http.CurlSslVersion.CURL_SSLVERSION_TLSv1);
+                easy.SetCurlOption(CURLoption.CURLOPT_SSLVERSION, (long)CurlSslVersion.CURL_SSLVERSION_TLSv1);
 
                 // Create a client certificate provider if client certs may be used.
                 X509Certificate2Collection clientCertificates = easy._handler._clientCertificates;
@@ -61,8 +60,8 @@ namespace System.Net.Http
                         // the host name matches and will inform the callback of that.
                         if (easy._handler.ServerCertificateValidationCallback != null)
                         {
-                            easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_SSL_VERIFYPEER, 0); // don't verify the peer cert
-                            easy.SetCurlOption(Interop.Http.CURLoption.CURLOPT_SSL_VERIFYHOST, 0); // don't verify the peer cert's hostname
+                            easy.SetCurlOption(CURLoption.CURLOPT_SSL_VERIFYPEER, 0); // don't verify the peer cert
+                            easy.SetCurlOption(CURLoption.CURLOPT_SSL_VERIFYHOST, 0); // don't verify the peer cert's hostname
                         }
                         break;
 
@@ -137,7 +136,7 @@ namespace System.Net.Http
             {
                 Debug.Assert(curlPtr != IntPtr.Zero, "curlPtr is not null");
                 IntPtr gcHandlePtr;
-                CURLcode getInfoResult = Interop.Http.EasyGetInfoPointer(curlPtr, CURLINFO.CURLINFO_PRIVATE, out gcHandlePtr);
+                CURLcode getInfoResult = EasyGetInfoPointer(curlPtr, CURLINFO.CURLINFO_PRIVATE, out gcHandlePtr);
                 Debug.Assert(getInfoResult == CURLcode.CURLE_OK, "Failed to get info on a completing easy handle");
                 if (getInfoResult == CURLcode.CURLE_OK)
                 {

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -11,10 +11,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 
-using CURLAUTH = Interop.Http.CURLAUTH;
-using CURLcode = Interop.Http.CURLcode;
-using CURLMcode = Interop.Http.CURLMcode;
-using CURLoption = Interop.Http.CURLoption;
+using static Interop.Http;
 
 namespace System.Net.Http
 {
@@ -93,7 +90,7 @@ namespace System.Net.Http
             // curl_global_init call handled by Interop.LibCurl's cctor
 
             int age;
-            if (!Interop.Http.GetCurlVersionInfo(
+            if (!GetCurlVersionInfo(
                 out age, 
                 out s_supportsSSL, 
                 out s_supportsAutomaticDecompression, 


### PR DESCRIPTION
Saw [this](https://github.com/dotnet/corefx/compare/master...jamesqo:curl-todo?expand=1#diff-e5ffb568f6f994c4243d35ef1b6830ceL14) TODO suggesting to replace all of the `using Foo = Interop.Http.Foo` with `using static` once C# 6 was being used. Now that it is, I took the liberty of adding the directives and running `sed` on all the files in the directory to replace all of the explicit references.

Do you guys think I should just remove the `using` directives at the top of the file and limit it to that, or should the changes I've made with `sed` be kept?

cc @davidsh @stephentoub