### PR TITLE
Remove unused array from Win32's FileStream

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileStream.Win32.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStream.Win32.cs
@@ -26,7 +26,5 @@ namespace System.IO
             if (fullPath.StartsWith("\\\\.\\", StringComparison.Ordinal))
                 throw new ArgumentException(SR.Arg_DevicesNotSupported, paramName);
         }
-
-        private static readonly char[] s_additionalInvalidChars = new[] { '?', '*' };
     }
 }


### PR DESCRIPTION
Found a static array that doesn't seem like it's being used; perhaps left over by some old code and someone forgot to delete the no longer-needed field.

cc @stephentoub