### PR TITLE
SqlClient: Avoid a delegate allocation on each call

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/Locale/Locale.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Locale/Locale.cs
@@ -32,7 +32,7 @@ namespace System.Data
             {
                 throw ADP.ArgumentOutOfRange("lcid");
             }
-            return s_cachedEncodings.GetOrAdd(lcid, GetDetailsInternal);
+            return s_cachedEncodings.GetOrAdd(lcid, id => GetDetailsInternal(id));
         }
 
         internal static Encoding GetEncodingForLcid(int lcid)


### PR DESCRIPTION
Allow the compiler to lazily allocate and cache the `Func` delegate instead of allocating a new delegate on each call to  `GetDetailsForLcid`.