### PR TITLE
Remove obscure repeated casts

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionFactory.cs
@@ -39,7 +39,7 @@ namespace System.Data.SqlClient
             SqlInternalConnection result = null;
             SessionData recoverySessionData = null;
 
-            SqlConnection sqlOwningConnection = owningConnection as SqlConnection;
+            SqlConnection sqlOwningConnection = (SqlConnection)owningConnection;
             bool applyTransientFaultHandling = sqlOwningConnection != null ? sqlOwningConnection._applyTransientFaultHandling : false;
 
             SqlConnectionString userOpt = null;
@@ -47,14 +47,14 @@ namespace System.Data.SqlClient
             {
                 userOpt = (SqlConnectionString)userOptions;
             }
-            else if (owningConnection != null)
+            else if (sqlOwningConnection != null)
             {
-                userOpt = (SqlConnectionString)(((SqlConnection)owningConnection).UserConnectionOptions);
+                userOpt = (SqlConnectionString)(sqlOwningConnection.UserConnectionOptions);
             }
 
-            if (owningConnection != null)
+            if (sqlOwningConnection != null)
             {
-                recoverySessionData = ((SqlConnection)owningConnection)._recoverySessionData;
+                recoverySessionData = sqlOwningConnection._recoverySessionData;
             }
 
             bool redirectedUserInstance = false;


### PR DESCRIPTION
In case `owningConnection` is not null but refers to an object which isn't of type `SqlConnection` then `as` succeeds, `applyTransientFaultHandling` is computed, then control falls through to either one or two cases where the reference is being cast to `SqlConnection` and those casts will yield `InvalidCastException`. Which means that this code actually needs a `SqlConnection`, not anything else.

The new code makes this requirement more explicit.

This resolves https://github.com/dotnet/corefx/issues/6110