### PR TITLE
Tweak SSL context callback in CurlHandler

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
@@ -20,10 +20,10 @@ internal static partial class Interop
         internal static extern void SslCtxDestroy(IntPtr ctx);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetCertVerifyCallback")]
-        internal static extern void SslCtxSetCertVerifyCallback(SafeSslContextHandle ctx, AppVerifyCallback cb, IntPtr arg);
+        internal static extern void SslCtxSetCertVerifyCallback(IntPtr ctx, AppVerifyCallback cb, IntPtr arg);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetClientCertCallback")]
-        internal static extern void SslCtxSetClientCertCallback(SafeSslContextHandle ctx, ClientCertCallback callback);
+        internal static extern void SslCtxSetClientCertCallback(IntPtr ctx, ClientCertCallback callback);
     }
 }
 


### PR DESCRIPTION
- Perf.  We were creating a SafeHandle for the SSL context, but it didn't own the underlying handle, and we were then just passing it back to two native functions.  We can skip the SafeHandle altogether, saving on the allocation and marshaling costs for all SSL connections.
- Error handling.  For robustness, we should be ensuring that any problems related to getting the state from the GCHandle result in returning an error code rather than propagating an exception, which will likely crash.
- Naming.  The name of the callback method is no longer correct, as it's used for more than just cert verification.

cc: @bartonjs, @ericeil, @kapilash