### PR TITLE
Fix runtime of S.R.WinRT netcore50aot build

### DIFF
--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
@@ -12,8 +12,9 @@
     <!-- CS1698 - Disable warning about reference to 4.0.0.0 System.Runtime.WindowsRuntime having same simple name as target assembly -->
     <NoWarn>$(NoWarn)1698</NoWarn>
     <ProjectGuid>{844A2A0B-4169-49C3-B367-AFDC4894E487}</ProjectGuid>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework> 
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
     <PackageTargetRuntime>win8</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' == 'netcore50aot'">win8-aot</PackageTargetRuntime>
     <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>


### PR DESCRIPTION
The netcore50aot build of System.Runtime.WindowsRuntime is only supposed
to be used by NETNative but it was being packaged with a `win8` RID
which caused it to be preferred over the netstandard1.3 build.  Fix the
RID by changing it to win8-aot.

Fixes #7387 
/cc @weshaggard @chcosta