### PR TITLE
Fixing bug #7472 to disable packaging VisualBasic on non-Windows OSes

### DIFF
--- a/src/Microsoft.VisualBasic/pkg/Microsoft.VisualBasic.builds
+++ b/src/Microsoft.VisualBasic/pkg/Microsoft.VisualBasic.builds
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <!-- Temporary workaround, VisualBasic projects cannot be built on non-Windows platforms. See issue #5230. -->
-    <Project Include="Microsoft.VisualBasic.pkgproj">
+    <Project Include="Microsoft.VisualBasic.pkgproj" Condition="'$(OS)'=='Windows_NT'">
       <OSGroup>Windows_NT</OSGroup>
     </Project>
   </ItemGroup>


### PR DESCRIPTION
Fixing bug #7472 to disable packaging VisualBasic on non-Windows OSes

/cc @joperezr @ericstj