### PR TITLE
Fix encoding of proxy credentials in CurlHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -377,9 +377,11 @@ namespace System.Net.Http
                         throw new ArgumentException(SR.net_http_argument_empty_string, "UserName");
                     }
 
+                    // Unlike normal credentials, proxy credentials are URL decoded by libcurl, so we URL encode 
+                    // them in order to allow, for example, a colon in the username.
                     string credentialText = string.IsNullOrEmpty(credentials.Domain) ?
-                        string.Format("{0}:{1}", credentials.UserName, credentials.Password) :
-                        string.Format("{2}\\{0}:{1}", credentials.UserName, credentials.Password, credentials.Domain);
+                        string.Format("{0}:{1}", WebUtility.UrlEncode(credentials.UserName), WebUtility.UrlEncode(credentials.Password)) :
+                        string.Format("{2}\\{0}:{1}", WebUtility.UrlEncode(credentials.UserName), WebUtility.UrlEncode(credentials.Password), WebUtility.UrlEncode(credentials.Domain));
 
                     EventSourceTrace("Proxy credentials set.");
                     SetCurlOption(CURLoption.CURLOPT_PROXYUSERPWD, credentialText);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1073,8 +1073,8 @@ namespace System.Net.Http.Functional.Tests
             foreach (bool wrapCredsInCache in new[] { true, false })
             {
                 yield return new object[] { CredentialCache.DefaultCredentials, wrapCredsInCache };
-                yield return new object[] { new NetworkCredential("username", "password"), wrapCredsInCache };
-                yield return new object[] { new NetworkCredential("username", "password", "domain"), wrapCredsInCache };
+                yield return new object[] { new NetworkCredential("user:name", "password"), wrapCredsInCache };
+                yield return new object[] { new NetworkCredential("username", "password", "dom:\\ain"), wrapCredsInCache };
             }
         }
         #endregion


### PR DESCRIPTION
We need to URL encode the username/password for a proxy.  Otherwise, for example, a colon in the name could mess up how the concatenated username and password are parsed.  libcurl URL decodes them.

cc: @ericeil, @kapilash