### PR TITLE
SqlClient: Reduce magic strings

### DIFF
--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SmiSettersStream.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SmiSettersStream.cs
@@ -95,7 +95,7 @@ namespace Microsoft.SqlServer.Server
         {
             if (value < 0)
             {
-                throw ADP.ArgumentOutOfRange("value");
+                throw ADP.ArgumentOutOfRange(nameof(value));
             }
             ValueUtilsSmi.SetBytesLength(_sink, _setters, _ordinal, _metaData, value);
         }

--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SqlDataRecord.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SqlDataRecord.cs
@@ -91,7 +91,7 @@ namespace Microsoft.SqlServer.Server
             EnsureSubclassOverride();
             if (null == values)
             {
-                throw ADP.ArgumentNull("values");
+                throw ADP.ArgumentNull(nameof(values));
             }
 
             int copyLength = (values.Length < FieldCount) ? values.Length : FieldCount;
@@ -278,7 +278,7 @@ namespace Microsoft.SqlServer.Server
             EnsureSubclassOverride();
             if (null == values)
             {
-                throw ADP.ArgumentNull("values");
+                throw ADP.ArgumentNull(nameof(values));
             }
 
 
@@ -395,7 +395,7 @@ namespace Microsoft.SqlServer.Server
             EnsureSubclassOverride();
             if (null == values)
             {
-                throw ADP.ArgumentNull("values");
+                throw ADP.ArgumentNull(nameof(values));
             }
 
             // Allow values array longer than FieldCount, just ignore the extra cells.
@@ -649,7 +649,7 @@ namespace Microsoft.SqlServer.Server
             // Initial consistency check
             if (null == metaData)
             {
-                throw ADP.ArgumentNull("metadata");
+                throw ADP.ArgumentNull(nameof(metaData));
             }
 
             _columnMetaData = new SqlMetaData[metaData.Length];
@@ -658,7 +658,7 @@ namespace Microsoft.SqlServer.Server
             {
                 if (null == metaData[i])
                 {
-                    throw ADP.ArgumentNull("metadata[" + i + "]");
+                    throw ADP.ArgumentNull($"{nameof(metaData)}[{i}]");
                 }
                 _columnMetaData[i] = metaData[i];
                 _columnSmiMetaData[i] = MetaDataUtilsSmi.SqlMetaDataToSmiExtendedMetaData(_columnMetaData[i]);

--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SqlRecordBuffer.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SqlRecordBuffer.cs
@@ -512,7 +512,7 @@ namespace Microsoft.SqlServer.Server
             {
                 if (ndataIndex != 0)
                 {    // set the first time: should start from the beginning
-                    throw ADP.ArgumentOutOfRange("fieldOffset");
+                    throw ADP.ArgumentOutOfRange(nameof(fieldOffset));
                 }
                 _object = new byte[length];
                 _type = StorageType.ByteArray;
@@ -523,7 +523,7 @@ namespace Microsoft.SqlServer.Server
             {
                 if (ndataIndex > BytesLength)
                 {    // no gap is allowed
-                    throw ADP.ArgumentOutOfRange("fieldOffset");
+                    throw ADP.ArgumentOutOfRange(nameof(fieldOffset));
                 }
                 if (ndataIndex + length > BytesLength)
                 {    // beyond the current length
@@ -552,7 +552,7 @@ namespace Microsoft.SqlServer.Server
             {
                 if (ndataIndex != 0)
                 {    // set the first time: should start from the beginning
-                    throw ADP.ArgumentOutOfRange("fieldOffset");
+                    throw ADP.ArgumentOutOfRange(nameof(fieldOffset));
                 }
                 _object = new char[length];
                 _type = StorageType.CharArray;
@@ -563,7 +563,7 @@ namespace Microsoft.SqlServer.Server
             {
                 if (ndataIndex > CharsLength)
                 {    // no gap is allowed
-                    throw ADP.ArgumentOutOfRange("fieldOffset");
+                    throw ADP.ArgumentOutOfRange(nameof(fieldOffset));
                 }
                 if (StorageType.String == _type)
                 {    // convert string to char[]

--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/ValueUtilsSmi.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/ValueUtilsSmi.cs
@@ -1232,7 +1232,7 @@ namespace Microsoft.SqlServer.Server
             ThrowIfInvalidSetterAccess(metaData, ExtendedClrTypeCode.ByteArray);
             if (null == buffer)
             {
-                throw ADP.ArgumentNull("buffer");
+                throw ADP.ArgumentNull(nameof(buffer));
             }
             length = CheckXetParameters(metaData.SqlDbType, metaData.MaxLength, NoLengthLimit /* actual */, fieldOffset, buffer.Length, bufferOffset, length);
             Debug.Assert(length >= 0, "Buffer.Length was invalid!");
@@ -1273,7 +1273,7 @@ namespace Microsoft.SqlServer.Server
             ThrowIfInvalidSetterAccess(metaData, ExtendedClrTypeCode.CharArray);
             if (null == buffer)
             {
-                throw ADP.ArgumentNull("buffer");
+                throw ADP.ArgumentNull(nameof(buffer));
             }
             length = CheckXetParameters(metaData.SqlDbType, metaData.MaxLength, NoLengthLimit /* actual */, fieldOffset, buffer.Length, bufferOffset, length);
             Debug.Assert(length >= 0, "Buffer.Length was invalid!");
@@ -2619,12 +2619,12 @@ namespace Microsoft.SqlServer.Server
                 int length)
         {
             if (0 > fieldOffset)
-                throw ADP.NegativeParameter("fieldOffset");
+                throw ADP.NegativeParameter(nameof(fieldOffset));
 
             // if negative buffer index, throw
             if (bufferOffset < 0)
             {
-                throw ADP.InvalidDestinationBufferIndex(bufferLength, bufferOffset, "bufferOffset");
+                throw ADP.InvalidDestinationBufferIndex(bufferLength, bufferOffset, nameof(bufferOffset));
             }
 
             // skip further length checks for LOB buffer lengths
@@ -2641,7 +2641,7 @@ namespace Microsoft.SqlServer.Server
             // if bad buffer index, throw
             if (bufferOffset > bufferLength)
             {
-                throw ADP.InvalidDestinationBufferIndex(bufferLength, bufferOffset, "bufferOffset");
+                throw ADP.InvalidDestinationBufferIndex(bufferLength, bufferOffset, nameof(bufferOffset));
             }
 
             // if there is not enough room in the buffer for data

--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
@@ -831,6 +831,7 @@ namespace System.Data.Common
         internal const string BeginExecuteNonQuery = "BeginExecuteNonQuery";
         internal const string BeginExecuteReader = "BeginExecuteReader";
         internal const string BeginExecuteXmlReader = "BeginExecuteXmlReader";
+        internal const string EndExecuteNonQuery = "EndExecuteNonQuery";
         internal const string EndExecuteReader = "EndExecuteReader";
         internal const string EndExecuteXmlReader = "EndExecuteXmlReader";
         internal const string Parameter = "Parameter";

--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
@@ -828,12 +828,6 @@ namespace System.Data.Common
 
 
         // global constant strings
-        internal const string BeginExecuteNonQuery = "BeginExecuteNonQuery";
-        internal const string BeginExecuteReader = "BeginExecuteReader";
-        internal const string BeginExecuteXmlReader = "BeginExecuteXmlReader";
-        internal const string EndExecuteNonQuery = "EndExecuteNonQuery";
-        internal const string EndExecuteReader = "EndExecuteReader";
-        internal const string EndExecuteXmlReader = "EndExecuteXmlReader";
         internal const string Parameter = "Parameter";
         internal const string ParameterName = "ParameterName";
         internal const string ParameterSetPosition = "set_Position";

--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Security;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
@@ -403,7 +404,7 @@ namespace System.Data.Common
             return InvalidOperation(Res.GetString(Res.ADP_NoConnectionString));
         }
 
-        static internal Exception MethodNotImplemented(string methodName)
+        static internal Exception MethodNotImplemented([CallerMemberName] string methodName = "")
         {
             return NotImplemented.ByDesignWithMessage(methodName);
         }
@@ -575,9 +576,9 @@ namespace System.Data.Common
         //
         // : IDbCommand
         //
-        static internal Exception InvalidCommandTimeout(int value)
+        static internal Exception InvalidCommandTimeout(int value, [CallerMemberName] string property = "")
         {
-            return Argument(Res.GetString(Res.ADP_InvalidCommandTimeout, value.ToString(CultureInfo.InvariantCulture)), ADP.CommandTimeout);
+            return Argument(Res.GetString(Res.ADP_InvalidCommandTimeout, value.ToString(CultureInfo.InvariantCulture)), property);
         }
         static internal Exception UninitializedParameterSize(int index, Type dataType)
         {
@@ -693,7 +694,7 @@ namespace System.Data.Common
         //
         // : DbDataReader
         //
-        static internal Exception DataReaderClosed(string method)
+        static internal Exception DataReaderClosed([CallerMemberName] string method = "")
         {
             return InvalidOperation(Res.GetString(Res.ADP_DataReaderClosed, method));
         }
@@ -721,7 +722,7 @@ namespace System.Data.Common
         //
         // : Stream
         //
-        static internal Exception StreamClosed(string method)
+        static internal Exception StreamClosed([CallerMemberName] string method = "")
         {
             return InvalidOperation(Res.GetString(Res.ADP_StreamClosed, method));
         }
@@ -827,69 +828,14 @@ namespace System.Data.Common
 
 
         // global constant strings
-        internal const string Append = "Append";
         internal const string BeginExecuteNonQuery = "BeginExecuteNonQuery";
         internal const string BeginExecuteReader = "BeginExecuteReader";
-        internal const string BeginTransaction = "BeginTransaction";
         internal const string BeginExecuteXmlReader = "BeginExecuteXmlReader";
-        internal const string ChangeDatabase = "ChangeDatabase";
-        internal const string Cancel = "Cancel";
-        internal const string Clone = "Clone";
-        internal const string CommitTransaction = "CommitTransaction";
-        internal const string CommandTimeout = "CommandTimeout";
-        internal const string ConnectionString = "ConnectionString";
-        internal const string DataSetColumn = "DataSetColumn";
-        internal const string DataSetTable = "DataSetTable";
-        internal const string Delete = "Delete";
-        internal const string DeleteCommand = "DeleteCommand";
-        internal const string DeriveParameters = "DeriveParameters";
-        internal const string EndExecuteNonQuery = "EndExecuteNonQuery";
         internal const string EndExecuteReader = "EndExecuteReader";
         internal const string EndExecuteXmlReader = "EndExecuteXmlReader";
-        internal const string ExecuteReader = "ExecuteReader";
-        internal const string ExecuteRow = "ExecuteRow";
-        internal const string ExecuteNonQuery = "ExecuteNonQuery";
-        internal const string ExecuteScalar = "ExecuteScalar";
-        internal const string ExecuteSqlScalar = "ExecuteSqlScalar";
-        internal const string ExecuteXmlReader = "ExecuteXmlReader";
-        internal const string Fill = "Fill";
-        internal const string FillPage = "FillPage";
-        internal const string FillSchema = "FillSchema";
-        internal const string GetBytes = "GetBytes";
-        internal const string GetChars = "GetChars";
-        internal const string GetOleDbSchemaTable = "GetOleDbSchemaTable";
-        internal const string GetProperties = "GetProperties";
-        internal const string GetSchema = "GetSchema";
-        internal const string GetSchemaTable = "GetSchemaTable";
-        internal const string GetServerTransactionLevel = "GetServerTransactionLevel";
-        internal const string Insert = "Insert";
-        internal const string Open = "Open";
         internal const string Parameter = "Parameter";
-        internal const string ParameterBuffer = "buffer";
-        internal const string ParameterCount = "count";
-        internal const string ParameterDestinationType = "destinationType";
-        internal const string ParameterIndex = "index";
         internal const string ParameterName = "ParameterName";
-        internal const string ParameterOffset = "offset";
         internal const string ParameterSetPosition = "set_Position";
-        internal const string ParameterService = "Service";
-        internal const string ParameterTimeout = "Timeout";
-        internal const string ParameterUserData = "UserData";
-        internal const string Prepare = "Prepare";
-        internal const string QuoteIdentifier = "QuoteIdentifier";
-        internal const string Read = "Read";
-        internal const string ReadAsync = "ReadAsync";
-        internal const string Remove = "Remove";
-        internal const string RollbackTransaction = "RollbackTransaction";
-        internal const string SaveTransaction = "SaveTransaction";
-        internal const string SetProperties = "SetProperties";
-        internal const string SourceColumn = "SourceColumn";
-        internal const string SourceVersion = "SourceVersion";
-        internal const string SourceTable = "SourceTable";
-        internal const string UnquoteIdentifier = "UnquoteIdentifier";
-        internal const string Update = "Update";
-        internal const string UpdateCommand = "UpdateCommand";
-        internal const string UpdateRows = "UpdateRows";
 
         internal const CompareOptions compareOptions = CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase;
         internal const int DecimalMaxPrecision = 29;

--- a/src/System.Data.SqlClient/src/System/Data/Common/DataRecordInternal.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/DataRecordInternal.cs
@@ -45,7 +45,7 @@ namespace System.Data.Common
         {
             if (null == values)
             {
-                throw ADP.ArgumentNull("values");
+                throw ADP.ArgumentNull(nameof(values));
             }
 
             int copyLen = (values.Length < _schemaInfo.Length) ? values.Length : _schemaInfo.Length;
@@ -122,7 +122,7 @@ namespace System.Data.Common
             // is invalid
             if (dataIndex > Int32.MaxValue)
             {
-                throw ADP.InvalidSourceBufferIndex(cbytes, dataIndex, "dataIndex");
+                throw ADP.InvalidSourceBufferIndex(cbytes, dataIndex, nameof(dataIndex));
             }
 
             ndataIndex = (int)dataIndex;
@@ -156,11 +156,11 @@ namespace System.Data.Common
 
                     // if bad buffer index, throw
                     if (bufferIndex < 0 || bufferIndex >= buffer.Length)
-                        throw ADP.InvalidDestinationBufferIndex(length, bufferIndex, "bufferIndex");
+                        throw ADP.InvalidDestinationBufferIndex(length, bufferIndex, nameof(bufferIndex));
 
                     // if bad data index, throw
                     if (dataIndex < 0 || dataIndex >= cbytes)
-                        throw ADP.InvalidSourceBufferIndex(length, dataIndex, "dataIndex");
+                        throw ADP.InvalidSourceBufferIndex(length, dataIndex, nameof(dataIndex));
 
                     // if there is not enough room in the buffer for data
                     if (cbytes + bufferIndex > buffer.Length)
@@ -188,7 +188,7 @@ namespace System.Data.Common
             // is invalid
             if (dataIndex > Int32.MaxValue)
             {
-                throw ADP.InvalidSourceBufferIndex(cchars, dataIndex, "dataIndex");
+                throw ADP.InvalidSourceBufferIndex(cchars, dataIndex, nameof(dataIndex));
             }
 
             int ndataIndex = (int)dataIndex;
@@ -221,11 +221,11 @@ namespace System.Data.Common
 
                     // if bad buffer index, throw
                     if (bufferIndex < 0 || bufferIndex >= buffer.Length)
-                        throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, "bufferIndex");
+                        throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
 
                     // if bad data index, throw
                     if (ndataIndex < 0 || ndataIndex >= cchars)
-                        throw ADP.InvalidSourceBufferIndex(cchars, dataIndex, "dataIndex");
+                        throw ADP.InvalidSourceBufferIndex(cchars, dataIndex, nameof(dataIndex));
 
                     // if there is not enough room in the buffer for data
                     if (cchars + bufferIndex > buffer.Length)

--- a/src/System.Data.SqlClient/src/System/Data/Common/DbEnumerator.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/DbEnumerator.cs
@@ -26,7 +26,7 @@ namespace System.Data.Common
         {
             if (null == reader)
             {
-                throw ADP.ArgumentNull("reader");
+                throw ADP.ArgumentNull(nameof(reader));
             }
             _reader = reader;
             _closeReader = closeReader;

--- a/src/System.Data.SqlClient/src/System/Data/Common/FieldNameLookup.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/FieldNameLookup.cs
@@ -29,7 +29,7 @@ namespace System.Data.ProviderBase
         {
             if (null == fieldNames)
             {
-                throw ADP.ArgumentNull("fieldNames");
+                throw ADP.ArgumentNull(nameof(fieldNames));
             }
             _fieldNames = fieldNames;
             _defaultLocaleID = defaultLocaleID;
@@ -64,7 +64,7 @@ namespace System.Data.ProviderBase
         {
             if (null == fieldName)
             {
-                throw ADP.ArgumentNull("fieldName");
+                throw ADP.ArgumentNull(nameof(fieldName));
             }
             int index = IndexOf(fieldName);
             if (-1 == index)

--- a/src/System.Data.SqlClient/src/System/Data/Locale/Locale.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Locale/Locale.cs
@@ -30,7 +30,7 @@ namespace System.Data
         {
             if (lcid < 0)
             {
-                throw ADP.ArgumentOutOfRange("lcid");
+                throw ADP.ArgumentOutOfRange(nameof(lcid));
             }
             return s_cachedEncodings.GetOrAdd(lcid, id => GetDetailsInternal(id));
         }

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionFactory.cs
@@ -61,7 +61,7 @@ namespace System.Data.ProviderBase
 
         public void ClearPool(DbConnection connection)
         {
-            ADP.CheckArgumentNull(connection, "connection");
+            ADP.CheckArgumentNull(connection, nameof(connection));
 
             DbConnectionPoolGroup poolGroup = GetConnectionPoolGroup(connection);
             if (null != poolGroup)
@@ -73,7 +73,7 @@ namespace System.Data.ProviderBase
         public void ClearPool(DbConnectionPoolKey key)
         {
             Debug.Assert(key != null, "key cannot be null");
-            ADP.CheckArgumentNull(key.ConnectionString, "key.ConnectionString");
+            ADP.CheckArgumentNull(key.ConnectionString, nameof(key) + "." + nameof(key.ConnectionString));
 
             DbConnectionPoolGroup poolGroup;
             Dictionary<DbConnectionPoolKey, DbConnectionPoolGroup> connectionPoolGroups = _connectionPoolGroups;

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionInternal.cs
@@ -209,7 +209,7 @@ namespace System.Data.ProviderBase
 
         virtual public void ChangeDatabase(string value)
         {
-            throw ADP.MethodNotImplemented("ChangeDatabase");
+            throw ADP.MethodNotImplemented();
         }
 
         internal virtual void CloseConnection(DbConnection owningObject, DbConnectionFactory connectionFactory)
@@ -428,7 +428,7 @@ namespace System.Data.ProviderBase
 
         internal virtual bool TryReplaceConnection(DbConnection outerConnection, DbConnectionFactory connectionFactory, TaskCompletionSource<DbConnectionInternal> retry, DbConnectionOptions userOptions)
         {
-            throw ADP.MethodNotImplemented("TryReplaceConnection");
+            throw ADP.MethodNotImplemented();
         }
 
         protected bool TryOpenConnectionInternal(DbConnection outerConnection, DbConnectionFactory connectionFactory, TaskCompletionSource<DbConnectionInternal> retry, DbConnectionOptions userOptions)

--- a/src/System.Data.SqlClient/src/System/Data/Sql/SqlMetaData.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Sql/SqlMetaData.cs
@@ -463,49 +463,49 @@ namespace Microsoft.SqlServer.Server
             if (SqlDbType.Char == dbType)
             {
                 if (maxLength > x_lServerMaxANSI || maxLength < 0)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), "maxLength");
+                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
                 lLocale = Locale.GetCurrentCultureLcid();
             }
             else if (SqlDbType.VarChar == dbType)
             {
                 if ((maxLength > x_lServerMaxANSI || maxLength < 0) && maxLength != Max)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), "maxLength");
+                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
                 lLocale = Locale.GetCurrentCultureLcid();
             }
             else if (SqlDbType.NChar == dbType)
             {
                 if (maxLength > x_lServerMaxUnicode || maxLength < 0)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), "maxLength");
+                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
                 lLocale = Locale.GetCurrentCultureLcid();
             }
             else if (SqlDbType.NVarChar == dbType)
             {
                 if ((maxLength > x_lServerMaxUnicode || maxLength < 0) && maxLength != Max)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), "maxLength");
+                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
                 lLocale = Locale.GetCurrentCultureLcid();
             }
             else if (SqlDbType.NText == dbType || SqlDbType.Text == dbType)
             {
                 // old-style lobs only allowed with Max length
                 if (SqlMetaData.Max != maxLength)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), "maxLength");
+                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
                 lLocale = Locale.GetCurrentCultureLcid();
             }
             else if (SqlDbType.Binary == dbType)
             {
                 if (maxLength > x_lServerMaxBinary || maxLength < 0)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), "maxLength");
+                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
             }
             else if (SqlDbType.VarBinary == dbType)
             {
                 if ((maxLength > x_lServerMaxBinary || maxLength < 0) && maxLength != Max)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), "maxLength");
+                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
             }
             else if (SqlDbType.Image == dbType)
             {
                 // old-style lobs only allowed with Max length
                 if (SqlMetaData.Max != maxLength)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), "maxLength");
+                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
             }
             else
                 throw SQL.InvalidSqlDbTypeForConstructor(dbType);
@@ -540,28 +540,28 @@ namespace Microsoft.SqlServer.Server
             if (SqlDbType.Char == dbType)
             {
                 if (maxLength > x_lServerMaxANSI || maxLength < 0)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), "maxLength");
+                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
             }
             else if (SqlDbType.VarChar == dbType)
             {
                 if ((maxLength > x_lServerMaxANSI || maxLength < 0) && maxLength != Max)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), "maxLength");
+                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
             }
             else if (SqlDbType.NChar == dbType)
             {
                 if (maxLength > x_lServerMaxUnicode || maxLength < 0)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), "maxLength");
+                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
             }
             else if (SqlDbType.NVarChar == dbType)
             {
                 if ((maxLength > x_lServerMaxUnicode || maxLength < 0) && maxLength != Max)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), "maxLength");
+                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
             }
             else if (SqlDbType.NText == dbType || SqlDbType.Text == dbType)
             {
                 // old-style lobs only allowed with Max length
                 if (SqlMetaData.Max != maxLength)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), "maxLength");
+                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
             }
             else
                 throw SQL.InvalidSqlDbTypeForConstructor(dbType);
@@ -660,7 +660,7 @@ namespace Microsoft.SqlServer.Server
             {
                 if (null == objectName)
                 {
-                    throw ADP.ArgumentNull("objectName");
+                    throw ADP.ArgumentNull(nameof(objectName));
                 }
             }
 
@@ -679,10 +679,10 @@ namespace Microsoft.SqlServer.Server
         private void AssertNameIsValid(string name)
         {
             if (null == name)
-                throw ADP.ArgumentNull("name");
+                throw ADP.ArgumentNull(nameof(name));
 
             if (Microsoft.SqlServer.Server.SmiMetaData.MaxNameLength < name.Length)
-                throw SQL.NameTooLong("name");
+                throw SQL.NameTooLong(nameof(name));
         }
 
         private void ValidateSortOrder(SortOrder columnSortOrder, int sortOrdinal)
@@ -1118,17 +1118,17 @@ namespace Microsoft.SqlServer.Server
             else if (value is long)
                 value = this.Adjust((Int64)value);
             else if (value is sbyte)
-                throw ADP.InvalidDataType("SByte");
+                throw ADP.InvalidDataType(nameof(SByte));
             else if (value is float)
                 value = this.Adjust((Single)value);
             else if (value is string)
                 value = this.Adjust((String)value);
             else if (value is ushort)
-                throw ADP.InvalidDataType("UInt16");
+                throw ADP.InvalidDataType(nameof(UInt16));
             else if (value is uint)
-                throw ADP.InvalidDataType("UInt32");
+                throw ADP.InvalidDataType(nameof(UInt32));
             else if (value is ulong)
-                throw ADP.InvalidDataType("UInt64");
+                throw ADP.InvalidDataType(nameof(UInt64));
             else if (value is byte[])
                 value = this.Adjust((System.Byte[])value);
             else if (value is char[])
@@ -1180,7 +1180,7 @@ namespace Microsoft.SqlServer.Server
         public static SqlMetaData InferFromValue(object value, String name)
         {
             if (value == null)
-                throw ADP.ArgumentNull("value");
+                throw ADP.ArgumentNull(nameof(value));
 
             SqlMetaData smd;
 
@@ -1188,7 +1188,7 @@ namespace Microsoft.SqlServer.Server
             else if (value is Byte) smd = new SqlMetaData(name, SqlDbType.TinyInt);
             else if (value is Char) smd = new SqlMetaData(name, SqlDbType.NVarChar, 1);
             else if (value is DateTime) smd = new SqlMetaData(name, SqlDbType.DateTime);
-            else if (value is DBNull) throw ADP.InvalidDataType("DBNull");
+            else if (value is DBNull) throw ADP.InvalidDataType(nameof(DBNull));
             else if (value is Decimal)
             {
                 // use logic inside SqlDecimal to infer precision and scale.
@@ -1199,7 +1199,7 @@ namespace Microsoft.SqlServer.Server
             else if (value is Int16) smd = new SqlMetaData(name, SqlDbType.SmallInt);
             else if (value is Int32) smd = new SqlMetaData(name, SqlDbType.Int);
             else if (value is Int64) smd = new SqlMetaData(name, SqlDbType.BigInt);
-            else if (value is SByte) throw ADP.InvalidDataType("SByte");
+            else if (value is SByte) throw ADP.InvalidDataType(nameof(SByte));
             else if (value is Single) smd = new SqlMetaData(name, SqlDbType.Real);
             else if (value is String)
             {
@@ -1211,9 +1211,9 @@ namespace Microsoft.SqlServer.Server
 
                 smd = new SqlMetaData(name, SqlDbType.NVarChar, maxLen);
             }
-            else if (value is UInt16) throw ADP.InvalidDataType("UInt16");
-            else if (value is UInt32) throw ADP.InvalidDataType("UInt32");
-            else if (value is UInt64) throw ADP.InvalidDataType("UInt64");
+            else if (value is UInt16) throw ADP.InvalidDataType(nameof(UInt16));
+            else if (value is UInt32) throw ADP.InvalidDataType(nameof(UInt32));
+            else if (value is UInt64) throw ADP.InvalidDataType(nameof(UInt64));
             else if (value is System.Byte[])
             {
                 long maxLen = ((System.Byte[])value).Length;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
@@ -258,7 +258,7 @@ namespace System.Data.SqlClient
         {
             if (connection == null)
             {
-                throw ADP.ArgumentNull("connection");
+                throw ADP.ArgumentNull(nameof(connection));
             }
             _connection = connection;
             _columnMappings = new SqlBulkCopyColumnMappingCollection();
@@ -283,7 +283,7 @@ namespace System.Data.SqlClient
         {
             if (connectionString == null)
             {
-                throw ADP.ArgumentNull("connectionString");
+                throw ADP.ArgumentNull(nameof(connectionString));
             }
             _connection = new SqlConnection(connectionString);
             _columnMappings = new SqlBulkCopyColumnMappingCollection();
@@ -310,7 +310,7 @@ namespace System.Data.SqlClient
                 }
                 else
                 {
-                    throw ADP.ArgumentOutOfRange("BatchSize");
+                    throw ADP.ArgumentOutOfRange(nameof(BatchSize));
                 }
             }
         }
@@ -361,11 +361,11 @@ namespace System.Data.SqlClient
             {
                 if (value == null)
                 {
-                    throw ADP.ArgumentNull("DestinationTableName");
+                    throw ADP.ArgumentNull(nameof(DestinationTableName));
                 }
                 else if (value.Length == 0)
                 {
-                    throw ADP.ArgumentOutOfRange("DestinationTableName");
+                    throw ADP.ArgumentOutOfRange(nameof(DestinationTableName));
                 }
                 _destinationTableName = value;
             }
@@ -385,7 +385,7 @@ namespace System.Data.SqlClient
                 }
                 else
                 {
-                    throw ADP.ArgumentOutOfRange("NotifyAfter");
+                    throw ADP.ArgumentOutOfRange(nameof(NotifyAfter));
                 }
             }
         }
@@ -1503,7 +1503,7 @@ namespace System.Data.SqlClient
             bool finishedSynchronously = true;
             _isBulkCopyingInProgress = true;
 
-            CreateOrValidateConnection(SQL.WriteToServer);
+            CreateOrValidateConnection(nameof(WriteToServer));
             SqlInternalConnectionTds internalConnection = _connection.GetOpenTdsConnection();
 
             Debug.Assert(_parserLock == null, "Previous parser lock not cleaned");
@@ -1803,7 +1803,7 @@ namespace System.Data.SqlClient
                             // In case the target connection is closed accidentally.
                             if (ConnectionState.Open != _connection.State)
                             {
-                                exception = ADP.OpenConnectionRequired("CheckAndRaiseNotification", _connection.State);
+                                exception = ADP.OpenConnectionRequired(nameof(CheckAndRaiseNotification), _connection.State);
                             }
                         }
                         catch (Exception e)
@@ -1838,7 +1838,7 @@ namespace System.Data.SqlClient
             }
             if (_connection.State != ConnectionState.Open)
             {
-                throw ADP.OpenConnectionRequired(SQL.WriteToServer, _connection.State);
+                throw ADP.OpenConnectionRequired(nameof(WriteToServer), _connection.State);
             }
             if (exception != null)
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -539,7 +539,7 @@ namespace System.Data.SqlClient
             else
             {
                 // Validate the command outside of the try\catch to avoid putting the _stateObj on error
-                ValidateCommand(nameof(Prepare), async: false);
+                ValidateCommand(async: false);
 
                 bool processFinallyBlock = true;
                 try
@@ -794,7 +794,7 @@ namespace System.Data.SqlClient
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
-                InternalExecuteNonQuery(null, nameof(ExecuteNonQuery), false, CommandTimeout);
+                InternalExecuteNonQuery(completion: null, sendToPipe: false, timeout: CommandTimeout);
                 return _rowsAffected;
             }
             finally
@@ -804,12 +804,7 @@ namespace System.Data.SqlClient
         }
 
 
-        private IAsyncResult BeginExecuteNonQueryAsync(AsyncCallback callback, object stateObject)
-        {
-            return BeginExecuteNonQueryInternal(callback, stateObject, CommandTimeout, asyncWrite: true);
-        }
-
-        private IAsyncResult BeginExecuteNonQueryInternal(AsyncCallback callback, object stateObject, int timeout, bool asyncWrite = false)
+        private IAsyncResult BeginExecuteNonQuery(AsyncCallback callback, object stateObject)
         {
             // Reset _pendingCancel upon entry into any Execute - used to synchronize state
             // between entry into Execute* API and the thread obtaining the stateObject.
@@ -826,10 +821,10 @@ namespace System.Data.SqlClient
 
                 try
                 { // InternalExecuteNonQuery already has reliability block, but if failure will not put stateObj back into pool.
-                    Task execNQ = InternalExecuteNonQuery(completion, ADP.BeginExecuteNonQuery, false, timeout, asyncWrite);
+                    Task execNQ = InternalExecuteNonQuery(completion, false, CommandTimeout, asyncWrite: true);
 
                     // must finish caching information before ReadSni which can activate the callback before returning
-                    cachedAsyncState.SetActiveConnectionAndResult(completion, ADP.EndExecuteNonQuery, _activeConnection);
+                    cachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteNonQuery), _activeConnection);
                     if (execNQ != null)
                     {
                         AsyncHelper.ContinueTask(execNQ, completion, () => BeginExecuteNonQueryInternalReadStage(completion));
@@ -946,7 +941,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        private int EndExecuteNonQueryAsync(IAsyncResult asyncResult)
+        private int EndExecuteNonQuery(IAsyncResult asyncResult)
         {
             Exception asyncException = ((Task)asyncResult).Exception;
             if (asyncException != null)
@@ -973,7 +968,7 @@ namespace System.Data.SqlClient
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
-                VerifyEndExecuteState((Task)asyncResult, ADP.EndExecuteNonQuery);
+                VerifyEndExecuteState((Task)asyncResult, nameof(EndExecuteNonQuery));
                 WaitForAsyncResults(asyncResult);
 
                 bool processFinallyBlock = true;
@@ -1039,7 +1034,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        private Task InternalExecuteNonQuery(TaskCompletionSource<object> completion, string methodName, bool sendToPipe, int timeout, bool asyncWrite = false)
+        private Task InternalExecuteNonQuery(TaskCompletionSource<object> completion, bool sendToPipe, int timeout, bool asyncWrite = false, [CallerMemberName] string methodName = "")
         {
             bool async = (null != completion);
 
@@ -1048,7 +1043,7 @@ namespace System.Data.SqlClient
 
             // this function may throw for an invalid connection
             // returns false for empty command text
-            ValidateCommand(methodName, async);
+            ValidateCommand(async, methodName);
 
             Task task = null;
 
@@ -1073,7 +1068,7 @@ namespace System.Data.SqlClient
             else
             { // otherwise, use a full-fledged execute that can handle params and stored procs
                 Debug.Assert(!sendToPipe, "trying to send non-context command to pipe");
-                SqlDataReader reader = RunExecuteReader(0, RunBehavior.UntilDone, false, methodName, completion, timeout, out task, asyncWrite);
+                SqlDataReader reader = RunExecuteReader(0, RunBehavior.UntilDone, false, completion, timeout, out task, asyncWrite, methodName);
                 if (null != reader)
                 {
                     if (task != null)
@@ -1113,12 +1108,7 @@ namespace System.Data.SqlClient
         }
 
 
-        private IAsyncResult BeginExecuteXmlReaderAsync(AsyncCallback callback, object stateObject)
-        {
-            return BeginExecuteXmlReaderInternal(callback, stateObject, CommandTimeout, asyncWrite: true);
-        }
-
-        private IAsyncResult BeginExecuteXmlReaderInternal(AsyncCallback callback, object stateObject, int timeout, bool asyncWrite = false)
+        private IAsyncResult BeginExecuteXmlReader(AsyncCallback callback, object stateObject)
         {
             // Reset _pendingCancel upon entry into any Execute - used to synchronize state
             // between entry into Execute* API and the thread obtaining the stateObject.
@@ -1136,7 +1126,7 @@ namespace System.Data.SqlClient
                 Task writeTask;
                 try
                 { // InternalExecuteNonQuery already has reliability block, but if failure will not put stateObj back into pool.
-                    RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, true, ADP.BeginExecuteXmlReader, completion, timeout, out writeTask, asyncWrite);
+                    RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, true, completion, CommandTimeout, out writeTask, asyncWrite: true);
                 }
                 catch (Exception e)
                 {
@@ -1152,7 +1142,7 @@ namespace System.Data.SqlClient
                 }
 
                 // must finish caching information before ReadSni which can activate the callback before returning
-                cachedAsyncState.SetActiveConnectionAndResult(completion, ADP.EndExecuteXmlReader, _activeConnection);
+                cachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteXmlReader), _activeConnection);
                 if (writeTask != null)
                 {
                     AsyncHelper.ContinueTask(writeTask, completion, () => BeginExecuteXmlReaderInternalReadStage(completion));
@@ -1197,7 +1187,7 @@ namespace System.Data.SqlClient
         }
 
 
-        private XmlReader EndExecuteXmlReaderAsync(IAsyncResult asyncResult)
+        private XmlReader EndExecuteXmlReader(IAsyncResult asyncResult)
         {
             Exception asyncException = ((Task)asyncResult).Exception;
             if (asyncException != null)
@@ -1221,7 +1211,7 @@ namespace System.Data.SqlClient
         {
             try
             {
-                return CompleteXmlReader(InternalEndExecuteReader(asyncResult, ADP.EndExecuteXmlReader), async: true);
+                return CompleteXmlReader(InternalEndExecuteReader(asyncResult, nameof(EndExecuteXmlReader)), async: true);
             }
             catch (Exception e)
             {
@@ -1310,7 +1300,7 @@ namespace System.Data.SqlClient
         }
 
 
-        private SqlDataReader EndExecuteReaderAsync(IAsyncResult asyncResult)
+        private SqlDataReader EndExecuteReader(IAsyncResult asyncResult)
         {
             Exception asyncException = ((Task)asyncResult).Exception;
             if (asyncException != null)
@@ -1336,7 +1326,7 @@ namespace System.Data.SqlClient
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
-                return InternalEndExecuteReader(asyncResult, ADP.EndExecuteReader);
+                return InternalEndExecuteReader(asyncResult, nameof(EndExecuteReader));
             }
             catch (Exception e)
             {
@@ -1356,12 +1346,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        private IAsyncResult BeginExecuteReaderAsync(CommandBehavior behavior, AsyncCallback callback, object stateObject)
-        {
-            return BeginExecuteReaderInternal(behavior, callback, stateObject, CommandTimeout, asyncWrite: true);
-        }
-
-        private IAsyncResult BeginExecuteReaderInternal(CommandBehavior behavior, AsyncCallback callback, object stateObject, int timeout, bool asyncWrite = false)
+        private IAsyncResult BeginExecuteReader(CommandBehavior behavior, AsyncCallback callback, object stateObject)
         {
             // Reset _pendingCancel upon entry into any Execute - used to synchronize state
             // between entry into Execute* API and the thread obtaining the stateObject.
@@ -1379,7 +1364,7 @@ namespace System.Data.SqlClient
                 Task writeTask = null;
                 try
                 { // InternalExecuteNonQuery already has reliability block, but if failure will not put stateObj back into pool.
-                    RunExecuteReader(behavior, RunBehavior.ReturnImmediately, true, ADP.BeginExecuteReader, completion, timeout, out writeTask, asyncWrite);
+                    RunExecuteReader(behavior, RunBehavior.ReturnImmediately, true, completion, CommandTimeout, out writeTask, asyncWrite: true);
                 }
                 catch (Exception e)
                 {
@@ -1395,7 +1380,7 @@ namespace System.Data.SqlClient
                 }
 
                 // must finish caching information before ReadSni which can activate the callback before returning
-                cachedAsyncState.SetActiveConnectionAndResult(completion, ADP.EndExecuteReader, _activeConnection);
+                cachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteReader), _activeConnection);
                 if (writeTask != null)
                 {
                     AsyncHelper.ContinueTask(writeTask, completion, () => BeginExecuteReaderInternalReadStage(completion));
@@ -1471,7 +1456,7 @@ namespace System.Data.SqlClient
             {
                 RegisterForConnectionCloseNotification(ref returnedTask);
 
-                Task<int>.Factory.FromAsync(BeginExecuteNonQueryAsync, EndExecuteNonQueryAsync, null).ContinueWith((t) =>
+                Task<int>.Factory.FromAsync(BeginExecuteNonQuery, EndExecuteNonQuery, null).ContinueWith((t) =>
                 {
                     registration.Dispose();
                     if (t.IsFaulted)
@@ -1547,7 +1532,7 @@ namespace System.Data.SqlClient
             {
                 RegisterForConnectionCloseNotification(ref returnedTask);
 
-                Task<SqlDataReader>.Factory.FromAsync(BeginExecuteReaderAsync, EndExecuteReaderAsync, behavior, null).ContinueWith((t) =>
+                Task<SqlDataReader>.Factory.FromAsync(BeginExecuteReader, EndExecuteReader, behavior, null).ContinueWith((t) =>
                 {
                     registration.Dispose();
                     if (t.IsFaulted)
@@ -1675,7 +1660,7 @@ namespace System.Data.SqlClient
             {
                 RegisterForConnectionCloseNotification(ref returnedTask);
 
-                Task<XmlReader>.Factory.FromAsync(BeginExecuteXmlReaderAsync, EndExecuteXmlReaderAsync, null).ContinueWith((t) =>
+                Task<XmlReader>.Factory.FromAsync(BeginExecuteXmlReader, EndExecuteXmlReader, null).ContinueWith((t) =>
                 {
                     registration.Dispose();
                     if (t.IsFaulted)
@@ -1847,13 +1832,13 @@ namespace System.Data.SqlClient
         internal SqlDataReader RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, [CallerMemberName] string method = "")
         {
             Task unused; // sync execution 
-            SqlDataReader reader = RunExecuteReader(cmdBehavior, runBehavior, returnStream, method, completion: null, timeout: CommandTimeout, task: out unused);
+            SqlDataReader reader = RunExecuteReader(cmdBehavior, runBehavior, returnStream, completion: null, timeout: CommandTimeout, task: out unused, method: method);
             Debug.Assert(unused == null, "returned task during synchronous execution");
             return reader;
         }
 
         // task is created in case of pending asynchronous write, returned SqlDataReader should not be utilized until that task is complete 
-        internal SqlDataReader RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, string method, TaskCompletionSource<object> completion, int timeout, out Task task, bool asyncWrite = false)
+        internal SqlDataReader RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, TaskCompletionSource<object> completion, int timeout, out Task task, bool asyncWrite = false, [CallerMemberName] string method = "")
         {
             bool async = (null != completion);
 
@@ -1869,7 +1854,7 @@ namespace System.Data.SqlClient
 
             // this function may throw for an invalid connection
             // returns false for empty command text
-            ValidateCommand(method, async);
+            ValidateCommand(async, method);
             SqlStatistics statistics = Statistics;
             if (null != statistics)
             {
@@ -2237,7 +2222,7 @@ namespace System.Data.SqlClient
 
         // validates that a command has commandText and a non-busy open connection
         // throws exception for error case, returns false if the commandText is empty
-        private void ValidateCommand(string method, bool async)
+        private void ValidateCommand(bool async, [CallerMemberName] string method = "")
         {
             if (null == _activeConnection)
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -236,7 +236,7 @@ namespace System.Data.SqlClient
                 { // If new value...
                     if (cachedAsyncState.PendingAsyncOperation)
                     { // If in pending async state, throw.
-                        throw SQL.CannotModifyPropertyAsyncOperationInProgress(SQL.Connection);
+                        throw SQL.CannotModifyPropertyAsyncOperationInProgress();
                     }
                 }
 
@@ -320,7 +320,7 @@ namespace System.Data.SqlClient
                 { // If new value...
                     if (cachedAsyncState.PendingAsyncOperation)
                     { // If in pending async state, throw
-                        throw SQL.CannotModifyPropertyAsyncOperationInProgress(SQL.Transaction);
+                        throw SQL.CannotModifyPropertyAsyncOperationInProgress();
                     }
                 }
 
@@ -542,7 +542,7 @@ namespace System.Data.SqlClient
             else
             {
                 // Validate the command outside of the try\catch to avoid putting the _stateObj on error
-                ValidateCommand(ADP.Prepare, false /*not async*/);
+                ValidateCommand(nameof(Prepare), async: false);
 
                 bool processFinallyBlock = true;
                 try
@@ -748,7 +748,7 @@ namespace System.Data.SqlClient
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
                 SqlDataReader ds;
-                ds = RunExecuteReader(0, RunBehavior.ReturnImmediately, true, ADP.ExecuteScalar);
+                ds = RunExecuteReader(0, RunBehavior.ReturnImmediately, true, nameof(ExecuteScalar));
                 return CompleteExecuteScalar(ds, false);
             }
             finally
@@ -797,7 +797,7 @@ namespace System.Data.SqlClient
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
-                InternalExecuteNonQuery(null, ADP.ExecuteNonQuery, false, CommandTimeout);
+                InternalExecuteNonQuery(null, nameof(ExecuteNonQuery), false, CommandTimeout);
                 return _rowsAffected;
             }
             finally
@@ -832,7 +832,7 @@ namespace System.Data.SqlClient
                     Task execNQ = InternalExecuteNonQuery(completion, ADP.BeginExecuteNonQuery, false, timeout, asyncWrite);
 
                     // must finish caching information before ReadSni which can activate the callback before returning
-                    cachedAsyncState.SetActiveConnectionAndResult(completion, ADP.EndExecuteNonQuery, _activeConnection);
+                    cachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteNonQuery), _activeConnection);
                     if (execNQ != null)
                     {
                         AsyncHelper.ContinueTask(execNQ, completion, () => BeginExecuteNonQueryInternalReadStage(completion));
@@ -889,13 +889,13 @@ namespace System.Data.SqlClient
             }
         }
 
-        private void VerifyEndExecuteState(Task completionTask, String endMethod)
+        private void VerifyEndExecuteState(Task asyncResult, String endMethod)
         {
-            if (null == completionTask)
+            if (null == asyncResult)
             {
-                throw ADP.ArgumentNull("asyncResult");
+                throw ADP.ArgumentNull(nameof(asyncResult));
             }
-            if (completionTask.IsCanceled)
+            if (asyncResult.IsCanceled)
             {
                 if (_stateObj != null)
                 {
@@ -909,9 +909,9 @@ namespace System.Data.SqlClient
                     throw SQL.CR_ReconnectionCancelled();
                 }
             }
-            else if (completionTask.IsFaulted)
+            else if (asyncResult.IsFaulted)
             {
-                throw completionTask.Exception.InnerException;
+                throw asyncResult.Exception.InnerException;
             }
             if (cachedAsyncState.EndMethodName == null)
             {
@@ -989,7 +989,7 @@ namespace System.Data.SqlClient
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
-                VerifyEndExecuteState((Task)asyncResult, ADP.EndExecuteNonQuery);
+                VerifyEndExecuteState((Task)asyncResult, nameof(EndExecuteNonQuery));
                 WaitForAsyncResults(asyncResult);
 
                 bool processFinallyBlock = true;
@@ -1119,7 +1119,7 @@ namespace System.Data.SqlClient
 
                 // use the reader to consume metadata
                 SqlDataReader ds;
-                ds = RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, true, ADP.ExecuteXmlReader);
+                ds = RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, true, nameof(ExecuteXmlReader));
                 return CompleteXmlReader(ds);
             }
             finally
@@ -1289,7 +1289,7 @@ namespace System.Data.SqlClient
 
         override protected DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
         {
-            return ExecuteReader(behavior, ADP.ExecuteReader);
+            return ExecuteReader(behavior, nameof(ExecuteReader));
         }
 
         new public SqlDataReader ExecuteReader()
@@ -1298,7 +1298,7 @@ namespace System.Data.SqlClient
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
-                return ExecuteReader(CommandBehavior.Default, ADP.ExecuteReader);
+                return ExecuteReader(CommandBehavior.Default, nameof(ExecuteReader));
             }
             finally
             {
@@ -1308,7 +1308,7 @@ namespace System.Data.SqlClient
 
         new public SqlDataReader ExecuteReader(CommandBehavior behavior)
         {
-            return ExecuteReader(behavior, ADP.ExecuteReader);
+            return ExecuteReader(behavior, nameof(ExecuteReader));
         }
 
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -437,7 +437,7 @@ namespace System.Data.SqlClient
 
         static public void ClearPool(SqlConnection connection)
         {
-            ADP.CheckArgumentNull(connection, "connection");
+            ADP.CheckArgumentNull(connection, nameof(connection));
 
             DbConnectionOptions connectionOptions = connection.UserConnectionOptions;
             if (null != connectionOptions)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionHelper.cs
@@ -80,7 +80,7 @@ namespace System.Data.SqlClient
             }
             if (!flag)
             {
-                throw ADP.OpenConnectionPropertySet(ADP.ConnectionString, connectionInternal.State);
+                throw ADP.OpenConnectionPropertySet(nameof(ConnectionString), connectionInternal.State);
             }
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionStringBuilder.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionStringBuilder.cs
@@ -613,7 +613,7 @@ namespace System.Data.SqlClient
 
         public override bool ContainsKey(string keyword)
         {
-            ADP.CheckArgumentNull(keyword, "keyword");
+            ADP.CheckArgumentNull(keyword, nameof(keyword));
             return s_keywords.ContainsKey(keyword);
         }
 
@@ -679,7 +679,7 @@ namespace System.Data.SqlClient
 
         private Keywords GetIndex(string keyword)
         {
-            ADP.CheckArgumentNull(keyword, "keyword");
+            ADP.CheckArgumentNull(keyword, nameof(keyword));
             Keywords index;
             if (s_keywords.TryGetValue(keyword, out index))
             {
@@ -691,7 +691,7 @@ namespace System.Data.SqlClient
 
         public override bool Remove(string keyword)
         {
-            ADP.CheckArgumentNull(keyword, "keyword");
+            ADP.CheckArgumentNull(keyword, nameof(keyword));
             Keywords index;
             if (s_keywords.TryGetValue(keyword, out index))
             {
@@ -819,7 +819,7 @@ namespace System.Data.SqlClient
 
         public override bool ShouldSerialize(string keyword)
         {
-            ADP.CheckArgumentNull(keyword, "keyword");
+            ADP.CheckArgumentNull(keyword, nameof(keyword));
             Keywords index;
             return s_keywords.TryGetValue(keyword, out index) && base.ShouldSerialize(s_validKeywords[(int)index]);
         }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
@@ -7,19 +7,19 @@
 //------------------------------------------------------------------------------
 
 using System.Collections;
-using System.Data.SqlTypes;
+using System.Collections.ObjectModel;
 using System.Data.Common;
 using System.Data.ProviderBase;
+using System.Data.SqlTypes;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Xml;
 
 using Microsoft.SqlServer.Server;
-using System.Threading.Tasks;
-using System.Collections.ObjectModel;
-using System.Collections.Generic;
 
 namespace System.Data.SqlClient
 {
@@ -149,7 +149,7 @@ namespace System.Data.SqlClient
             {
                 if (this.IsClosed)
                 {
-                    throw ADP.DataReaderClosed("Depth");
+                    throw ADP.DataReaderClosed();
                 }
 
                 return 0;
@@ -163,7 +163,7 @@ namespace System.Data.SqlClient
             {
                 if (this.IsClosed)
                 {
-                    throw ADP.DataReaderClosed("FieldCount");
+                    throw ADP.DataReaderClosed();
                 }
                 if (_currentTask != null)
                 {
@@ -185,7 +185,7 @@ namespace System.Data.SqlClient
             {
                 if (this.IsClosed)
                 {
-                    throw ADP.DataReaderClosed("HasRows");
+                    throw ADP.DataReaderClosed();
                 }
                 if (_currentTask != null)
                 {
@@ -235,7 +235,7 @@ namespace System.Data.SqlClient
             {
                 if (IsClosed)
                 {
-                    throw ADP.DataReaderClosed("MetaData");
+                    throw ADP.DataReaderClosed();
                 }
                 // metaData comes in pieces: colmetadata, tabname, colinfo, etc
                 // if we have any metaData, return it.  If we have none,
@@ -359,7 +359,7 @@ namespace System.Data.SqlClient
             {
                 if (this.IsClosed)
                 {
-                    throw ADP.DataReaderClosed("VisibleFieldCount");
+                    throw ADP.DataReaderClosed();
                 }
                 _SqlMetaDataSet md = this.MetaData;
                 if (md == null)
@@ -1078,7 +1078,7 @@ namespace System.Data.SqlClient
         {
             // NOTE: sql_variant can not contain a XML data type: http://msdn.microsoft.com/en-us/library/ms173829.aspx
             // If this ever changes, the following code should be changed to be like GetStream\GetTextReader
-            CheckDataIsReady(columnIndex: i, methodName: "GetXmlReader");
+            CheckDataIsReady(columnIndex: i);
 
             MetaType mt = _metaData[i].metaType;
 
@@ -1115,7 +1115,7 @@ namespace System.Data.SqlClient
 
         override public Stream GetStream(int i)
         {
-            CheckDataIsReady(columnIndex: i, methodName: "GetStream");
+            CheckDataIsReady(columnIndex: i);
 
             // Stream is only for Binary, Image, VarBinary, Udt and Xml types
             // NOTE: IsBinType also includes Timestamp for some reason...
@@ -1165,7 +1165,7 @@ namespace System.Data.SqlClient
             SqlStatistics statistics = null;
             long cbBytes = 0;
 
-            CheckDataIsReady(columnIndex: i, allowPartiallyReadColumn: true, methodName: "GetBytes");
+            CheckDataIsReady(columnIndex: i, allowPartiallyReadColumn: true);
 
             // don't allow get bytes on non-long or non-binary columns
             MetaType mt = _metaData[i].metaType;
@@ -1258,11 +1258,11 @@ namespace System.Data.SqlClient
                 }
 
                 if (dataIndex < 0)
-                    throw ADP.NegativeParameter("dataIndex");
+                    throw ADP.NegativeParameter(nameof(dataIndex));
 
                 if (dataIndex < _columnDataBytesRead)
                 {
-                    throw ADP.NonSeqByteAccess(dataIndex, _columnDataBytesRead, ADP.GetBytes);
+                    throw ADP.NonSeqByteAccess(dataIndex, _columnDataBytesRead, nameof(GetBytes));
                 }
 
                 // if the dataIndex is not equal to bytes read, then we have to skip bytes
@@ -1276,7 +1276,7 @@ namespace System.Data.SqlClient
 
                 // if bad buffer index, throw
                 if (bufferIndex < 0 || bufferIndex >= buffer.Length)
-                    throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, "bufferIndex");
+                    throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
 
                 // if there is not enough room in the buffer for data
                 if (length + bufferIndex > buffer.Length)
@@ -1318,11 +1318,11 @@ namespace System.Data.SqlClient
             // note that since we are caching in an array, and arrays aren't 64 bit ready yet,
             // we need can cast to int if the dataIndex is in range
             if (dataIndex < 0)
-                throw ADP.NegativeParameter("dataIndex");
+                throw ADP.NegativeParameter(nameof(dataIndex));
 
             if (dataIndex > Int32.MaxValue)
             {
-                throw ADP.InvalidSourceBufferIndex(cbytes, dataIndex, "dataIndex");
+                throw ADP.InvalidSourceBufferIndex(cbytes, dataIndex, nameof(dataIndex));
             }
 
             int ndataIndex = (int)dataIndex;
@@ -1392,7 +1392,7 @@ namespace System.Data.SqlClient
 
                 // if bad buffer index, throw
                 if (bufferIndex < 0 || bufferIndex >= buffer.Length)
-                    throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, "bufferIndex");
+                    throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
 
                 // if there is not enough room in the buffer for data
                 if (cbytes + bufferIndex > buffer.Length)
@@ -1491,7 +1491,7 @@ namespace System.Data.SqlClient
 
         override public TextReader GetTextReader(int i)
         {
-            CheckDataIsReady(columnIndex: i, methodName: "GetTextReader");
+            CheckDataIsReady(columnIndex: i);
 
             // Xml type is not supported
             MetaType mt = _metaData[i].metaType;
@@ -1571,7 +1571,7 @@ namespace System.Data.SqlClient
                     // if bad buffer index, throw
                     if ((bufferIndex < 0) || (buffer != null && bufferIndex >= buffer.Length))
                     {
-                        throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, "bufferIndex");
+                        throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
                     }
 
                     // if there is not enough room in the buffer for data
@@ -1584,7 +1584,7 @@ namespace System.Data.SqlClient
                     {
                         try
                         {
-                            CheckDataIsReady(columnIndex: i, allowPartiallyReadColumn: true, methodName: "GetChars");
+                            CheckDataIsReady(columnIndex: i, allowPartiallyReadColumn: true);
                         }
                         catch (Exception ex)
                         {
@@ -1602,7 +1602,7 @@ namespace System.Data.SqlClient
                     }
                     else
                     {
-                        CheckDataIsReady(columnIndex: i, allowPartiallyReadColumn: true, methodName: "GetChars");
+                        CheckDataIsReady(columnIndex: i, allowPartiallyReadColumn: true);
                         charsRead = GetCharsFromPlpData(i, dataIndex, buffer, bufferIndex, length);
                     }
                     _lastColumnWithDataChunkRead = i;
@@ -1613,7 +1613,7 @@ namespace System.Data.SqlClient
                 if ((_sharedState._nextColumnDataToRead == (i + 1)) && (_sharedState._nextColumnHeaderToRead == (i + 1)) && (_columnDataChars != null) && (IsCommandBehavior(CommandBehavior.SequentialAccess)) && (dataIndex < _columnDataCharsRead))
                 {
                     // Don't allow re-read of same chars in sequential access mode
-                    throw ADP.NonSeqByteAccess(dataIndex, _columnDataCharsRead, ADP.GetChars);
+                    throw ADP.NonSeqByteAccess(dataIndex, _columnDataCharsRead, nameof(GetChars));
                 }
 
                 if (_columnDataCharsIndex != i)
@@ -1632,7 +1632,7 @@ namespace System.Data.SqlClient
                 // we need can cast to int if the dataIndex is in range
                 if (dataIndex > Int32.MaxValue)
                 {
-                    throw ADP.InvalidSourceBufferIndex(cchars, dataIndex, "dataIndex");
+                    throw ADP.InvalidSourceBufferIndex(cchars, dataIndex, nameof(dataIndex));
                 }
                 int ndataIndex = (int)dataIndex;
 
@@ -1671,7 +1671,7 @@ namespace System.Data.SqlClient
 
                     // if bad buffer index, throw
                     if (bufferIndex < 0 || bufferIndex >= buffer.Length)
-                        throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, "bufferIndex");
+                        throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
 
                     // if there is not enough room in the buffer for data
                     if (cchars + bufferIndex > buffer.Length)
@@ -1718,7 +1718,7 @@ namespace System.Data.SqlClient
             if (dataIndex < _columnDataCharsRead)
             {
                 // Don't allow re-read of same chars in sequential access mode
-                throw ADP.NonSeqByteAccess(dataIndex, _columnDataCharsRead, ADP.GetChars);
+                throw ADP.NonSeqByteAccess(dataIndex, _columnDataCharsRead, nameof(GetChars));
             }
 
             // If we start reading the new column, either dataIndex is 0 or 
@@ -2062,7 +2062,7 @@ namespace System.Data.SqlClient
                     }
                     else
                     {
-                        throw ADP.DataReaderClosed("GetSqlValueFromSqlBufferInternal");
+                        throw ADP.DataReaderClosed();
                     }
                 }
                 else
@@ -2094,7 +2094,7 @@ namespace System.Data.SqlClient
                 CheckDataIsReady();
                 if (null == values)
                 {
-                    throw ADP.ArgumentNull("values");
+                    throw ADP.ArgumentNull(nameof(values));
                 }
 
                 SetTimeout(_defaultTimeoutMilliseconds);
@@ -2252,7 +2252,7 @@ namespace System.Data.SqlClient
                     }
                     else
                     {
-                        throw ADP.DataReaderClosed("GetValueFromSqlBufferInternal");
+                        throw ADP.DataReaderClosed();
                     }
                 }
             }
@@ -2339,7 +2339,7 @@ namespace System.Data.SqlClient
 
                 if (null == values)
                 {
-                    throw ADP.ArgumentNull("values");
+                    throw ADP.ArgumentNull(nameof(values));
                 }
 
                 CheckMetaDataIsReady();
@@ -2590,7 +2590,7 @@ namespace System.Data.SqlClient
         override public bool IsDBNull(int i)
         {
             {
-                CheckHeaderIsReady(columnIndex: i, methodName: "IsDBNull");
+                CheckHeaderIsReady(columnIndex: i);
 
                 SetTimeout(_defaultTimeoutMilliseconds);
 
@@ -2634,7 +2634,7 @@ namespace System.Data.SqlClient
 
                 if (IsClosed)
                 {
-                    throw ADP.DataReaderClosed("NextResult");
+                    throw ADP.DataReaderClosed(nameof(NextResult));
                 }
                 _fieldNameLookup = null;
 
@@ -2911,7 +2911,7 @@ namespace System.Data.SqlClient
                 }
                 else if (IsClosed)
                 {
-                    throw ADP.DataReaderClosed("Read");
+                    throw ADP.DataReaderClosed(nameof(Read));
                 }
                 more = false;
 
@@ -2950,7 +2950,7 @@ namespace System.Data.SqlClient
 
         private bool TryReadColumn(int i, bool setTimeout, bool allowPartiallyReadColumn = false)
         {
-            CheckDataIsReady(columnIndex: i, permitAsync: true, allowPartiallyReadColumn: allowPartiallyReadColumn);
+            CheckDataIsReady(columnIndex: i, permitAsync: true, allowPartiallyReadColumn: allowPartiallyReadColumn, methodName: null);
 
             Debug.Assert(_sharedState._nextColumnHeaderToRead <= _metaData.Length, "_sharedState._nextColumnHeaderToRead too large");
             Debug.Assert(_sharedState._nextColumnDataToRead <= _metaData.Length, "_sharedState._nextColumnDataToRead too large");
@@ -3517,11 +3517,11 @@ namespace System.Data.SqlClient
             }
         }
 
-        private void CheckHeaderIsReady(int columnIndex, bool permitAsync = false, string methodName = null)
+        private void CheckHeaderIsReady(int columnIndex, bool permitAsync = false, [CallerMemberName] string methodName = null)
         {
             if (_isClosed)
             {
-                throw ADP.DataReaderClosed(methodName ?? "CheckHeaderIsReady");
+                throw ADP.DataReaderClosed(methodName ?? nameof(CheckHeaderIsReady));
             }
             if ((!permitAsync) && (_currentTask != null))
             {
@@ -3543,11 +3543,11 @@ namespace System.Data.SqlClient
             }
         }
 
-        private void CheckDataIsReady(int columnIndex, bool allowPartiallyReadColumn = false, bool permitAsync = false, string methodName = null)
+        private void CheckDataIsReady(int columnIndex, bool allowPartiallyReadColumn = false, bool permitAsync = false, [CallerMemberName] string methodName = null)
         {
             if (_isClosed)
             {
-                throw ADP.DataReaderClosed(methodName ?? "CheckDataIsReady");
+                throw ADP.DataReaderClosed(methodName ?? nameof(CheckDataIsReady));
             }
             if ((!permitAsync) && (_currentTask != null))
             {
@@ -3591,7 +3591,7 @@ namespace System.Data.SqlClient
 
             if (IsClosed)
             {
-                source.SetException(ADP.ExceptionWithStackTrace(ADP.DataReaderClosed("NextResultAsync")));
+                source.SetException(ADP.ExceptionWithStackTrace(ADP.DataReaderClosed()));
                 return source.Task;
             }
 
@@ -3656,7 +3656,7 @@ namespace System.Data.SqlClient
             if (IsClosed)
             {
                 TaskCompletionSource<int> source = new TaskCompletionSource<int>();
-                source.SetException(ADP.ExceptionWithStackTrace(ADP.DataReaderClosed("GetBytesAsync")));
+                source.SetException(ADP.ExceptionWithStackTrace(ADP.DataReaderClosed()));
                 return source.Task;
             }
 
@@ -3876,7 +3876,7 @@ namespace System.Data.SqlClient
         {
             if (IsClosed)
             {
-                return ADP.CreatedTaskWithException<bool>(ADP.ExceptionWithStackTrace(ADP.DataReaderClosed("ReadAsync")));
+                return ADP.CreatedTaskWithException<bool>(ADP.ExceptionWithStackTrace(ADP.DataReaderClosed()));
             }
 
             // If user's token is canceled, return a canceled task
@@ -4030,7 +4030,7 @@ namespace System.Data.SqlClient
         {
             try
             {
-                CheckHeaderIsReady(columnIndex: i, methodName: "IsDBNullAsync");
+                CheckHeaderIsReady(columnIndex: i);
             }
             catch (Exception ex)
             {
@@ -4052,7 +4052,7 @@ namespace System.Data.SqlClient
                 else
                 {
                     // Reader was closed between the CheckHeaderIsReady and accessing _data - throw closed exception
-                    return ADP.CreatedTaskWithException<bool>(ADP.ExceptionWithStackTrace(ADP.DataReaderClosed("IsDBNullAsync")));
+                    return ADP.CreatedTaskWithException<bool>(ADP.ExceptionWithStackTrace(ADP.DataReaderClosed()));
                 }
             }
             else
@@ -4154,7 +4154,7 @@ namespace System.Data.SqlClient
         {
             try
             {
-                CheckDataIsReady(columnIndex: i, methodName: "GetFieldValueAsync");
+                CheckDataIsReady(columnIndex: i);
 
                 // Shortcut - if there are no issues and the data is already read, then just return the value
                 if ((!IsCommandBehavior(CommandBehavior.SequentialAccess)) && (_sharedState._nextColumnDataToRead > i) && (!cancellationToken.IsCancellationRequested) && (_currentTask == null))
@@ -4168,7 +4168,7 @@ namespace System.Data.SqlClient
                     else
                     {
                         // Reader was closed between the CheckDataIsReady and accessing _data\_metaData - throw closed exception
-                        return ADP.CreatedTaskWithException<T>(ADP.ExceptionWithStackTrace(ADP.DataReaderClosed("GetFieldValueAsync")));
+                        return ADP.CreatedTaskWithException<T>(ADP.ExceptionWithStackTrace(ADP.DataReaderClosed()));
                     }
                 }
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlEnums.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlEnums.cs
@@ -337,27 +337,27 @@ namespace System.Data.SqlClient
             else if (dataType == typeof(DateTimeOffset))
                 return MetaDateTimeOffset;
             else if (dataType == typeof(DBNull))
-                throw ADP.InvalidDataType("DBNull");
+                throw ADP.InvalidDataType(nameof(DBNull));
             else if (dataType == typeof(Boolean))
                 return s_metaBit;
             else if (dataType == typeof(Char))
-                throw ADP.InvalidDataType("Char");
+                throw ADP.InvalidDataType(nameof(Char));
             else if (dataType == typeof(SByte))
-                throw ADP.InvalidDataType("SByte");
+                throw ADP.InvalidDataType(nameof(SByte));
             else if (dataType == typeof(Byte))
                 return s_metaTinyInt;
             else if (dataType == typeof(Int16))
                 return s_metaSmallInt;
             else if (dataType == typeof(UInt16))
-                throw ADP.InvalidDataType("UInt16");
+                throw ADP.InvalidDataType(nameof(UInt16));
             else if (dataType == typeof(Int32))
                 return s_metaInt;
             else if (dataType == typeof(UInt32))
-                throw ADP.InvalidDataType("UInt32");
+                throw ADP.InvalidDataType(nameof(UInt32));
             else if (dataType == typeof(Int64))
                 return s_metaBigInt;
             else if (dataType == typeof(UInt64))
-                throw ADP.InvalidDataType("UInt64");
+                throw ADP.InvalidDataType(nameof(UInt64));
             else if (dataType == typeof(Single))
                 return s_metaReal;
             else if (dataType == typeof(Double))

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -150,7 +150,7 @@ namespace System.Data.SqlClient
                 }
                 if ((value & SqlString.x_iValidSqlCompareOptionMask) != value)
                 {
-                    throw ADP.ArgumentOutOfRange("CompareInfo");
+                    throw ADP.ArgumentOutOfRange(nameof(CompareInfo));
                 }
                 collation.SqlCompareOptions = value;
             }
@@ -252,7 +252,7 @@ namespace System.Data.SqlClient
                 }
                 if (value != (SqlCollation.MaskLcid & value))
                 {
-                    throw ADP.ArgumentOutOfRange("LocaleId");
+                    throw ADP.ArgumentOutOfRange(nameof(LocaleId));
                 }
                 collation.LCID = value;
             }
@@ -382,14 +382,14 @@ namespace System.Data.SqlClient
                 }
                 else
                 {
-                    throw ADP.ArgumentOutOfRange("names");
+                    throw ADP.ArgumentOutOfRange(nameof(names));
                 }
 
                 if ((!ADP.IsEmpty(typeSpecificNamePart1) && TdsEnums.MAX_SERVERNAME < typeSpecificNamePart1.Length)
                     || (!ADP.IsEmpty(typeSpecificNamePart2) && TdsEnums.MAX_SERVERNAME < typeSpecificNamePart2.Length)
                     || (!ADP.IsEmpty(typeSpecificNamePart3) && TdsEnums.MAX_SERVERNAME < typeSpecificNamePart3.Length))
                 {
-                    throw ADP.ArgumentOutOfRange("names");
+                    throw ADP.ArgumentOutOfRange(nameof(names));
                 }
             }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameterCollectionHelper.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameterCollectionHelper.cs
@@ -64,7 +64,7 @@ namespace System.Data.SqlClient
             OnChange();
             if (null == values)
             {
-                throw ADP.ArgumentNull("values");
+                throw ADP.ArgumentNull(nameof(values));
             }
             foreach (object value in values)
             {
@@ -277,7 +277,7 @@ namespace System.Data.SqlClient
         {
             if (null == value)
             {
-                throw ADP.ParameterNull("value", this, s_itemType);
+                throw ADP.ParameterNull(nameof(value), this, s_itemType);
             }
 
             object parent = ((SqlParameter)value).CompareExchangeParent(this, null);
@@ -310,7 +310,7 @@ namespace System.Data.SqlClient
         {
             if (null == value)
             {
-                throw ADP.ParameterNull("value", this, s_itemType);
+                throw ADP.ParameterNull(nameof(value), this, s_itemType);
             }
             else if (!s_itemType.IsInstanceOfType(value))
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlSequentialStream.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlSequentialStream.cs
@@ -83,7 +83,7 @@ namespace System.Data.SqlClient
                 }
                 else
                 {
-                    throw ADP.ArgumentOutOfRange("value");
+                    throw ADP.ArgumentOutOfRange(nameof(value));
                 }
             }
         }
@@ -283,15 +283,15 @@ namespace System.Data.SqlClient
         {
             if (buffer == null)
             {
-                throw ADP.ArgumentNull(ADP.ParameterBuffer);
+                throw ADP.ArgumentNull(nameof(buffer));
             }
             if (offset < 0)
             {
-                throw ADP.ArgumentOutOfRange(ADP.ParameterOffset);
+                throw ADP.ArgumentOutOfRange(nameof(offset));
             }
             if (count < 0)
             {
-                throw ADP.ArgumentOutOfRange(ADP.ParameterCount);
+                throw ADP.ArgumentOutOfRange(nameof(count));
             }
             try
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlSequentialTextReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlSequentialTextReader.cs
@@ -451,15 +451,15 @@ namespace System.Data.SqlClient
         {
             if (buffer == null)
             {
-                throw ADP.ArgumentNull(ADP.ParameterBuffer);
+                throw ADP.ArgumentNull(nameof(buffer));
             }
             if (index < 0)
             {
-                throw ADP.ArgumentOutOfRange(ADP.ParameterIndex);
+                throw ADP.ArgumentOutOfRange(nameof(index));
             }
             if (count < 0)
             {
-                throw ADP.ArgumentOutOfRange(ADP.ParameterCount);
+                throw ADP.ArgumentOutOfRange(nameof(count));
             }
             try
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlStream.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlStream.cs
@@ -113,19 +113,19 @@ namespace System.Data.SqlClient
 
             if ((null == _reader))
             {
-                throw ADP.StreamClosed(ADP.Read);
+                throw ADP.StreamClosed();
             }
             if (null == buffer)
             {
-                throw ADP.ArgumentNull(ADP.ParameterBuffer);
+                throw ADP.ArgumentNull(nameof(buffer));
             }
             if ((offset < 0) || (count < 0))
             {
-                throw ADP.ArgumentOutOfRange(String.Empty, (offset < 0 ? ADP.ParameterOffset : ADP.ParameterCount));
+                throw ADP.ArgumentOutOfRange(String.Empty, (offset < 0 ? nameof(offset) : nameof(count)));
             }
             if (buffer.Length - offset < count)
             {
-                throw ADP.ArgumentOutOfRange(ADP.ParameterCount);
+                throw ADP.ArgumentOutOfRange(nameof(count));
             }
 
             // Need to find out if we should add byte order mark or not. 
@@ -412,22 +412,22 @@ namespace System.Data.SqlClient
 
             if (null == _cachedBytes)
             {
-                throw ADP.StreamClosed(ADP.Read);
+                throw ADP.StreamClosed();
             }
 
             if (null == buffer)
             {
-                throw ADP.ArgumentNull(ADP.ParameterBuffer);
+                throw ADP.ArgumentNull(nameof(buffer));
             }
 
             if ((offset < 0) || (count < 0))
             {
-                throw ADP.ArgumentOutOfRange(String.Empty, (offset < 0 ? ADP.ParameterOffset : ADP.ParameterCount));
+                throw ADP.ArgumentOutOfRange(String.Empty, (offset < 0 ? nameof(offset) : nameof(count)));
             }
 
             if (buffer.Length - offset < count)
             {
-                throw ADP.ArgumentOutOfRange(ADP.ParameterCount);
+                throw ADP.ArgumentOutOfRange(nameof(count));
             }
 
             if (_cachedBytes.Count <= _currentArrayIndex)
@@ -469,27 +469,27 @@ namespace System.Data.SqlClient
 
             if (null == _cachedBytes)
             {
-                throw ADP.StreamClosed(ADP.Read);
+                throw ADP.StreamClosed();
             }
 
             switch (origin)
             {
                 case SeekOrigin.Begin:
-                    SetInternalPosition(offset, ADP.ParameterOffset);
+                    SetInternalPosition(offset, nameof(offset));
                     break;
 
                 case SeekOrigin.Current:
                     pos = offset + Position;
-                    SetInternalPosition(pos, ADP.ParameterOffset);
+                    SetInternalPosition(pos, nameof(offset));
                     break;
 
                 case SeekOrigin.End:
                     pos = TotalLength + offset;
-                    SetInternalPosition(pos, ADP.ParameterOffset);
+                    SetInternalPosition(pos, nameof(offset));
                     break;
 
                 default:
-                    throw ADP.InvalidSeekOrigin(ADP.ParameterOffset);
+                    throw ADP.InvalidSeekOrigin(nameof(offset));
             }
             return pos;
         }
@@ -597,7 +597,7 @@ namespace System.Data.SqlClient
             int cnt = 0;
             if (dataIndex < _charsRemoved)
             {
-                throw ADP.NonSeqByteAccess(dataIndex, _charsRemoved, ADP.GetChars);
+                throw ADP.NonSeqByteAccess(dataIndex, _charsRemoved, nameof(GetChars));
             }
             else if (dataIndex > _charsRemoved)
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
@@ -9,10 +9,11 @@
 using System.Data.Common;
 using System.Diagnostics;
 using System.Globalization;
-using System.Threading;
-using System.Text;
-using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Data.SqlClient
 {
@@ -212,7 +213,7 @@ namespace System.Data.SqlClient
             return ADP.InvalidOperation(Res.GetString(Res.SQL_MarsUnsupportedOnConnection));
         }
 
-        static internal Exception CannotModifyPropertyAsyncOperationInProgress(string property)
+        static internal Exception CannotModifyPropertyAsyncOperationInProgress([CallerMemberName] string property = "")
         {
             return ADP.InvalidOperation(Res.GetString(Res.SQL_CannotModifyPropertyAsyncOperationInProgress, property));
         }
@@ -784,14 +785,6 @@ namespace System.Data.SqlClient
             string errorMessageId = String.Format((IFormatProvider)null, "SNI_ERROR_{0}", sniError);
             return SR.GetResourceString(errorMessageId, errorMessageId);
         }
-
-        // BulkLoad
-        internal const string WriteToServer = "WriteToServer";
-
-
-        // constant strings
-        internal const string Transaction = "Transaction";
-        internal const string Connection = "Connection";
     }
 
     sealed internal class SQLMessage

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -8453,15 +8453,15 @@ namespace System.Data.SqlClient
             {
                 if (buffer == null)
                 {
-                    throw ADP.ArgumentNull(ADP.ParameterBuffer);
+                    throw ADP.ArgumentNull(nameof(buffer));
                 }
                 if (offset < 0)
                 {
-                    throw ADP.ArgumentOutOfRange(ADP.ParameterOffset);
+                    throw ADP.ArgumentOutOfRange(nameof(offset));
                 }
                 if (count < 0)
                 {
-                    throw ADP.ArgumentOutOfRange(ADP.ParameterCount);
+                    throw ADP.ArgumentOutOfRange(nameof(count));
                 }
                 try
                 {
@@ -8577,15 +8577,15 @@ namespace System.Data.SqlClient
             {
                 if (buffer == null)
                 {
-                    throw ADP.ArgumentNull(ADP.ParameterBuffer);
+                    throw ADP.ArgumentNull(nameof(buffer));
                 }
                 if (offset < 0)
                 {
-                    throw ADP.ArgumentOutOfRange(ADP.ParameterOffset);
+                    throw ADP.ArgumentOutOfRange(nameof(offset));
                 }
                 if (count < 0)
                 {
-                    throw ADP.ArgumentOutOfRange(ADP.ParameterCount);
+                    throw ADP.ArgumentOutOfRange(nameof(count));
                 }
                 try
                 {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/sqlinternaltransaction.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/sqlinternaltransaction.cs
@@ -330,7 +330,7 @@ namespace System.Data.SqlClient
                 parameter.Direction = ParameterDirection.Output;
                 transactionLevelCommand.Parameters.Add(parameter);
 
-                transactionLevelCommand.RunExecuteReader(0, RunBehavior.UntilDone, false /* returnDataStream */, nameof(GetServerTransactionLevel));
+                transactionLevelCommand.RunExecuteReader(CommandBehavior.Default, RunBehavior.UntilDone, returnStream: false);
 
                 return (int)parameter.Value;
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/sqlinternaltransaction.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/sqlinternaltransaction.cs
@@ -330,7 +330,7 @@ namespace System.Data.SqlClient
                 parameter.Direction = ParameterDirection.Output;
                 transactionLevelCommand.Parameters.Add(parameter);
 
-                transactionLevelCommand.RunExecuteReader(0, RunBehavior.UntilDone, false /* returnDataStream */, ADP.GetServerTransactionLevel);
+                transactionLevelCommand.RunExecuteReader(0, RunBehavior.UntilDone, false /* returnDataStream */, nameof(GetServerTransactionLevel));
 
                 return (int)parameter.Value;
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLBytes.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLBytes.cs
@@ -9,8 +9,8 @@
 using System.Diagnostics;
 using System.Data.Common;
 using System.IO;
+using System.Runtime.CompilerServices;
 using Res = System.SR;
-
 
 namespace System.Data.SqlTypes
 {
@@ -597,7 +597,7 @@ namespace System.Data.SqlTypes
 
         public override long Seek(long offset, SeekOrigin origin)
         {
-            CheckIfStreamClosed("Seek");
+            CheckIfStreamClosed();
 
             long lPosition = 0;
 
@@ -624,7 +624,7 @@ namespace System.Data.SqlTypes
                     break;
 
                 default:
-                    throw ADP.InvalidSeekOrigin("offset");
+                    throw ADP.InvalidSeekOrigin(nameof(offset));
             }
 
             return _lPosition;
@@ -633,7 +633,7 @@ namespace System.Data.SqlTypes
         // The Read/Write/ReadByte/WriteByte simply delegates to SqlBytes
         public override int Read(byte[] buffer, int offset, int count)
         {
-            CheckIfStreamClosed("Read");
+            CheckIfStreamClosed();
 
             if (buffer == null)
                 throw new ArgumentNullException(nameof(buffer));
@@ -650,7 +650,7 @@ namespace System.Data.SqlTypes
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            CheckIfStreamClosed("Write");
+            CheckIfStreamClosed();
 
             if (buffer == null)
                 throw new ArgumentNullException(nameof(buffer));
@@ -665,7 +665,7 @@ namespace System.Data.SqlTypes
 
         public override int ReadByte()
         {
-            CheckIfStreamClosed("ReadByte");
+            CheckIfStreamClosed();
 
             // If at the end of stream, return -1, rather than call SqlBytes.ReadByte,
             // which will throw exception. This is the behavior for Stream.
@@ -680,7 +680,7 @@ namespace System.Data.SqlTypes
 
         public override void WriteByte(byte value)
         {
-            CheckIfStreamClosed("WriteByte");
+            CheckIfStreamClosed();
 
             _sb[_lPosition] = value;
             _lPosition++;
@@ -688,7 +688,7 @@ namespace System.Data.SqlTypes
 
         public override void SetLength(long value)
         {
-            CheckIfStreamClosed("SetLength");
+            CheckIfStreamClosed();
 
             _sb.SetLength(value);
             if (_lPosition > value)
@@ -726,7 +726,7 @@ namespace System.Data.SqlTypes
             return _sb == null;
         }
 
-        private void CheckIfStreamClosed(string methodname)
+        private void CheckIfStreamClosed([CallerMemberName] string methodname = "")
         {
             if (FClosed())
                 throw ADP.StreamClosed(methodname);

--- a/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLChars.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLChars.cs
@@ -7,8 +7,8 @@
 using System.IO;
 using System.Diagnostics;
 using System.Data.Common;
+using System.Runtime.CompilerServices;
 using Res = System.SR;
-
 
 namespace System.Data.SqlTypes
 {
@@ -598,7 +598,7 @@ namespace System.Data.SqlTypes
 
         public override long Seek(long offset, SeekOrigin origin)
         {
-            CheckIfStreamClosed("Seek");
+            CheckIfStreamClosed();
 
             long lPosition = 0;
 
@@ -606,26 +606,26 @@ namespace System.Data.SqlTypes
             {
                 case SeekOrigin.Begin:
                     if (offset < 0 || offset > _sqlchars.Length)
-                        throw ADP.ArgumentOutOfRange("offset");
+                        throw ADP.ArgumentOutOfRange(nameof(offset));
                     _lPosition = offset;
                     break;
 
                 case SeekOrigin.Current:
                     lPosition = _lPosition + offset;
                     if (lPosition < 0 || lPosition > _sqlchars.Length)
-                        throw ADP.ArgumentOutOfRange("offset");
+                        throw ADP.ArgumentOutOfRange(nameof(offset));
                     _lPosition = lPosition;
                     break;
 
                 case SeekOrigin.End:
                     lPosition = _sqlchars.Length + offset;
                     if (lPosition < 0 || lPosition > _sqlchars.Length)
-                        throw ADP.ArgumentOutOfRange("offset");
+                        throw ADP.ArgumentOutOfRange(nameof(offset));
                     _lPosition = lPosition;
                     break;
 
                 default:
-                    throw ADP.ArgumentOutOfRange("offset"); ;
+                    throw ADP.ArgumentOutOfRange(nameof(offset)); ;
             }
 
             return _lPosition;
@@ -634,7 +634,7 @@ namespace System.Data.SqlTypes
         // The Read/Write/Readchar/Writechar simply delegates to SqlChars
         public override int Read(char[] buffer, int offset, int count)
         {
-            CheckIfStreamClosed("Read");
+            CheckIfStreamClosed();
 
             if (buffer == null)
                 throw new ArgumentNullException(nameof(buffer));
@@ -651,7 +651,7 @@ namespace System.Data.SqlTypes
 
         public override void Write(char[] buffer, int offset, int count)
         {
-            CheckIfStreamClosed("Write");
+            CheckIfStreamClosed();
 
             if (buffer == null)
                 throw new ArgumentNullException(nameof(buffer));
@@ -666,7 +666,7 @@ namespace System.Data.SqlTypes
 
         public override int ReadChar()
         {
-            CheckIfStreamClosed("ReadChar");
+            CheckIfStreamClosed();
 
             // If at the end of stream, return -1, rather than call SqlChars.Readchar,
             // which will throw exception. This is the behavior for Stream.
@@ -681,7 +681,7 @@ namespace System.Data.SqlTypes
 
         public override void WriteChar(char value)
         {
-            CheckIfStreamClosed("WriteChar");
+            CheckIfStreamClosed();
 
             _sqlchars[_lPosition] = value;
             _lPosition++;
@@ -689,7 +689,7 @@ namespace System.Data.SqlTypes
 
         public override void SetLength(long value)
         {
-            CheckIfStreamClosed("SetLength");
+            CheckIfStreamClosed();
 
             _sqlchars.SetLength(value);
             if (_lPosition > value)
@@ -720,7 +720,7 @@ namespace System.Data.SqlTypes
             return _sqlchars == null;
         }
 
-        private void CheckIfStreamClosed(string methodname)
+        private void CheckIfStreamClosed([CallerMemberName] string methodname = "")
         {
             if (FClosed())
                 throw ADP.StreamClosed(methodname);

--- a/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLString.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLString.cs
@@ -782,7 +782,7 @@ namespace System.Data.SqlTypes
             ValidateSqlCompareOptions(compareOptions);
 
             if ((compareOptions & (SqlCompareOptions.BinarySort | SqlCompareOptions.BinarySort2)) != 0)
-                throw ADP.ArgumentOutOfRange("compareOptions");
+                throw ADP.ArgumentOutOfRange(nameof(compareOptions));
             else
             {
                 if ((compareOptions & SqlCompareOptions.IgnoreCase) != 0)

--- a/src/System.Data.SqlClient/src/System/Data/SqlTypes/SqlXml.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlTypes/SqlXml.cs
@@ -309,7 +309,7 @@ namespace System.Data.SqlTypes
                     break;
 
                 default:
-                    throw ADP.InvalidSeekOrigin("offset");
+                    throw ADP.InvalidSeekOrigin(nameof(offset));
             }
 
             return _lPosition;


### PR DESCRIPTION
Use `nameof()` and `[CallerMemberName]` to reduce magic strings in SqlClient. Also delete unused string constants.

Part of #7290.

cc: @saurabh500