### PR TITLE
Add missing coverage for Crypto CSP

### DIFF
--- a/src/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderBackCompat.cs
+++ b/src/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderBackCompat.cs
@@ -116,6 +116,48 @@ namespace System.Security.Cryptography.Csp.Tests
             }
         }
 
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        // (false, false) is not required, that would be equivalent to the RSA AlgorithmImplementation suite.
+        public static void VerifyLegacySignVerifyHash(bool useLegacySign, bool useLegacyVerify)
+        {
+            byte[] dataHash, signature;
+
+            using (HashAlgorithm hash = SHA256.Create())
+            {
+                dataHash = hash.ComputeHash(TestData.HelloBytes);
+            }
+
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                rsa.ImportParameters(TestData.RSA2048Params);
+
+                signature = useLegacySign ?
+                    rsa.SignHash(dataHash, "SHA256") :
+                    rsa.SignHash(dataHash, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            }
+
+            bool verified;
+
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                rsa.ImportParameters(
+                    new RSAParameters
+                    {
+                        Modulus = TestData.RSA2048Params.Modulus,
+                        Exponent = TestData.RSA2048Params.Exponent,
+                    });
+
+                verified = useLegacyVerify ?
+                    rsa.VerifyHash(dataHash, "SHA256", signature) :
+                    rsa.VerifyHash(dataHash, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            }
+
+            Assert.True(verified);
+        }
+
         public static IEnumerable<object[]> AlgorithmIdentifiers()
         {
             return new[]


### PR DESCRIPTION
One of the VerifyHash methods in RSACryptoServiceProvider wasn't being tested. I modified the existing VerifyHashSignature test to use this VerifyHash method in addition to the one already in place (RSA.VerifyHash).

resolves #6450