### PR TITLE
SqlClient: Replace ADP.IsEmpty with string.IsNullOrEmpty

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
@@ -967,13 +967,13 @@ namespace System.Data.Common
         static internal string BuildQuotedString(string quotePrefix, string quoteSuffix, string unQuotedString)
         {
             StringBuilder resultString = new StringBuilder();
-            if (ADP.IsEmpty(quotePrefix) == false)
+            if (string.IsNullOrEmpty(quotePrefix) == false)
             {
                 resultString.Append(quotePrefix);
             }
 
             // Assuming that the suffix is escaped by doubling it. i.e. foo"bar becomes "foo""bar".
-            if (ADP.IsEmpty(quoteSuffix) == false)
+            if (string.IsNullOrEmpty(quoteSuffix) == false)
             {
                 resultString.Append(unQuotedString.Replace(quoteSuffix, quoteSuffix + quoteSuffix));
                 resultString.Append(quoteSuffix);
@@ -1079,12 +1079,6 @@ namespace System.Data.Common
             }
         }
 #endif
-
-        static internal bool IsEmpty(string str)
-        {
-            return ((null == str) || (0 == str.Length));
-        }
-
 
         static internal bool IsNull(object value)
         {

--- a/src/System.Data.SqlClient/src/System/Data/Common/DbConnectionOptions.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/DbConnectionOptions.cs
@@ -344,7 +344,7 @@ namespace System.Data.Common
                     case ParserState.KeyEqual: // \\s*=(?!=)\\s*
                         if ('=' == currentChar) { parserState = ParserState.Key; break; }
                         keyname = GetKeyName(buffer);
-                        if (ADP.IsEmpty(keyname)) { throw ADP.ConnectionStringSyntax(startposition); }
+                        if (string.IsNullOrEmpty(keyname)) { throw ADP.ConnectionStringSyntax(startposition); }
                         buffer.Length = 0;
                         parserState = ParserState.KeyEnd;
                         goto case ParserState.KeyEnd;
@@ -428,7 +428,7 @@ namespace System.Data.Common
                 case ParserState.KeyEqual:
                     // equal sign at end of line
                     keyname = GetKeyName(buffer);
-                    if (ADP.IsEmpty(keyname)) { throw ADP.ConnectionStringSyntax(startposition); }
+                    if (string.IsNullOrEmpty(keyname)) { throw ADP.ConnectionStringSyntax(startposition); }
                     break;
 
                 case ParserState.UnquotedValue:
@@ -618,7 +618,7 @@ namespace System.Data.Common
 
                     string keyname, keyvalue;
                     nextStartPosition = GetKeyValuePair(connectionString, startPosition, buffer, out keyname, out keyvalue);
-                    if (ADP.IsEmpty(keyname))
+                    if (string.IsNullOrEmpty(keyname))
                     {
                         // if (nextStartPosition != endPosition) { throw; }
                         break;

--- a/src/System.Data.SqlClient/src/System/Data/Common/NameValuePair.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/NameValuePair.cs
@@ -20,7 +20,7 @@ namespace System.Data.Common
 
         internal NameValuePair(string name, string value, int length)
         {
-            System.Diagnostics.Debug.Assert(!ADP.IsEmpty(name), "empty keyname");
+            System.Diagnostics.Debug.Assert(!string.IsNullOrEmpty(name), "empty keyname");
             _name = name;
             _value = value;
             _length = length;

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionFactory.cs
@@ -133,7 +133,7 @@ namespace System.Data.ProviderBase
         protected DbConnectionOptions FindConnectionOptions(DbConnectionPoolKey key)
         {
             Debug.Assert(key != null, "key cannot be null");
-            if (!ADP.IsEmpty(key.ConnectionString))
+            if (!string.IsNullOrEmpty(key.ConnectionString))
             {
                 DbConnectionPoolGroup connectionPoolGroup;
                 Dictionary<DbConnectionPoolKey, DbConnectionPoolGroup> connectionPoolGroups = _connectionPoolGroups;
@@ -354,7 +354,7 @@ namespace System.Data.ProviderBase
 
         internal DbConnectionPoolGroup GetConnectionPoolGroup(DbConnectionPoolKey key, DbConnectionPoolGroupOptions poolOptions, ref DbConnectionOptions userConnectionOptions)
         {
-            if (ADP.IsEmpty(key.ConnectionString))
+            if (string.IsNullOrEmpty(key.ConnectionString))
             {
                 return (DbConnectionPoolGroup)null;
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
@@ -444,7 +444,7 @@ namespace System.Data.SqlClient
             {
                 throw SQL.BulkLoadInvalidDestinationTable(this.DestinationTableName, e);
             }
-            if (ADP.IsEmpty(parts[MultipartIdentifier.TableIndex]))
+            if (string.IsNullOrEmpty(parts[MultipartIdentifier.TableIndex]))
             {
                 throw SQL.BulkLoadInvalidDestinationTable(this.DestinationTableName, null);
             }
@@ -466,7 +466,7 @@ namespace System.Data.SqlClient
 
             string TableName = parts[MultipartIdentifier.TableIndex];
             bool isTempTable = TableName.Length > 0 && '#' == TableName[0];
-            if (!ADP.IsEmpty(TableName))
+            if (!string.IsNullOrEmpty(TableName))
             {
                 // Escape table name to be put inside TSQL literal block (within N'').
                 TableName = SqlServerEscapeHelper.EscapeStringAsLiteral(TableName);
@@ -475,7 +475,7 @@ namespace System.Data.SqlClient
             }
 
             string SchemaName = parts[MultipartIdentifier.SchemaIndex];
-            if (!ADP.IsEmpty(SchemaName))
+            if (!string.IsNullOrEmpty(SchemaName))
             {
                 // Escape schema name to be put inside TSQL literal block (within N'').
                 SchemaName = SqlServerEscapeHelper.EscapeStringAsLiteral(SchemaName);
@@ -484,7 +484,7 @@ namespace System.Data.SqlClient
             }
 
             string CatalogName = parts[MultipartIdentifier.CatalogIndex];
-            if (isTempTable && ADP.IsEmpty(CatalogName))
+            if (isTempTable && string.IsNullOrEmpty(CatalogName))
             {
                 TDSCommand += String.Format((IFormatProvider)null, "exec tempdb..{0} N'{1}.{2}'",
                     TableCollationsStoredProc,
@@ -495,7 +495,7 @@ namespace System.Data.SqlClient
             else
             {
                 // Escape the catalog name
-                if (!ADP.IsEmpty(CatalogName))
+                if (!string.IsNullOrEmpty(CatalogName))
                 {
                     CatalogName = SqlServerEscapeHelper.EscapeIdentifier(CatalogName);
                 }
@@ -1222,7 +1222,7 @@ namespace System.Data.SqlClient
 
         private string UnquotedName(string name)
         {
-            if (ADP.IsEmpty(name)) return null;
+            if (string.IsNullOrEmpty(name)) return null;
             if (name[0] == '[')
             {
                 int l = name.Length;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopyColumnMappingCollection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopyColumnMappingCollection.cs
@@ -63,9 +63,9 @@ namespace System.Data.SqlClient
         public SqlBulkCopyColumnMapping Add(SqlBulkCopyColumnMapping bulkCopyColumnMapping)
         {
             AssertWriteAccess();
-            Debug.Assert(ADP.IsEmpty(bulkCopyColumnMapping.SourceColumn) || bulkCopyColumnMapping._internalSourceColumnOrdinal == -1, "BulkLoadAmbiguousSourceColumn");
-            if (((ADP.IsEmpty(bulkCopyColumnMapping.SourceColumn)) && (bulkCopyColumnMapping.SourceOrdinal == -1))
-                || ((ADP.IsEmpty(bulkCopyColumnMapping.DestinationColumn)) && (bulkCopyColumnMapping.DestinationOrdinal == -1)))
+            Debug.Assert(string.IsNullOrEmpty(bulkCopyColumnMapping.SourceColumn) || bulkCopyColumnMapping._internalSourceColumnOrdinal == -1, "BulkLoadAmbiguousSourceColumn");
+            if (((string.IsNullOrEmpty(bulkCopyColumnMapping.SourceColumn)) && (bulkCopyColumnMapping.SourceOrdinal == -1))
+                || ((string.IsNullOrEmpty(bulkCopyColumnMapping.DestinationColumn)) && (bulkCopyColumnMapping.DestinationOrdinal == -1)))
             {
                 throw SQL.BulkLoadNonMatchingColumnMapping();
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -2310,7 +2310,7 @@ namespace System.Data.SqlClient
             if (null != _transaction && _activeConnection != _transaction.Connection)
                 throw ADP.TransactionConnectionMismatch();
 
-            if (ADP.IsEmpty(this.CommandText))
+            if (string.IsNullOrEmpty(this.CommandText))
                 throw ADP.CommandTextRequired(method);
         }
 
@@ -2837,7 +2837,7 @@ namespace System.Data.SqlClient
                 else if (mt.SqlDbType == SqlDbType.Structured)
                 {
                     string typeName = sqlParam.TypeName;
-                    if (ADP.IsEmpty(typeName))
+                    if (string.IsNullOrEmpty(typeName))
                     {
                         throw SQL.MustSetTypeNameForParam(mt.TypeName, sqlParam.ParameterNameFixed);
                     }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -1017,7 +1017,7 @@ namespace System.Data.SqlClient
         // as native OleDb and Odbc.
         static internal string FixupDatabaseTransactionName(string name)
         {
-            if (!ADP.IsEmpty(name))
+            if (!string.IsNullOrEmpty(name))
             {
                 return SqlServerEscapeHelper.EscapeIdentifier(name);
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionFactory.cs
@@ -136,7 +136,7 @@ namespace System.Data.SqlClient
 
         protected override DbConnectionOptions CreateConnectionOptions(string connectionString, DbConnectionOptions previous)
         {
-            Debug.Assert(!ADP.IsEmpty(connectionString), "empty connectionString");
+            Debug.Assert(!string.IsNullOrEmpty(connectionString), "empty connectionString");
             SqlConnectionString result = new SqlConnectionString(connectionString);
             return result;
         }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionPoolGroupProviderInfo.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionPoolGroupProviderInfo.cs
@@ -24,7 +24,7 @@ namespace System.Data.SqlClient
             // env change.
             _failoverPartner = connectionOptions.FailoverPartner;
 
-            if (ADP.IsEmpty(_failoverPartner))
+            if (string.IsNullOrEmpty(_failoverPartner))
             {
                 _failoverPartner = null;
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
@@ -310,12 +310,12 @@ namespace System.Data.SqlClient
             }
 
 
-            if (true == _userInstance && !ADP.IsEmpty(_failoverPartner))
+            if (true == _userInstance && !string.IsNullOrEmpty(_failoverPartner))
             {
                 throw SQL.UserInstanceFailoverNotCompatible();
             }
 
-            if (ADP.IsEmpty(typeSystemVersionString))
+            if (string.IsNullOrEmpty(typeSystemVersionString))
             {
                 typeSystemVersionString = DbConnectionStringDefaults.TypeSystemVersion;
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionStringBuilder.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionStringBuilder.cs
@@ -195,7 +195,7 @@ namespace System.Data.SqlClient
 
         public SqlConnectionStringBuilder(string connectionString) : base()
         {
-            if (!ADP.IsEmpty(connectionString))
+            if (!string.IsNullOrEmpty(connectionString))
             {
                 ConnectionString = connectionString;
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlException.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlException.cs
@@ -166,7 +166,7 @@ namespace System.Data.SqlClient
 
             exception.Data.Add("HelpLink.ProdName", "Microsoft SQL Server");
 
-            if (!ADP.IsEmpty(serverVersion))
+            if (!string.IsNullOrEmpty(serverVersion))
             {
                 exception.Data.Add("HelpLink.ProdVer", serverVersion);
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnection.cs
@@ -146,7 +146,7 @@ namespace System.Data.SqlClient
 
         override public void ChangeDatabase(string database)
         {
-            if (ADP.IsEmpty(database))
+            if (string.IsNullOrEmpty(database))
             {
                 throw ADP.EmptyDatabaseName();
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -977,7 +977,7 @@ namespace System.Data.SqlClient
 
             _timeoutErrorInternal.SetInternalSourceType(useFailoverPartner ? SqlConnectionInternalSourceType.Failover : SqlConnectionInternalSourceType.Principle);
 
-            bool hasFailoverPartner = !ADP.IsEmpty(failoverPartner);
+            bool hasFailoverPartner = !string.IsNullOrEmpty(failoverPartner);
 
             // Open the connection and Login
             try
@@ -1792,7 +1792,7 @@ namespace System.Data.SqlClient
             // when using the Dbnetlib dll.  If the protocol is not specified, the netlib will
             // try all protocols in the order listed in the Client Network Utility.  Connect will
             // then fail if all protocols fail.
-            if (!ADP.IsEmpty(protocol))
+            if (!string.IsNullOrEmpty(protocol))
             {
                 ExtendedServerName = protocol + ":" + serverName;
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -351,7 +351,7 @@ namespace System.Data.SqlClient
                 typeSpecificNamePart2 = this.XmlSchemaCollectionOwningSchema;
                 typeSpecificNamePart3 = this.XmlSchemaCollectionName;
             }
-            else if (SqlDbType.Udt == mt.SqlDbType || (SqlDbType.Structured == mt.SqlDbType && !ADP.IsEmpty(this.TypeName)))
+            else if (SqlDbType.Udt == mt.SqlDbType || (SqlDbType.Structured == mt.SqlDbType && !string.IsNullOrEmpty(this.TypeName)))
             {
                 // Split the input name. The type name is specified as single 3 part name.
                 // NOTE: ParseTypeName throws if format is incorrect
@@ -385,9 +385,9 @@ namespace System.Data.SqlClient
                     throw ADP.ArgumentOutOfRange("names");
                 }
 
-                if ((!ADP.IsEmpty(typeSpecificNamePart1) && TdsEnums.MAX_SERVERNAME < typeSpecificNamePart1.Length)
-                    || (!ADP.IsEmpty(typeSpecificNamePart2) && TdsEnums.MAX_SERVERNAME < typeSpecificNamePart2.Length)
-                    || (!ADP.IsEmpty(typeSpecificNamePart3) && TdsEnums.MAX_SERVERNAME < typeSpecificNamePart3.Length))
+                if ((!string.IsNullOrEmpty(typeSpecificNamePart1) && TdsEnums.MAX_SERVERNAME < typeSpecificNamePart1.Length)
+                    || (!string.IsNullOrEmpty(typeSpecificNamePart2) && TdsEnums.MAX_SERVERNAME < typeSpecificNamePart2.Length)
+                    || (!string.IsNullOrEmpty(typeSpecificNamePart3) && TdsEnums.MAX_SERVERNAME < typeSpecificNamePart3.Length))
                 {
                     throw ADP.ArgumentOutOfRange("names");
                 }
@@ -450,7 +450,7 @@ namespace System.Data.SqlClient
             }
             set
             {
-                if (ADP.IsEmpty(value) || (value.Length < TdsEnums.MAX_PARAMETER_NAME_LENGTH)
+                if (string.IsNullOrEmpty(value) || (value.Length < TdsEnums.MAX_PARAMETER_NAME_LENGTH)
                     || (('@' == value[0]) && (value.Length <= TdsEnums.MAX_PARAMETER_NAME_LENGTH)))
                 {
                     if (_parameterName != value)
@@ -1396,7 +1396,7 @@ namespace System.Data.SqlClient
             // Validate structured-type-specific details.
             if (metaType.SqlDbType == SqlDbType.Structured)
             {
-                if (!isCommandProc && ADP.IsEmpty(TypeName))
+                if (!isCommandProc && string.IsNullOrEmpty(TypeName))
                     throw SQL.MustSetTypeNameForParam(metaType.TypeName, this.ParameterName);
 
                 if (ParameterDirection.Input != this.Direction)
@@ -1409,7 +1409,7 @@ namespace System.Data.SqlClient
                     throw SQL.DBNullNotSupportedForTVPValues(this.ParameterName);
                 }
             }
-            else if (!ADP.IsEmpty(TypeName))
+            else if (!string.IsNullOrEmpty(TypeName))
             {
                 throw SQL.UnexpectedTypeNameForNonStructParams(this.ParameterName);
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
@@ -933,7 +933,7 @@ namespace System.Data.SqlClient
         /// <returns>escapes the name with [], also escapes the last close bracket with double-bracket</returns>
         static internal string EscapeIdentifier(string name)
         {
-            Debug.Assert(!ADP.IsEmpty(name), "null or empty identifiers are not allowed");
+            Debug.Assert(!string.IsNullOrEmpty(name), "null or empty identifiers are not allowed");
             return "[" + name.Replace("]", "]]") + "]";
         }
 
@@ -943,7 +943,7 @@ namespace System.Data.SqlClient
         static internal void EscapeIdentifier(StringBuilder builder, string name)
         {
             Debug.Assert(builder != null, "builder cannot be null");
-            Debug.Assert(!ADP.IsEmpty(name), "null or empty identifiers are not allowed");
+            Debug.Assert(!string.IsNullOrEmpty(name), "null or empty identifiers are not allowed");
 
             builder.Append("[");
             builder.Append(name.Replace("]", "]]"));

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -1261,15 +1261,15 @@ namespace System.Data.SqlClient
             //
 
 #if MANAGED_SNI
-            Debug.Assert(!ADP.IsEmpty(errorMessage) || sniError.sniError != 0, "Empty error message received from SNI");
+            Debug.Assert(!string.IsNullOrEmpty(errorMessage) || sniError.sniError != 0, "Empty error message received from SNI");
 #else
-            Debug.Assert(!ADP.IsEmpty(errorMessage), "Empty error message received from SNI");
+            Debug.Assert(!string.IsNullOrEmpty(errorMessage), "Empty error message received from SNI");
 #endif
 
             string sqlContextInfo = SR.GetResourceString(Enum.GetName(typeof(SniContext), stateObj.SniContext), Enum.GetName(typeof(SniContext), stateObj.SniContext));
             string providerRid = String.Format((IFormatProvider)null, "SNI_PN{0}", (int)sniError.provider);
             string providerName = SR.GetResourceString(providerRid, providerRid);
-            Debug.Assert(!ADP.IsEmpty(providerName), String.Format((IFormatProvider)null, "invalid providerResourceId '{0}'", providerRid));
+            Debug.Assert(!string.IsNullOrEmpty(providerName), String.Format((IFormatProvider)null, "invalid providerResourceId '{0}'", providerRid));
             uint win32ErrorCode = sniError.nativeError;
 
             if (sniError.sniError == 0)
@@ -2994,7 +2994,7 @@ namespace System.Data.SqlClient
 
             // Fail if SSE UserInstance and we have not received this info.
             if (_connHandler.ConnectionOptions.UserInstance &&
-                ADP.IsEmpty(_connHandler.InstanceName))
+                string.IsNullOrEmpty(_connHandler.InstanceName))
             {
                 stateObj.AddError(new SqlError(0, 0, TdsEnums.FATAL_ERROR_CLASS, Server, SQLMessage.UserInstanceFailure(), "", 0));
                 ThrowExceptionAndWarning(stateObj);
@@ -6342,8 +6342,8 @@ namespace System.Data.SqlClient
 
         private void SSPIError(string error, string procedure)
         {
-            Debug.Assert(!ADP.IsEmpty(procedure), "TdsParser.SSPIError called with an empty or null procedure string");
-            Debug.Assert(!ADP.IsEmpty(error), "TdsParser.SSPIError called with an empty or null error string");
+            Debug.Assert(!string.IsNullOrEmpty(procedure), "TdsParser.SSPIError called with an empty or null procedure string");
+            Debug.Assert(!string.IsNullOrEmpty(error), "TdsParser.SSPIError called with an empty or null error string");
 
             _physicalStateObj.AddError(new SqlError(0, (byte)0x00, (byte)TdsEnums.MIN_ERROR_CLASS, _server, error, procedure, 0));
             ThrowExceptionAndWarning(_physicalStateObj);
@@ -6781,7 +6781,7 @@ namespace System.Data.SqlClient
                             }
                             else
                             {
-                                Debug.Assert(!ADP.IsEmpty(rpcext.rpcName), "must have an RPC name");
+                                Debug.Assert(!string.IsNullOrEmpty(rpcext.rpcName), "must have an RPC name");
                                 tempLen = rpcext.rpcName.Length;
                                 WriteShort(tempLen, stateObj);
                                 WriteString(rpcext.rpcName, tempLen, 0, stateObj);
@@ -7261,7 +7261,7 @@ namespace System.Data.SqlClient
         {
             // paramLen
             // paramName
-            if (!ADP.IsEmpty(parameterName))
+            if (!string.IsNullOrEmpty(parameterName))
             {
                 Debug.Assert(parameterName.Length <= 0xff, "parameter name can only be 255 bytes, shouldn't get to TdsParser!");
                 int tempLen = parameterName.Length & 0xff;
@@ -7494,8 +7494,8 @@ namespace System.Data.SqlClient
                 case SqlDbType.Xml:
                     stateObj.WriteByte(TdsEnums.SQLXMLTYPE);
                     // Is there a schema
-                    if (ADP.IsEmpty(metaData.TypeSpecificNamePart1) && ADP.IsEmpty(metaData.TypeSpecificNamePart2) &&
-                            ADP.IsEmpty(metaData.TypeSpecificNamePart3))
+                    if (string.IsNullOrEmpty(metaData.TypeSpecificNamePart1) && string.IsNullOrEmpty(metaData.TypeSpecificNamePart2) &&
+                            string.IsNullOrEmpty(metaData.TypeSpecificNamePart3))
                     {
                         stateObj.WriteByte(0);  // schema not present
                     }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/sqlinternaltransaction.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/sqlinternaltransaction.cs
@@ -404,7 +404,7 @@ namespace System.Data.SqlClient
             // transaction name.  NOTE: for simplicity it is possible to give all save point names
             // the same name, and ROLLBACK will simply rollback to the most recent save point with the
             // save point name.
-            if (ADP.IsEmpty(transactionName))
+            if (string.IsNullOrEmpty(transactionName))
                 throw SQL.NullEmptyTransactionName();
 
             try
@@ -431,7 +431,7 @@ namespace System.Data.SqlClient
             // SAVE TRANSACTION MUST HAVE AN ARGUMENT!!!  Save Transaction without an arg throws an
             // exception from the server.  So, an overload for SaveTransaction without an arg doesn't make
             // sense to have.  Save Transaction does not affect the transaction level.
-            if (ADP.IsEmpty(savePointName))
+            if (string.IsNullOrEmpty(savePointName))
                 throw SQL.NullEmptyTransactionName();
 
             try


### PR DESCRIPTION
Replace `ADP.IsEmpty` with the built-in `string.IsNullOrEmpty`.

cc: @saurabh500