### PR TITLE
Add IsNotWindowsNanoServer to Platform detection.

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -13,9 +13,11 @@ namespace System
     public static class PlatformDetection
     {
         public static bool IsWindows { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-        public static bool IsWindows7 { get; } =  IsWindows && GetWindowsVersion() == 6 && GetWindowsMinorVersion() == 1;
+        public static bool IsWindows7 { get; } = IsWindows && GetWindowsVersion() == 6 && GetWindowsMinorVersion() == 1;
         public static bool IsOSX { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         public static bool IsNetBSD { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"));
+        public static bool IsNotWindowsNanoServer { get; } = (IsWindows && GetWindowsVersion() == 10 &&
+                File.Exists(Path.Combine(Environment.GetEnvironmentVariable("windir"), "regedit.exe")));
 
         public static int WindowsVersion { get; } = GetWindowsVersion();
 
@@ -44,7 +46,7 @@ namespace System
             IdVersionPair ret = new IdVersionPair();
             ret.Id = "";
             ret.VersionId = "";
-            
+
             if (File.Exists("/etc/os-release"))
             {
                 foreach (string line in File.ReadLines("/etc/os-release"))
@@ -88,7 +90,7 @@ namespace System
 
             return -1;
         }
-    
+
         private static int GetWindowsMinorVersion()
         {
             if (IsWindows)

--- a/src/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
@@ -12,7 +12,7 @@ namespace System.Diagnostics.Tests
     {
         private const int s_ConsoleEncoding = 437;
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection)+"."+nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void TestChangesInConsoleEncoding()
         {
             Action<int> run = expectedCodePage =>

--- a/src/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
@@ -12,7 +12,7 @@ namespace System.Diagnostics.Tests
     {
         private const int s_ConsoleEncoding = 437;
 
-        [ConditionalFact(nameof(PlatformDetection)+"."+nameof(PlatformDetection.IsNotWindowsNanoServer))]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void TestChangesInConsoleEncoding()
         {
             Action<int> run = expectedCodePage =>

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -51,7 +51,8 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [Fact, PlatformSpecific(PlatformID.Windows)]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
+        [PlatformSpecific(PlatformID.Windows)]
         public void TestBasePriorityOnWindows()
         {
             ProcessPriorityClass originalPriority = _process.PriorityClass;

--- a/src/System.Diagnostics.Process/tests/ProcessThreadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessThreadTests.cs
@@ -114,7 +114,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void TestStartAddressProperty()
         {
             Process p = Process.GetCurrentProcess();

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
@@ -26,6 +26,9 @@
     <Compile Include="$(CommonTestPath)\System\Diagnostics\AssertWithCallerAttributes.cs">
       <Link>Common\tests\System\Diagnostics\AssertWithCallerAttributes.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\tests\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorTestBase.cs">
       <Link>Common\System\Diagnostics\RemoteExecutorTestBase.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
@@ -26,7 +26,7 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentOutOfRangeException>("options", () => CreateFileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.Read, c_DefaultBufferSize, ~FileOptions.None));
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PlatformDetection)+"."+nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(FileOptions.None)]
         [InlineData(FileOptions.DeleteOnClose)]
         [InlineData(FileOptions.Encrypted)]

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
@@ -26,7 +26,7 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentOutOfRangeException>("options", () => CreateFileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.Read, c_DefaultBufferSize, ~FileOptions.None));
         }
 
-        [ConditionalTheory(nameof(PlatformDetection)+"."+nameof(PlatformDetection.IsNotWindowsNanoServer))]
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(FileOptions.None)]
         [InlineData(FileOptions.DeleteOnClose)]
         [InlineData(FileOptions.Encrypted)]

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -151,6 +151,9 @@
     <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorTestBase.cs">
       <Link>Common\System\Diagnostics\RemoteExecutorTestBase.cs</Link>
     </Compile>

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -78,6 +78,9 @@
     <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
     <!-- Performance Tests -->
     <Compile Include="Performance\Perf.Environment.cs" />
     <Compile Include="Performance\Perf.Path.cs" />

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -632,7 +632,7 @@ namespace System.IO.Tests
         }
 
         [PlatformSpecific(PlatformID.Windows)]
-        [Fact]
+        [ConditionalFact(nameof(PlatformDetection)+"."+nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public static void GetFullPath_Windows_83Paths()
         {
             // Create a temporary file name with a name longer than 8.3 such that it'll need to be shortened.

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -632,7 +632,7 @@ namespace System.IO.Tests
         }
 
         [PlatformSpecific(PlatformID.Windows)]
-        [ConditionalFact(nameof(PlatformDetection)+"."+nameof(PlatformDetection.IsNotWindowsNanoServer))]
+        [ConditionalFact(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public static void GetFullPath_Windows_83Paths()
         {
             // Create a temporary file name with a name longer than 8.3 such that it'll need to be shortened.


### PR DESCRIPTION
Disable failing Windows Nano tests.