### PR TITLE
Add *.VC.db to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ ipch/
 *.opensdf
 *.sdf
 *.cachefile
+*.VC.db
 
 # Visual Studio profiler
 *.psess


### PR DESCRIPTION
After upgrading to Visual Studio 2015 Update 2, I'm seeing these files being added frequently.