### PR TITLE
Remove "UnsupportedPlatforms" metadata

### DIFF
--- a/Documentation/building/windows-instructions.md
+++ b/Documentation/building/windows-instructions.md
@@ -120,12 +120,7 @@ xunit.console.netcore.exe *.dll -notrait category=nonosxtests -trait category=Ou
 xunit.console.netcore.exe *.dll -notrait category=nonlinuxtests -trait category=failing
 ```
 
-All the required dlls to run a test project can be found in `bin\tests\{Flavor}\{Project}.Tests\aspnetcore50\` which should be created when the test project is built.
-
-To skip an entire test project on a specific platform, for example, to skip running registry tests on Linux and Mac OS X, use the `<UnsupportedPlatforms>` MSBuild property in the csproj. Valid platform values are
-```xml
-<UnsupportedPlatforms>Windows_NT;Linux;OSX</UnsupportedPlatforms>
-```
+All the required dlls to run a test project can be found in `bin\tests\{Configration}\{Project}.Tests\dnxcore50\` which should be created when the test project is built.
 
 ### Running tests from Visual Studio
 

--- a/run-test.sh
+++ b/run-test.sh
@@ -89,12 +89,12 @@ create_test_overlay()
   local mscorlibLocation="$MscorlibBins/mscorlib.dll"
 
   # Make the overlay
-    
+
   rm -rf $OverlayDir
   mkdir -p $OverlayDir
-  
+
   local LowerConfigurationGroup="$(echo $ConfigurationGroup | awk '{print tolower($0)}')"
- 
+
   # Copy the CoreCLR native binaries
   if [ ! -d $CoreClrBins ]
   then
@@ -102,16 +102,16 @@ create_test_overlay()
 	exit 1
   fi
   cp -r $CoreClrBins/* $OverlayDir
-  
+
   # Then the mscorlib from the upstream build.
-  # TODO When the mscorlib flavors get properly changed then 
+  # TODO When the mscorlib flavors get properly changed then
   if [ ! -f $mscorlibLocation ]
   then
 	echo "error: Mscorlib not found at $mscorlibLocation"
 	exit 1
   fi
   cp -r $mscorlibLocation $OverlayDir
-  
+
   # Then the native CoreFX binaries
   if [ ! -d $CoreFxNativeBins ]
   then
@@ -141,9 +141,9 @@ runtest()
     echo "Test project file $1 indicates this test is not supported on $OS, skipping"
     exit 0
   fi
-  
+
   # Check for project restrictions
-  
+
   if [[ ! $testProject =~ $TestSelection ]]; then
     echo "Skipping $testProject"
     exit 0
@@ -186,7 +186,7 @@ runtest()
   fi
 
   chmod +x ./corerun
-  
+
   # Invoke xunit
 
   echo

--- a/run-test.sh
+++ b/run-test.sh
@@ -27,7 +27,7 @@ usage()
     echo "                                      default: <repo_root>/bin/Product/<OS>.x64.<ConfigurationGroup>"
     echo "    --corefx-tests <location>         Location of the root binaries location containing"
     echo "                                      the tests to run"
-    echo "                                      default: <repo_root>/bin/tests/<OS>.AnyCPU.<ConfigurationGroup>"
+    echo "                                      default: <repo_root>/bin/tests"
     echo "    --corefx-native-bins <location>   Location of the FreeBSD, Linux, NetBSD or OSX native corefx binaries"
     echo "                                      default: <repo_root>/bin/<OS>.x64.<ConfigurationGroup>"
     echo
@@ -129,18 +129,30 @@ copy_test_overlay()
 }
 
 
-# $1 is the name of the test project
-runtest()
+# $1 is the name of the platform folder (e.g Unix.AnyCPU.Debug)
+run_all_tests()
 {
-  testProject=$1
+  for testFolder in "$CoreFxTests/$1/"*
+  do
+     run_test $testFolder &
+     pids="$pids $!"
+     numberOfProcesses=$(($numberOfProcesses+1))
+     if [ "$numberOfProcesses" -ge $maxProcesses ]; then
+       wait_on_pids "$pids"
+       numberOfProcesses=0
+       pids=""
+     fi
+  done
 
-  # Check here to see whether we should run this project
+  # Wait on the last processes
+  wait_on_pids "$pids"
+  pids=""
+}
 
-  if grep "UnsupportedPlatforms.*$OS.*" $1 > /dev/null
-  then
-    echo "Test project file $1 indicates this test is not supported on $OS, skipping"
-    exit 0
-  fi
+# $1 is the path to the test folder
+run_test()
+{
+  testProject=`basename $1`
 
   # Check for project restrictions
 
@@ -149,30 +161,7 @@ runtest()
     exit 0
   fi
 
-  # Grab the directory name that would correspond to this test
-
-  lowerOS="$(echo $OS | awk '{print tolower($0)}')"
-  fileName="${file##*/}"
-  fileNameWithoutExtension="${fileName%.*}"
-  testDllName="$fileNameWithoutExtension.dll"
-  xunitOSCategory="non$lowerOS"
-  xunitOSCategory+="tests"
-
-  dirName="$CoreFxTests/$fileNameWithoutExtension/dnxcore50"
-
-  if [ ! -d "$dirName" ] || [ ! -f "$dirName/$testDllName" ]
-  then
-    dirName="$AnyOsTestDir/$fileNameWithoutExtension/dnxcore50"
-    if [ ! -d "$dirName" ] || [ ! -f "$dirName/$testDllName" ]
-    then
-      dirName="$UnixTestDir/$fileNameWithoutExtension/dnxcore50"
-      if [ ! -d "$dirName" ] || [ ! -f "$dirName/$testDllName" ]
-      then
-        echo "error: Did not find corresponding test dll for $testProject"
-        exit 1
-      fi
-    fi
-  fi
+  dirName="$1/dnxcore50"
 
   copy_test_overlay $dirName
 
@@ -188,12 +177,15 @@ runtest()
   chmod +x ./corerun
 
   # Invoke xunit
+  lowerOS="$(echo $OS | awk '{print tolower($0)}')"
+  xunitOSCategory="non$lowerOS"
+  xunitOSCategory+="tests"
 
   echo
   echo "Running tests in $dirName"
-  echo "./corerun xunit.console.netcore.exe $testDllName -xml testResults.xml -notrait category=failing $OuterLoop -notrait category=$xunitOSCategory" -notrait Benchmark=true
+  echo "./corerun xunit.console.netcore.exe $testProject.dll -xml testResults.xml -notrait category=failing $OuterLoop -notrait category=$xunitOSCategory -notrait Benchmark=true"
   echo
-  ./corerun xunit.console.netcore.exe $testDllName -xml testResults.xml -notrait category=failing $OuterLoop -notrait category=$xunitOSCategory -notrait Benchmark=true
+  ./corerun xunit.console.netcore.exe "$testProject.dll" -xml testResults.xml -notrait category=failing $OuterLoop -notrait category=$xunitOSCategory -notrait Benchmark=true
   exitCode=$?
 
   if [ $exitCode -ne 0 ]
@@ -328,7 +320,7 @@ fi
 
 if [ "$CoreFxTests" == "" ]
 then
-    CoreFxTests="$ProjectRoot/bin/tests/$OS.AnyCPU.$ConfigurationGroup"
+    CoreFxTests="$ProjectRoot/bin/tests"
 fi
 
 if [ "$CoreFxNativeBins" == "" ]
@@ -377,22 +369,9 @@ else
   maxProcesses=$(($(getconf _NPROCESSORS_ONLN)+1))
 fi
 
-TestProjects=($(find . -regex ".*/src/.*/tests/.*\.Tests\.csproj"))
-for file in ${TestProjects[@]}
-do
-  runtest $file &
-  pids="$pids $!"
-  numberOfProcesses=$(($numberOfProcesses+1))
-  if [ "$numberOfProcesses" -ge $maxProcesses ]; then
-    wait_on_pids "$pids"
-    numberOfProcesses=0
-    pids=""
-  fi
-done
-
-# Wait on the last processes
-wait_on_pids "$pids"
-
+run_all_tests "AnyOS.AnyCPU.$ConfigurationGroup"
+run_all_tests "Unix.AnyCPU.$ConfigurationGroup"
+run_all_tests "$OS.AnyCPU.$ConfigurationGroup"
 
 if [ "$CoreClrCoverage" == "ON" ]
 then

--- a/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.csproj
+++ b/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{82B54697-0251-47A1-8546-FC507D0F3B08}</ProjectGuid>
     <AssemblyName>Microsoft.VisualBasic.Tests</AssemblyName>
     <RootNamespace>Microsoft.VisualBasic.Tests</RootNamespace>
-    <UnsupportedPlatforms>Linux;NetBSD;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/Microsoft.Win32.Registry.AccessControl/tests/Microsoft.Win32.Registry.AccessControl.Tests.csproj
+++ b/src/Microsoft.Win32.Registry.AccessControl/tests/Microsoft.Win32.Registry.AccessControl.Tests.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{82B54697-0251-47A1-8546-FC507D0F3B08}</ProjectGuid>
     <AssemblyName>Microsoft.Win32.Registry.AccessControl.Tests</AssemblyName>
     <RootNamespace>Microsoft.Win32.Registry.AccessControl.Tests</RootNamespace>
-    <UnsupportedPlatforms>Linux;NetBSD;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
+++ b/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
@@ -11,7 +11,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Win32.Registry.Tests</RootNamespace>
     <AssemblyName>Microsoft.Win32.Registry.Tests</AssemblyName>
-    <UnsupportedPlatforms>Linux;NetBSD;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -9,7 +9,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>System.Data.SqlClient.Tests</RootNamespace>
     <AssemblyName>System.Data.SqlClient.Tests</AssemblyName>
-    <UnsupportedPlatforms>Linux;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU'" />

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -14,7 +14,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <PropertyGroup Condition=" '$(TargetsWindows)' != 'true' ">
     <DefineConstants>$(DefineConstants);MANAGED_SNI</DefineConstants>
-    <UnsupportedPlatforms>Linux;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Data.SqlClient.csproj">

--- a/src/System.IO.FileSystem.AccessControl/tests/System.IO.FileSystem.AccessControl.Tests.csproj
+++ b/src/System.IO.FileSystem.AccessControl/tests/System.IO.FileSystem.AccessControl.Tests.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{D77FBA6C-1AA6-45A4-93E2-97A370672C53}</ProjectGuid>
     <AssemblyName>System.IO.FileSystem.AccessControl.Tests</AssemblyName>
     <RootNamespace>System.IO.FileSystem.AccessControl.Tests</RootNamespace>
-    <UnsupportedPlatforms>Linux;NetBSD;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
@@ -10,7 +10,6 @@
     <ProjectGuid>{17D5CC82-F72C-4DD2-B6DB-DE7FB2F19C34}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Net.Http.WinHttpHandler.Functional.Tests</AssemblyName>
-    <UnsupportedPlatforms>FreeBSD;Linux;NetBSD;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -12,7 +12,6 @@
     <AssemblyName>System.Net.Http.WinHttpHandler.Unit.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
-    <UnsupportedPlatforms>FreeBSD;Linux;NetBSD;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   
   <!-- Help VS understand available configurations -->

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -10,7 +10,6 @@
     <ProjectGuid>{C85CF035-7804-41FF-9557-48B7C948B58D}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Net.Http.Functional.Tests</AssemblyName>
-    <UnsupportedPlatforms>FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Release|AnyCPU'" />

--- a/src/System.Net.NameResolution/tests/FunctionalTests/System.Net.NameResolution.Functional.Tests.csproj
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/System.Net.NameResolution.Functional.Tests.csproj
@@ -9,7 +9,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{4FE5ECEE-ACC5-4558-A946-573426599B73}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <UnsupportedPlatforms>FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   
   <!-- Help VS understand available configurations -->

--- a/src/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
+++ b/src/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
@@ -10,7 +10,6 @@
     <ProjectGuid>{F6D1C093-081D-46DE-B5A8-516533375FDD}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
-    <UnsupportedPlatforms>FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   
   <!-- Help VS understand available configurations -->

--- a/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
+++ b/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
@@ -9,7 +9,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{4FE5ECEE-ACC5-4558-A946-573426599B73}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <UnsupportedPlatforms>FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Net.Primitives/tests/PalTests/System.Net.Primitives.Pal.Tests.csproj
+++ b/src/System.Net.Primitives/tests/PalTests/System.Net.Primitives.Pal.Tests.csproj
@@ -23,10 +23,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
 
   <PropertyGroup>
-    <UnsupportedPlatforms>FreeBSD</UnsupportedPlatforms>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <!-- SYSTEM_NET_PRIMITIVES_DLL is required to allow source-level code sharing for types defined within the 
          System.Net.Internals namespace. -->
     <DefineConstants>$(DefineConstants);SYSTEM_NET_PRIMITIVES_DLL</DefineConstants>

--- a/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
+++ b/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
@@ -21,7 +21,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <PropertyGroup>
-    <UnsupportedPlatforms>FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   <PropertyGroup>
     <!-- SYSTEM_NET_PRIMITIVES_DLL is required to allow source-level code sharing for types defined within the 

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <UnsupportedPlatforms>FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Net.Sockets/tests/PerformanceTests/System.Net.Sockets.Async.Performance.Tests.csproj
+++ b/src/System.Net.Sockets/tests/PerformanceTests/System.Net.Sockets.Async.Performance.Tests.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <ProjectGuid>{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <UnsupportedPlatforms>FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />

--- a/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -10,7 +10,6 @@
     <ProjectGuid>{7C395A91-D955-444C-98BF-D3F809A56CE1}</ProjectGuid>
     <OutputType>Library</OutputType>
     <StringResourcesPath>../src/Resources/Strings.resx</StringResourcesPath>
-    <UnsupportedPlatforms>Linux;OSX</UnsupportedPlatforms>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->

--- a/src/System.Private.Uri/tests/System.Private.Uri.Tests.csproj
+++ b/src/System.Private.Uri/tests/System.Private.Uri.Tests.csproj
@@ -6,7 +6,6 @@
     <ProjectGuid>{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Private.Uri.Tests</AssemblyName>
-    <UnsupportedPlatforms>FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/System.Reflection.Context/tests/System.Reflection.Context.Tests.csproj
+++ b/src/System.Reflection.Context/tests/System.Reflection.Context.Tests.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{D77FBA6C-1AA6-45A4-93E2-97A370672C53}</ProjectGuid>
     <AssemblyName>System.Reflection.Context.Tests</AssemblyName>
     <RootNamespace>System.Reflection.Context.Tests</RootNamespace>
-    <UnsupportedPlatforms>FreeBSD;Linux;NetBSD;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/System.Runtime.InteropServices.PInvoke/tests/System.Runtime.InteropServices.PInvoke.Tests.csproj
+++ b/src/System.Runtime.InteropServices.PInvoke/tests/System.Runtime.InteropServices.PInvoke.Tests.csproj
@@ -11,7 +11,6 @@
     <RootNamespace>System.Runtime.InteropServices</RootNamespace>
     <AssemblyName>System.Runtime.InteropServices.PInvoke.Tests</AssemblyName>
     <ProjectGuid>{A824F4CD-935B-4496-A1B2-C3664936DA7B}</ProjectGuid>
-    <UnsupportedPlatforms>Linux;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -10,7 +10,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.Cng.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.Cng.Tests</RootNamespace>
-    <UnsupportedPlatforms>Linux;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />

--- a/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
+++ b/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
@@ -10,7 +10,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.Csp.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.Csp.Tests</RootNamespace>
-    <UnsupportedPlatforms>Linux;OSX</UnsupportedPlatforms>
   </PropertyGroup>
     <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />

--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -10,7 +10,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.OpenSsl.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.OpenSsl.Tests</RootNamespace>
-    <UnsupportedPlatforms>Windows_NT</UnsupportedPlatforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Release|AnyCPU'" />

--- a/src/System.Security.Cryptography.ProtectedData/tests/System.Security.Cryptography.ProtectedData.Tests.csproj
+++ b/src/System.Security.Cryptography.ProtectedData/tests/System.Security.Cryptography.ProtectedData.Tests.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.ProtectedData.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.ProtectedData.Tests</RootNamespace>
-    <UnsupportedPlatforms>Linux;OSX</UnsupportedPlatforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>false</CLSCompliant>
   </PropertyGroup>

--- a/src/System.Security.Principal.Windows/tests/System.Security.Principal.Windows.Tests.csproj
+++ b/src/System.Security.Principal.Windows/tests/System.Security.Principal.Windows.Tests.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>System.Security.Principal.Windows.Tests</AssemblyName>
     <RootNamespace>System.Security.Principal.Windows.Tests</RootNamespace>
     <ProjectGuid>{6C36F3AC-54A1-4021-9F5D-CDEFF7347277}</ProjectGuid>
-    <UnsupportedPlatforms>Linux;NetBSD;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="WindowsIdentityTests.cs" />

--- a/src/System.Security.Principal/tests/System.Security.Principal.Tests.csproj
+++ b/src/System.Security.Principal/tests/System.Security.Principal.Tests.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>System.Security.Principal.Tests</AssemblyName>
     <RootNamespace>System.Security.Principal.Tests</RootNamespace>
     <ProjectGuid>{49A64F00-C66B-472C-B7D0-6D1FBCC3E7CD}</ProjectGuid>
-    <UnsupportedPlatforms>Linux;NetBSD;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <ItemGroup>
     <!--<Compile Include="AddTestsHere.cs" /> -->

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/System.ServiceProcess.ServiceController.Tests.csproj
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/System.ServiceProcess.ServiceController.Tests.csproj
@@ -8,7 +8,6 @@
     <RootNamespace>System.ServiceProcess.ServiceController.Tests</RootNamespace>
     <AssemblyName>System.ServiceProcess.ServiceController.Tests</AssemblyName>
     <ProjectGuid>{F7D9984B-02EB-4573-84EF-00FFFBFB872C}</ProjectGuid>
-    <UnsupportedPlatforms>Linux;NetBSD;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />

--- a/src/System.Threading.AccessControl/tests/System.Threading.AccessControl.Tests.csproj
+++ b/src/System.Threading.AccessControl/tests/System.Threading.AccessControl.Tests.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{D77FBA6C-1AA6-45A4-93E2-97A370672C53}</ProjectGuid>
     <AssemblyName>System.Threading.AccessControl.Tests</AssemblyName>
     <RootNamespace>System.Threading.AccessControl.Tests</RootNamespace>
-    <UnsupportedPlatforms>Linux;NetBSD;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/System.Threading.Overlapped/tests/System.Threading.Overlapped.Tests.csproj
+++ b/src/System.Threading.Overlapped/tests/System.Threading.Overlapped.Tests.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>System.Threading.Overlapped.Tests</AssemblyName>
     <ProjectGuid>{861A3318-35AD-46ac-8257-8D5D2479BAD9}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <UnsupportedPlatforms>Linux;NetBSD;OSX</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />


### PR DESCRIPTION
Since #6572 was merged, we only build test projects for the platforms
they test.  This means the UnsupportedPlatforms metadata is no longer
needed (instead using the .builds file to control when the project is
built is the right thing to do).

Leverage this in run-test.sh, we now simply loop over all the tests in
the relevent folders under bin/tests, depending on the platform in
question.