### PR TITLE
Linux/ARM: Support arm architecture to GSS data type

### DIFF
--- a/src/Native/System.Net.Security.Native/pal_gssapi.cpp
+++ b/src/Native/System.Net.Security.Native/pal_gssapi.cpp
@@ -43,7 +43,7 @@ static void NetSecurityNative_MoveBuffer(gss_buffer_t gssBuffer, struct PAL_GssB
     assert(gssBuffer != nullptr);
     assert(targetBuffer != nullptr);
 
-    targetBuffer->length = gssBuffer->length;
+    targetBuffer->length = static_cast<uint64_t>(gssBuffer->length);
     targetBuffer->data = static_cast<uint8_t*>(gssBuffer->value);
 }
 

--- a/src/Native/System.Net.Security.Native/pal_gssapi.h
+++ b/src/Native/System.Net.Security.Native/pal_gssapi.h
@@ -38,12 +38,17 @@ enum PAL_GssFlags : uint32_t
     PAL_GSS_C_EXTENDED_ERROR_FLAG = 0x4000,
     PAL_GSS_C_DELEG_POLICY_FLAG = 0x8000
 };
-
+/*
+Tracking PR: #7511 (length typecasts size_t to uint64_t which causes padded warning)
+*/
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpadded"
 struct PAL_GssBuffer
 {
     uint64_t length;
     uint8_t* data;
 };
+#pragma clang diagnostic pop
 
 /*
 Shims the gss_release_buffer method.


### PR DESCRIPTION
Recently, Generic Security Service Library (GSS-API) is appended
by '`System.Net.Security.Native`' native code. This patch is to handle arm32 architecture.

Signed-off-by: Geunsik Lim geunsik.lim@samsung.com
Signed-off-by: MyungJoo Ham myungjoo.ham@samsung.com
Signed-off-by: Prajwal A N an.prajwal@samsung.com

\CC: @benpye , @jkotas , @kapilash , @myungjoo , @prajwal-aithal 
