### PR TITLE
Add CurlHandler.MaxResponseHeadersLength

### DIFF
--- a/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -11,6 +11,7 @@ namespace System.Net.Http
     {
         public const int DefaultMaxAutomaticRedirections = 50;
         public const int DefaultMaxConnectionsPerServer = int.MaxValue;
+        public const int DefaultMaxResponseHeaderLength = 64 * 1024;
         public const DecompressionMethods DefaultAutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
         public const bool DefaultAutomaticRedirection = true;
         public const bool DefaultUseCookies = true;

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -354,4 +354,7 @@
   <data name="net_http_buffer_insufficient_length" xml:space="preserve">
     <value>The buffer was not long enough.</value>
   </data>
+  <data name="net_http_response_headers_exceeded_length" xml:space="preserve">
+    <value>The HTTP response headers length exceeded the set limit of {0} bytes.</value>
+  </data>
 </root>

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
@@ -131,6 +131,12 @@ namespace System.Net.Http
             set { throw new PlatformNotSupportedException(); }
         }
 
+        public int MaxResponseHeadersLength
+        {
+            get { return _curlHandler.MaxResponseHeadersLength; }
+            set { _curlHandler.MaxResponseHeadersLength = value; }
+        }
+
         #endregion Properties
 
         #region De/Constructors

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
@@ -15,8 +15,9 @@ namespace System.Net.Http
     {
         private sealed class CurlResponseMessage : HttpResponseMessage
         {
-            internal readonly EasyRequest _easy;
             private readonly CurlResponseStream _responseStream;
+            internal readonly EasyRequest _easy;
+            internal uint _headerBytesReceived;
 
             internal CurlResponseMessage(EasyRequest easy)
             {

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -89,6 +89,7 @@ namespace System.Net.Http
         private bool _automaticRedirection = HttpHandlerDefaults.DefaultAutomaticRedirection;
         private int _maxAutomaticRedirections = HttpHandlerDefaults.DefaultMaxAutomaticRedirections;
         private int _maxConnectionsPerServer = HttpHandlerDefaults.DefaultMaxConnectionsPerServer;
+        private int _maxResponseHeadersLength = HttpHandlerDefaults.DefaultMaxResponseHeaderLength;
         private ClientCertificateOption _clientCertificateOption = HttpHandlerDefaults.DefaultClientCertificateOption;
         private X509Certificate2Collection _clientCertificates;
         private Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> _serverCertificateValidationCallback;
@@ -293,7 +294,7 @@ namespace System.Net.Http
             }
         }
 
-        public int MaxConnectionsPerServer
+        internal int MaxConnectionsPerServer
         {
             get { return _maxConnectionsPerServer; }
             set
@@ -321,6 +322,21 @@ namespace System.Net.Http
 
                 CheckDisposedOrStarted();
                 _maxConnectionsPerServer = value;
+            }
+        }
+
+        internal int MaxResponseHeadersLength
+        {
+            get { return _maxResponseHeadersLength; }
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value, SR.Format(SR.net_http_value_must_be_greater_than, 0));
+                }
+
+                CheckDisposedOrStarted();
+                _maxResponseHeadersLength = value;
             }
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -85,7 +85,7 @@ namespace System.Net.Http
         private CredentialCache _credentialCache = null; // protected by LockObject
         private CookieContainer _cookieContainer = new CookieContainer();
         private bool _useCookie = HttpHandlerDefaults.DefaultUseCookies;
-        private TimeSpan _connectTimeout = HttpHandlerDefaults.DefaultConnectTimeout;
+        private TimeSpan _connectTimeout = Timeout.InfiniteTimeSpan; // TODO: Use the WinHttp default once we determine how to expose this. HttpHandlerDefaults.DefaultConnectTimeout;
         private bool _automaticRedirection = HttpHandlerDefaults.DefaultAutomaticRedirection;
         private int _maxAutomaticRedirections = HttpHandlerDefaults.DefaultMaxAutomaticRedirections;
         private int _maxConnectionsPerServer = HttpHandlerDefaults.DefaultMaxConnectionsPerServer;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Net.Sockets;
+using System.Net.Test.Common;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class HttpClientHandler_MaxResponseHeadersLength_Test : RemoteExecutorTestBase
+    {
+        [Fact]
+        public void Default_MaxResponseHeadersLength()
+        {
+            using (var handler = new HttpClientHandler())
+            {
+                Assert.Equal(64 * 1024, handler.MaxResponseHeadersLength);
+            }
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void InvalidValue_ThrowsException(int invalidValue)
+        {
+            using (var handler = new HttpClientHandler())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => handler.MaxResponseHeadersLength = invalidValue);
+            }
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(65 * 1024)]
+        [InlineData(int.MaxValue)]
+        public void ValidValue_SetGet_Roundtrips(int validValue)
+        {
+            using (var handler = new HttpClientHandler())
+            {
+                handler.MaxResponseHeadersLength = validValue;
+                Assert.Equal(validValue, handler.MaxResponseHeadersLength);
+            }
+        }
+
+        [Fact]
+        public async Task SetAfterUse_Throws()
+        {
+            using (var handler = new HttpClientHandler())
+            using (var client = new HttpClient(handler))
+            {
+                handler.MaxResponseHeadersLength = int.MaxValue;
+                await client.GetStreamAsync(HttpTestServers.RemoteEchoServer);
+                Assert.Throws<InvalidOperationException>(() => handler.MaxResponseHeadersLength = int.MaxValue);
+            }
+        }
+
+        [Theory]
+        [InlineData("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n", 37, false)]
+        [InlineData("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n", 38, true)]
+        [InlineData("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n", 39, true)]
+        public async Task ThresholdExceeded_ThrowsException(string responseHeaders, int maxResponseHeadersLength, bool shouldSucceed)
+        {
+            using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                s.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                s.Listen(1);
+                var ep = (IPEndPoint)s.LocalEndPoint;
+
+                using (var handler = new HttpClientHandler() { MaxResponseHeadersLength = maxResponseHeadersLength })
+                using (var client = new HttpClient(handler))
+                {
+                    Task<HttpResponseMessage> getAsync = client.GetAsync($"http://{ep.Address}:{ep.Port}", HttpCompletionOption.ResponseHeadersRead);
+
+                    using (Socket server = s.Accept())
+                    using (Stream serverStream = new NetworkStream(server, ownsSocket: false))
+                    using (StreamReader reader = new StreamReader(serverStream, Encoding.ASCII))
+                    {
+                        string line;
+                        while ((line = reader.ReadLine()) != null && !string.IsNullOrEmpty(line)) ;
+
+                        byte[] headerData = Encoding.ASCII.GetBytes(responseHeaders);
+                        serverStream.Write(headerData, 0, headerData.Length);
+                    }
+
+                    if (shouldSucceed)
+                    {
+                        (await getAsync).Dispose();
+                    }
+                    else
+                    {
+                        await Assert.ThrowsAsync<HttpRequestException>(() => getAsync);
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Timeouts.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Timeouts.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Net.Sockets;
 using System.Net.Test.Common;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -17,7 +18,7 @@ namespace System.Net.Http.Functional.Tests
         {
             using (var handler = new HttpClientHandler())
             {
-                Assert.Equal(TimeSpan.FromSeconds(60), handler.ConnectTimeout);
+                Assert.Equal(Timeout.InfiniteTimeSpan, handler.ConnectTimeout);
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -66,6 +66,7 @@
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="HttpClientHandlerTest.DefaultProxyCredentials.cs" />
     <Compile Include="HttpClientHandlerTest.MaxConnectionsPerServer.cs" />
+    <Compile Include="HttpClientHandlerTest.MaxResponseHeadersLength.cs" />
     <Compile Include="HttpClientHandlerTest.ServerCertificates.cs" />
     <Compile Include="HttpClientHandlerTest.SslProtocols.cs" />
     <Compile Include="HttpClientHandlerTest.Timeouts.cs" />


### PR DESCRIPTION
Adds the MaxResponseHeadersLength property to CurlHandler.

I also changed the ConnectTimeout default to Infinite until the property is exposed; otherwise, we're enforcing a 60 second timeout on connects without providing any way to override it.

cc: @davidsh, @cipop, @ericeil, @kapilash