### PR TITLE
Fix runtime of S.P.Uri netcore50aot build

### DIFF
--- a/src/System.Private.Uri/src/System.Private.Uri.csproj
+++ b/src/System.Private.Uri/src/System.Private.Uri.csproj
@@ -16,6 +16,7 @@
     <SkipCommonResourcesIncludes Condition="'$(TargetGroup)'=='netcore50aot' Or '$(TargetGroup)'=='netstandard13aot'">true</SkipCommonResourcesIncludes>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.0</NuGetTargetMoniker>
     <PackageTargetRuntime Condition="'$(OSGroup)' == 'Windows_NT'">win7</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetGroup)' == 'netcore50aot'">win8-aot</PackageTargetRuntime>
     <PackageTargetRuntime Condition="'$(OSGroup)' == 'Unix'">unix</PackageTargetRuntime>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->


### PR DESCRIPTION
We need to make sure to use the AOT RID for the AOT build otherwise
non-AOT will pick up the AOT version which depends on the wrong core
assembly.

/cc @chcosta @weshaggard