### PR TITLE
Make S.R.WinRT work in UWP

### DIFF
--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
@@ -36,12 +36,17 @@
     <!-- Needed for the compiler to resolve IObservableMap.MapChanged. -->
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj"/>
     <ProjectReference Include="..\..\System.Diagnostics.Tools\src\System.Diagnostics.Tools.csproj" />
-    <ProjectReference Include="..\..\System.ObjectModel\src\System.ObjectModel.csproj"/>
     <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.csproj" />
     <ProjectReference Include="..\..\System.Runtime.InteropServices.WindowsRuntime\src\System.Runtime.InteropServices.WindowsRuntime.csproj">
       <UndefineProperties>OSGroup</UndefineProperties>
     </ProjectReference>
-    <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
+    <!-- ensure we use the lower-versioned UWP compatible facades so that this facade is compatible with UWP -->
+    <ProjectReference Include="..\..\System.ObjectModel\src\redist\System.ObjectModel.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="..\..\System.Runtime\src\redist\System.Runtime.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
     <Compile Include="System\IO\StreamOperationAsyncResult.netstandard.cs" />
     <Compile Include="System\Runtime\InteropServices\WindowsRuntime\MarshalingHelpers.cs" />
     <Compile Include="System\Runtime\InteropServices\WindowsRuntime\RestrictedErrorInfoHelper.cs" />


### PR DESCRIPTION
The default targetgroup of S.R.WinRT is used for netcore50.  As a result
it needs to only take dependencies on versions of assemblies that are
supported by UWP.

Since this is also a partial facade it needs to compile against
implementation assemblies.  It was referencing the latest implementation
which had a version that was not supported by UWP for S.Runtime and
S.ObjectModel.  Fix these by using the depproj instead.

/cc @weshaggard @chcosta