### PR TITLE
Fix path to native binaries for packaging

### DIFF
--- a/src/Native/pkg/dir.props
+++ b/src/Native/pkg/dir.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- common properties that point to output of native build.  Can be overriden in case of 
          a coordinating build that produces all packages from OS-specific native builds -->
-    <BuildNativePath Condition="'$(BuildNativePath)' == ''">$(BinDir)native\</BuildNativePath>
+    <BuildNativePath Condition="'$(BuildNativePath)' == ''">$(BinDir)$(OSGroup).$(PackagePlatform).$(ConfigurationGroup)\Native\</BuildNativePath>
     <WinNativePath Condition="'$(WinNativePath)' == ''">$(BuildNativePath)</WinNativePath>
     <RHELNativePath Condition="'$(RHELNativePath)' == ''">$(BuildNativePath)</RHELNativePath>
     <DebianNativePath Condition="'$(DebianNativePath)' == ''">$(BuildNativePath)</DebianNativePath>


### PR DESCRIPTION
A wrong path to the native binaries was preventing nupkgs from being built.