### PR TITLE
Remove the ApiCompatBaseline file for System.Runtime.Extensions

### DIFF
--- a/src/System.Runtime.Extensions/src/ApiCompatBaseline.netstandard15aot.txt
+++ b/src/System.Runtime.Extensions/src/ApiCompatBaseline.netstandard15aot.txt
@@ -1,6 +1,0 @@
-# Devdiv: Bug 158880: Expose Environment.Exit in ProjectN
-MembersMustExist : Member 'System.Environment.Exit(System.Int32)' does not exist in the implementation but it does exist in the contract.
-# Devdiv: Bug 163398: Expose Environment.GetCommandLineArgs in ProjectN
-MembersMustExist : Member 'System.Environment.GetCommandLineArgs()' does not exist in the implementation but it does exist in the contract.
-# Devdiv: Changes in ProjectN branch: Baselining till changeset is merged: Expose Environment.MachineName in ProjectN
-MembersMustExist : Member 'System.Environment.MachineName.get()' does not exist in the implementation but it does exist in the contract.


### PR DESCRIPTION
System.Runtime.Extensions 4.1.0.0 package is only supported on .NetStandard1.5 and so we do not need the baseline file anymore.