### PR TITLE
Avoid box allocations when enumerating IDictionary

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -93,9 +93,18 @@ namespace System.Diagnostics
                         CaseSensitiveEnvironmentVariables ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
 #pragma warning restore 0429
 
-                    foreach (DictionaryEntry entry in envVars)
+                    IDictionaryEnumerator e = envVars.GetEnumerator();
+                    try
                     {
-                        _environmentVariables.Add((string)entry.Key, (string)entry.Value);
+                        while (e.MoveNext())
+                        {
+                            DictionaryEntry entry = e.Entry;
+                            _environmentVariables.Add((string)entry.Key, (string)entry.Value);
+                        }
+                    }
+                    finally
+                    {
+                        (e as IDisposable)?.Dispose();
                     }
                 }
                 return _environmentVariables;

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -93,6 +93,7 @@ namespace System.Diagnostics
                         CaseSensitiveEnvironmentVariables ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
 #pragma warning restore 0429
 
+                    // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
                     IDictionaryEnumerator e = envVars.GetEnumerator();
                     try
                     {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JavaScriptSerializer.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JavaScriptSerializer.cs
@@ -89,21 +89,30 @@ namespace System.Runtime.Serialization.Json
         {
             sb.Append('{');
             bool isFirstElement = true;
-            foreach (DictionaryEntry entry in (IDictionary)o)
+            IDictionaryEnumerator e = o.GetEnumerator();
+            try
             {
-                if (!isFirstElement)
+                while (e.MoveNext())
                 {
-                    sb.Append(',');
+                    DictionaryEntry entry = e.Entry;
+                    if (!isFirstElement)
+                    {
+                        sb.Append(',');
+                    }
+                    string key = entry.Key as string;
+                    if (key == null)
+                    {
+                        throw new SerializationException(SR.Format(SR.ObjectSerializer_DictionaryNotSupported, o.GetType().FullName));
+                    }
+                    SerializeString(key, sb);
+                    sb.Append(':');
+                    SerializeValue(entry.Value, sb, depth, objectsInUse);
+                    isFirstElement = false;
                 }
-                string key = entry.Key as string;
-                if (key == null)
-                {
-                    throw new SerializationException(SR.Format(SR.ObjectSerializer_DictionaryNotSupported, o.GetType().FullName));
-                }
-                SerializeString((string)entry.Key, sb);
-                sb.Append(':');
-                SerializeValue(entry.Value, sb, depth, objectsInUse);
-                isFirstElement = false;
+            }
+            finally
+            {
+                (e as IDisposable)?.Dispose();
             }
             sb.Append('}');
         }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JavaScriptSerializer.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JavaScriptSerializer.cs
@@ -89,6 +89,7 @@ namespace System.Runtime.Serialization.Json
         {
             sb.Append('{');
             bool isFirstElement = true;
+            // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
             IDictionaryEnumerator e = o.GetEnumerator();
             try
             {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
@@ -235,10 +235,19 @@ namespace System.Runtime.Serialization.Json
                 {
                     // Convert non-generic dictionary to generic dictionary
                     IDictionary dictionaryObj = obj as IDictionary;
-                    Dictionary<object, object> genericDictionaryObj = new Dictionary<object, object>();
-                    foreach (DictionaryEntry entry in dictionaryObj)
+                    Dictionary<object, object> genericDictionaryObj = new Dictionary<object, object>(dictionaryObj.Count);
+                    IDictionaryEnumerator e = dictionaryObj.GetEnumerator();
+                    try
                     {
-                        genericDictionaryObj.Add(entry.Key, entry.Value);
+                        while (e.MoveNext())
+                        {
+                            DictionaryEntry entry = e.Entry;
+                            genericDictionaryObj.Add(entry.Key, entry.Value);
+                        }
+                    }
+                    finally
+                    {
+                        (e as IDisposable)?.Dispose();
                     }
                     obj = genericDictionaryObj;
                 }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
@@ -236,6 +236,7 @@ namespace System.Runtime.Serialization.Json
                     // Convert non-generic dictionary to generic dictionary
                     IDictionary dictionaryObj = obj as IDictionary;
                     Dictionary<object, object> genericDictionaryObj = new Dictionary<object, object>(dictionaryObj.Count);
+                    // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
                     IDictionaryEnumerator e = dictionaryObj.GetEnumerator();
                     try
                     {


### PR DESCRIPTION
Enumerating `IDictionary` using `foreach` results in box allocations for each entry in the dictionary because `Current` returns a `DictionaryEntry` struct but is typed as `object`.

These box allocations can be avoided by using `IDictionaryEnumerator` directly.

cc: @stephentoub, @khdang

---

Notes:

 - There are two other places in the repo that could have been modified similarly (in SqlClient), but one is in an error path where it doesn't matter much and the other will be obviated when I submit a separate PR that removes SqlClient's dependency on `System.Collections.NonGeneric`.

 - `JavaScriptSerializer.cs` isn't currently being compiled in any CoreFx projects, but the source exists, so I went ahead and updated it.

---

I profiled a quick one-off sample...

Before: 10,000 instances of `DictionaryEntry` allocated:

```csharp
using System;
using System.Collections;
using System.Linq;

class Program
{
    static void Main()
    {
        IDictionary d = Enumerable.Range(0, 10000).ToDictionary(i => i.ToString(), i => string.Empty);
        string value = null;

        foreach (DictionaryEntry entry in d)
        {
            value = (string)entry.Value;
        }
    }
}
```

After: No `DictionaryEntry` allocations:

```csharp
using System;
using System.Collections;
using System.Linq;

class Program
{
    static void Main()
    {
        IDictionary d = Enumerable.Range(0, 10000).ToDictionary(i => i.ToString(), i => string.Empty);
        string value = null;

        IDictionaryEnumerator e = d.GetEnumerator();
        try
        {
            while (e.MoveNext())
            {
                DictionaryEntry entry = e.Entry;
                value = (string)entry.Value;
            }
        }
        finally
        {
            (e as IDisposable)?.Dispose();
        }
    }
}
```