### PR TITLE
Avoid overflow on 32-bit system

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -67,14 +67,17 @@ namespace System.Diagnostics
                 }
 
                 // It's not a continuation of a previous entry but a new one: add it.
-                modules.Add(new ModuleInfo()
+                unsafe
                 {
-                    _fileName = entry.FileName,
-                    _baseName = Path.GetFileName(entry.FileName),
-                    _baseOfDll = new IntPtr(entry.AddressRange.Key),
-                    _sizeOfImage = sizeOfImage,
-                    _entryPoint = IntPtr.Zero // unknown
-                });
+                    modules.Add(new ModuleInfo()
+                    {
+                        _fileName = entry.FileName,
+                        _baseName = Path.GetFileName(entry.FileName),
+                        _baseOfDll = new IntPtr((void *)entry.AddressRange.Key),
+                        _sizeOfImage = sizeOfImage,
+                        _entryPoint = IntPtr.Zero // unknown
+                    });
+                }
             }
 
             // Return the set of modules found
@@ -136,16 +139,19 @@ namespace System.Diagnostics
                     if (int.TryParse(dirName, NumberStyles.Integer, CultureInfo.InvariantCulture, out tid) &&
                         Interop.procfs.TryReadStatFile(pid, tid, out stat, reusableReader))
                     {
-                        pi._threadInfoList.Add(new ThreadInfo()
+                        unsafe
                         {
-                            _processId = pid,
-                            _threadId = (ulong)tid,
-                            _basePriority = pi.BasePriority,
-                            _currentPriority = (int)stat.nice,
-                            _startAddress = (IntPtr)stat.startstack,
-                            _threadState = ProcFsStateToThreadState(stat.state),
-                            _threadWaitReason = ThreadWaitReason.Unknown
-                        });
+                            pi._threadInfoList.Add(new ThreadInfo()
+                            {
+                                _processId = pid,
+                                _threadId = (ulong)tid,
+                                _basePriority = pi.BasePriority,
+                                _currentPriority = (int)stat.nice,
+                                _startAddress = (IntPtr)(void *)stat.startstack,
+                                _threadState = ProcFsStateToThreadState(stat.state),
+                                _threadWaitReason = ThreadWaitReason.Unknown
+                            });
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Because IntPtr does not allow addresses in the range 0x80000000 to 0xFFFFFFFF
we cast the long value to Void *. Downside is that no obvious validity check is done
and we have to make some method unsafe.

See dotnet/coreclr#4062 for an attempt to fix this in mscorlib.