### PR TITLE
Improve description of build type spelling for consistency

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ usage()
     echo "native - optional argument to build the native code"
     echo "The following arguments affect native builds only:"
     echo "BuildArch can be: x64, x86, arm, arm64"
-    echo "BuildType can be: Debug, Release"
+    echo "BuildType can be: debug, release"
     echo "clean - optional argument to force a clean build."
     echo "verbose - optional argument to enable verbose build output."
     echo "clangx.y - optional argument to build using clang version x.y."


### PR DESCRIPTION
This is trivial patch. Such as coreCLR, let's display a help manual
with lower case for better consistency when the developers run
"./build.sh --help" command.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>