### PR TITLE
Improve performance of WebUtility

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -331,13 +331,28 @@ namespace System.Net
 
             // expand not 'safe' characters into %XX, spaces to +s
             byte[] expandedBytes = new byte[count + cUnsafe * 2];
+            GetEncodedBytes(bytes, offset, count, expandedBytes);
+            return expandedBytes;
+        }
+
+        private static void GetEncodedBytes(byte[] originalBytes, int offset, int count, byte[] expandedBytes)
+        {
             int pos = 0;
-
-            for (int i = 0; i < count; i++)
+            int end = offset + count;
+            Debug.Assert(offset < end && end <= originalBytes.Length);
+            for (int i = offset; i < end; i++)
             {
-                byte b = bytes[offset + i];
-                char ch = (char)b;
+#if DEBUG
+                // Make sure we never overwrite any bytes if originalBytes and
+                // expandedBytes refer to the same array
+                if (originalBytes == expandedBytes)
+                {
+                    Debug.Assert(i >= pos);
+                }
+#endif
 
+                byte b = originalBytes[i];
+                char ch = (char)b;
                 if (IsUrlSafeChar(ch))
                 {
                     expandedBytes[pos++] = b;
@@ -353,13 +368,11 @@ namespace System.Net
                     expandedBytes[pos++] = (byte)IntToHex(b & 0x0f);
                 }
             }
-
-            return expandedBytes;
         }
 
-        #endregion
+#endregion
 
-        #region UrlEncode public methods
+#region UrlEncode public methods
 
         [SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "Already shipped public API; code moved here as part of API consolidation")]
         public static string UrlEncode(string value)
@@ -367,9 +380,43 @@ namespace System.Net
             if (string.IsNullOrEmpty(value))
                 return value;
 
-            byte[] bytes = Encoding.UTF8.GetBytes(value);
-            byte[] encodedBytes = UrlEncode(bytes, 0, bytes.Length, false /* alwaysCreateNewReturnValue */);
-            return Encoding.UTF8.GetString(encodedBytes, 0, encodedBytes.Length);
+            int cSafe = 0;
+            int cSpaces = 0;
+            for (int i = 0; i < value.Length; i++)
+            {
+                char ch = value[i];
+                if (IsUrlSafeChar(ch))
+                {
+                    cSafe++;
+                }
+                else if (ch == ' ')
+                {
+                    cSpaces++;
+                }
+            }
+
+            if (cSafe == value.Length)
+            {
+                // Nothing to expand
+                return value;
+            }
+
+            int unsafeByteCount = Encoding.UTF8.GetByteCount(value) - cSafe - cSpaces;
+            int byteIndex = unsafeByteCount * 2;
+
+            // Instead of allocating one array of length Encoding.UTF8.GetByteCount(value) to store
+            // the UTF8 encoded bytes and then a second array of length 
+            // cSafe + cSpaces + 3 * (Encoding.UTF8.GetByteCount(value) - cSafe - cSpaces) 
+            // to store the URL encoded UTF8 bytes, we allocate a single array of length
+            // cSafe + cSpaces + 3 * Encoding.UTF8.GetByteCount(value), 
+            // saving Encoding.UTF8.GetByteCount(value) - 3 * (cSafe +cSpaces) bytes allocated.
+            // We encode the UTF8 to the end of this array, and then URL encode to the
+            // beginning of the array.
+            byte[] newBytes = new byte[cSafe + cSpaces + unsafeByteCount + byteIndex];
+            Encoding.UTF8.GetBytes(value, 0, value.Length, newBytes, byteIndex);
+            
+            GetEncodedBytes(newBytes, byteIndex, newBytes.Length - byteIndex, newBytes);
+            return Encoding.UTF8.GetString(newBytes);
         }
 
         public static byte[] UrlEncodeToBytes(byte[] value, int offset, int count)
@@ -377,9 +424,9 @@ namespace System.Net
             return UrlEncode(value, offset, count, true /* alwaysCreateNewReturnValue */);
         }
 
-        #endregion
+#endregion
 
-        #region UrlDecode implementation
+#region UrlDecode implementation
 
         private static string UrlDecodeInternal(string value, Encoding encoding)
         {
@@ -485,9 +532,9 @@ namespace System.Net
             return decodedBytes;
         }
 
-        #endregion
+#endregion
 
-        #region UrlDecode public methods
+#region UrlDecode public methods
 
 
         [SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "Already shipped public API; code moved here as part of API consolidation")]
@@ -501,9 +548,9 @@ namespace System.Net
             return UrlDecodeInternal(encodedValue, offset, count);
         }
 
-        #endregion
+#endregion
 
-        #region Helper methods
+#region Helper methods
 
         // similar to Char.ConvertFromUtf32, but doesn't check arguments or generate strings
         // input is assumed to be an SMP character
@@ -620,7 +667,7 @@ namespace System.Net
             return false;
         }
 
-        #endregion
+#endregion
 
         // Internal struct to facilitate URL decoding -- keeps char buffer and byte buffer, allows appending of either chars or bytes
         private struct UrlDecoder

--- a/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
@@ -69,6 +69,7 @@ namespace System.Net.Tests
 
             // No escaping needed
             yield return Tuple.Create("abc", "abc");
+            yield return Tuple.Create("", "");
             yield return Tuple.Create("Hello, world", "Hello, world");
             yield return Tuple.Create("\u1234\u2345", "\u1234\u2345");
             yield return Tuple.Create("abc\u1234\u2345def\u1234", "abc\u1234\u2345def\u1234");
@@ -86,7 +87,16 @@ namespace System.Net.Tests
             yield return Tuple.Create("/\\\"\tHello! \u2665?/\\\"\tWorld! \u2665?\u2665", "%2F%5C%22%09Hello!+%E2%99%A5%3F%2F%5C%22%09World!+%E2%99%A5%3F%E2%99%A5");
             yield return Tuple.Create("'", "%27");
             yield return Tuple.Create("\uD800\uDFFF", "%F0%90%8F%BF"); // Surrogate pairs should be encoded as 4 bytes together
-            
+
+            // No escaping needed
+            yield return Tuple.Create("abc", "abc");
+            yield return Tuple.Create("", "");
+
+            // Spaces
+            yield return Tuple.Create("abc def", "abc+def");
+            yield return Tuple.Create("    ", "++++");
+            yield return Tuple.Create("++++", "%2B%2B%2B%2B");
+
             // TODO: Uncomment this block out when dotnet/corefx#7166 is fixed.
 
             /*
@@ -237,6 +247,10 @@ namespace System.Net.Tests
                 byte[] output = Encoding.UTF8.GetBytes(tuple.Item2);
                 yield return new object[] { input, 0, input.Length, output };
             }
+            // Mixture of ASCII and non-URL safe chars (full and in a range)
+            yield return new object[] { new byte[] { 97, 225, 136, 180, 98 }, 0, 5, new byte[] { 97, 37, 69, 49, 37, 56, 56, 37, 66, 52, 98 } };
+            yield return new object[] { new byte[] { 97, 225, 136, 180, 98 }, 1, 3, new byte[] { 37, 69, 49, 37, 56, 56, 37, 66, 52 } };
+
             yield return new object[] { null, 0, 0, null };
         }
 


### PR DESCRIPTION
## Summary
No escaping needed:
- x5 performance improvement
- 0 allocations

Basic escaping needed (single char):
- 20% performance improvement
- Allocations cut by a third

Advanced escaping needed (surrogate pair):
- 15% performance improvement
- Allocations cut by a third

## Benchmark Results
- No breaking change in behaviour in these validation tests
- Times measured in seconds

![benchmark](https://cloud.githubusercontent.com/assets/1275900/14318468/e4ba70d0-fc04-11e5-8a42-3604666dbab3.png)

## Benchmark Code and !!Validation Tests!!
- **To ensure there were no breaking changes** I ran the new output against the old output for every single char and surrogate pair in the UTF16 plane.
```c#
static unsafe void Main(string[] args)
{
    PerformanceTests();
    VerificationTests();    
    Console.ReadLine();
}

private static void PerformanceTests()
{
    Console.WriteLine("**** MEASURE NO ESCAPING ****");
    TimeAction("Old: ", () => Old.UrlEncode("abcxyz"));
    TimeAction("New: ", () => New.UrlEncode("abcxyz"));

    Console.WriteLine("**** MEASURE SPACES ****");
    TimeAction("Old: ", () => Old.UrlEncode("abc xyz"));
    TimeAction("New: ", () => New.UrlEncode("abc xyz"));

    Console.WriteLine("**** MEASURE ESCAPING 1 TIMES ****");
    TimeAction("Old: ", () => Old.UrlEncode("\u007F"));
    TimeAction("New: ", () => New.UrlEncode("\u007F"));

    Console.WriteLine("**** MEASURE ESCAPING 2 TIMES ****");
    TimeAction("Old: ", () => Old.UrlEncode("\u07FF"));
    TimeAction("New: ", () => New.UrlEncode("\u07FF"));

    Console.WriteLine("**** MEASURE ESCAPING 3 TIMES ****");
    TimeAction("Old: ", () => Old.UrlEncode("\u1234"));
    TimeAction("New: ", () => New.UrlEncode("\u1234"));

    Console.WriteLine("**** MEASURE ESCAPING SURROGATE PAIR ****");
    TimeAction("Old: ", () => Old.UrlEncode("\uD801\uDC37"));
    TimeAction("New: ", () => New.UrlEncode("\uD801\uDC37"));
}

public static void TimeAction(string prefix, Action action)
{
    action();
    GC.Collect();

    var sw = new Stopwatch();
    for (int iter = 0; iter < 5; iter++)
    {
        int gen0 = GC.CollectionCount(0);
        sw.Restart();
        for (int i = 0; i < 100000000; i++)
        {
            action();
        }
        sw.Stop();
        Console.WriteLine($"{prefix}Time: {sw.Elapsed.TotalSeconds}\tGC0: {GC.CollectionCount(0) - gen0}");
    }
}

private static void VerificationTests()
{
    for (int i = 0; i < char.MaxValue; i++)
    {
        char c = (char)i;

        string oldString = Old.UrlEncode(c.ToString());
        string newString = New.UrlEncode(c.ToString());
        if (!oldString.Equals(newString))
        {
            Console.WriteLine($"FAIL for char {i}. Expected: {oldString}. Actual: {newString}");
        }
    }
    for (int i = 0x10000; i < 0x10FFFF; i++)
    {
        string utf32 = char.ConvertFromUtf32(i);
        string oldString = Old.UrlEncode(utf32);
        string newString = New.UrlEncode(utf32);
        if (!oldString.Equals(newString))
        {
            Console.WriteLine($"FAIL for char {i}. Expected: {oldString}. Actual: {newString}");
        }
    }
    Console.WriteLine("Passes Validation Tests");
}
```

/cc @davidsh, @stephentoub, @jamesqo