### PR TITLE
Disable errors for incorrect Pinvoke calls

### DIFF
--- a/src/System.Reflection.Metadata/src/PinvokeAnalyzerExceptionList.analyzerdata
+++ b/src/System.Reflection.Metadata/src/PinvokeAnalyzerExceptionList.analyzerdata
@@ -1,3 +1,0 @@
-<!-- This PInvoke is allowed on Windows, however the DLL is built as AnyCPU. -->
-<!-- To remove the error, consider building only for Windows, or remove the PInvoke dependency. -->
-api-ms-win-core-file-l1-1-0.dll!ReadFile

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.cs
@@ -142,6 +142,9 @@ namespace System.Reflection.Internal
             return true;
         }
 
+
+// The library guards against unavailable entrypoints by using EntryPointNotFoundException.
+#pragma warning disable BCL0015 // Diasable Pinvoke analyzer errors.
         private static unsafe class NativeMethods
         {
             // API sets available on modern platforms:
@@ -156,7 +159,7 @@ namespace System.Reflection.Internal
             );
 
             // older Windows systems:
-            [DllImport(@"api-ms-win-core-file-l1-1-0.dll", EntryPoint = "ReadFile", ExactSpelling = true, SetLastError = true)]
+            [DllImport(@"kernel32.dll", EntryPoint = "ReadFile", ExactSpelling = true, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
             internal static extern bool ReadFileCompat(
                  SafeHandle fileHandle,
@@ -166,5 +169,6 @@ namespace System.Reflection.Internal
                  IntPtr overlapped
             );
         }
+#pragma warning restore BCL0015
     }
 }


### PR DESCRIPTION
This change disables Pinvoke errors for System.Reflection.Metadata 