### PR TITLE
Add /usr/local/include back to the include path on OSX.

### DIFF
--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -11,6 +11,10 @@ if (CMAKE_SYSTEM_NAME STREQUAL Linux)
     set(PAL_UNIX_NAME \"LINUX\")
 elseif (CMAKE_SYSTEM_NAME STREQUAL Darwin)
     set(PAL_UNIX_NAME \"OSX\")
+
+    # Xcode's clang does not include /usr/local/include by default, but brew's does.
+    # This ensures an even playing field.
+    include_directories(SYSTEM /usr/local/include)
 elseif (CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
     set(PAL_UNIX_NAME \"FREEBSD\")
     include_directories(SYSTEM /usr/local/include)


### PR DESCRIPTION
/usr/local/include used to be unconditionally added to the include path, then it was
moved into a FreeBSD-specific path. On OSX this directive was needed when building with
the Xcode-provided copy of clang; but not the brew-provided copy of clang.

By always adding it to the include path on OSX we're not making any assumptions about where
the user got clang from.

Fixes #7496.
cc: @stephentoub @ellismg 

(Verified on my macbook, OSX 10.11 with Xcode's clang)