### PR TITLE
Convert ReusableTextReader to be a struct

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
@@ -23,7 +23,7 @@ namespace System.Diagnostics
                 processName = string.Empty;
             }
 
-            var reusableReader = new ReusableTextReader();
+            var reusableReader = new ReusableTextReader(Encoding.UTF8);
             var processes = new List<Process>();
             foreach (int pid in ProcessManager.EnumerateProcessIds())
             {
@@ -194,7 +194,7 @@ namespace System.Diagnostics
         {
             EnsureState(State.HaveId);
             Interop.procfs.ParsedStat stat;
-            if (!Interop.procfs.TryReadStatFile(_processId, out stat, new ReusableTextReader()))
+            if (!Interop.procfs.TryReadStatFile(_processId, out stat, new ReusableTextReader(Encoding.UTF8)))
             {
                 throw new Win32Exception(SR.ProcessInformationUnavailable);
             }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -26,7 +26,7 @@ namespace System.Diagnostics
             int[] procIds = GetProcessIds(machineName);
 
             // Iterate through all process IDs to load information about each process
-            var reusableReader = new ReusableTextReader();
+            var reusableReader = new ReusableTextReader(Encoding.UTF8);
             var processes = new List<ProcessInfo>(procIds.Length);
             foreach (int pid in procIds)
             {
@@ -88,13 +88,8 @@ namespace System.Diagnostics
         /// <summary>
         /// Creates a ProcessInfo from the specified process ID.
         /// </summary>
-        internal static ProcessInfo CreateProcessInfo(int pid, ReusableTextReader reusableReader = null)
+        internal static ProcessInfo CreateProcessInfo(int pid, ReusableTextReader reusableReader)
         {
-            if (reusableReader == null)
-            {
-                reusableReader = new ReusableTextReader();
-            }
-
             Interop.procfs.ParsedStat stat;
             return Interop.procfs.TryReadStatFile(pid, out stat, reusableReader) ?
                 CreateProcessInfo(stat, reusableReader) :

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -81,12 +81,20 @@ namespace System.Diagnostics
             return modules.ToArray();
         }
 
+        /// <summary>
+        /// Creates a ProcessInfo from the specified process ID.
+        /// </summary>
+        internal static ProcessInfo CreateProcessInfo(int pid)
+        {
+            return CreateProcessInfo(pid, new ReusableTextReader(Encoding.UTF8));
+        }
+
         // -----------------------------
         // ---- PAL layer ends here ----
         // -----------------------------
 
         /// <summary>
-        /// Creates a ProcessInfo from the specified process ID.
+        /// Creates a ProcessInfo from the specified process ID and ReusableTextReader.
         /// </summary>
         internal static ProcessInfo CreateProcessInfo(int pid, ReusableTextReader reusableReader)
         {


### PR DESCRIPTION
Since the `ReusableTextReader` class in Common is sealed with all-readonly fields, it looks like it could be converted to a struct (the field references are copied, not the contents themselves). I've changed the type declaration to be a struct in this PR, as well as modifying all call sites that used the parameterless constructor.

Here is a list of all the places it's being used currently (all in System.Diagnostics.Process): https://github.com/dotnet/corefx/search?utf8=%E2%9C%93&q=ReusableTextReader

cc @stephentoub