### PR TITLE
Disable per-merge FreeBSD Jenkins runs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -12,7 +12,6 @@ def osGroupMap = ['Ubuntu':'Linux',
                   'Debian8.2':'Linux',
                   'OSX':'OSX',
                   'Windows_NT':'Windows_NT',
-                  'FreeBSD':'FreeBSD',
                   'CentOS7.1': 'Linux',
                   'OpenSUSE13.2': 'Linux',
                   'RHEL7.2': 'Linux']
@@ -21,7 +20,6 @@ def targetNugetRuntimeMap = ['OSX' : 'osx.10.10-x64',
                              'Ubuntu' : 'ubuntu.14.04-x64',
                              'Ubuntu15.10' : 'ubuntu.14.04-x64',
                              'Debian8.2' : 'ubuntu.14.04-x64',
-                             'FreeBSD' : 'ubuntu.14.04-x64',
                              'CentOS7.1' : 'centos.7-x64',
                              'OpenSUSE13.2' : 'ubuntu.14.04-x64',
                              'RHEL7.2': 'rhel.7-x64']
@@ -462,7 +460,7 @@ branchList.each { branchName ->
 // and then a build for the test of corefx on the target platform.  Then we link them with a build
 // flow job.
 
-def innerLoopNonWindowsOSs = ['Ubuntu', 'Ubuntu15.10', 'Debian8.2', 'OSX', 'FreeBSD', 'CentOS7.1', 'OpenSUSE13.2', 'RHEL7.2']
+def innerLoopNonWindowsOSs = ['Ubuntu', 'Ubuntu15.10', 'Debian8.2', 'OSX', 'CentOS7.1', 'OpenSUSE13.2', 'RHEL7.2']
 branchList.each { branchName ->
     ['Debug', 'Release'].each { configurationGroup ->
         innerLoopNonWindowsOSs.each { os ->


### PR DESCRIPTION
The FreeBSD build has been on the floor for a while (not surpursing
given that we never had a badge in README.md). The native components
build has been broken since the NegotiateStream work was merged (maybe
just due to missing components in our FreeBSD images or maybe due to a
larger issue) and I don't believe the CoreFX test leg was ever clean.

Feels wasteful to spend machine time testing something that's always
broken and we aren't paying attention to.

If the FreeBSD port team wants to help us get the native build off the
floor, we should consider at least adding native legs back per
merge (and putting them on README.md in a work in progress section) so
we can at least stay clean there.

We'll continue to build CoreCLR on FreeBSD and the images will remain in
Jenkins for when we want to try to enable some of this stuff in the future.