### PR TITLE
Add a few GCSettings tests

### DIFF
--- a/src/System.Runtime/tests/System/GC.cs
+++ b/src/System.Runtime/tests/System/GC.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime;
 using Xunit;
 
 public static class GCTests
@@ -355,6 +356,44 @@ public static class GCTests
         {
             Assert.InRange(GC.GetGeneration(obj), 0, GC.MaxGeneration);
             GC.Collect();
+        }
+    }
+
+    [Theory]
+    [InlineData(GCLargeObjectHeapCompactionMode.CompactOnce)]
+    [InlineData(GCLargeObjectHeapCompactionMode.Default)]
+    public static void TestLargeObjectHeapCompactionModeRoundTrips(GCLargeObjectHeapCompactionMode value)
+    {
+        GCLargeObjectHeapCompactionMode orig = GCSettings.LargeObjectHeapCompactionMode;
+        try
+        {
+            GCSettings.LargeObjectHeapCompactionMode = value;
+            Assert.Equal(value, GCSettings.LargeObjectHeapCompactionMode);
+        }
+        finally
+        {
+            GCSettings.LargeObjectHeapCompactionMode = orig;
+            Assert.Equal(orig, GCSettings.LargeObjectHeapCompactionMode);
+        }
+    }
+
+    [Theory]
+    [InlineData(GCLatencyMode.Batch)]
+    [InlineData(GCLatencyMode.Interactive)]
+    //[InlineData(GCLatencyMode.LowLatency)] Concurent GC is not enabled on Unix
+    //[InlineData(GCLatencyMode.SustainedLowLatency)] 
+    public static void TestLatencyRoundtrips(GCLatencyMode value)
+    {
+        GCLatencyMode orig = GCSettings.LatencyMode;
+        try
+        {
+            GCSettings.LatencyMode = value;
+            Assert.Equal(value, GCSettings.LatencyMode);
+        }
+        finally
+        {
+            GCSettings.LatencyMode = orig;
+            Assert.Equal(orig, GCSettings.LatencyMode);
         }
     }
 }

--- a/src/System.Runtime/tests/System/GC.cs
+++ b/src/System.Runtime/tests/System/GC.cs
@@ -380,8 +380,6 @@ public static class GCTests
     [Theory]
     [InlineData(GCLatencyMode.Batch)]
     [InlineData(GCLatencyMode.Interactive)]
-    //[InlineData(GCLatencyMode.LowLatency)] Concurent GC is not enabled on Unix
-    //[InlineData(GCLatencyMode.SustainedLowLatency)] 
     public static void TestLatencyRoundtrips(GCLatencyMode value)
     {
         GCLatencyMode orig = GCSettings.LatencyMode;
@@ -396,4 +394,10 @@ public static class GCTests
             Assert.Equal(orig, GCSettings.LatencyMode);
         }
     }
+
+    [Theory]
+    [PlatformSpecific(PlatformID.Windows)] //Concurent GC is not enabled on Unix. Recombine to TestLatencyRoundTrips once addressed.
+    [InlineData(GCLatencyMode.LowLatency)]
+    [InlineData(GCLatencyMode.SustainedLowLatency)]
+    public static void TestLatencyRoundtrips_LowLatency(GCLatencyMode value) => TestLatencyRoundtrips(value);
 }


### PR DESCRIPTION
Tests round-tripping for GCSettings properties.

Taken from the tests in ```QA\ToF\tests\FX\GC```, though there are a number of tests present there that are far more in depth than these. I won't be disabling those tests without the go-ahead from someone more familiar with the GC.