### PR TITLE
Move PerfTesting.targets to build.proj

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -29,6 +29,7 @@
     <GenerateCodeCoverageReportForAll>true</GenerateCodeCoverageReportForAll>
   </PropertyGroup>
   <Import Project="$(ToolsDir)CodeCoverage.targets" Condition="Exists('$(ToolsDir)CodeCoverage.targets')" />
+  <Import Project="$(ToolsDir)PerfTesting.targets" Condition="Exists('$(ToolsDir)PerfTesting.targets') and '$(Performance)' == 'true'"/>
 
   <ItemGroup>
     <Project Include="src\dirs.proj">

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -19,8 +19,6 @@
     </TraversalBuildDependsOn>
   </PropertyGroup>
 
-  <Import Project="$(ToolsDir)PerfTesting.targets" Condition="Exists('$(ToolsDir)PerfTesting.targets')" />
-
   <PropertyGroup Condition="Exists('$(ToolsDir)toolruntime.targets')">
     <TraversalBuildDependsOn>
       EnsureBuildToolsRuntime;


### PR DESCRIPTION
With change #7237 , we started building the tests in build.proj instead of dirs.proj. For consistency, I move PerfTesting.targets to build.proj too.

cc: @weshaggard @dsgouda