### PR TITLE
Add support for filtering building of packages based on Linux variants.

### DIFF
--- a/build-packages.cmd
+++ b/build-packages.cmd
@@ -6,7 +6,7 @@ set binclashLoggerDll=%~dp0Tools\net45\Microsoft.DotNet.Build.Tasks.dll
 set binclashlog=%~dp0binclash.log
 echo Running build-packages.cmd %* > %packagesLog%
 
-set options=/nologo /maxcpucount /v:minimal /clp:Summary /nodeReuse:false /flp:v=detailed;Append;LogFile=%packagesLog% /l:BinClashLogger,%binclashLoggerDll%;LogFile=%binclashlog%
+set options=/nologo /maxcpucount /v:minimal /clp:Summary /nodeReuse:false /flp:v=detailed;Append;LogFile=%packagesLog% /l:BinClashLogger,%binclashLoggerDll%;LogFile=%binclashlog% /p:FilterToOSGroup=Windows_NT
 set allargs=%*
 
 if /I [%1] == [/?] goto Usage

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -32,11 +32,14 @@
         <AdditionalProperties Condition="'%(Project.InputOSGroup)' != ''">InputOSGroup=%(Project.InputOSGroup);%(Project.AdditionalProperties)</AdditionalProperties>
       </Project>
       <Project>
+        <AdditionalProperties Condition="'%(Project.BuildAllOSGroups)' != ''">BuildAllOSGroups=%(Project.BuildAllOSGroups);%(Project.AdditionalProperties)</AdditionalProperties>
+      </Project>
+      <Project>
         <!-- If a project isn't setting the OSGroup via metadata then undefine it so that the globally set OSGroup doesn't override empty OSGroup -->
         <UndefineProperties Condition="'%(Project.OSGroup)'==''">%(Project.UndefineProperties);OSGroup</UndefineProperties>
       </Project>
       <Project>
-        <UndefineProperties Condition="'%(Project.Extension)'!='.builds' and '%(Project.Extension)'!='.proj'">%(Project.UndefineProperties);FilterToOSGroup;DefaultBuildAllTarget;SerializeProjects</UndefineProperties>
+        <UndefineProperties Condition="'%(Project.Extension)'!='.builds' and '%(Project.Extension)'!='.proj'">%(Project.UndefineProperties);FilterToOSGroup;DefaultBuildAllTarget;SerializeProjects;BuildAllOSGroups</UndefineProperties>
       </Project>
     </ItemGroup>
 
@@ -54,7 +57,7 @@
       <OSGroupList Condition="'$(FilterToOSGroup)'=='FreeBSD'">$(OSGroupList);Unix;</OSGroupList>
       <OSGroupList Condition="'$(FilterToOSGroup)'=='NetBSD'">$(OSGroupList);Unix;</OSGroupList>
     </PropertyGroup>
- 
+
     <ItemGroup Condition="'$(FilterToOSGroup)'!='' and '$(BuildAllOSGroups)' != 'true'">
       <ProjectsToBuild Include="@(Project)" Condition="$(OSGroupList.Contains('%(Project.OSGroup);'))" />
  

--- a/src/Native/pkg/dir.props
+++ b/src/Native/pkg/dir.props
@@ -1,9 +1,16 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.props))\dir.props" />
+  <!-- coalesce RIDs into the correct build output directory -->
+  <PropertyGroup>
+    <OSGroupPath Condition="$(OSGroup.StartsWith('debian'))">Linux</OSGroupPath>
+    <OSGroupPath Condition="$(OSGroup.StartsWith('osx'))">OSX</OSGroupPath>
+    <OSGroupPath Condition="$(OSGroup.StartsWith('rhel'))">Linux</OSGroupPath>
+    <OSGroupPath Condition="$(OSGroup.StartsWith('ubuntu'))">Linux</OSGroupPath>
+  </PropertyGroup>
   <PropertyGroup>
     <!-- common properties that point to output of native build.  Can be overriden in case of 
          a coordinating build that produces all packages from OS-specific native builds -->
-    <BuildNativePath Condition="'$(BuildNativePath)' == ''">$(BinDir)$(OSGroup).$(PackagePlatform).$(ConfigurationGroup)\Native\</BuildNativePath>
+    <BuildNativePath Condition="'$(BuildNativePath)' == ''">$(BinDir)$(OSGroupPath).$(PackagePlatform).$(ConfigurationGroup)\Native\</BuildNativePath>
     <WinNativePath Condition="'$(WinNativePath)' == ''">$(BuildNativePath)</WinNativePath>
     <RHELNativePath Condition="'$(RHELNativePath)' == ''">$(BuildNativePath)</RHELNativePath>
     <DebianNativePath Condition="'$(DebianNativePath)' == ''">$(BuildNativePath)</DebianNativePath>

--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.builds
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.builds
@@ -14,4 +14,3 @@
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
-

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
@@ -4,23 +4,19 @@
   <ItemGroup>
     <Project Include="runtime.native.System.IO.Compression.pkgproj"/>
     <Project Include="rhel\runtime.native.System.IO.Compression.pkgproj">
-      <!-- currently we build both "rhel" and "ubuntu" packages on Linux,
-           but will only publish one of the packages based on what OS we
-           were actually building on.  
-           Remove this when fixing https://github.com/dotnet/corefx/issues/5190 -->
-      <OSGroup>Linux</OSGroup>
+      <OSGroup>rhel.7</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="debian\runtime.native.System.IO.Compression.pkgproj">
-      <OSGroup>Linux</OSGroup>
+      <OSGroup>debian.8</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="ubuntu\runtime.native.System.IO.Compression.pkgproj">
-      <OSGroup>Linux</OSGroup>
+      <OSGroup>ubuntu.14.04</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="osx\runtime.native.System.IO.Compression.pkgproj">
-      <OSGroup>OSX</OSGroup>
+      <OSGroup>osx.10.10</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="win7\runtime.native.System.IO.Compression.pkgproj">

--- a/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.builds
+++ b/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.builds
@@ -4,23 +4,19 @@
   <ItemGroup>
     <Project Include="runtime.native.System.Net.Http.pkgproj"/>
     <Project Include="rhel\runtime.native.System.Net.Http.pkgproj">
-      <!-- currently we build both "rhel" and "ubuntu" packages on Linux,
-           but will only publish one of the packages based on what OS we
-           were actually building on.  
-           Remove this when fixing https://github.com/dotnet/corefx/issues/5190 -->
-      <OSGroup>Linux</OSGroup>
+      <OSGroup>rhel.7</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="debian\runtime.native.System.Net.Http.pkgproj">
-      <OSGroup>Linux</OSGroup>
+      <OSGroup>debian.8</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="ubuntu\runtime.native.System.Net.Http.pkgproj">
-      <OSGroup>Linux</OSGroup>
+      <OSGroup>ubuntu.14.04</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="osx\runtime.native.System.Net.Http.pkgproj">
-      <OSGroup>OSX</OSGroup>
+      <OSGroup>osx.10.10</OSGroup>
       <Platform>amd64</Platform>
     </Project>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.builds
+++ b/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.builds
@@ -4,23 +4,19 @@
   <ItemGroup>
     <Project Include="runtime.native.System.Net.Security.pkgproj"/>
     <Project Include="rhel\runtime.native.System.Net.Security.pkgproj">
-      <!-- currently we build both "rhel" and "ubuntu" packages on Linux,
-           but will only publish one of the packages based on what OS we
-           were actually building on.
-           Remove this when fixing https://github.com/dotnet/corefx/issues/5190 -->
-      <OSGroup>Linux</OSGroup>
+      <OSGroup>rhel.7</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="debian\runtime.native.System.Net.Security.pkgproj">
-      <OSGroup>Linux</OSGroup>
+      <OSGroup>debian.8</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="ubuntu\runtime.native.System.Net.Security.pkgproj">
-      <OSGroup>Linux</OSGroup>
+      <OSGroup>ubuntu.14.04</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="osx\runtime.native.System.Net.Security.pkgproj">
-      <OSGroup>OSX</OSGroup>
+      <OSGroup>osx.10.10</OSGroup>
       <Platform>amd64</Platform>
     </Project>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.builds
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.builds
@@ -4,23 +4,19 @@
   <ItemGroup>
     <Project Include="runtime.native.System.Security.Cryptography.pkgproj"/>
     <Project Include="rhel\runtime.native.System.Security.Cryptography.pkgproj">
-      <!-- currently we build both "rhel" and "ubuntu" packages on Linux,
-           but will only publish one of the packages based on what OS we
-           were actually building on.  
-           Remove this when fixing https://github.com/dotnet/corefx/issues/5190 -->
-      <OSGroup>Linux</OSGroup>
+      <OSGroup>rhel.7</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="debian\runtime.native.System.Security.Cryptography.pkgproj">
-      <OSGroup>Linux</OSGroup>
+      <OSGroup>debian.8</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="ubuntu\runtime.native.System.Security.Cryptography.pkgproj">
-      <OSGroup>Linux</OSGroup>
+      <OSGroup>ubuntu.14.04</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="osx\runtime.native.System.Security.Cryptography.pkgproj">
-      <OSGroup>OSX</OSGroup>
+      <OSGroup>osx.10.10</OSGroup>
       <Platform>amd64</Platform>
     </Project>
   </ItemGroup>

--- a/src/Native/pkg/runtime.native.System/runtime.native.System.builds
+++ b/src/Native/pkg/runtime.native.System/runtime.native.System.builds
@@ -4,23 +4,19 @@
   <ItemGroup>
     <Project Include="runtime.native.System.pkgproj"/>
     <Project Include="rhel\runtime.native.System.pkgproj">
-      <!-- currently we build both "rhel" and "ubuntu" packages on Linux,
-           but will only publish one of the packages based on what OS we
-           were actually building on.  
-           Remove this when fixing https://github.com/dotnet/corefx/issues/5190 -->
-      <OSGroup>Linux</OSGroup>
+      <OSGroup>rhel.7</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="debian\runtime.native.System.pkgproj">
-      <OSGroup>Linux</OSGroup>
+      <OSGroup>debian.8</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="ubuntu\runtime.native.System.pkgproj">
-      <OSGroup>Linux</OSGroup>
+      <OSGroup>ubuntu.14.04</OSGroup>
       <Platform>amd64</Platform>
     </Project>
     <Project Include="osx\runtime.native.System.pkgproj">
-      <OSGroup>OSX</OSGroup>
+      <OSGroup>osx.10.10</OSGroup>
       <Platform>amd64</Platform>
     </Project>
   </ItemGroup>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -5,11 +5,13 @@
   <PropertyGroup>
     <AdditionalProperties>BuildPackageLibraryReferences=false</AdditionalProperties>
     <PackageReportDir Condition="'$(PackageReportDir)' == ''">$(BinDir)pkg/reports/</PackageReportDir>
+    <BuildAllOSGroups Condition="'$(FilterToOSGroup)' != ''">false</BuildAllOSGroups>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Project Include="Native\pkg\**\*.builds" Condition="'$(SkipNativePackageBuild)' != 'true'">
       <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+      <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
     </Project>
     <Project Include="*\pkg\*.builds" Condition="'$(SkipManagedPackageBuild)' != 'true'">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>


### PR DESCRIPTION
When building native Linux packages we need the ability to build the
packages specific to the distro on which we're building.  I have
overloaded the OSGroup property to specify the Linux distro to which
a package build belongs so the other distros get filtered out.