### PR TITLE
BOOL result should be compared against FALSE

### DIFF
--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/Win32.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/Win32.cs
@@ -132,7 +132,7 @@ namespace System.Security.Principal
 
             try
             {
-                if (TRUE != Interop.mincore.ConvertStringSidToSid(stringSid, out ByteArray))
+                if (FALSE == Interop.mincore.ConvertStringSidToSid(stringSid, out ByteArray))
                 {
                     ErrorCode = Marshal.GetLastWin32Error();
                     goto Error;


### PR DESCRIPTION
No behavior change, this makes code more reliable and conformant to common WinAPI contracts.

This resolves https://github.com/dotnet/corefx/issues/7545