### PR TITLE
Fix signing workaround when building on Linux

### DIFF
--- a/src/System.Globalization.Calendars/tests/System.Globalization.Calendars.Tests.csproj
+++ b/src/System.Globalization.Calendars/tests/System.Globalization.Calendars.Tests.csproj
@@ -139,7 +139,7 @@
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   
-  <PropertyGroup Condition="'$(TargetGroup)' == 'net46'">
+  <PropertyGroup Condition="'$(OSEnvironment)' == 'Windows_NT'">
     <DelaySign>false</DelaySign>
   </PropertyGroup>
 </Project>

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -152,7 +152,7 @@
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 
-  <PropertyGroup Condition="'$(TargetGroup)' == 'net46'">
+  <PropertyGroup Condition="'$(OSEnvironment)' == 'Windows_NT'">
     <DelaySign>false</DelaySign>
   </PropertyGroup>
 


### PR DESCRIPTION
When building on Linux machines we shouldn't enable the signing as this is not working today. after we introduced .builds files we started to build Windows flavour on Linux machines which break on
the projects explicitly use signing