### PR TITLE
SqlClient: Avoid StringBuilder interop marshalling overhead

### DIFF
--- a/src/System.Data.SqlClient/src/Interop/LocaleMapper.Windows.cs
+++ b/src/System.Data.SqlClient/src/Interop/LocaleMapper.Windows.cs
@@ -1,10 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace System.Data
 {
@@ -22,25 +22,26 @@ namespace System.Data
         private static extern int GetLocaleInfoEx(string lpLocaleName, uint LCType, [Out] out uint lpLCData, int cchData);
 
         [DllImport(ApiWinCoreLocalizationObsolete, SetLastError = true, CharSet = CharSet.Unicode)]
-        private static extern int LCIDToLocaleName(uint Locale, StringBuilder lpName, int cchName, int dwFlags);
+        private static extern unsafe int LCIDToLocaleName(uint Locale, char* lpName, int cchName, int dwFlags);
 
         [DllImport(ApiWinCoreLocalization, SetLastError = true, CharSet = CharSet.Unicode)]
         private static extern uint LocaleNameToLCID(string lpName, uint dwFlags);
 
 
-        public static string LcidToLocaleNameInternal(int lcid)
+        public static unsafe string LcidToLocaleNameInternal(int lcid)
         {
-            StringBuilder localName = new StringBuilder(LOCALE_NAME_MAX_LENGTH);
+            char* localeName = stackalloc char[LOCALE_NAME_MAX_LENGTH];
+            int length = LCIDToLocaleName(unchecked((uint)lcid), localeName, LOCALE_NAME_MAX_LENGTH, 0);
 
-            if (LCIDToLocaleName(unchecked((uint)lcid), localName, localName.Capacity, 0) != 0)
+            if (length != 0)
             {
-                return localName.ToString();
+                return new string(localeName, 0, length - 1);
             }
             else
             {
                 // LCIDToLocaleName should not return any other errors if we have sufficient buffer space
                 int win32Error = Marshal.GetLastWin32Error();
-                Debug.Assert(win32Error == ERROR_INVALID_PARAMETER, string.Format("Unknown error returned by LCIDToLocaleName: {0}. Lcid: {1}", win32Error, lcid));
+                Debug.Assert(win32Error == ERROR_INVALID_PARAMETER, $"Unknown error returned by {nameof(LCIDToLocaleName)}: {win32Error}. Lcid: {lcid}");
 
                 throw new CultureNotFoundException(nameof(lcid), lcid.ToString(), message: null);
             }
@@ -57,7 +58,7 @@ namespace System.Data
             {
                 // GetLocaleInfoEx should not return any other errors if we have sufficient buffer space
                 int win32Error = Marshal.GetLastWin32Error();
-                Debug.Assert(win32Error == ERROR_INVALID_PARAMETER, string.Format("Unknown error returned by GetLocaleInfoEx: {0}. LocaleName: {1}", win32Error, localeName));
+                Debug.Assert(win32Error == ERROR_INVALID_PARAMETER, $"Unknown error returned by {nameof(GetLocaleInfoEx)}: {win32Error}. LocaleName: {localeName}");
 
                 throw new CultureNotFoundException(nameof(localeName), localeName, message: null);
             }
@@ -76,11 +77,10 @@ namespace System.Data
             {
                 // LocaleNameToLCID should not return any other errors
                 int win32Error = Marshal.GetLastWin32Error();
-                Debug.Assert(win32Error == ERROR_INVALID_PARAMETER, string.Format("Unknown error returned by LocaleNameToLCID: {0}. LocaleName: {1}", win32Error, localeName));
+                Debug.Assert(win32Error == ERROR_INVALID_PARAMETER, $"Unknown error returned by {nameof(LocaleNameToLCID)}: {win32Error}. LocaleName: {localeName}");
 
                 throw new CultureNotFoundException(nameof(localeName), localeName, message: null);
             }
         }
-        
     }
 }

--- a/src/System.Data.SqlClient/src/System/Data/Locale/LocaleMapper.Unix.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Locale/LocaleMapper.Unix.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace System.Data
@@ -450,7 +451,13 @@ namespace System.Data
 
         public static string LcidToLocaleNameInternal(int lcid)
         {
-            return s_mapper[lcid].LocaleName;
+            LocaleCodePage value;
+            if (s_mapper.TryGetValue(lcid, out value))
+            {
+                return value.LocaleName;
+            }
+
+            throw new CultureNotFoundException(nameof(lcid), lcid.ToString(), message: null);
         }
 
         public static int LocaleNameToAnsiCodePage(string localeName)

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlStringTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlStringTest.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Data.SqlTypes;
+using System.Globalization;
+
+using Xunit;
+
+namespace System.Data.SqlClient.Tests
+{
+    public class SqlStringTest
+    {
+        private const SqlCompareOptions DefaultOptions =
+            SqlCompareOptions.IgnoreCase | SqlCompareOptions.IgnoreKanaType | SqlCompareOptions.IgnoreWidth;
+
+        [Fact]
+        public void Constructor_Value_Success()
+        {
+            const string value = "foo";
+            ValidateProperties(value, CultureInfo.CurrentCulture, new SqlString(value));
+        }
+
+        [Theory]
+        [InlineData(1033, "en-US")]
+        [InlineData(1036, "fr-FR")]
+        public void Constructor_ValueLcid_Success(int lcid, string name)
+        {
+            const string value = "foo";
+            ValidateProperties(value, new CultureInfo(name), new SqlString(value, lcid));
+        }
+
+        private static void ValidateProperties(string value, CultureInfo culture, SqlString sqlString)
+        {
+            Assert.Same(value, sqlString.Value);
+            Assert.False(sqlString.IsNull);
+            Assert.Equal(DefaultOptions, sqlString.SqlCompareOptions);
+            Assert.Equal(culture, sqlString.CultureInfo);
+            Assert.Equal(culture.CompareInfo, sqlString.CompareInfo);
+        }
+
+        [Fact]
+        public void CultureInfo_InvalidLcid_Throws()
+        {
+            const string value = "foo";
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => new SqlString(value, int.MinValue).CultureInfo);
+            Assert.Throws<ArgumentOutOfRangeException>(() => new SqlString(value, -1).CultureInfo);
+
+            Assert.Throws<CultureNotFoundException>(() => new SqlString(value, int.MaxValue).CultureInfo);
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <Compile Include="ExceptionTest.cs" />
     <Compile Include="SqlBulkCopyColumnMappingCollectionTest.cs" />
+    <Compile Include="SqlStringTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Data.SqlClient.csproj"> 


### PR DESCRIPTION
Use a stack allocated `char*` instead of `StringBuilder` when pinvoking `LCIDToLocaleName` to avoid `StringBuilder` marshalling costs and unnecessary heap allocations.

Also some minor cleanup: use interpolated strings instead of `string.Format` for `Debug.Assert` messages while making changes here.

cc: @saurabh500