### PR TITLE
Use IntPtr-based file descriptors exclusively, in native calls from Sockets code.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.Accept.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Accept.cs
@@ -9,24 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Accept")]
-        private static extern unsafe Error DangerousAccept(int socket, byte* socketAddress, int* socketAddressLen, int* acceptedFd);
-
-        internal static unsafe Error Accept(SafeHandle socket, byte* socketAddress, int* socketAddressLen, int* acceptedFd)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousAccept((int)socket.DangerousGetHandle(), socketAddress, socketAddressLen, acceptedFd);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Accept_IntPtr")]
+        internal static extern unsafe Error Accept(SafeHandle socket, byte* socketAddress, int* socketAddressLen, IntPtr* acceptedFd);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Bind.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Bind.cs
@@ -9,24 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Bind")]
-        private static extern unsafe Error DangerousBind(int socket, byte* socketAddress, int socketAddressLen);
-
-        internal static unsafe Error Bind(SafeHandle socket, byte* socketAddress, int socketAddressLen)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousBind((int)socket.DangerousGetHandle(), socketAddress, socketAddressLen);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Bind_IntPtr")]
+        internal static extern unsafe Error Bind(SafeHandle socket, byte* socketAddress, int socketAddressLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Connect.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Connect.cs
@@ -9,24 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Connect")]
-        private static extern unsafe Error DangerousConnect(int socket, byte* socketAddress, int socketAddressLen);
-
-        internal static unsafe Error Connect(SafeHandle socket, byte* socketAddress, int socketAddressLen)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousConnect((int)socket.DangerousGetHandle(), socketAddress, socketAddressLen);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Connect_IntPtr")]
+        internal static extern unsafe Error Connect(SafeHandle socket, byte* socketAddress, int socketAddressLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetBytesAvailable.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetBytesAvailable.cs
@@ -9,24 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetBytesAvailable")]
-        private static extern unsafe Error DangerousGetBytesAvailable(int socket, int* available);
-
-        internal static unsafe Error GetBytesAvailable(SafeHandle socket, int* available)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousGetBytesAvailable((int)socket.DangerousGetHandle(), available);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetBytesAvailable_IntPtr")]
+        internal static extern unsafe Error GetBytesAvailable(SafeHandle socket, int* available);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetPeerName.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetPeerName.cs
@@ -9,24 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPeerName")]
-        private static extern unsafe Error DangerousGetPeerName(int socket, byte* socketAddress, int* socketAddressLen);
-
-        internal static unsafe Error GetPeerName(SafeHandle socket, byte* socketAddress, int* socketAddressLen)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousGetPeerName((int)socket.DangerousGetHandle(), socketAddress, socketAddressLen);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPeerName_IntPtr")]
+        internal static extern unsafe Error GetPeerName(SafeHandle socket, byte* socketAddress, int* socketAddressLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSockName.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSockName.cs
@@ -9,24 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSockName")]
-        private static extern unsafe Error DangerousGetSockName(int socket, byte* socketAddress, int* socketAddressLen);
-
-        internal static unsafe Error GetSockName(SafeHandle socket, byte* socketAddress, int* socketAddressLen)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousGetSockName((int)socket.DangerousGetHandle(), socketAddress, socketAddressLen);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSockName_IntPtr")]
+        internal static extern unsafe Error GetSockName(SafeHandle socket, byte* socketAddress, int* socketAddressLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSockOpt.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSockOpt.cs
@@ -10,24 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSockOpt")]
-        private static extern unsafe Error DangerousGetSockOpt(int socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int* optionLen);
-
-        internal static unsafe Error GetSockOpt(SafeHandle socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int* optionLen)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousGetSockOpt((int)socket.DangerousGetHandle(), optionLevel, optionName, optionValue, optionLen);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSockOpt_IntPtr")]
+        internal static extern unsafe Error GetSockOpt(SafeHandle socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int* optionLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSocketErrorOption.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSocketErrorOption.cs
@@ -10,24 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSocketErrorOption")]
-        private static extern unsafe Error DangerousGetSocketErrorOption(int socket, Error* socketError);
-
-        internal static unsafe Error GetSocketErrorOption(SafeHandle socket, Error* socketError)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousGetSocketErrorOption((int)socket.DangerousGetHandle(), socketError);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSocketErrorOption_IntPtr")]
+        internal static extern unsafe Error GetSocketErrorOption(SafeHandle socket, Error* socketError);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.LingerOption.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.LingerOption.cs
@@ -16,44 +16,13 @@ internal static partial class Interop
             public int Seconds; // Number of seconds to linger for
         }
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetLingerOption")]
-        private static extern unsafe Error DangerousGetLingerOption(int socket, LingerOption* option);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetLingerOption_IntPtr")]
+        internal static extern unsafe Error GetLingerOption(SafeHandle socket, LingerOption* option);
 
-        internal static unsafe Error GetLingerOption(SafeHandle socket, LingerOption* option)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousGetLingerOption((int)socket.DangerousGetHandle(), option);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetLingerOption_IntPtr")]
+        internal static extern unsafe Error SetLingerOption(SafeHandle socket, LingerOption* option);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetLingerOption")]
-        internal static extern unsafe Error DangerousSetLingerOption(int socket, LingerOption* option);
-
-        internal static unsafe Error SetLingerOption(SafeHandle socket, LingerOption* option)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousSetLingerOption((int)socket.DangerousGetHandle(), option);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetLingerOption_IntPtr")]
+        internal static extern unsafe Error SetLingerOption(IntPtr socket, LingerOption* option);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Listen.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Listen.cs
@@ -9,24 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Listen")]
-        private static extern Error DangerousListen(int socket, int backlog);
-
-        internal static Error Listen(SafeHandle socket, int backlog)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousListen((int)socket.DangerousGetHandle(), backlog);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Listen_IntPtr")]
+        internal static extern Error Listen(SafeHandle socket, int backlog);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MulticastOption.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MulticastOption.cs
@@ -32,84 +32,16 @@ internal static partial class Interop
             private int _padding;
         }
        
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv4MulticastOption")]
-        private static extern unsafe Error DangerousGetIPv4MulticastOption(int socket, MulticastOption multicastOption, IPv4MulticastOption* option);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv4MulticastOption_IntPtr")]
+        internal static extern unsafe Error GetIPv4MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv4MulticastOption* option);
 
-        internal static unsafe Error GetIPv4MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv4MulticastOption* option)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousGetIPv4MulticastOption((int)socket.DangerousGetHandle(), multicastOption, option);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv4MulticastOption_IntPtr")]
+        internal static extern unsafe Error SetIPv4MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv4MulticastOption* option);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv4MulticastOption")]
-        private static extern unsafe Error DangerousSetIPv4MulticastOption(int socket, MulticastOption multicastOption, IPv4MulticastOption* option);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv6MulticastOption_IntPtr")]
+        internal static extern unsafe Error GetIPv6MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv6MulticastOption* option);
 
-        internal static unsafe Error SetIPv4MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv4MulticastOption* option)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousSetIPv4MulticastOption((int)socket.DangerousGetHandle(), multicastOption, option);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
-
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv6MulticastOption")]
-        private static extern unsafe Error DangerousGetIPv6MulticastOption(int socket, MulticastOption multicastOption, IPv6MulticastOption* option);
-
-        internal static unsafe Error GetIPv6MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv6MulticastOption* option)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousGetIPv6MulticastOption((int)socket.DangerousGetHandle(), multicastOption, option);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
-
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv6MulticastOption")]
-        private static extern unsafe Error DangerousSetIPv6MulticastOption(int socket, MulticastOption multicastOption, IPv6MulticastOption* option);
-
-        internal static unsafe Error SetIPv6MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv6MulticastOption* option)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousSetIPv6MulticastOption((int)socket.DangerousGetHandle(), multicastOption, option);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv6MulticastOption_IntPtr")]
+        internal static extern unsafe Error SetIPv6MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv6MulticastOption* option);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReceiveMessage.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReceiveMessage.cs
@@ -10,24 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReceiveMessage")]
-        private static extern unsafe Error DangerousReceiveMessage(int socket, MessageHeader* messageHeader, SocketFlags flags, long* received);
-
-        internal static unsafe Error ReceiveMessage(SafeHandle socket, MessageHeader* messageHeader, SocketFlags flags, long* received)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousReceiveMessage((int)socket.DangerousGetHandle(), messageHeader, flags, received);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReceiveMessage_IntPtr")]
+        internal static extern unsafe Error ReceiveMessage(SafeHandle socket, MessageHeader* messageHeader, SocketFlags flags, long* received);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SendMessage.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SendMessage.cs
@@ -10,24 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SendMessage")]
-        private static extern unsafe Error DangerousSendMessage(int socket, MessageHeader* messageHeader, SocketFlags flags, long* sent);
-
-        internal static unsafe Error SendMessage(SafeHandle socket, MessageHeader* messageHeader, SocketFlags flags, long* sent)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousSendMessage((int)socket.DangerousGetHandle(), messageHeader, flags, sent);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SendMessage_IntPtr")]
+        internal static extern unsafe Error SendMessage(SafeHandle socket, MessageHeader* messageHeader, SocketFlags flags, long* sent);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetReceiveTimeout.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetReceiveTimeout.cs
@@ -10,24 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetReceiveTimeout")]
-        private static extern unsafe Error DangerousSetReceiveTimeout(int socket, int millisecondsTimeout);
-
-        internal static unsafe Error SetReceiveTimeout(SafeHandle socket, int millisecondsTimeout)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousSetReceiveTimeout((int)socket.DangerousGetHandle(), millisecondsTimeout);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetReceiveTimeout_IntPtr")]
+        internal static extern unsafe Error SetReceiveTimeout(SafeHandle socket, int millisecondsTimeout);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetSendTimeout.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetSendTimeout.cs
@@ -10,24 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSendTimeout")]
-        private static extern unsafe Error DangerousSetSendTimeout(int socket, int millisecondsTimeout);
-
-        internal static unsafe Error SetSendTimeout(SafeHandle socket, int millisecondsTimeout)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousSetSendTimeout((int)socket.DangerousGetHandle(), millisecondsTimeout);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSendTimeout_IntPtr")]
+        internal static extern unsafe Error SetSendTimeout(SafeHandle socket, int millisecondsTimeout);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetSockOpt.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetSockOpt.cs
@@ -10,24 +10,10 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSockOpt")]
-        internal static extern unsafe Error DangerousSetSockOpt(int socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int optionLen);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSockOpt_IntPtr")]
+        internal static extern unsafe Error SetSockOpt(SafeHandle socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int optionLen);
 
-        internal static unsafe Error SetSockOpt(SafeHandle socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int optionLen)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousSetSockOpt((int)socket.DangerousGetHandle(), optionLevel, optionName, optionValue, optionLen);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSockOpt_IntPtr")]
+        internal static extern unsafe Error SetSockOpt(IntPtr socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int optionLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Shutdown.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Shutdown.cs
@@ -10,24 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Shutdown")]
-        private static extern Error DangerousShutdown(int socket, SocketShutdown how);
-
-        internal static Error Shutdown(SafeHandle socket, SocketShutdown how)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousShutdown((int)socket.DangerousGetHandle(), how);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Shutdown_IntPtr")]
+        internal static extern Error Shutdown(SafeHandle socket, SocketShutdown how);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Socket.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Socket.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Socket")]
-        internal static extern unsafe Error Socket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, int* socket);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Socket_IntPtr")]
+        internal static extern unsafe Error Socket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, IntPtr* socket);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
@@ -28,11 +28,11 @@ internal static partial class Interop
             private int _padding;
         }
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateSocketEventPort")]
-        internal static extern unsafe Error CreateSocketEventPort(out int port);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateSocketEventPort_IntPtr")]
+        internal static extern unsafe Error CreateSocketEventPort(out IntPtr port);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CloseSocketEventPort")]
-        internal static extern Error CloseSocketEventPort(int port);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CloseSocketEventPort_IntPtr")]
+        internal static extern Error CloseSocketEventPort(IntPtr port);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateSocketEventBuffer")]
         internal static extern unsafe Error CreateSocketEventBuffer(int count, out SocketEvent* buffer);
@@ -40,27 +40,13 @@ internal static partial class Interop
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FreeSocketEventBuffer")]
         internal static extern unsafe Error FreeSocketEventBuffer(SocketEvent* buffer);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_TryChangeSocketEventRegistration")]
-        internal static extern Error DangerousTryChangeSocketEventRegistration(int port, int socket, SocketEvents currentEvents, SocketEvents newEvents, IntPtr data);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_TryChangeSocketEventRegistration_IntPtr")]
+        internal static extern Error TryChangeSocketEventRegistration(IntPtr port, SafeHandle socket, SocketEvents currentEvents, SocketEvents newEvents, IntPtr data);
 
-        internal static Error TryChangeSocketEventRegistration(int port, SafeHandle socket, SocketEvents currentEvents, SocketEvents newEvents, IntPtr data)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousTryChangeSocketEventRegistration(port, (int)socket.DangerousGetHandle(), currentEvents, newEvents, data);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_TryChangeSocketEventRegistration_IntPtr")]
+        internal static extern Error TryChangeSocketEventRegistration(IntPtr port, IntPtr socket, SocketEvents currentEvents, SocketEvents newEvents, IntPtr data);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_WaitForSocketEvents")]
-        internal static extern unsafe Error WaitForSocketEvents(int port, SocketEvent* buffer, int* count);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_WaitForSocketEvents_IntPtr")]
+        internal static extern unsafe Error WaitForSocketEvents(IntPtr port, SocketEvent* buffer, int* count);
     }
 }

--- a/src/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
+++ b/src/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
@@ -55,7 +55,7 @@ namespace System.Net
 
         private static unsafe bool IsProtocolSupported(AddressFamily af)
         {
-            int socket = -1;
+            IntPtr socket = (IntPtr)(-1);
             try
             {
                 Interop.Error err = Interop.Sys.Socket(af, SocketType.Dgram, (ProtocolType)0, &socket);
@@ -63,9 +63,9 @@ namespace System.Net
             }
             finally
             {
-                if (socket != -1)
+                if (socket != (IntPtr)(-1))
                 {
-                    Interop.Sys.Close((IntPtr)socket);
+                    Interop.Sys.Close(socket);
                 }
             }
         }

--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -1357,10 +1357,17 @@ static bool GetMulticastOptionName(int32_t multicastOption, bool isIPv6, int& op
 
 extern "C" Error SystemNative_GetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option)
 {
+    return SystemNative_GetIPv4MulticastOption_IntPtr(socket, multicastOption, option);
+}
+
+extern "C" Error SystemNative_GetIPv4MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option)
+{
     if (option == nullptr)
     {
         return PAL_EFAULT;
     }
+
+    int fd = ToFileDescriptor(socket);
 
     int optionName;
     if (!GetMulticastOptionName(multicastOption, false, optionName))
@@ -1374,7 +1381,7 @@ extern "C" Error SystemNative_GetIPv4MulticastOption(int32_t socket, int32_t mul
     ip_mreq opt;
 #endif
     socklen_t len = sizeof(opt);
-    int err = getsockopt(socket, IPPROTO_IP, optionName, &opt, &len);
+    int err = getsockopt(fd, IPPROTO_IP, optionName, &opt, &len);
     if (err != 0)
     {
         return SystemNative_ConvertErrorPlatformToPal(errno);
@@ -1393,10 +1400,17 @@ extern "C" Error SystemNative_GetIPv4MulticastOption(int32_t socket, int32_t mul
 
 extern "C" Error SystemNative_SetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option)
 {
+    return SystemNative_SetIPv4MulticastOption_IntPtr(socket, multicastOption, option);
+}
+
+extern "C" Error SystemNative_SetIPv4MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option)
+{
     if (option == nullptr)
     {
         return PAL_EFAULT;
     }
+
+    int fd = ToFileDescriptor(socket);
 
     int optionName;
     if (!GetMulticastOptionName(multicastOption, false, optionName))
@@ -1416,16 +1430,23 @@ extern "C" Error SystemNative_SetIPv4MulticastOption(int32_t socket, int32_t mul
         return PAL_ENOPROTOOPT;
     }
 #endif
-    int err = setsockopt(socket, IPPROTO_IP, optionName, &opt, sizeof(opt));
+    int err = setsockopt(fd, IPPROTO_IP, optionName, &opt, sizeof(opt));
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
 extern "C" Error SystemNative_GetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option)
 {
+    return SystemNative_GetIPv6MulticastOption_IntPtr(socket, multicastOption, option);
+}
+
+extern "C" Error SystemNative_GetIPv6MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option)
+{
     if (option == nullptr)
     {
         return PAL_EFAULT;
     }
+
+    int fd = ToFileDescriptor(socket);
 
     int optionName;
     if (!GetMulticastOptionName(multicastOption, false, optionName))
@@ -1435,7 +1456,7 @@ extern "C" Error SystemNative_GetIPv6MulticastOption(int32_t socket, int32_t mul
 
     ipv6_mreq opt;
     socklen_t len = sizeof(opt);
-    int err = getsockopt(socket, IPPROTO_IP, optionName, &opt, &len);
+    int err = getsockopt(fd, IPPROTO_IP, optionName, &opt, &len);
     if (err != 0)
     {
         return SystemNative_ConvertErrorPlatformToPal(errno);
@@ -1448,10 +1469,17 @@ extern "C" Error SystemNative_GetIPv6MulticastOption(int32_t socket, int32_t mul
 
 extern "C" Error SystemNative_SetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option)
 {
+    return SystemNative_SetIPv6MulticastOption_IntPtr(socket, multicastOption, option);
+}
+
+extern "C" Error SystemNative_SetIPv6MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option)
+{
     if (option == nullptr)
     {
         return PAL_EFAULT;
     }
+
+    int fd = ToFileDescriptor(socket);
 
     int optionName;
     if (!GetMulticastOptionName(multicastOption, false, optionName))
@@ -1462,7 +1490,7 @@ extern "C" Error SystemNative_SetIPv6MulticastOption(int32_t socket, int32_t mul
     ipv6_mreq opt = {.ipv6mr_interface = static_cast<unsigned int>(option->InterfaceIndex)};
     ConvertByteArrayToIn6Addr(opt.ipv6mr_multiaddr, &option->Address.Address[0], NUM_BYTES_IN_IPV6_ADDRESS);
 
-    int err = setsockopt(socket, IPPROTO_IP, optionName, &opt, sizeof(opt));
+    int err = setsockopt(fd, IPPROTO_IP, optionName, &opt, sizeof(opt));
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
@@ -1505,14 +1533,21 @@ constexpr int32_t GetMaxLingerTime()
 
 extern "C" Error SystemNative_GetLingerOption(int32_t socket, LingerOption* option)
 {
+    return SystemNative_GetLingerOption_IntPtr(socket, option);
+}
+
+extern "C" Error SystemNative_GetLingerOption_IntPtr(intptr_t socket, LingerOption* option)
+{
     if (option == nullptr)
     {
         return PAL_EFAULT;
     }
 
+    int fd = ToFileDescriptor(socket);
+
     linger opt;
     socklen_t len = sizeof(opt);
-    int err = getsockopt(socket, SOL_SOCKET, LINGER_OPTION_NAME, &opt, &len);
+    int err = getsockopt(fd, SOL_SOCKET, LINGER_OPTION_NAME, &opt, &len);
     if (err != 0)
     {
         return SystemNative_ConvertErrorPlatformToPal(errno);
@@ -1524,6 +1559,11 @@ extern "C" Error SystemNative_GetLingerOption(int32_t socket, LingerOption* opti
 
 extern "C" Error SystemNative_SetLingerOption(int32_t socket, LingerOption* option)
 {
+    return SystemNative_SetLingerOption_IntPtr(socket, option);
+}
+
+extern "C" Error SystemNative_SetLingerOption_IntPtr(intptr_t socket, LingerOption* option)
+{
     if (option == nullptr)
     {
         return PAL_EFAULT;
@@ -1534,8 +1574,10 @@ extern "C" Error SystemNative_SetLingerOption(int32_t socket, LingerOption* opti
         return PAL_EINVAL;
     }
 
+    int fd = ToFileDescriptor(socket);
+
     linger opt = {.l_onoff = option->OnOff, .l_linger = option->Seconds};
-    int err = setsockopt(socket, SOL_SOCKET, LINGER_OPTION_NAME, &opt, sizeof(opt));
+    int err = setsockopt(fd, SOL_SOCKET, LINGER_OPTION_NAME, &opt, sizeof(opt));
 
 #if defined(__APPLE__) && __APPLE__
     if (err != 0 && errno == EINVAL)
@@ -1569,12 +1611,22 @@ Error SetTimeoutOption(int32_t socket, int32_t millisecondsTimeout, int optionNa
 
 extern "C" Error SystemNative_SetReceiveTimeout(int32_t socket, int32_t millisecondsTimeout)
 {
-    return SetTimeoutOption(socket, millisecondsTimeout, SO_RCVTIMEO);
+    return SystemNative_SetReceiveTimeout_IntPtr(socket, millisecondsTimeout);
+}
+
+extern "C" Error SystemNative_SetReceiveTimeout_IntPtr(intptr_t socket, int32_t millisecondsTimeout)
+{
+    return SetTimeoutOption(ToFileDescriptor(socket), millisecondsTimeout, SO_RCVTIMEO);
 }
 
 extern "C" Error SystemNative_SetSendTimeout(int32_t socket, int32_t millisecondsTimeout)
 {
-    return SetTimeoutOption(socket, millisecondsTimeout, SO_SNDTIMEO);
+    return SystemNative_SetSendTimeout_IntPtr(socket, millisecondsTimeout);
+}
+
+extern "C" Error SystemNative_SetSendTimeout_IntPtr(intptr_t socket, int32_t millisecondsTimeout)
+{
+    return SetTimeoutOption(ToFileDescriptor(socket), millisecondsTimeout, SO_SNDTIMEO);
 }
 
 static bool ConvertSocketFlagsPalToPlatform(int32_t palFlags, int& platformFlags)
@@ -1609,11 +1661,18 @@ static int32_t ConvertSocketFlagsPlatformToPal(int platformFlags)
 
 extern "C" Error SystemNative_ReceiveMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received)
 {
+    return SystemNative_ReceiveMessage_IntPtr(socket, messageHeader, flags, received);
+}
+
+extern "C" Error SystemNative_ReceiveMessage_IntPtr(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received)
+{
     if (messageHeader == nullptr || received == nullptr || messageHeader->SocketAddressLen < 0 ||
         messageHeader->ControlBufferLen < 0 || messageHeader->IOVectorCount < 0)
     {
         return PAL_EFAULT;
     }
+
+    int fd = ToFileDescriptor(socket);
 
     int socketFlags;
     if (!ConvertSocketFlagsPalToPlatform(flags, socketFlags))
@@ -1625,7 +1684,7 @@ extern "C" Error SystemNative_ReceiveMessage(int32_t socket, MessageHeader* mess
     ConvertMessageHeaderToMsghdr(&header, *messageHeader);
 
     ssize_t res;
-    while (CheckInterrupted(res = recvmsg(socket, &header, socketFlags)));
+    while (CheckInterrupted(res = recvmsg(fd, &header, socketFlags)));
 
     assert(static_cast<int32_t>(header.msg_namelen) <= messageHeader->SocketAddressLen);
     messageHeader->SocketAddressLen = Min(static_cast<int32_t>(header.msg_namelen), messageHeader->SocketAddressLen);
@@ -1649,11 +1708,18 @@ extern "C" Error SystemNative_ReceiveMessage(int32_t socket, MessageHeader* mess
 
 extern "C" Error SystemNative_SendMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent)
 {
+    return SystemNative_SendMessage_IntPtr(socket, messageHeader, flags, sent);
+}
+
+extern "C" Error SystemNative_SendMessage_IntPtr(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent)
+{
     if (messageHeader == nullptr || sent == nullptr || messageHeader->SocketAddressLen < 0 ||
         messageHeader->ControlBufferLen < 0 || messageHeader->IOVectorCount < 0)
     {
         return PAL_EFAULT;
     }
+
+    int fd = ToFileDescriptor(socket);
 
     int socketFlags;
     if (!ConvertSocketFlagsPalToPlatform(flags, socketFlags))
@@ -1665,7 +1731,7 @@ extern "C" Error SystemNative_SendMessage(int32_t socket, MessageHeader* message
     ConvertMessageHeaderToMsghdr(&header, *messageHeader);
 
     ssize_t res;
-    while (CheckInterrupted(res = sendmsg(socket, &header, flags)));
+    while (CheckInterrupted(res = sendmsg(fd, &header, flags)));
     if (res != -1)
     {
         *sent = res;
@@ -1678,14 +1744,24 @@ extern "C" Error SystemNative_SendMessage(int32_t socket, MessageHeader* message
 
 extern "C" Error SystemNative_Accept(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, int32_t* acceptedSocket)
 {
+    intptr_t accepted;
+    Error err = SystemNative_Accept_IntPtr(socket, socketAddress, socketAddressLen, &accepted);
+    *acceptedSocket = ToFileDescriptorUnchecked(accepted);
+    return err;
+}
+
+extern "C" Error SystemNative_Accept_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, intptr_t* acceptedSocket)
+{
     if (socketAddress == nullptr || socketAddressLen == nullptr || acceptedSocket == nullptr || *socketAddressLen < 0)
     {
         return PAL_EFAULT;
     }
 
+    int fd = ToFileDescriptor(socket);
+
     socklen_t addrLen = static_cast<socklen_t>(*socketAddressLen);
     int accepted;
-    while (CheckInterrupted(accepted = accept(socket, reinterpret_cast<sockaddr*>(socketAddress), &addrLen)));
+    while (CheckInterrupted(accepted = accept(fd, reinterpret_cast<sockaddr*>(socketAddress), &addrLen)));
     if (accepted == -1)
     {
         *acceptedSocket = -1;
@@ -1700,36 +1776,57 @@ extern "C" Error SystemNative_Accept(int32_t socket, uint8_t* socketAddress, int
 
 extern "C" Error SystemNative_Bind(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
 {
-    if (socketAddress == nullptr || socketAddressLen < 0)
-    {
-        return PAL_EFAULT;
-    }
-
-    int err = bind(socket, reinterpret_cast<sockaddr*>(socketAddress), static_cast<socklen_t>(socketAddressLen));
-    return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
+    return SystemNative_Bind_IntPtr(socket, socketAddress, socketAddressLen);
 }
 
-extern "C" Error SystemNative_Connect(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
+extern "C" Error SystemNative_Bind_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
 {
     if (socketAddress == nullptr || socketAddressLen < 0)
     {
         return PAL_EFAULT;
     }
 
+    int fd = ToFileDescriptor(socket);
+
+    int err = bind(fd, reinterpret_cast<sockaddr*>(socketAddress), static_cast<socklen_t>(socketAddressLen));
+    return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
+}
+
+extern "C" Error SystemNative_Connect(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
+{
+    return SystemNative_Connect_IntPtr(socket, socketAddress, socketAddressLen);
+}
+
+extern "C" Error SystemNative_Connect_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
+{
+    if (socketAddress == nullptr || socketAddressLen < 0)
+    {
+        return PAL_EFAULT;
+    }
+
+    int fd = ToFileDescriptor(socket);
+
     int err;
-    while (CheckInterrupted(err = connect(socket, reinterpret_cast<sockaddr*>(socketAddress), static_cast<socklen_t>(socketAddressLen))));
+    while (CheckInterrupted(err = connect(fd, reinterpret_cast<sockaddr*>(socketAddress), static_cast<socklen_t>(socketAddressLen))));
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
 extern "C" Error SystemNative_GetPeerName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
+{
+    return SystemNative_GetPeerName_IntPtr(socket, socketAddress, socketAddressLen);
+}
+
+extern "C" Error SystemNative_GetPeerName_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
 {
     if (socketAddress == nullptr || socketAddressLen == nullptr || *socketAddressLen < 0)
     {
         return PAL_EFAULT;
     }
 
+    int fd = ToFileDescriptor(socket);
+
     socklen_t addrLen = static_cast<socklen_t>(*socketAddressLen);
-    int err = getpeername(socket, reinterpret_cast<sockaddr*>(socketAddress), &addrLen);
+    int err = getpeername(fd, reinterpret_cast<sockaddr*>(socketAddress), &addrLen);
     if (err != 0)
     {
         return SystemNative_ConvertErrorPlatformToPal(errno);
@@ -1742,13 +1839,20 @@ extern "C" Error SystemNative_GetPeerName(int32_t socket, uint8_t* socketAddress
 
 extern "C" Error SystemNative_GetSockName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
 {
+    return SystemNative_GetSockName_IntPtr(socket, socketAddress, socketAddressLen);
+}
+
+extern "C" Error SystemNative_GetSockName_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
+{
     if (socketAddress == nullptr || socketAddressLen == nullptr || *socketAddressLen < 0)
     {
         return PAL_EFAULT;
     }
 
+    int fd = ToFileDescriptor(socket);
+
     socklen_t addrLen = static_cast<socklen_t>(*socketAddressLen);
-    int err = getsockname(socket, reinterpret_cast<sockaddr*>(socketAddress), &addrLen);
+    int err = getsockname(fd, reinterpret_cast<sockaddr*>(socketAddress), &addrLen);
     if (err != 0)
     {
         return SystemNative_ConvertErrorPlatformToPal(errno);
@@ -1761,12 +1865,25 @@ extern "C" Error SystemNative_GetSockName(int32_t socket, uint8_t* socketAddress
 
 extern "C" Error SystemNative_Listen(int32_t socket, int32_t backlog)
 {
-    int err = listen(socket, backlog);
+    return SystemNative_Listen_IntPtr(socket, backlog);
+}
+
+extern "C" Error SystemNative_Listen_IntPtr(intptr_t socket, int32_t backlog)
+{
+    int fd = ToFileDescriptor(socket);
+    int err = listen(fd, backlog);
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
 extern "C" Error SystemNative_Shutdown(int32_t socket, int32_t socketShutdown)
 {
+    return SystemNative_Shutdown_IntPtr(socket, socketShutdown);
+}
+
+extern "C" Error SystemNative_Shutdown_IntPtr(intptr_t socket, int32_t socketShutdown)
+{
+    int fd = ToFileDescriptor(socket);
+
     int how;
     switch (socketShutdown)
     {
@@ -1786,20 +1903,27 @@ extern "C" Error SystemNative_Shutdown(int32_t socket, int32_t socketShutdown)
             return PAL_EINVAL;
     }
 
-    int err = shutdown(socket, how);
+    int err = shutdown(fd, how);
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
 extern "C" Error SystemNative_GetSocketErrorOption(int32_t socket, Error* error)
+{
+    return SystemNative_GetSocketErrorOption_IntPtr(socket, error);
+}
+
+extern "C" Error SystemNative_GetSocketErrorOption_IntPtr(intptr_t socket, Error* error)
 {
     if (error == nullptr)
     {
         return PAL_EFAULT;
     }
 
+    int fd = ToFileDescriptor(socket);
+
     int socketErrno;
     socklen_t optLen = sizeof(socketErrno);
-    int err = getsockopt(socket, SOL_SOCKET, SO_ERROR, &socketErrno, &optLen);
+    int err = getsockopt(fd, SOL_SOCKET, SO_ERROR, &socketErrno, &optLen);
     if (err != 0)
     {
         return SystemNative_ConvertErrorPlatformToPal(errno);
@@ -2033,10 +2157,18 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionName, int32_t socketO
 extern "C" Error SystemNative_GetSockOpt(
     int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen)
 {
+    return SystemNative_GetSockOpt_IntPtr(socket, socketOptionLevel, socketOptionName, optionValue, optionLen);
+}
+
+extern "C" Error SystemNative_GetSockOpt_IntPtr(
+    intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen)
+{
     if (optionLen == nullptr || *optionLen < 0)
     {
         return PAL_EFAULT;
     }
+
+    int fd = ToFileDescriptor(socket);
 
     int optLevel, optName;
     if (!TryGetPlatformSocketOption(socketOptionLevel, socketOptionName, optLevel, optName))
@@ -2045,7 +2177,7 @@ extern "C" Error SystemNative_GetSockOpt(
     }
 
     auto optLen = static_cast<socklen_t>(*optionLen);
-    int err = getsockopt(socket, optLevel, optName, optionValue, &optLen);
+    int err = getsockopt(fd, optLevel, optName, optionValue, &optLen);
     if (err != 0)
     {
         return SystemNative_ConvertErrorPlatformToPal(errno);
@@ -2059,10 +2191,18 @@ extern "C" Error SystemNative_GetSockOpt(
 extern "C" Error
 SystemNative_SetSockOpt(int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen)
 {
+    return SystemNative_SetSockOpt_IntPtr(socket, socketOptionLevel, socketOptionName, optionValue, optionLen);
+}
+
+extern "C" Error
+SystemNative_SetSockOpt_IntPtr(intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen)
+{
     if (optionLen < 0)
     {
         return PAL_EFAULT;
     }
+
+    int fd = ToFileDescriptor(socket);
 
     int optLevel, optName;
     if (!TryGetPlatformSocketOption(socketOptionLevel, socketOptionName, optLevel, optName))
@@ -2070,7 +2210,7 @@ SystemNative_SetSockOpt(int32_t socket, int32_t socketOptionLevel, int32_t socke
         return PAL_ENOTSUP;
     }
 
-    int err = setsockopt(socket, optLevel, optName, optionValue, static_cast<socklen_t>(optionLen));
+    int err = setsockopt(fd, optLevel, optName, optionValue, static_cast<socklen_t>(optionLen));
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
@@ -2140,6 +2280,14 @@ static bool TryConvertProtocolTypePalToPlatform(int32_t palProtocolType, int* pl
 
 extern "C" Error SystemNative_Socket(int32_t addressFamily, int32_t socketType, int32_t protocolType, int32_t* createdSocket)
 {
+    intptr_t socket;
+    Error err = SystemNative_Socket_IntPtr(addressFamily, socketType, protocolType, &socket);
+    *createdSocket = ToFileDescriptorUnchecked(socket);
+    return err;
+}
+
+extern "C" Error SystemNative_Socket_IntPtr(int32_t addressFamily, int32_t socketType, int32_t protocolType, intptr_t* createdSocket)
+{
     if (createdSocket == nullptr)
     {
         return PAL_EFAULT;
@@ -2172,14 +2320,21 @@ extern "C" Error SystemNative_Socket(int32_t addressFamily, int32_t socketType, 
 
 extern "C" Error SystemNative_GetBytesAvailable(int32_t socket, int32_t* available)
 {
+    return SystemNative_GetBytesAvailable_IntPtr(socket, available);
+}
+
+extern "C" Error SystemNative_GetBytesAvailable_IntPtr(intptr_t socket, int32_t* available)
+{
     if (available == nullptr)
     {
         return PAL_EFAULT;
     }
 
+    int fd = ToFileDescriptor(socket);
+
     int avail;
     int err;
-    while (CheckInterrupted(err = ioctl(socket, FIONREAD, &avail)));
+    while (CheckInterrupted(err = ioctl(fd, FIONREAD, &avail)));
     if (err == -1)
     {
         return SystemNative_ConvertErrorPlatformToPal(errno);
@@ -2466,17 +2621,33 @@ static Error WaitForSocketEventsInner(int32_t port, SocketEvent* buffer, int32_t
 
 extern "C" Error SystemNative_CreateSocketEventPort(int32_t* port)
 {
+    intptr_t portIntPtr;
+    Error err = SystemNative_CreateSocketEventPort_IntPtr(&portIntPtr);
+    *port = ToFileDescriptor(portIntPtr);
+    return err;
+}
+
+extern "C" Error SystemNative_CreateSocketEventPort_IntPtr(intptr_t* port)
+{
     if (port == nullptr)
     {
         return PAL_EFAULT;
     }
 
-    return CreateSocketEventPortInner(port);
+    int fd;
+    Error error = CreateSocketEventPortInner(&fd);
+    *port = fd;
+    return error;
 }
 
 extern "C" Error SystemNative_CloseSocketEventPort(int32_t port)
 {
-    return CloseSocketEventPortInner(port);
+    return SystemNative_CloseSocketEventPort_IntPtr(port);
+}
+
+extern "C" Error SystemNative_CloseSocketEventPort_IntPtr(intptr_t port)
+{
+    return CloseSocketEventPortInner(ToFileDescriptor(port));
 }
 
 extern "C" Error SystemNative_CreateSocketEventBuffer(int32_t count, SocketEvent** buffer)
@@ -2506,6 +2677,15 @@ extern "C" Error SystemNative_FreeSocketEventBuffer(SocketEvent* buffer)
 extern "C" Error
 SystemNative_TryChangeSocketEventRegistration(int32_t port, int32_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data)
 {
+    return SystemNative_TryChangeSocketEventRegistration_IntPtr(port, socket, currentEvents, newEvents, data);
+}
+
+extern "C" Error
+SystemNative_TryChangeSocketEventRegistration_IntPtr(intptr_t port, intptr_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data)
+{
+    int portFd = ToFileDescriptor(port);
+    int socketFd = ToFileDescriptor(socket);
+
     const int32_t SupportedEvents = PAL_SA_READ | PAL_SA_WRITE | PAL_SA_READCLOSE | PAL_SA_CLOSE | PAL_SA_ERROR;
 
     if ((currentEvents & ~SupportedEvents) != 0 || (newEvents & ~SupportedEvents) != 0)
@@ -2519,17 +2699,24 @@ SystemNative_TryChangeSocketEventRegistration(int32_t port, int32_t socket, int3
     }
 
     return TryChangeSocketEventRegistrationInner(
-        port, socket, static_cast<SocketEvents>(currentEvents), static_cast<SocketEvents>(newEvents), data);
+        portFd, socketFd, static_cast<SocketEvents>(currentEvents), static_cast<SocketEvents>(newEvents), data);
 }
 
 extern "C" Error SystemNative_WaitForSocketEvents(int32_t port, SocketEvent* buffer, int32_t* count)
+{
+    return SystemNative_WaitForSocketEvents_IntPtr(port, buffer, count);
+}
+
+extern "C" Error SystemNative_WaitForSocketEvents_IntPtr(intptr_t port, SocketEvent* buffer, int32_t* count)
 {
     if (buffer == nullptr || count == nullptr || *count < 0)
     {
         return PAL_EFAULT;
     }
 
-    return WaitForSocketEventsInner(port, buffer, count);
+    int fd = ToFileDescriptor(port);
+
+    return WaitForSocketEventsInner(fd, buffer, count);
 }
 
 extern "C" int32_t SystemNative_PlatformSupportsDualModeIPv4PacketInfo()

--- a/src/Native/System.Native/pal_networking.h
+++ b/src/Native/System.Native/pal_networking.h
@@ -354,54 +354,80 @@ extern "C" int32_t
 SystemNative_TryGetIPPacketInformation(MessageHeader* messageHeader, int32_t isIPv4, IPPacketInformation* packetInfo);
 
 extern "C" Error SystemNative_GetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option);
+extern "C" Error SystemNative_GetIPv4MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option);
 
 extern "C" Error SystemNative_SetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option);
+extern "C" Error SystemNative_SetIPv4MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option);
 
 extern "C" Error SystemNative_GetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option);
+extern "C" Error SystemNative_GetIPv6MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option);
 
 extern "C" Error SystemNative_SetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option);
+extern "C" Error SystemNative_SetIPv6MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option);
 
 extern "C" Error SystemNative_GetLingerOption(int32_t socket, LingerOption* option);
+extern "C" Error SystemNative_GetLingerOption_IntPtr(intptr_t socket, LingerOption* option);
 
 extern "C" Error SystemNative_SetLingerOption(int32_t socket, LingerOption* option);
+extern "C" Error SystemNative_SetLingerOption_IntPtr(intptr_t socket, LingerOption* option);
 
 extern "C" Error SystemNative_SetReceiveTimeout(int32_t socket, int32_t millisecondsTimeout);
+extern "C" Error SystemNative_SetReceiveTimeout_IntPtr(intptr_t socket, int32_t millisecondsTimeout);
 
 extern "C" Error SystemNative_SetSendTimeout(int32_t socket, int32_t millisecondsTimeout);
+extern "C" Error SystemNative_SetSendTimeout_IntPtr(intptr_t socket, int32_t millisecondsTimeout);
 
 extern "C" Error SystemNative_ReceiveMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received);
+extern "C" Error SystemNative_ReceiveMessage_IntPtr(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received);
 
 extern "C" Error SystemNative_SendMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent);
+extern "C" Error SystemNative_SendMessage_IntPtr(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent);
 
 extern "C" Error SystemNative_Accept(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, int32_t* acceptedSocket);
+extern "C" Error SystemNative_Accept_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, intptr_t* acceptedSocket);
 
 extern "C" Error SystemNative_Bind(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
+extern "C" Error SystemNative_Bind_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
 
 extern "C" Error SystemNative_Connect(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
+extern "C" Error SystemNative_Connect_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
 
 extern "C" Error SystemNative_GetPeerName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
+extern "C" Error SystemNative_GetPeerName_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
 
 extern "C" Error SystemNative_GetSockName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
+extern "C" Error SystemNative_GetSockName_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
 
 extern "C" Error SystemNative_Listen(int32_t socket, int32_t backlog);
+extern "C" Error SystemNative_Listen_IntPtr(intptr_t socket, int32_t backlog);
 
 extern "C" Error SystemNative_Shutdown(int32_t socket, int32_t socketShutdown);
+extern "C" Error SystemNative_Shutdown_IntPtr(intptr_t socket, int32_t socketShutdown);
 
 extern "C" Error SystemNative_GetSocketErrorOption(int32_t socket, Error* error);
+extern "C" Error SystemNative_GetSocketErrorOption_IntPtr(intptr_t socket, Error* error);
 
 extern "C" Error SystemNative_GetSockOpt(
     int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen);
+extern "C" Error SystemNative_GetSockOpt_IntPtr(
+    intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen);
 
 extern "C" Error SystemNative_SetSockOpt(
     int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen);
+extern "C" Error SystemNative_SetSockOpt_IntPtr(
+    intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen);
 
 extern "C" Error SystemNative_Socket(int32_t addressFamily, int32_t socketType, int32_t protocolType, int32_t* createdSocket);
+extern "C" Error SystemNative_Socket_IntPtr(int32_t addressFamily, int32_t socketType, int32_t protocolType, intptr_t* createdSocket);
 
 extern "C" Error SystemNative_GetBytesAvailable(int32_t socket, int32_t* available);
+extern "C" Error SystemNative_GetBytesAvailable_IntPtr(intptr_t socket, int32_t* available);
 
 extern "C" Error SystemNative_CreateSocketEventPort(int32_t* port);
+extern "C" Error SystemNative_CreateSocketEventPort_IntPtr(intptr_t* port);
 
 extern "C" Error SystemNative_CloseSocketEventPort(int32_t port);
+extern "C" Error SystemNative_CloseSocketEventPort_IntPtr(intptr_t port);
 
 extern "C" Error SystemNative_CreateSocketEventBuffer(int32_t count, SocketEvent** buffer);
 
@@ -409,8 +435,11 @@ extern "C" Error SystemNative_FreeSocketEventBuffer(SocketEvent* buffer);
 
 extern "C" Error SystemNative_TryChangeSocketEventRegistration(
     int32_t port, int32_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data);
+extern "C" Error SystemNative_TryChangeSocketEventRegistration_IntPtr(
+    intptr_t port, intptr_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data);
 
 extern "C" Error SystemNative_WaitForSocketEvents(int32_t port, SocketEvent* buffer, int32_t* count);
+extern "C" Error SystemNative_WaitForSocketEvents_IntPtr(intptr_t port, SocketEvent* buffer, int32_t* count);
 
 extern "C" int32_t SystemNative_PlatformSupportsDualModeIPv4PacketInfo();
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Unix.cs
@@ -26,7 +26,7 @@ namespace System.Net.Sockets
             }
         }
 
-        public void CompletionCallback(int acceptedFileDescriptor, byte[] socketAddress, int socketAddressLen, SocketError errorCode)
+        public void CompletionCallback(IntPtr acceptedFileDescriptor, byte[] socketAddress, int socketAddressLen, SocketError errorCode)
         {
             // TODO: receive bytes on accepted socket if requested
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -57,7 +57,7 @@ namespace System.Net.Sockets
         //
         private static SocketAsyncEngine s_currentEngine;
 
-        private readonly int _port;
+        private readonly IntPtr _port;
         private readonly Interop.Sys.SocketEvent* _buffer;
 
         //
@@ -205,7 +205,7 @@ namespace System.Net.Sockets
 
         private SocketAsyncEngine()
         {
-            _port = -1;
+            _port = (IntPtr)(-1);
             _shutdownReadPipe = -1;
             _shutdownWritePipe = -1;
             try
@@ -234,7 +234,7 @@ namespace System.Net.Sockets
                 _shutdownReadPipe = pipeFds[Interop.Sys.ReadEndOfPipe];
                 _shutdownWritePipe = pipeFds[Interop.Sys.WriteEndOfPipe];
 
-                if (Interop.Sys.DangerousTryChangeSocketEventRegistration(_port, _shutdownReadPipe, Interop.Sys.SocketEvents.None, Interop.Sys.SocketEvents.Read, ShutdownHandle) != Interop.Error.SUCCESS)
+                if (Interop.Sys.TryChangeSocketEventRegistration(_port, (IntPtr)_shutdownReadPipe, Interop.Sys.SocketEvents.None, Interop.Sys.SocketEvents.Read, ShutdownHandle) != Interop.Error.SUCCESS)
                 {
                     throw new InternalException();
                 }
@@ -325,7 +325,7 @@ namespace System.Net.Sockets
             {
                 Interop.Sys.FreeSocketEventBuffer(_buffer);
             }
-            if (_port != -1)
+            if (_port != (IntPtr)(-1))
             {
                 Interop.Sys.CloseSocketEventPort(_port);
             }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -9,7 +9,7 @@ namespace System.Net.Sockets
 {
     public partial class SocketAsyncEventArgs : EventArgs, IDisposable
     {
-        private int _acceptedFileDescriptor;
+        private IntPtr _acceptedFileDescriptor;
         private int _socketAddressSize;
         private SocketFlags _receivedFlags;
 
@@ -47,10 +47,10 @@ namespace System.Net.Sockets
 
         private void InnerStartOperationAccept(bool userSuppliedBuffer)
         {
-            _acceptedFileDescriptor = -1;
+            _acceptedFileDescriptor = (IntPtr)(-1);
         }
 
-        private void AcceptCompletionCallback(int acceptedFileDescriptor, byte[] socketAddress, int socketAddressSize, SocketError socketError)
+        private void AcceptCompletionCallback(IntPtr acceptedFileDescriptor, byte[] socketAddress, int socketAddressSize, SocketError socketError)
         {
             // TODO: receive bytes on socket if requested
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -357,9 +357,9 @@ namespace System.Net.Sockets
             return checked((int)received);
         }
 
-        public static unsafe bool TryCompleteAccept(SafeCloseSocket socket, byte[] socketAddress, ref int socketAddressLen, out int acceptedFd, out SocketError errorCode)
+        public static unsafe bool TryCompleteAccept(SafeCloseSocket socket, byte[] socketAddress, ref int socketAddressLen, out IntPtr acceptedFd, out SocketError errorCode)
         {
-            int fd;
+            IntPtr fd;
             Interop.Error errno;
             int sockAddrLen = socketAddressLen;
             fixed (byte* rawSocketAddress = socketAddress)
@@ -372,14 +372,14 @@ namespace System.Net.Sockets
                 {
                     // The socket was closed, or is closing.
                     errorCode = SocketError.OperationAborted;
-                    acceptedFd = -1;
+                    acceptedFd = (IntPtr)(-1);
                     return true;
                 }
             }
 
             if (errno == Interop.Error.SUCCESS)
             {
-                Debug.Assert(fd != -1, "Expected fd != -1");
+                Debug.Assert(fd != (IntPtr)(-1), "Expected fd != -1");
 
                 socketAddressLen = sockAddrLen;
                 errorCode = SocketError.Success;
@@ -388,7 +388,7 @@ namespace System.Net.Sockets
                 return true;
             }
 
-            acceptedFd = -1;
+            acceptedFd = (IntPtr)(-1);
             if (errno != Interop.Error.EAGAIN && errno != Interop.Error.EWOULDBLOCK)
             {
                 errorCode = GetSocketErrorForErrorCode(errno);


### PR DESCRIPTION
This is step 1 of the fix for #6928.  This change introduces new native methods that take `IntPtr` file descriptor arguments instead of `int`, and moves all callers to use the new methods, eliminating custom SafeHandle marshaling.  Once this new `System.Native` propagates everywhere, we can remove the old methods and eliminate the `_IntPtr` suffix on the names.

@stephentoub