### PR TITLE
Adding version information to non-Windows native build output

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,7 @@ usage()
     echo "cross - optional argument to signify cross compilation,"
     echo "      - will use ROOTFS_DIR environment variable if set."
     echo "skiptests - skip the tests in the './bin/*/*Tests/' subdirectory."
+    echo "generateversion - if building native only, pass this in to get a version on the build output."
     echo "cmakeargs - user-settable additional arguments passed to CMake."
     exit 1
 }
@@ -97,6 +98,11 @@ prepare_native_build()
     if [ $__VerboseBuild == 1 ]; then
         export VERBOSE=1
     fi
+
+    # If managed build is supported, then generate version
+    if [ $__buildmanaged == true ]; then
+        __generateversionsource=true
+    fi
 }
 
 build_managed()
@@ -122,6 +128,15 @@ build_native()
 
     echo "Commencing build of corefx native components for $__BuildOS.$__BuildArch.$__BuildType"
     cd "$__IntermediatesDir"
+
+    # Generate version.c if specified, else have an empty one.
+    __versionSourceFile=$__scriptpath/bin/obj/version.c
+    if [ $__generateversionsource == true ]; then
+        $__scriptpath/Tools/corerun $__scriptpath/Tools/MSBuild.exe "$__scriptpath/build.proj" /t:GenerateVersionSourceFile /p:NativeVersionSourceFile=$__scriptpath/bin/obj/version.c /p:GenerateVersionSourceFile=true /v:minimal
+    else
+        __versionSourceLine="static char sccsid[] __attribute__((used)) = \"@(#)No version information produced\";"
+        echo $__versionSourceLine > $__versionSourceFile
+    fi
 
     # Regenerate the CMake solution
     echo "Invoking cmake with arguments: \"$__nativeroot\" $__CMakeArgs $__CMakeExtraArgs"
@@ -167,6 +182,7 @@ __nugetpath=$__packageroot/NuGet.exe
 __nugetconfig=$__sourceroot/NuGet.Config
 __rootbinpath="$__scriptpath/bin"
 __msbuildpackageid="Microsoft.Build.Mono.Debug"
+__generateversionsource=false
 __msbuildpackageversion="14.1.0.0-prerelease"
 __msbuildpath=$__packageroot/$__msbuildpackageid.$__msbuildpackageversion/lib/MSBuild.exe
 __buildmanaged=false
@@ -303,6 +319,9 @@ while :; do
             ;;
         verbose)
             __VerboseBuild=1
+            ;;
+        generateversion)
+            __generateversionsource=true
             ;;
         clang3.5)
             __ClangMajorVersion=3

--- a/build.sh
+++ b/build.sh
@@ -103,6 +103,20 @@ prepare_native_build()
     if [ $__buildmanaged == true ]; then
         __generateversionsource=true
     fi
+
+    # Ensure tools are present if we will generate version.c
+    if [ $__generateversionsource == true ]; then
+        $__scriptpath/init-tools.sh
+    fi
+
+    # Generate version.c if specified, else have an empty one.
+    __versionSourceFile=$__scriptpath/bin/obj/version.c
+    if [ $__generateversionsource == true ]; then
+        $__scriptpath/Tools/corerun $__scriptpath/Tools/MSBuild.exe "$__scriptpath/build.proj" /t:GenerateVersionSourceFile /p:NativeVersionSourceFile=$__scriptpath/bin/obj/version.c /p:GenerateVersionSourceFile=true /v:minimal
+    else
+        __versionSourceLine="static char sccsid[] __attribute__((used)) = \"@(#)No version information produced\";"
+        echo $__versionSourceLine > $__versionSourceFile
+    fi
 }
 
 build_managed()
@@ -128,15 +142,6 @@ build_native()
 
     echo "Commencing build of corefx native components for $__BuildOS.$__BuildArch.$__BuildType"
     cd "$__IntermediatesDir"
-
-    # Generate version.c if specified, else have an empty one.
-    __versionSourceFile=$__scriptpath/bin/obj/version.c
-    if [ $__generateversionsource == true ]; then
-        $__scriptpath/Tools/corerun $__scriptpath/Tools/MSBuild.exe "$__scriptpath/build.proj" /t:GenerateVersionSourceFile /p:NativeVersionSourceFile=$__scriptpath/bin/obj/version.c /p:GenerateVersionSourceFile=true /v:minimal
-    else
-        __versionSourceLine="static char sccsid[] __attribute__((used)) = \"@(#)No version information produced\";"
-        echo $__versionSourceLine > $__versionSourceFile
-    fi
 
     # Regenerate the CMake solution
     echo "Invoking cmake with arguments: \"$__nativeroot\" $__CMakeArgs $__CMakeExtraArgs"

--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_C_FLAGS "-std=c11")
 set(CMAKE_CXX_FLAGS "-std=c++11")
 set(CMAKE_SHARED_LIBRARY_PREFIX "")
+set(VERSION_FILE_PATH "${CMAKE_BINARY_DIR}/../../version.c")
 
 add_compile_options(-Weverything)
 add_compile_options(-Wno-format-nonliteral)

--- a/src/Native/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/Native/System.IO.Compression.Native/CMakeLists.txt
@@ -9,6 +9,7 @@ set(NATIVECOMPRESSION_SOURCES
 add_library(System.IO.Compression.Native
     SHARED
     ${NATIVECOMPRESSION_SOURCES}
+    ${VERSION_FILE_PATH}
 )
 
 target_link_libraries(System.IO.Compression.Native

--- a/src/Native/System.Native/CMakeLists.txt
+++ b/src/Native/System.Native/CMakeLists.txt
@@ -30,12 +30,14 @@ endif ()
 add_library(System.Native
     SHARED
     ${NATIVE_SOURCES}
+    ${VERSION_FILE_PATH}
 )
 
 
 add_library(System.Native-Static
     STATIC
     ${NATIVE_SOURCES}
+    ${VERSION_FILE_PATH}
 )
 SET_TARGET_PROPERTIES(System.Native-Static PROPERTIES PREFIX "")
 SET_TARGET_PROPERTIES(System.Native-Static PROPERTIES OUTPUT_NAME System.Native CLEAN_DIRECT_OUTPUT 1)

--- a/src/Native/System.Net.Http.Native/CMakeLists.txt
+++ b/src/Native/System.Net.Http.Native/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(SYSTEM ${CURL_INCLUDE_DIR})
 add_library(System.Net.Http.Native
     SHARED
     ${NATIVEHTTP_SOURCES}
+    ${VERSION_FILE_PATH}
 )
 
 target_link_libraries(System.Net.Http.Native

--- a/src/Native/System.Net.Security.Native/CMakeLists.txt
+++ b/src/Native/System.Net.Security.Native/CMakeLists.txt
@@ -23,6 +23,7 @@ set(NATIVEGSS_SOURCES
 add_library(System.Net.Security.Native
     SHARED
     ${NATIVEGSS_SOURCES}
+    ${VERSION_FILE_PATH}
 )
 
 target_link_libraries(System.Net.Security.Native

--- a/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
@@ -41,6 +41,7 @@ set(NATIVECRYPTO_SOURCES
 add_library(System.Security.Cryptography.Native
     SHARED
     ${NATIVECRYPTO_SOURCES}
+    ${VERSION_FILE_PATH}
 )
 
 # Disable the "lib" prefix.


### PR DESCRIPTION
Adding version info to non-Windows native build output. When doing a full build (managed + native) this will be on by default, but when only building native, then an extra param needs to be passed in to build.sh.

cc: @weshaggard @ellismg 
FYI: @gkhanna79 

related: dotnet/coreclr#3133