### PR TITLE
Replace ProcessManager.GetModuleInfos on OSX

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessCollectionTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessCollectionTests.cs
@@ -10,7 +10,6 @@ namespace System.Diagnostics.Tests
 {
     public class ProcessCollectionTests : ProcessTestBase
     {
-        [ActiveIssue(6677, PlatformID.OSX)]
         [Fact]
         public void TestModuleCollectionBehavior()
         {

--- a/src/System.Diagnostics.Process/tests/ProcessModuleTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessModuleTests.cs
@@ -9,7 +9,6 @@ namespace System.Diagnostics.Tests
 {
     public class ProcessModuleTests : ProcessTestBase
     {
-        [ActiveIssue(6677, PlatformID.OSX)]
         [Fact]
         public void TestModuleProperties()
         {
@@ -23,15 +22,22 @@ namespace System.Diagnostics.Tests
                 Assert.NotNull(module.FileName);
                 Assert.NotEmpty(module.FileName);
 
-                Assert.InRange(module.BaseAddress.ToInt64(), 1, long.MaxValue);
+                Assert.InRange(module.BaseAddress.ToInt64(), 0, long.MaxValue);
                 Assert.InRange(module.EntryPointAddress.ToInt64(), 0, long.MaxValue);
-                Assert.InRange(module.ModuleMemorySize, 1, long.MaxValue);
+                Assert.InRange(module.ModuleMemorySize, 0, long.MaxValue);
             }
         }
 
-        [ActiveIssue(6677, PlatformID.OSX)]
         [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)]
+        public void TestModulesContainsCorerun()
+        {
+            ProcessModuleCollection modules = Process.GetCurrentProcess().Modules;
+            Assert.Contains(modules.Cast<ProcessModule>(), m => m.FileName.Contains("corerun"));
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Linux)] // OSX only includes the main module
         public void TestModulesContainsUnixNativeLibs()
         {
             ProcessModuleCollection modules = Process.GetCurrentProcess().Modules;

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -214,7 +214,6 @@ namespace System.Diagnostics.Tests
             Assert.NotNull(_process.MachineName);
         }
 
-        [ActiveIssue(6677, PlatformID.OSX)]
         [Fact]
         public void TestMainModuleOnNonOSX()
         {
@@ -299,7 +298,6 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ActiveIssue(6677, PlatformID.OSX)]
         [Fact]
         public void TestModules()
         {
@@ -308,12 +306,12 @@ namespace System.Diagnostics.Tests
             {
                 // Validated that we can get a value for each of the following.
                 Assert.NotNull(pModule);
-                Assert.NotEqual(IntPtr.Zero, pModule.BaseAddress);
                 Assert.NotNull(pModule.FileName);
                 Assert.NotNull(pModule.ModuleName);
 
                 // Just make sure these don't throw
-                IntPtr addr = pModule.EntryPointAddress;
+                IntPtr baseAddr = pModule.BaseAddress;
+                IntPtr entryAddr = pModule.EntryPointAddress;
                 int memSize = pModule.ModuleMemorySize;
             }
         }


### PR DESCRIPTION
I recently added this implementation, which shells out to the vmmap utility to get details on the modules in the process.  Unfortunately, it's proven to be very unreliable.  It seems that due to the special nature of the vmmap utility/process and the permissions it requires to get details on other process' memory,
attempting to use it in this manner often results in deadlock, in particular when accessing module information for the current process.

As a replacement, since the most common reason for accessing Modules is to get the path to the MainModule, I've provided a very simple replacement implementation that just returns a module representing the main executable for the process.

Fixes #6677 
cc: @Priya91, @pallavit, @sokket, @ianhays, @anurse