### PR TITLE
Use IntPtr-based file descriptors exclusively, in native calls from Sockets code, part 2

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.Accept.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Accept.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Accept_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Accept")]
         internal static extern unsafe Error Accept(SafeHandle socket, byte* socketAddress, int* socketAddressLen, IntPtr* acceptedFd);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Bind.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Bind.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Bind_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Bind")]
         internal static extern unsafe Error Bind(SafeHandle socket, byte* socketAddress, int socketAddressLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Connect.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Connect.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Connect_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Connect")]
         internal static extern unsafe Error Connect(SafeHandle socket, byte* socketAddress, int socketAddressLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetBytesAvailable.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetBytesAvailable.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetBytesAvailable_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetBytesAvailable")]
         internal static extern unsafe Error GetBytesAvailable(SafeHandle socket, int* available);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetPeerName.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetPeerName.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPeerName_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPeerName")]
         internal static extern unsafe Error GetPeerName(SafeHandle socket, byte* socketAddress, int* socketAddressLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSockName.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSockName.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSockName_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSockName")]
         internal static extern unsafe Error GetSockName(SafeHandle socket, byte* socketAddress, int* socketAddressLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSockOpt.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSockOpt.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSockOpt_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSockOpt")]
         internal static extern unsafe Error GetSockOpt(SafeHandle socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int* optionLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSocketErrorOption.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSocketErrorOption.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSocketErrorOption_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSocketErrorOption")]
         internal static extern unsafe Error GetSocketErrorOption(SafeHandle socket, Error* socketError);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.LingerOption.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.LingerOption.cs
@@ -16,13 +16,13 @@ internal static partial class Interop
             public int Seconds; // Number of seconds to linger for
         }
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetLingerOption_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetLingerOption")]
         internal static extern unsafe Error GetLingerOption(SafeHandle socket, LingerOption* option);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetLingerOption_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetLingerOption")]
         internal static extern unsafe Error SetLingerOption(SafeHandle socket, LingerOption* option);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetLingerOption_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetLingerOption")]
         internal static extern unsafe Error SetLingerOption(IntPtr socket, LingerOption* option);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Listen.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Listen.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Listen_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Listen")]
         internal static extern Error Listen(SafeHandle socket, int backlog);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MulticastOption.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MulticastOption.cs
@@ -32,16 +32,16 @@ internal static partial class Interop
             private int _padding;
         }
        
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv4MulticastOption_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv4MulticastOption")]
         internal static extern unsafe Error GetIPv4MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv4MulticastOption* option);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv4MulticastOption_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv4MulticastOption")]
         internal static extern unsafe Error SetIPv4MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv4MulticastOption* option);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv6MulticastOption_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv6MulticastOption")]
         internal static extern unsafe Error GetIPv6MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv6MulticastOption* option);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv6MulticastOption_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv6MulticastOption")]
         internal static extern unsafe Error SetIPv6MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv6MulticastOption* option);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReceiveMessage.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReceiveMessage.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReceiveMessage_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReceiveMessage")]
         internal static extern unsafe Error ReceiveMessage(SafeHandle socket, MessageHeader* messageHeader, SocketFlags flags, long* received);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SendMessage.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SendMessage.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SendMessage_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SendMessage")]
         internal static extern unsafe Error SendMessage(SafeHandle socket, MessageHeader* messageHeader, SocketFlags flags, long* sent);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetReceiveTimeout.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetReceiveTimeout.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetReceiveTimeout_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetReceiveTimeout")]
         internal static extern unsafe Error SetReceiveTimeout(SafeHandle socket, int millisecondsTimeout);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetSendTimeout.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetSendTimeout.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSendTimeout_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSendTimeout")]
         internal static extern unsafe Error SetSendTimeout(SafeHandle socket, int millisecondsTimeout);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetSockOpt.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetSockOpt.cs
@@ -10,10 +10,10 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSockOpt_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSockOpt")]
         internal static extern unsafe Error SetSockOpt(SafeHandle socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int optionLen);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSockOpt_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSockOpt")]
         internal static extern unsafe Error SetSockOpt(IntPtr socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int optionLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Shutdown.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Shutdown.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Shutdown_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Shutdown")]
         internal static extern Error Shutdown(SafeHandle socket, SocketShutdown how);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Socket.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Socket.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Socket_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Socket")]
         internal static extern unsafe Error Socket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, IntPtr* socket);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
@@ -28,10 +28,10 @@ internal static partial class Interop
             private int _padding;
         }
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateSocketEventPort_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateSocketEventPort")]
         internal static extern unsafe Error CreateSocketEventPort(out IntPtr port);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CloseSocketEventPort_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CloseSocketEventPort")]
         internal static extern Error CloseSocketEventPort(IntPtr port);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateSocketEventBuffer")]
@@ -40,13 +40,13 @@ internal static partial class Interop
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FreeSocketEventBuffer")]
         internal static extern unsafe Error FreeSocketEventBuffer(SocketEvent* buffer);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_TryChangeSocketEventRegistration_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_TryChangeSocketEventRegistration")]
         internal static extern Error TryChangeSocketEventRegistration(IntPtr port, SafeHandle socket, SocketEvents currentEvents, SocketEvents newEvents, IntPtr data);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_TryChangeSocketEventRegistration_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_TryChangeSocketEventRegistration")]
         internal static extern Error TryChangeSocketEventRegistration(IntPtr port, IntPtr socket, SocketEvents currentEvents, SocketEvents newEvents, IntPtr data);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_WaitForSocketEvents_IntPtr")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_WaitForSocketEvents")]
         internal static extern unsafe Error WaitForSocketEvents(IntPtr port, SocketEvent* buffer, int* count);
     }
 }

--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -1355,7 +1355,7 @@ static bool GetMulticastOptionName(int32_t multicastOption, bool isIPv6, int& op
     }
 }
 
-extern "C" Error SystemNative_GetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option)
+extern "C" Error SystemNative_GetIPv4MulticastOption(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option)
 {
     return SystemNative_GetIPv4MulticastOption_IntPtr(socket, multicastOption, option);
 }
@@ -1398,7 +1398,7 @@ extern "C" Error SystemNative_GetIPv4MulticastOption_IntPtr(intptr_t socket, int
     return PAL_SUCCESS;
 }
 
-extern "C" Error SystemNative_SetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option)
+extern "C" Error SystemNative_SetIPv4MulticastOption(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option)
 {
     return SystemNative_SetIPv4MulticastOption_IntPtr(socket, multicastOption, option);
 }
@@ -1434,7 +1434,7 @@ extern "C" Error SystemNative_SetIPv4MulticastOption_IntPtr(intptr_t socket, int
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" Error SystemNative_GetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option)
+extern "C" Error SystemNative_GetIPv6MulticastOption(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option)
 {
     return SystemNative_GetIPv6MulticastOption_IntPtr(socket, multicastOption, option);
 }
@@ -1467,7 +1467,7 @@ extern "C" Error SystemNative_GetIPv6MulticastOption_IntPtr(intptr_t socket, int
     return PAL_SUCCESS;
 }
 
-extern "C" Error SystemNative_SetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option)
+extern "C" Error SystemNative_SetIPv6MulticastOption(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option)
 {
     return SystemNative_SetIPv6MulticastOption_IntPtr(socket, multicastOption, option);
 }
@@ -1531,7 +1531,7 @@ constexpr int32_t GetMaxLingerTime()
 }
 #endif
 
-extern "C" Error SystemNative_GetLingerOption(int32_t socket, LingerOption* option)
+extern "C" Error SystemNative_GetLingerOption(intptr_t socket, LingerOption* option)
 {
     return SystemNative_GetLingerOption_IntPtr(socket, option);
 }
@@ -1557,7 +1557,7 @@ extern "C" Error SystemNative_GetLingerOption_IntPtr(intptr_t socket, LingerOpti
     return PAL_SUCCESS;
 }
 
-extern "C" Error SystemNative_SetLingerOption(int32_t socket, LingerOption* option)
+extern "C" Error SystemNative_SetLingerOption(intptr_t socket, LingerOption* option)
 {
     return SystemNative_SetLingerOption_IntPtr(socket, option);
 }
@@ -1609,7 +1609,7 @@ Error SetTimeoutOption(int32_t socket, int32_t millisecondsTimeout, int optionNa
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" Error SystemNative_SetReceiveTimeout(int32_t socket, int32_t millisecondsTimeout)
+extern "C" Error SystemNative_SetReceiveTimeout(intptr_t socket, int32_t millisecondsTimeout)
 {
     return SystemNative_SetReceiveTimeout_IntPtr(socket, millisecondsTimeout);
 }
@@ -1619,7 +1619,7 @@ extern "C" Error SystemNative_SetReceiveTimeout_IntPtr(intptr_t socket, int32_t 
     return SetTimeoutOption(ToFileDescriptor(socket), millisecondsTimeout, SO_RCVTIMEO);
 }
 
-extern "C" Error SystemNative_SetSendTimeout(int32_t socket, int32_t millisecondsTimeout)
+extern "C" Error SystemNative_SetSendTimeout(intptr_t socket, int32_t millisecondsTimeout)
 {
     return SystemNative_SetSendTimeout_IntPtr(socket, millisecondsTimeout);
 }
@@ -1659,7 +1659,7 @@ static int32_t ConvertSocketFlagsPlatformToPal(int platformFlags)
            ((platformFlags & MSG_CTRUNC) == 0 ? 0 : PAL_MSG_CTRUNC);
 }
 
-extern "C" Error SystemNative_ReceiveMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received)
+extern "C" Error SystemNative_ReceiveMessage(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received)
 {
     return SystemNative_ReceiveMessage_IntPtr(socket, messageHeader, flags, received);
 }
@@ -1706,7 +1706,7 @@ extern "C" Error SystemNative_ReceiveMessage_IntPtr(intptr_t socket, MessageHead
     return SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" Error SystemNative_SendMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent)
+extern "C" Error SystemNative_SendMessage(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent)
 {
     return SystemNative_SendMessage_IntPtr(socket, messageHeader, flags, sent);
 }
@@ -1742,12 +1742,9 @@ extern "C" Error SystemNative_SendMessage_IntPtr(intptr_t socket, MessageHeader*
     return SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" Error SystemNative_Accept(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, int32_t* acceptedSocket)
+extern "C" Error SystemNative_Accept(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, intptr_t* acceptedSocket)
 {
-    intptr_t accepted;
-    Error err = SystemNative_Accept_IntPtr(socket, socketAddress, socketAddressLen, &accepted);
-    *acceptedSocket = ToFileDescriptorUnchecked(accepted);
-    return err;
+    return SystemNative_Accept_IntPtr(socket, socketAddress, socketAddressLen, acceptedSocket);
 }
 
 extern "C" Error SystemNative_Accept_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, intptr_t* acceptedSocket)
@@ -1774,7 +1771,7 @@ extern "C" Error SystemNative_Accept_IntPtr(intptr_t socket, uint8_t* socketAddr
     return PAL_SUCCESS;
 }
 
-extern "C" Error SystemNative_Bind(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
+extern "C" Error SystemNative_Bind(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
 {
     return SystemNative_Bind_IntPtr(socket, socketAddress, socketAddressLen);
 }
@@ -1792,7 +1789,7 @@ extern "C" Error SystemNative_Bind_IntPtr(intptr_t socket, uint8_t* socketAddres
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" Error SystemNative_Connect(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
+extern "C" Error SystemNative_Connect(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
 {
     return SystemNative_Connect_IntPtr(socket, socketAddress, socketAddressLen);
 }
@@ -1811,7 +1808,7 @@ extern "C" Error SystemNative_Connect_IntPtr(intptr_t socket, uint8_t* socketAdd
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" Error SystemNative_GetPeerName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
+extern "C" Error SystemNative_GetPeerName(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
 {
     return SystemNative_GetPeerName_IntPtr(socket, socketAddress, socketAddressLen);
 }
@@ -1837,7 +1834,7 @@ extern "C" Error SystemNative_GetPeerName_IntPtr(intptr_t socket, uint8_t* socke
     return PAL_SUCCESS;
 }
 
-extern "C" Error SystemNative_GetSockName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
+extern "C" Error SystemNative_GetSockName(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
 {
     return SystemNative_GetSockName_IntPtr(socket, socketAddress, socketAddressLen);
 }
@@ -1863,7 +1860,7 @@ extern "C" Error SystemNative_GetSockName_IntPtr(intptr_t socket, uint8_t* socke
     return PAL_SUCCESS;
 }
 
-extern "C" Error SystemNative_Listen(int32_t socket, int32_t backlog)
+extern "C" Error SystemNative_Listen(intptr_t socket, int32_t backlog)
 {
     return SystemNative_Listen_IntPtr(socket, backlog);
 }
@@ -1875,7 +1872,7 @@ extern "C" Error SystemNative_Listen_IntPtr(intptr_t socket, int32_t backlog)
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" Error SystemNative_Shutdown(int32_t socket, int32_t socketShutdown)
+extern "C" Error SystemNative_Shutdown(intptr_t socket, int32_t socketShutdown)
 {
     return SystemNative_Shutdown_IntPtr(socket, socketShutdown);
 }
@@ -1907,7 +1904,7 @@ extern "C" Error SystemNative_Shutdown_IntPtr(intptr_t socket, int32_t socketShu
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" Error SystemNative_GetSocketErrorOption(int32_t socket, Error* error)
+extern "C" Error SystemNative_GetSocketErrorOption(intptr_t socket, Error* error)
 {
     return SystemNative_GetSocketErrorOption_IntPtr(socket, error);
 }
@@ -2155,7 +2152,7 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionName, int32_t socketO
 }
 
 extern "C" Error SystemNative_GetSockOpt(
-    int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen)
+    intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen)
 {
     return SystemNative_GetSockOpt_IntPtr(socket, socketOptionLevel, socketOptionName, optionValue, optionLen);
 }
@@ -2189,7 +2186,7 @@ extern "C" Error SystemNative_GetSockOpt_IntPtr(
 }
 
 extern "C" Error
-SystemNative_SetSockOpt(int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen)
+SystemNative_SetSockOpt(intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen)
 {
     return SystemNative_SetSockOpt_IntPtr(socket, socketOptionLevel, socketOptionName, optionValue, optionLen);
 }
@@ -2278,12 +2275,9 @@ static bool TryConvertProtocolTypePalToPlatform(int32_t palProtocolType, int* pl
     }
 }
 
-extern "C" Error SystemNative_Socket(int32_t addressFamily, int32_t socketType, int32_t protocolType, int32_t* createdSocket)
+extern "C" Error SystemNative_Socket(int32_t addressFamily, int32_t socketType, int32_t protocolType, intptr_t* createdSocket)
 {
-    intptr_t socket;
-    Error err = SystemNative_Socket_IntPtr(addressFamily, socketType, protocolType, &socket);
-    *createdSocket = ToFileDescriptorUnchecked(socket);
-    return err;
+    return SystemNative_Socket_IntPtr(addressFamily, socketType, protocolType, createdSocket);
 }
 
 extern "C" Error SystemNative_Socket_IntPtr(int32_t addressFamily, int32_t socketType, int32_t protocolType, intptr_t* createdSocket)
@@ -2318,7 +2312,7 @@ extern "C" Error SystemNative_Socket_IntPtr(int32_t addressFamily, int32_t socke
     return *createdSocket != -1 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" Error SystemNative_GetBytesAvailable(int32_t socket, int32_t* available)
+extern "C" Error SystemNative_GetBytesAvailable(intptr_t socket, int32_t* available)
 {
     return SystemNative_GetBytesAvailable_IntPtr(socket, available);
 }
@@ -2619,12 +2613,9 @@ static Error WaitForSocketEventsInner(int32_t port, SocketEvent* buffer, int32_t
 #error Asynchronous sockets require epoll or kqueue support.
 #endif
 
-extern "C" Error SystemNative_CreateSocketEventPort(int32_t* port)
+extern "C" Error SystemNative_CreateSocketEventPort(intptr_t* port)
 {
-    intptr_t portIntPtr;
-    Error err = SystemNative_CreateSocketEventPort_IntPtr(&portIntPtr);
-    *port = ToFileDescriptor(portIntPtr);
-    return err;
+    return SystemNative_CreateSocketEventPort_IntPtr(port);
 }
 
 extern "C" Error SystemNative_CreateSocketEventPort_IntPtr(intptr_t* port)
@@ -2640,7 +2631,7 @@ extern "C" Error SystemNative_CreateSocketEventPort_IntPtr(intptr_t* port)
     return error;
 }
 
-extern "C" Error SystemNative_CloseSocketEventPort(int32_t port)
+extern "C" Error SystemNative_CloseSocketEventPort(intptr_t port)
 {
     return SystemNative_CloseSocketEventPort_IntPtr(port);
 }
@@ -2675,7 +2666,7 @@ extern "C" Error SystemNative_FreeSocketEventBuffer(SocketEvent* buffer)
 }
 
 extern "C" Error
-SystemNative_TryChangeSocketEventRegistration(int32_t port, int32_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data)
+SystemNative_TryChangeSocketEventRegistration(intptr_t port, intptr_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data)
 {
     return SystemNative_TryChangeSocketEventRegistration_IntPtr(port, socket, currentEvents, newEvents, data);
 }
@@ -2702,7 +2693,7 @@ SystemNative_TryChangeSocketEventRegistration_IntPtr(intptr_t port, intptr_t soc
         portFd, socketFd, static_cast<SocketEvents>(currentEvents), static_cast<SocketEvents>(newEvents), data);
 }
 
-extern "C" Error SystemNative_WaitForSocketEvents(int32_t port, SocketEvent* buffer, int32_t* count)
+extern "C" Error SystemNative_WaitForSocketEvents(intptr_t port, SocketEvent* buffer, int32_t* count)
 {
     return SystemNative_WaitForSocketEvents_IntPtr(port, buffer, count);
 }

--- a/src/Native/System.Native/pal_networking.h
+++ b/src/Native/System.Native/pal_networking.h
@@ -353,80 +353,80 @@ extern "C" int32_t SystemNative_GetControlMessageBufferSize(int32_t isIPv4, int3
 extern "C" int32_t
 SystemNative_TryGetIPPacketInformation(MessageHeader* messageHeader, int32_t isIPv4, IPPacketInformation* packetInfo);
 
-extern "C" Error SystemNative_GetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option);
+extern "C" Error SystemNative_GetIPv4MulticastOption(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option);
 extern "C" Error SystemNative_GetIPv4MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option);
 
-extern "C" Error SystemNative_SetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option);
+extern "C" Error SystemNative_SetIPv4MulticastOption(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option);
 extern "C" Error SystemNative_SetIPv4MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option);
 
-extern "C" Error SystemNative_GetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option);
+extern "C" Error SystemNative_GetIPv6MulticastOption(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option);
 extern "C" Error SystemNative_GetIPv6MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option);
 
-extern "C" Error SystemNative_SetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option);
+extern "C" Error SystemNative_SetIPv6MulticastOption(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option);
 extern "C" Error SystemNative_SetIPv6MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option);
 
-extern "C" Error SystemNative_GetLingerOption(int32_t socket, LingerOption* option);
+extern "C" Error SystemNative_GetLingerOption(intptr_t socket, LingerOption* option);
 extern "C" Error SystemNative_GetLingerOption_IntPtr(intptr_t socket, LingerOption* option);
 
-extern "C" Error SystemNative_SetLingerOption(int32_t socket, LingerOption* option);
+extern "C" Error SystemNative_SetLingerOption(intptr_t socket, LingerOption* option);
 extern "C" Error SystemNative_SetLingerOption_IntPtr(intptr_t socket, LingerOption* option);
 
-extern "C" Error SystemNative_SetReceiveTimeout(int32_t socket, int32_t millisecondsTimeout);
+extern "C" Error SystemNative_SetReceiveTimeout(intptr_t socket, int32_t millisecondsTimeout);
 extern "C" Error SystemNative_SetReceiveTimeout_IntPtr(intptr_t socket, int32_t millisecondsTimeout);
 
-extern "C" Error SystemNative_SetSendTimeout(int32_t socket, int32_t millisecondsTimeout);
+extern "C" Error SystemNative_SetSendTimeout(intptr_t socket, int32_t millisecondsTimeout);
 extern "C" Error SystemNative_SetSendTimeout_IntPtr(intptr_t socket, int32_t millisecondsTimeout);
 
-extern "C" Error SystemNative_ReceiveMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received);
+extern "C" Error SystemNative_ReceiveMessage(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received);
 extern "C" Error SystemNative_ReceiveMessage_IntPtr(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received);
 
-extern "C" Error SystemNative_SendMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent);
+extern "C" Error SystemNative_SendMessage(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent);
 extern "C" Error SystemNative_SendMessage_IntPtr(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent);
 
-extern "C" Error SystemNative_Accept(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, int32_t* acceptedSocket);
+extern "C" Error SystemNative_Accept(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, intptr_t* acceptedSocket);
 extern "C" Error SystemNative_Accept_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, intptr_t* acceptedSocket);
 
-extern "C" Error SystemNative_Bind(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
+extern "C" Error SystemNative_Bind(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
 extern "C" Error SystemNative_Bind_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
 
-extern "C" Error SystemNative_Connect(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
+extern "C" Error SystemNative_Connect(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
 extern "C" Error SystemNative_Connect_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
 
-extern "C" Error SystemNative_GetPeerName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
+extern "C" Error SystemNative_GetPeerName(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
 extern "C" Error SystemNative_GetPeerName_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
 
-extern "C" Error SystemNative_GetSockName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
+extern "C" Error SystemNative_GetSockName(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
 extern "C" Error SystemNative_GetSockName_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
 
-extern "C" Error SystemNative_Listen(int32_t socket, int32_t backlog);
+extern "C" Error SystemNative_Listen(intptr_t socket, int32_t backlog);
 extern "C" Error SystemNative_Listen_IntPtr(intptr_t socket, int32_t backlog);
 
-extern "C" Error SystemNative_Shutdown(int32_t socket, int32_t socketShutdown);
+extern "C" Error SystemNative_Shutdown(intptr_t socket, int32_t socketShutdown);
 extern "C" Error SystemNative_Shutdown_IntPtr(intptr_t socket, int32_t socketShutdown);
 
-extern "C" Error SystemNative_GetSocketErrorOption(int32_t socket, Error* error);
+extern "C" Error SystemNative_GetSocketErrorOption(intptr_t socket, Error* error);
 extern "C" Error SystemNative_GetSocketErrorOption_IntPtr(intptr_t socket, Error* error);
 
 extern "C" Error SystemNative_GetSockOpt(
-    int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen);
+    intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen);
 extern "C" Error SystemNative_GetSockOpt_IntPtr(
     intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen);
 
 extern "C" Error SystemNative_SetSockOpt(
-    int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen);
+    intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen);
 extern "C" Error SystemNative_SetSockOpt_IntPtr(
     intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen);
 
-extern "C" Error SystemNative_Socket(int32_t addressFamily, int32_t socketType, int32_t protocolType, int32_t* createdSocket);
+extern "C" Error SystemNative_Socket(int32_t addressFamily, int32_t socketType, int32_t protocolType, intptr_t* createdSocket);
 extern "C" Error SystemNative_Socket_IntPtr(int32_t addressFamily, int32_t socketType, int32_t protocolType, intptr_t* createdSocket);
 
-extern "C" Error SystemNative_GetBytesAvailable(int32_t socket, int32_t* available);
+extern "C" Error SystemNative_GetBytesAvailable(intptr_t socket, int32_t* available);
 extern "C" Error SystemNative_GetBytesAvailable_IntPtr(intptr_t socket, int32_t* available);
 
-extern "C" Error SystemNative_CreateSocketEventPort(int32_t* port);
+extern "C" Error SystemNative_CreateSocketEventPort(intptr_t* port);
 extern "C" Error SystemNative_CreateSocketEventPort_IntPtr(intptr_t* port);
 
-extern "C" Error SystemNative_CloseSocketEventPort(int32_t port);
+extern "C" Error SystemNative_CloseSocketEventPort(intptr_t port);
 extern "C" Error SystemNative_CloseSocketEventPort_IntPtr(intptr_t port);
 
 extern "C" Error SystemNative_CreateSocketEventBuffer(int32_t count, SocketEvent** buffer);
@@ -434,11 +434,11 @@ extern "C" Error SystemNative_CreateSocketEventBuffer(int32_t count, SocketEvent
 extern "C" Error SystemNative_FreeSocketEventBuffer(SocketEvent* buffer);
 
 extern "C" Error SystemNative_TryChangeSocketEventRegistration(
-    int32_t port, int32_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data);
+    intptr_t port, intptr_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data);
 extern "C" Error SystemNative_TryChangeSocketEventRegistration_IntPtr(
     intptr_t port, intptr_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data);
 
-extern "C" Error SystemNative_WaitForSocketEvents(int32_t port, SocketEvent* buffer, int32_t* count);
+extern "C" Error SystemNative_WaitForSocketEvents(intptr_t port, SocketEvent* buffer, int32_t* count);
 extern "C" Error SystemNative_WaitForSocketEvents_IntPtr(intptr_t port, SocketEvent* buffer, int32_t* count);
 
 extern "C" int32_t SystemNative_PlatformSupportsDualModeIPv4PacketInfo();


### PR DESCRIPTION
Part 2 of the fix for #6928.  Change signatures of the "permanent" native networking methods to take IntPtr arguments, and switch back to using those methods.  Once this change propagates everywhere, we can remove the *_IntPtr methods introduced in #7587.

@stephentoub