### PR TITLE
Add globalization tests and fix RemoteInvoke for net46

### DIFF
--- a/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/AssemblyAttributes.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/AssemblyAttributes.cs
@@ -1,0 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/RemoteExecutorConsoleApp.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/RemoteExecutorConsoleApp.cs
@@ -5,8 +5,6 @@
 using System;
 using System.Reflection;
 
-[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-
 namespace RemoteExecutorConsoleApp
 {
     /// <summary>
@@ -41,7 +39,7 @@ namespace RemoteExecutorConsoleApp
             {
                 a = Assembly.Load(new AssemblyName(assemblyName));
                 t = a.GetType(typeName);
-                mi = t.GetMethod(methodName);
+                mi = t.GetTypeInfo().GetDeclaredMethod(methodName);
                 if (!mi.IsStatic)
                 {
                     instance = Activator.CreateInstance(t);

--- a/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/RemoteExecutorConsoleApp.csproj
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/RemoteExecutorConsoleApp.csproj
@@ -11,11 +11,22 @@
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="RemoteExecutorConsoleApp.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+    <Compile Include="AssemblyAttributes.cs"/>
     <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
       <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+    <TargetingPackReference Include="System" />
+    <TargetingPackReference Include="System.Threading.Tasks" />
+    <TargetingPackReference Include="System.Core" />
+    <TargetingPackReference Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/project.json
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/project.json
@@ -1,13 +1,26 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-rc3-24008-00",
-    "System.Console": "4.0.0-rc3-24008-00",
-    "System.IO": "4.1.0-rc3-24008-00",
-    "System.Reflection": "4.1.0-rc3-24008-00",
     "System.Runtime": "4.1.0-rc3-24008-00",
-    "System.Threading.Tasks": "4.0.11-rc3-24008-00"
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "Microsoft.NETCore.Platforms": "1.0.1-rc3-24008-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "dependencies": {
+        "System.Console": "4.0.0-rc3-24008-00",
+        "System.Diagnostics.Process": "4.0.1-rc3-24008-00",
+        "System.IO": "4.1.0-rc3-24008-00",
+        "System.Reflection": "4.1.0-rc3-24008-00",
+        "System.Threading.Tasks": "4.0.11-rc3-24008-00"
+      },
+      "imports": "portable-net45+win8"
+    },
+    "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
+    }
   }
 }

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -492,7 +493,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void TestProcessName()
         {
-            Assert.Equal(_process.ProcessName, HostRunner, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(Path.GetFileNameWithoutExtension(_process.ProcessName), Path.GetFileNameWithoutExtension(HostRunner), StringComparer.OrdinalIgnoreCase);
         }
 
         [Fact]

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -2,35 +2,32 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Globalization.Tests
 {
-    public class DateTimeFormatInfoCurrentCultureTests
+    public class DateTimeFormatInfoCurrentCultureTests : RemoteExecutorTestBase
     {
         [Fact]
         public void CurrentCulture()
         {
-            // Run all tests in one method to avoid multi-threading issues
-            CultureInfo defaultCulture = CultureInfo.CurrentCulture;
-            Assert.NotEqual(CultureInfo.InvariantCulture, defaultCulture);
-
-            CultureInfo newCulture = new CultureInfo(defaultCulture.Name.Equals("ja-JP", StringComparison.OrdinalIgnoreCase) ? "ar-SA" : "ja-JP");
-            CultureInfo.CurrentCulture = newCulture;
-            try
+            RemoteInvoke(() =>
             {
+                CultureInfo newCulture = new CultureInfo(CultureInfo.CurrentCulture.Name.Equals("ja-JP", StringComparison.OrdinalIgnoreCase) ? "ar-SA" : "ja-JP");
+                CultureInfo.CurrentCulture = newCulture;
+
                 Assert.Equal(CultureInfo.CurrentCulture, newCulture);
 
                 newCulture = new CultureInfo("de-DE_phoneb");
                 CultureInfo.CurrentCulture = newCulture;
+
                 Assert.Equal(CultureInfo.CurrentCulture, newCulture);
                 Assert.Equal("de-DE_phoneb", newCulture.CompareInfo.Name);
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = defaultCulture;
-            }
-            Assert.Equal(CultureInfo.CurrentCulture, defaultCulture);
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
@@ -42,26 +39,58 @@ namespace System.Globalization.Tests
         [Fact]
         public void CurrentUICulture()
         {
-            // Run all tests in one method to avoid multi-threading issues
-            CultureInfo defaultUICulture = CultureInfo.CurrentUICulture;
-            Assert.NotEqual(CultureInfo.InvariantCulture, defaultUICulture);
-
-            CultureInfo newUICulture = new CultureInfo(defaultUICulture.Name.Equals("ja-JP", StringComparison.OrdinalIgnoreCase) ? "ar-SA" : "ja-JP");
-            CultureInfo.CurrentUICulture = newUICulture;
-            try
+            RemoteInvoke(() =>
             {
+                CultureInfo newUICulture = new CultureInfo(CultureInfo.CurrentUICulture.Name.Equals("ja-JP", StringComparison.OrdinalIgnoreCase) ? "ar-SA" : "ja-JP");
+                CultureInfo.CurrentUICulture = newUICulture;
+
                 Assert.Equal(CultureInfo.CurrentUICulture, newUICulture);
 
                 newUICulture = new CultureInfo("de-DE_phoneb");
                 CultureInfo.CurrentUICulture = newUICulture;
+
                 Assert.Equal(CultureInfo.CurrentUICulture, newUICulture);
                 Assert.Equal("de-DE_phoneb", newUICulture.CompareInfo.Name);
-            }
-            finally
+                return SuccessExitCode;
+            }).Dispose();
+        }
+
+        [Fact]
+        public void DefaultThreadCurrentCulture()
+        {
+            RemoteInvoke(() =>
             {
-                CultureInfo.CurrentUICulture = defaultUICulture;
-            }
-            Assert.Equal(CultureInfo.CurrentUICulture, defaultUICulture);
+                CultureInfo newCulture = new CultureInfo(CultureInfo.DefaultThreadCurrentCulture == null || CultureInfo.DefaultThreadCurrentCulture.Name.Equals("ja-JP", StringComparison.OrdinalIgnoreCase) ? "ar-SA" : "ja-JP");
+                CultureInfo.DefaultThreadCurrentCulture = newCulture;
+
+                Task task = Task.Run(() =>
+                {
+                    Assert.Equal(CultureInfo.CurrentCulture, newCulture);
+                });
+                ((IAsyncResult)task).AsyncWaitHandle.WaitOne();
+                task.Wait();
+
+                return SuccessExitCode;
+            }).Dispose();
+        }
+
+        [Fact]
+        public void DefaultThreadCurrentUICulture()
+        {
+            RemoteInvoke(() =>
+            {
+                CultureInfo newUICulture = new CultureInfo(CultureInfo.DefaultThreadCurrentUICulture == null || CultureInfo.DefaultThreadCurrentUICulture.Name.Equals("ja-JP", StringComparison.OrdinalIgnoreCase) ? "ar-SA" : "ja-JP");
+                CultureInfo.DefaultThreadCurrentUICulture = newUICulture;
+
+                Task task = Task.Run(() =>
+                {
+                    Assert.Equal(CultureInfo.CurrentUICulture, newUICulture);
+                });
+                ((IAsyncResult)task).AsyncWaitHandle.WaitOne();
+                task.Wait();
+
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
@@ -3,11 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Globalization.Tests
 {
-    public class CultureInfoDateTimeFormat
+    public class CultureInfoDateTimeFormat : RemoteExecutorTestBase
     {
         public static IEnumerable<object[]> DateTimeFormatInfo_Set_TestData()
         {
@@ -29,6 +30,20 @@ namespace System.Globalization.Tests
             CultureInfo culture = new CultureInfo(name);
             culture.DateTimeFormat = newDateTimeFormatInfo;
             Assert.Equal(newDateTimeFormatInfo, culture.DateTimeFormat);
+        }
+
+        [Fact]
+        public void TestSettingThreadCultures()
+        {
+            RemoteInvoke(() =>
+            {
+                CultureInfo culture = new CultureInfo("ja-JP");
+                CultureInfo.CurrentCulture = culture;
+                DateTime dt = new DateTime(2014, 3, 14, 3, 14, 0);
+                Assert.Equal(dt.ToString(), dt.ToString(culture));
+                Assert.Equal(dt.ToString(), dt.ToString(culture.DateTimeFormat));
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrentInfo.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrentInfo.cs
@@ -3,11 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using Xunit;
 
 namespace System.Globalization.Tests
 {
-    public class NumberFormatInfoCurrentInfo
+    public class NumberFormatInfoCurrentInfo : RemoteExecutorTestBase
     {
         public static IEnumerable<object[]> CurrentInfo_CustomCulture_TestData()
         {
@@ -20,46 +21,37 @@ namespace System.Globalization.Tests
         [MemberData(nameof(CurrentInfo_CustomCulture_TestData))]
         public void CurrentInfo_CustomCulture(CultureInfo newCurrentCulture)
         {
-            CultureInfo oldCurrentCulture = CultureInfo.CurrentCulture;
-            try
+            RemoteInvoke((cultureName) =>
             {
-                CultureInfo.CurrentCulture = newCurrentCulture;
-                Assert.Same(newCurrentCulture.NumberFormat, NumberFormatInfo.CurrentInfo);
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = oldCurrentCulture;
-            }
+                if (cultureName.Equals("EmptyString"))
+                    cultureName = string.Empty;
+                CultureInfo newCulture = new CultureInfo(cultureName);
+                CultureInfo.CurrentCulture = newCulture;
+                Assert.Same(newCulture.NumberFormat, NumberFormatInfo.CurrentInfo);
+                return SuccessExitCode;
+            }, newCurrentCulture.Name.Length > 0 ? newCurrentCulture.Name : "EmptyString").Dispose();
         }
 
         [Fact]
         public void CurrentInfo_Subclass_OverridesGetFormat()
         {
-            CultureInfo oldCurrentCulture = CultureInfo.CurrentCulture;
-            try
+            RemoteInvoke(() =>
             {
                 CultureInfo.CurrentCulture = new CultureInfoSubclassOverridesGetFormat("en-US");
                 Assert.Same(CultureInfoSubclassOverridesGetFormat.CustomFormat, NumberFormatInfo.CurrentInfo);
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = oldCurrentCulture;
-            }
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void CurrentInfo_Subclass_OverridesNumberFormat()
         {
-            CultureInfo oldCurrentCulture = CultureInfo.CurrentCulture;
-            try
+            RemoteInvoke(() =>
             {
                 CultureInfo.CurrentCulture = new CultureInfoSubclassOverridesNumberFormat("en-US");
                 Assert.Same(CultureInfoSubclassOverridesNumberFormat.CustomFormat, NumberFormatInfo.CurrentInfo);
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = oldCurrentCulture;
-            }
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         private class CultureInfoSubclassOverridesGetFormat : CultureInfo

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -136,12 +136,23 @@
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>
     </Compile>
+    <!-- Helpers -->
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs">
       <Link>Common\System\RandomDataGenerator.cs</Link>
-    </Compile>  
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorTestBase.cs">
+      <Link>Common\System\Diagnostics\RemoteExecutorTestBase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
+      <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
+    </Compile>
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
     <TargetingPackReference Include="System" />

--- a/src/System.Globalization/tests/project.json
+++ b/src/System.Globalization/tests/project.json
@@ -9,6 +9,7 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
+        "System.Diagnostics.Process": "4.0.1-rc3-24008-00",
         "System.Globalization": "4.0.11-rc3-24008-00",
         "System.Globalization.Calendars": "4.0.1-rc3-24008-00",
         "System.Linq.Expressions": "4.0.11-rc3-24008-00",


### PR DESCRIPTION
Cherry-picks the commit from https://github.com/dotnet/corefx/pull/7402 unchanged, and adds one that enables the RemoteInvoke utility to be used in net46.

cc: @ianhays, @tarekgh, @weshaggard