### PR TITLE
Linux/ARM: Add type casting to gssBuffer->length (GSS-API)

### DIFF
--- a/src/Native/System.Net.Security.Native/pal_gssapi.cpp
+++ b/src/Native/System.Net.Security.Native/pal_gssapi.cpp
@@ -44,7 +44,7 @@ static void NetSecurityNative_MoveBuffer(gss_buffer_t gssBuffer, struct PAL_GssB
     assert(gssBuffer != nullptr);
     assert(targetBuffer != nullptr);
 
-    targetBuffer->length = gssBuffer->length;
+    targetBuffer->length = static_cast<uint64_t>(gssBuffer->length);
     targetBuffer->data = static_cast<uint8_t*>(gssBuffer->value);
 }
 


### PR DESCRIPTION
Recently, GNU Generic Security Service Library (GSS-API) is used
by 'System.Net.Security.Native' (native corefx).

The varaible type of The PAL_GssBuffer->length is different from
that of the gssBuffer->length (GSS-API).
Let's add the type casting to convert gssBuffer->length data type
form size_t to uint64_t.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
Signed-off-by: Prajwal A N <an.prajwal@samsung.com>
CC  : Jan Kotas <jkotas@microsoft.com>
CC  : Stephen Toub <@stephentoub>