### PR TITLE
Initial System.Net.Http 4.1 contract

### DIFF
--- a/pkg/NETStandard.Library/NETStandard.Library.packages.targets
+++ b/pkg/NETStandard.Library/NETStandard.Library.packages.targets
@@ -31,6 +31,10 @@
     <Package Include="System.Runtime.InteropServices" />
     <Package Include="System.Runtime.InteropServices.RuntimeInformation" />
     <Package Include="System.Runtime.Numerics" />
+    <Package Include="System.Security.Cryptography.Algorithms" />
+    <Package Include="System.Security.Cryptography.Encoding" />
+    <Package Include="System.Security.Cryptography.Primitives" />
+    <Package Include="System.Security.Cryptography.X509Certificates" />
     <Package Include="System.Text.Encoding" />
     <Package Include="System.Text.Encoding.Extensions" />
     <Package Include="System.Text.RegularExpressions" />

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -220,6 +220,7 @@ nameof(value),
 
             set
             {
+                CheckDisposedOrStarted();
                 _checkCertificateRevocationList = value;
             }
         }

--- a/src/System.Net.Http/pkg/System.Net.Http.pkgproj
+++ b/src/System.Net.Http/pkg/System.Net.Http.pkgproj
@@ -1,12 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Version>4.0.1.0</Version>
+    <Version>4.1.0.0</Version>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <ProjectReference Include="..\ref\4.0\System.Net.Http.depproj">
+      <SupportedFramework>net45;netcore45;wpa81</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\ref\System.Net.Http.csproj">
-      <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Net.Http.builds" />
     <ProjectReference Include="$(NativePackagePath)\runtime.native.System\runtime.native.System.pkgproj" />
@@ -14,6 +17,9 @@
     <ProjectReference Include="$(NativePackagePath)\runtime.native.System.Security.Cryptography\runtime.native.System.Security.Cryptography.pkgproj" />
   </ItemGroup>
   <ItemGroup>
+    <!-- We treat net46 as out-of-band, using the PCL reference assembly and PCL implementation. -->
+    <OutOfBoxFramework Include="net46" />
+
     <InboxOnTargetFramework Include="monoandroid10">
       <AsFrameworkReference>true</AsFrameworkReference>
     </InboxOnTargetFramework>
@@ -22,9 +28,6 @@
     </InboxOnTargetFramework>
     <InboxOnTargetFramework Include="net45">
       <AsFrameworkReference>true</AsFrameworkReference>
-    </InboxOnTargetFramework>
-    <InboxOnTargetFramework Include="net46">
-      <PackageTargetRuntime>win7</PackageTargetRuntime>
     </InboxOnTargetFramework>
     <InboxOnTargetFramework Include="win8" />
     <InboxOnTargetFramework Include="wpa81" />

--- a/src/System.Net.Http/ref/4.0/System.Net.Http.depproj
+++ b/src/System.Net.Http/ref/4.0/System.Net.Http.depproj
@@ -2,14 +2,11 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.1</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.1</NuGetTargetMoniker>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="System.Net.Http.cs" />
-  </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.Net.Http/ref/4.0/project.json
+++ b/src/System.Net.Http/ref/4.0/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Net.Http": "4.0.0"
+  },
+  "frameworks": {
+    "netstandard1.1": {
+      "imports": [
+        "dotnet5.2"
+      ]
+    }
+  }
+}

--- a/src/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/System.Net.Http/ref/System.Net.Http.cs
@@ -80,13 +80,16 @@ namespace System.Net.Http
         public HttpClientHandler() { }
         public bool AllowAutoRedirect { get { return default(bool); } set { } }
         public System.Net.DecompressionMethods AutomaticDecompression { get { return default(System.Net.DecompressionMethods); } set { } }
+        public bool CheckCertificateRevocationList { get { return default(bool); } set { } }
         public System.Net.Http.ClientCertificateOption ClientCertificateOptions { get { return default(System.Net.Http.ClientCertificateOption); } set { } }
+        public System.Security.Cryptography.X509Certificates.X509CertificateCollection ClientCertificates { get { return default(System.Security.Cryptography.X509Certificates.X509CertificateCollection); } }
         public System.Net.CookieContainer CookieContainer { get { return default(System.Net.CookieContainer); } set { } }
         public System.Net.ICredentials Credentials { get { return default(System.Net.ICredentials); } set { } }
         public int MaxAutomaticRedirections { get { return default(int); } set { } }
         public long MaxRequestContentBufferSize { get { return default(long); } set { } }
         public bool PreAuthenticate { get { return default(bool); } set { } }
         public System.Net.IWebProxy Proxy { get { return default(System.Net.IWebProxy); } set { } }
+        public System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool> ServerCertificateCustomValidationCallback { get { return default(System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool>); } set { } }
         public virtual bool SupportsAutomaticDecompression { get { return default(bool); } }
         public virtual bool SupportsProxy { get { return default(bool); } }
         public virtual bool SupportsRedirectConfiguration { get { return default(bool); } }

--- a/src/System.Net.Http/ref/project.json
+++ b/src/System.Net.Http/ref/project.json
@@ -3,13 +3,14 @@
     "System.Runtime": "4.0.0",
     "System.Threading.Tasks": "4.0.0",
     "System.IO": "4.0.0",
-    "System.Net.Primitives": "4.0.0",
+    "System.Net.Primitives": "4.0.10",
+    "System.Security.Cryptography.X509Certificates": "4.1.0-rc3-24013-00",
     "System.Text.Encoding": "4.0.0"
   },
   "frameworks": {
-    "netstandard1.1": {
+    "netstandard1.3": {
       "imports": [
-        "dotnet5.2"
+        "dotnet5.4"
       ]
     }
   }

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -10,12 +10,11 @@
     <ProjectGuid>{1D422B1D-D7C4-41B9-862D-EB3D98DF37DE}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Net.Http</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(AssemblyVersionTransition)' == 'true'">4.0.1.0</AssemblyVersion>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(AssemblyVersionTransition)' == 'true'">4.1.0.0</AssemblyVersion>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
     <PackageTargetFramework Condition="'$(TargetsUnix)' == 'true'">netstandard1.4</PackageTargetFramework>
-    <PackageTargetRuntime Condition="'$(TargetsWindows)' == 'true'">win7</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(TargetsWindows)' == 'true'">win</PackageTargetRuntime>
     <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
     <NuGetTargetMoniker Condition="'$(TargetsUnix)' == 'true'">.NETStandard,Version=v1.4</NuGetTargetMoniker>

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
@@ -38,9 +38,9 @@ namespace System.Net.Http
             set { _curlHandler.ClientCertificateOptions = value; }
         }
 
-        public X509Certificate2Collection ClientCertificates => _curlHandler.ClientCertificates;
+        public X509CertificateCollection ClientCertificates => _curlHandler.ClientCertificates;
 
-        public Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateValidationCallback
+        public Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateCustomValidationCallback
         {
             get { return _curlHandler.ServerCertificateValidationCallback; }
             set { _curlHandler.ServerCertificateValidationCallback = value; }

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -5,6 +5,8 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net.Http.Headers;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -137,6 +139,23 @@ namespace System.Net.Http
             // TODO: Add message/link to exception explaining the deprecation. 
             // Update corresponding exception in HttpClientHandler.Unix.cs if/when this is updated.
             set { throw new PlatformNotSupportedException(); }
+        }
+
+        public X509CertificateCollection ClientCertificates
+        {
+            get { return _winHttpHandler.ClientCertificates; }
+        }
+
+        public Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateCustomValidationCallback
+        {
+            get { return _winHttpHandler.ServerCertificateValidationCallback; }
+            set { _winHttpHandler.ServerCertificateValidationCallback = value; }
+        }
+
+        public bool CheckCertificateRevocationList
+        {
+            get { return _winHttpHandler.CheckCertificateRevocationList; }
+            set { _winHttpHandler.CheckCertificateRevocationList = value; }
         }
 
         #endregion Properties

--- a/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -139,12 +139,12 @@ namespace System.Net.Http
         {
             _bufferedContent = new MemoryStream(buffer, offset, count, writable: false, publiclyVisible: true);
         }
-        
+
         internal bool TryGetBuffer(out ArraySegment<byte> buffer)
         {
             return _bufferedContent != null && _bufferedContent.TryGetBuffer(out buffer);
         }
-     
+
         protected HttpContent()
         {
             // Log to get an ID for the current content. This ID is used when the content gets associated to a message.

--- a/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
@@ -7,8 +7,10 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Security;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -43,6 +45,7 @@ namespace System.Net.Http
         private bool useCookies;
         private DecompressionMethods automaticDecompression;
         private IWebProxy proxy;
+        private X509Certificate2Collection clientCertificates;
 
         #endregion Fields
 
@@ -270,6 +273,52 @@ namespace System.Net.Http
             get
             {
                 return s_RTCookieUsageBehaviorSupported.Value;
+            }
+        }
+
+        public X509CertificateCollection ClientCertificates
+        {
+            // TODO: Not yet implemented. Issue #7623.
+            get
+            {
+                if (clientCertificates == null)
+                {
+                    clientCertificates = new X509Certificate2Collection();
+                }
+
+                return clientCertificates;
+            }
+        }
+
+        public Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateCustomValidationCallback
+        {
+            // TODO: Not yet implemented. Issue #7623.
+            get{ return null; }
+            set
+            {
+                CheckDisposedOrStarted();
+                if (value != null)
+                {
+                    throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,
+                        SR.net_http_value_not_supported, value, nameof(ServerCertificateCustomValidationCallback)));
+                }
+            }
+        }
+
+        public bool CheckCertificateRevocationList
+        {
+            // TODO: We can't get this property to actually work yet since the current WinRT Windows.Web.Http APIs don't have a setting for this.
+            // FYI: The WinRT API always checks for certificate revocation. If the revocation status can't be determined completely, i.e.
+            // the revocation server is offline, then the request is still allowed.
+            get { return true; }
+            set
+            {
+                CheckDisposedOrStarted();
+                if (!value)
+                {
+                    throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,
+                        SR.net_http_value_not_supported, value, nameof(CheckCertificateRevocationList)));
+                }
             }
         }
 

--- a/src/System.Net.Http/src/netcore50/project.json
+++ b/src/System.Net.Http/src/netcore50/project.json
@@ -16,6 +16,7 @@
         "System.Resources.ResourceManager": "4.0.0",
         "System.Runtime.Extensions": "4.0.10",
         "System.Runtime.WindowsRuntime": "4.0.10",
+        "System.Security.Cryptography.X509Certificates": "4.1.0-rc3-24013-00",
         "System.Text.Encoding.Extensions": "4.0.10",
         "System.Threading.Tasks": "4.0.10"
       }

--- a/src/System.Net.Http/src/project.json
+++ b/src/System.Net.Http/src/project.json
@@ -27,11 +27,6 @@
         "System.Threading": "4.0.0",
         "System.Threading.Tasks": "4.0.10"
       }
-    },
-    "net46": {
-      "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
-      }
     }
   }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -21,7 +21,7 @@ namespace System.Net.Http.Functional.Tests
             var handler = new HttpClientHandler();
             using (var client = new HttpClient(handler))
             {
-                Assert.Null(handler.ServerCertificateValidationCallback);
+                Assert.Null(handler.ServerCertificateCustomValidationCallback);
                 Assert.False(handler.CheckCertificateRevocationList);
 
                 using (HttpResponseMessage response = await client.GetAsync(HttpTestServers.SecureRemoteEchoServer))
@@ -29,7 +29,7 @@ namespace System.Net.Http.Functional.Tests
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 }
 
-                Assert.Throws<InvalidOperationException>(() => handler.ServerCertificateValidationCallback = null);
+                Assert.Throws<InvalidOperationException>(() => handler.ServerCertificateCustomValidationCallback = null);
                 Assert.Throws<InvalidOperationException>(() => handler.CheckCertificateRevocationList = false);
             }
         }
@@ -41,7 +41,7 @@ namespace System.Net.Http.Functional.Tests
             using (var client = new HttpClient(handler))
             {
                 bool callbackCalled = false;
-                handler.ServerCertificateValidationCallback = delegate { callbackCalled = true; return true; };
+                handler.ServerCertificateCustomValidationCallback = delegate { callbackCalled = true; return true; };
 
                 using (HttpResponseMessage response = await client.GetAsync(HttpTestServers.RemoteEchoServer))
                 {
@@ -70,7 +70,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 bool callbackCalled = false;
                 handler.CheckCertificateRevocationList = checkRevocation;
-                handler.ServerCertificateValidationCallback = (request, cert, chain, errors) => {
+                handler.ServerCertificateCustomValidationCallback = (request, cert, chain, errors) => {
                     callbackCalled = true;
                     Assert.NotNull(request);
                     Assert.Equal(SslPolicyErrors.None, errors);
@@ -95,7 +95,7 @@ namespace System.Net.Http.Functional.Tests
             var handler = new HttpClientHandler();
             using (var client = new HttpClient(handler))
             {
-                handler.ServerCertificateValidationCallback = delegate { return false; };
+                handler.ServerCertificateCustomValidationCallback = delegate { return false; };
                 await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(HttpTestServers.SecureRemoteEchoServer));
             }
         }
@@ -107,7 +107,7 @@ namespace System.Net.Http.Functional.Tests
             using (var client = new HttpClient(handler))
             {
                 var e = new DivideByZeroException();
-                handler.ServerCertificateValidationCallback = delegate { throw e; };
+                handler.ServerCertificateCustomValidationCallback = delegate { throw e; };
                 Assert.Same(e, await Assert.ThrowsAsync<DivideByZeroException>(() => client.GetAsync(HttpTestServers.SecureRemoteEchoServer)));
             }
         }
@@ -155,7 +155,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 bool callbackCalled = false;
 
-                handler.ServerCertificateValidationCallback = (request, cert, chain, errors) =>
+                handler.ServerCertificateCustomValidationCallback = (request, cert, chain, errors) =>
                 {
                     callbackCalled = true;
                     Assert.NotNull(request);
@@ -177,7 +177,7 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalFact(nameof(BackendDoesNotSupportCustomCertificateHandling))]
         public async Task SSLBackendNotSupported_Callback_ThrowsPlatformNotSupportedException()
         {
-            using (var client = new HttpClient(new HttpClientHandler() { ServerCertificateValidationCallback = delegate { return true; } }))
+            using (var client = new HttpClient(new HttpClientHandler() { ServerCertificateCustomValidationCallback = delegate { return true; } }))
             {
                 await Assert.ThrowsAsync<PlatformNotSupportedException>(() => client.GetAsync(HttpTestServers.SecureRemoteEchoServer));
             }
@@ -268,5 +268,6 @@ namespace System.Net.Http.Functional.Tests
 
         [DllImport("System.Net.Http.Native", EntryPoint = "HttpNative_GetSslVersionDescription")]
         private static extern string CurlSslVersionDescription();
+
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="FakeDiagnosticSourceListenerObserver.cs" />
     <Compile Include="FormUrlEncodedContentTest.cs" />
     <Compile Include="HttpClientHandlerTest.cs" />
+    <Compile Include="HttpClientHandlerTest.ServerCertificates.cs" />
     <Compile Include="HttpClientTest.cs" />
     <Compile Include="HttpContentTest.cs" />
     <Compile Include="HttpMessageInvokerTest.cs" />
@@ -66,7 +67,6 @@
     <Compile Include="HttpClientHandlerTest.DefaultProxyCredentials.cs" />
     <Compile Include="HttpClientHandlerTest.MaxConnectionsPerServer.cs" />
     <Compile Include="HttpClientHandlerTest.MaxResponseHeadersLength.cs" />
-    <Compile Include="HttpClientHandlerTest.ServerCertificates.cs" />
     <Compile Include="HttpClientHandlerTest.SslProtocols.cs" />
     <Compile Include="HttpClientHandlerTest.Timeouts.cs" />
   </ItemGroup>


### PR DESCRIPTION
To support important customer scenarios for CoreFx RTM, we will be updating the System.Net.Http contract from 4.0 to 4.1. We are focusing on HttpClientHandler enhancements.

We will be submitting the final proposed list of additions as part of issue #7623. As part of updating the contract to 4.1, we are also OOB'ing the Desktop (net46 Windows) implementation so that the package won't be a facade over Desktop but rather a full implementation. This is possible since System.Net.Http has always been a standalone dll in the .NET Framework. As part of this, we are changing the implementation for Desktop from the legacy HttpWebRequest sockets stack to the WinHttpHandler stack based on native WinHTTP. This will give us a good path forward as WinHttpHandler stack will be getting HTTP/2.0 support with newer versions of Windows 10.

This initial PR has a few API additions that we are definitely going to be adding. It's important to get these changes into the builds so that we can fully bake the OOB Http.dll assembly on all the platforms and continue package testing.

There is an existing System.Net.Http.WebRequestHandler class in the .NET Framework located in System.Net.Http.WebRequest.dll. This class is a subclass of HttpClientHandler. Due to this, we are being careful not to cause collisions with some of these added properties. WebRequestHandler has a 'ClientCertificates' property and a 'ServerCertificateValidationCallback' property. So, we are aligning/renaming the properties as we add them to HttpClientHandler OOB assembly. This may get altered slightly as we finalize the 4.1 System.Net.Http API.