### PR TITLE
Remove some dead code from Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -17,13 +17,7 @@ namespace System.Linq.Expressions.Interpreter
         // the offset to jump to (relative to this instruction):
         protected int _offset = Unknown;
 
-        public int Offset { get { return _offset; } }
         public abstract Instruction[] Cache { get; }
-
-        public override string InstructionName
-        {
-            get { return "Offset"; }
-        }
 
         public Instruction Fixup(int offset)
         {
@@ -223,10 +217,6 @@ namespace System.Linq.Expressions.Interpreter
     internal abstract class IndexedBranchInstruction : Instruction
     {
         protected const int CacheSize = 32;
-        public override string InstructionName
-        {
-            get { return "IndexedBranch"; }
-        }
         internal readonly int _labelIndex;
 
         public IndexedBranchInstruction(int labelIndex)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -38,11 +38,6 @@ namespace System.Linq.Expressions.Interpreter
             Labels = labels;
         }
 
-        internal int Length
-        {
-            get { return Instructions.Length; }
-        }
-
         #region Debug View
 
         internal sealed class DebugView


### PR DESCRIPTION
In particular, not overriding `InstructionName` in `OffsetInstruction` and `IndexedBranchInstruction` forces it to be overridden in derived classes, which is probably preferable (and currently done, anyway).

Contributes to #3836

cc @stephentoub @VSadov 