### PR TITLE
Remove dead code from HashHelpers

### DIFF
--- a/src/Common/src/System/Collections/HashHelpers.cs
+++ b/src/Common/src/System/Collections/HashHelpers.cs
@@ -60,11 +60,6 @@ namespace System.Collections
             return min;
         }
 
-        public static int GetMinPrime()
-        {
-            return primes[0];
-        }
-
         // Returns size of hashtable to grow to.
         public static int ExpandPrime(int oldSize)
         {


### PR DESCRIPTION
`GetMinPrime` isn't actually used anywhere in the repo, and callers of it should probably be hard-coding `3` instead of getting the value from a gigantic array allocated at runtime.

cc @stephentoub