### PR TITLE
Remove dead code from Dictionary and Hashtable

### DIFF
--- a/src/System.Collections.NonGeneric/src/System/Collections/Hashtable.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Hashtable.cs
@@ -109,14 +109,6 @@ namespace System.Collections
 
         internal const Int32 HashPrime = 101;
         private const Int32 InitialSize = 3;
-        private const String LoadFactorName = "LoadFactor";
-        private const String VersionName = "Version";
-        private const String ComparerName = "Comparer";
-        private const String HashCodeProviderName = "HashCodeProvider";
-        private const String HashSizeName = "HashSize";  // Must save buckets.Length
-        private const String KeysName = "Keys";
-        private const String ValuesName = "Values";
-        private const String KeyComparerName = "KeyComparer";
 
         // Deleted entries have their key set to buckets
 

--- a/src/System.Collections/src/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Dictionary.cs
@@ -35,12 +35,6 @@ namespace System.Collections.Generic
         private ValueCollection values;
         private Object _syncRoot;
 
-        // constants for serialization
-        private const String VersionName = "Version";
-        private const String HashSizeName = "HashSize";  // Must save buckets.Length
-        private const String KeyValuePairsName = "KeyValuePairs";
-        private const String ComparerName = "Comparer";
-
         public Dictionary() : this(0, null) { }
 
         public Dictionary(int capacity) : this(capacity, null) { }


### PR DESCRIPTION
There seem to be a bunch of `const` string fields in `Dictionary` and `Hashtable` that I'm not quite sure what they're there for. The comment in `Dictionary` says it's there for 'serialization', but since the fields are never actually used, and AFAIK `const` fields are simply substituted out at compile-time (and unlike `static readonly` ones, don't exist at runtime), I don't see how they could affect anything.

cc @stephentoub