### PR TITLE
Expand System.ComponentModel.TypeConverter test coverage

### DIFF
--- a/src/System.ComponentModel.TypeConverter/tests/DescriptorTestAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/DescriptorTestAttribute.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ComponentModel.Tests
+{
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+    internal class DescriptorTestAttribute : Attribute
+    {
+        public string TestString;
+
+        public DescriptorTestAttribute(string testString = nameof(TestString))
+        {
+            TestString = testString;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return (obj as DescriptorTestAttribute)?.TestString.Equals(TestString, StringComparison.Ordinal) ?? false;
+        }
+
+        public override int GetHashCode() => TestString.GetHashCode();
+    }
+}

--- a/src/System.ComponentModel.TypeConverter/tests/DescriptorTestComponent.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/DescriptorTestComponent.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ComponentModel.Tests
+{
+    internal class DescriptorTestComponent : IComponent, ISite
+    {
+        [DefaultValue(null)]
+        public event Action ActionEvent;
+        public bool DesignMode { get; set; } = true;
+        public const int DefaultPropertyValue = 42;
+
+        [DefaultValue(DefaultPropertyValue)]
+        public int Property { get; set; }
+
+        public object PropertyWhichThrows { get { throw new NotImplementedException(); } }
+
+        public string StringProperty { get; private set; }
+
+        public DescriptorTestComponent(string stringPropertyValue = "")
+        {
+            StringProperty = stringPropertyValue;
+        }
+
+        public void RaiseEvent() => ActionEvent();
+
+        public event EventHandler Disposed;
+
+        public void Dispose() => Disposed(new object(), new EventArgs());
+
+        public object GetService(Type serviceType) => null;
+
+        public IComponent Component => this;
+
+        public IContainer Container => null;
+
+        public string Name
+        {
+            get
+            {
+                return nameof(DescriptorTestComponent);
+            }
+            set
+            { }
+        }
+
+        public ISite Site
+        {
+            get
+            {
+                return this;
+            }
+            set
+            { }
+        }
+    }
+}

--- a/src/System.ComponentModel.TypeConverter/tests/EventDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/EventDescriptorTests.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using Xunit;
+
+namespace System.ComponentModel.Tests
+{
+    public class EventDescriptorTests
+    {
+        [Fact]
+        public void RaiseAddedEventHandler()
+        {
+            var component = new DescriptorTestComponent();
+            var eventHandlerWasCalled = false;
+            Action eventHandler = () => eventHandlerWasCalled = true;
+            var eventInfo = typeof(DescriptorTestComponent).GetTypeInfo().GetEvent(nameof(DescriptorTestComponent.ActionEvent));
+            EventDescriptor eventDescriptor = TypeDescriptor.CreateEvent(component.GetType(), nameof(component.ActionEvent), typeof(Action));
+
+            eventDescriptor.AddEventHandler(component, eventHandler);
+            component.RaiseEvent();
+
+            Assert.True(eventHandlerWasCalled);
+        }
+
+        [Fact]
+        public void RemoveAddedEventHandler()
+        {
+            var component = new DescriptorTestComponent();
+            Action eventHandler = () => Assert.True(false, "EventDescriptor failed to remove an event handler");
+            EventDescriptor eventDescriptor = TypeDescriptor.CreateEvent(component.GetType(), nameof(component.ActionEvent), typeof(Action));
+
+            eventDescriptor.AddEventHandler(component, eventHandler);
+            eventDescriptor.RemoveEventHandler(component, eventHandler);
+
+            // component.Event should now have no handler => raising it should throw a NullReferenceException
+            Assert.Throws(typeof(NullReferenceException), () => component.RaiseEvent());
+        }
+
+        [Fact]
+        public void CopyConstructorAddsAttribute()
+        {
+            var oldEventDescriptor = TypeDescriptor.CreateEvent(typeof(DescriptorTestComponent), nameof(DescriptorTestComponent.ActionEvent), typeof(Action));
+            var expectedString = "EventDescriptorTests.CopyConstructorAddsAttribute";
+            var newAttribute = new DescriptorTestAttribute(expectedString);
+
+            EventDescriptor newEventDescriptor = TypeDescriptor.CreateEvent(typeof(DescriptorTestComponent), oldEventDescriptor, new[] { newAttribute });
+
+            Assert.True(newEventDescriptor.Attributes.Contains(newAttribute));
+        }
+
+        [Fact]
+        public void GetComponentType()
+        {
+            var componentType = typeof(DescriptorTestComponent);
+            EventDescriptor eventDescriptor = TypeDescriptor.CreateEvent(componentType, nameof(DescriptorTestComponent.ActionEvent), typeof(Action));
+
+            Assert.Equal(componentType, eventDescriptor.ComponentType);
+        }
+
+        [Fact]
+        public void GetEventType()
+        {
+            var eventType = typeof(Action);
+            var eventDescriptor = TypeDescriptor.CreateEvent(typeof(DescriptorTestComponent), nameof(DescriptorTestComponent.ActionEvent), eventType, null);
+
+            Assert.Equal(eventType, eventDescriptor.EventType);
+        }
+    }
+}

--- a/src/System.ComponentModel.TypeConverter/tests/PropertyDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/PropertyDescriptorTests.cs
@@ -1,0 +1,146 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.ComponentModel.Tests
+{
+    public class PropertyDescriptorTests
+    {
+        [Fact]
+        public void CopyConstructorAddsAttribute()
+        {
+            var component = new DescriptorTestComponent();
+            var properties = TypeDescriptor.GetProperties(component.GetType());
+            PropertyDescriptor oldPropertyDescriptor = properties.Find(nameof(component.Property), false);
+            var newAttribute = new DescriptorTestAttribute();
+
+            PropertyDescriptor newPropertyDescriptor = TypeDescriptor.CreateProperty(component.GetType(), oldPropertyDescriptor, newAttribute);
+
+            Assert.True(newPropertyDescriptor.Attributes.Contains(newAttribute));
+        }
+
+        [Fact]
+        public void RaiseAddedValueChangedHandler()
+        {
+            var component = new DescriptorTestComponent();
+            var properties = TypeDescriptor.GetProperties(component.GetType());
+            PropertyDescriptor propertyDescriptor = properties.Find(nameof(component.Property), false);
+            var handlerWasCalled = false;
+            EventHandler valueChangedHandler = (_, __) => handlerWasCalled = true;
+
+            propertyDescriptor.AddValueChanged(component, valueChangedHandler);
+            propertyDescriptor.SetValue(component, int.MaxValue);
+
+            Assert.True(handlerWasCalled);
+        }
+
+        [Fact]
+        public void RemoveAddedValueChangedHandler()
+        {
+            var component = new DescriptorTestComponent();
+            var properties = TypeDescriptor.GetProperties(component.GetType());
+            var handlerWasCalled = false;
+            EventHandler valueChangedHandler = (_, __) => handlerWasCalled = true;
+            PropertyDescriptor propertyDescriptor = properties.Find(nameof(component.Property), false);
+
+            propertyDescriptor.AddValueChanged(component, valueChangedHandler);
+            propertyDescriptor.RemoveValueChanged(component, valueChangedHandler);
+            propertyDescriptor.SetValue(component, int.MaxValue);
+
+            Assert.False(handlerWasCalled);
+        }
+
+        [Fact]
+        public void ResetValueReturnsFalseWhenValueEqualsDefault()
+        {
+            var component = new DescriptorTestComponent();
+            component.Property = DescriptorTestComponent.DefaultPropertyValue;
+            var properties = TypeDescriptor.GetProperties(component.GetType());
+            PropertyDescriptor propertyDescriptor = properties.Find(nameof(component.Property), false);
+
+            Assert.False(propertyDescriptor.CanResetValue(component));
+        }
+
+        [Fact]
+        public void GetComponentType()
+        {
+            var component = new DescriptorTestComponent();
+            var properties = TypeDescriptor.GetProperties(component.GetType());
+            PropertyDescriptor propertyDescriptor = properties.Find(nameof(component.Property), false);
+
+            Assert.Equal(component.GetType(), propertyDescriptor.ComponentType);
+        }
+
+        [Fact]
+        public void GetPropertyType()
+        {
+            var component = new DescriptorTestComponent();
+            var properties = TypeDescriptor.GetProperties(component.GetType());
+            PropertyDescriptor propertyDescriptor = properties.Find(nameof(component.Property), false);
+
+            Assert.Equal(component.Property.GetType(), propertyDescriptor.PropertyType);
+        }
+
+        [Fact]
+        public void GetValue()
+        {
+            var component = new DescriptorTestComponent();
+            component.Property = 37;
+            var properties = TypeDescriptor.GetProperties(component.GetType());
+            PropertyDescriptor propertyDescriptor = properties.Find(nameof(component.Property), false);
+
+            var retrievedValue = propertyDescriptor.GetValue(component);
+
+            Assert.Equal(component.Property, retrievedValue);
+        }
+
+
+        [Fact]
+        public void GetValueDoesNotHandleExceptions()
+        {
+            var component = new DescriptorTestComponent();
+            var properties = TypeDescriptor.GetProperties(component.GetType());
+            PropertyDescriptor propertyDescriptor = properties.Find(nameof(component.PropertyWhichThrows), false);
+
+            Assert.ThrowsAny<Exception>(() => propertyDescriptor.GetValue(component));
+        }
+
+        [Fact]
+        public void ResetValue()
+        {
+            var component = new DescriptorTestComponent();
+            component.Property = DescriptorTestComponent.DefaultPropertyValue - 1;
+            var properties = TypeDescriptor.GetProperties(component.GetType());
+            PropertyDescriptor propertyDescriptor = properties.Find(nameof(component.Property), false);
+
+            // this should set the property's value to that provided by the DefaultValueAttribute
+            propertyDescriptor.ResetValue(component);
+
+            Assert.Equal(DescriptorTestComponent.DefaultPropertyValue, component.Property);
+        }
+
+        [Fact]
+        public void ShouldSerializeValueReturnsFalseWhenValueIsDefault()
+        {
+            var component = new DescriptorTestComponent();
+            component.Property = DescriptorTestComponent.DefaultPropertyValue;
+            var properties = TypeDescriptor.GetProperties(component.GetType());
+            PropertyDescriptor propertyDescriptor = properties.Find(nameof(component.Property), false);
+
+            Assert.False(propertyDescriptor.ShouldSerializeValue(component));
+        }
+
+        [Fact]
+        public void ShouldSerializeValueReturnsTrueWhenValueIsNotDefault()
+        {
+            var component = new DescriptorTestComponent();
+            component.Property = DescriptorTestComponent.DefaultPropertyValue - 1;
+            var properties = TypeDescriptor.GetProperties(component.GetType());
+            PropertyDescriptor propertyDescriptor = properties.Find(nameof(component.Property), false);
+
+            Assert.True(propertyDescriptor.ShouldSerializeValue(component));
+        }
+    }
+}

--- a/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -50,6 +50,7 @@
     <Compile Include="MultilineStringConverterTests.cs" />
     <Compile Include="NullableConverterTests.cs" />
     <Compile Include="PropertyDescriptorCollectionTests.cs" />
+    <Compile Include="PropertyDescriptorTests.cs" />
     <Compile Include="ProvidePropertyAttributeTests.cs" />
     <Compile Include="SampleClasses.cs" />
     <Compile Include="SByteConverterTests.cs" />

--- a/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -37,6 +37,7 @@
     <Compile Include="DoubleConverterTests.cs" />
     <Compile Include="EnumConverterTest.cs" />
     <Compile Include="EventDescriptorCollectionTests.cs" />
+    <Compile Include="EventDescriptorTests.cs" />
     <Compile Include="GuidConverterTests.cs" />
     <Compile Include="Int16ConverterTests.cs" />
     <Compile Include="Int32ConverterTests.cs" />

--- a/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -42,6 +42,8 @@
     <Compile Include="Int32ConverterTests.cs" />
     <Compile Include="Int64ConverterTests.cs" />
     <Compile Include="MemberDescriptorTests.cs" />
+    <Compile Include="DescriptorTestAttribute.cs" />
+    <Compile Include="DescriptorTestComponent.cs" />
     <Compile Include="Mocks\MockEventDescriptor.cs" />
     <Compile Include="Mocks\MockPropertyDescriptor.cs" />
     <Compile Include="MultilineStringConverterTests.cs" />

--- a/src/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.cs
@@ -10,6 +10,62 @@ namespace System.ComponentModel.Tests
     public class TypeDescriptorTests
     {
         [Fact]
+        public void AddAndRemoveProvider()
+        {
+            var provider = new InvocationRecordingTypeDescriptionProvider();
+            var component = new DescriptorTestComponent();
+            TypeDescriptor.AddProvider(provider, component);
+
+            var retrievedProvider = TypeDescriptor.GetProvider(component);
+            retrievedProvider.GetCache(component);
+
+            Assert.True(provider.ReceivedCall);
+
+            provider.Reset();
+            TypeDescriptor.RemoveProvider(provider, component);
+            retrievedProvider = TypeDescriptor.GetProvider(component);
+            retrievedProvider.GetCache(component);
+
+            Assert.False(provider.ReceivedCall);
+        }
+
+        [Fact]
+        public void AddAttribute()
+        {
+            var component = new DescriptorTestComponent();
+            var addedAttribute = new DescriptorTestAttribute("expected string");
+
+            TypeDescriptor.AddAttributes(component.GetType(), addedAttribute);
+
+            AttributeCollection attributes = TypeDescriptor.GetAttributes(component);
+            Assert.True(attributes.Contains(addedAttribute));
+        }
+
+        [Fact]
+        public void CreateInstancePassesCtorParameters()
+        {
+            var expectedString = "expected string";
+            var component = TypeDescriptor.CreateInstance(null, typeof(DescriptorTestComponent), new[] { expectedString.GetType() }, new[] { expectedString });
+
+            Assert.NotNull(component);
+            Assert.IsType(typeof(DescriptorTestComponent), component);
+            Assert.Equal(expectedString, (component as DescriptorTestComponent).StringProperty);
+        }
+
+        [Fact]
+        public void GetAssociationReturnsExpectedObject()
+        {
+            var primaryObject = new DescriptorTestComponent();
+            var secondaryObject = new MockEventDescriptor();
+            TypeDescriptor.CreateAssociation(primaryObject, secondaryObject);
+
+            var associatedObject = TypeDescriptor.GetAssociation(secondaryObject.GetType(), primaryObject);
+
+            Assert.IsType(secondaryObject.GetType(), associatedObject);
+            Assert.Equal(secondaryObject, associatedObject);
+        }
+
+        [Fact]
         public static void GetConverter()
         {
             foreach (Tuple<Type, Type> pair in s_typesWithConverters)
@@ -33,6 +89,135 @@ namespace System.ComponentModel.Tests
             Assert.Throws<MissingMethodException>(
                  () => TypeDescriptor.GetConverter(typeof(ClassWithInvalidConverter)));
             // GetConverter should throw MissingMethodException because parameterless constructor is missing in the InvalidConverter class.
+        }
+
+        [Fact]
+        public void GetEvents()
+        {
+            var component = new DescriptorTestComponent();
+
+            EventDescriptorCollection events = TypeDescriptor.GetEvents(component);
+
+            Assert.Equal(2, events.Count);
+        }
+
+        [Fact]
+        public void GetEventsFiltersByAttribute()
+        {
+            var defaultValueAttribute = new DefaultValueAttribute(null);
+            EventDescriptorCollection events = TypeDescriptor.GetEvents(typeof(DescriptorTestComponent), new[] { defaultValueAttribute });
+
+            Assert.Equal(1, events.Count);
+        }
+
+        [Fact]
+        public void GetPropertiesFiltersByAttribute()
+        {
+            var defaultValueAttribute = new DefaultValueAttribute(DescriptorTestComponent.DefaultPropertyValue);
+            PropertyDescriptorCollection properties = TypeDescriptor.GetProperties(typeof(DescriptorTestComponent), new[] { defaultValueAttribute });
+
+            Assert.Equal(1, properties.Count);
+        }
+
+        [Fact]
+        public void RemoveAssociationsRemovesAllAssociations()
+        {
+            var primaryObject = new DescriptorTestComponent();
+            var firstAssociatedObject = new MockEventDescriptor();
+            var secondAssociatedObject = new MockPropertyDescriptor();
+            TypeDescriptor.CreateAssociation(primaryObject, firstAssociatedObject);
+            TypeDescriptor.CreateAssociation(primaryObject, secondAssociatedObject);
+
+            TypeDescriptor.RemoveAssociations(primaryObject);
+
+            // GetAssociation never returns null. The default implementation returns the
+            // primary object when an association doesn't exist. This isn't documented,
+            // however, so here we only verify that the formerly associated objects aren't returned.
+            var firstAssociation = TypeDescriptor.GetAssociation(firstAssociatedObject.GetType(), primaryObject);
+            Assert.NotEqual(firstAssociatedObject, firstAssociation);
+            var secondAssociation = TypeDescriptor.GetAssociation(secondAssociatedObject.GetType(), primaryObject);
+            Assert.NotEqual(secondAssociatedObject, secondAssociation);
+        }
+
+        [Fact]
+        public void RemoveSingleAssociation()
+        {
+            var primaryObject = new DescriptorTestComponent();
+            var firstAssociatedObject = new MockEventDescriptor();
+            var secondAssociatedObject = new MockPropertyDescriptor();
+            TypeDescriptor.CreateAssociation(primaryObject, firstAssociatedObject);
+            TypeDescriptor.CreateAssociation(primaryObject, secondAssociatedObject);
+
+            TypeDescriptor.RemoveAssociation(primaryObject, firstAssociatedObject);
+
+            // the second association should remain
+            var secondAssociation = TypeDescriptor.GetAssociation(secondAssociatedObject.GetType(), primaryObject);
+            Assert.Equal(secondAssociatedObject, secondAssociation);
+
+            // the first association should not
+            var firstAssociation = TypeDescriptor.GetAssociation(firstAssociatedObject.GetType(), primaryObject);
+            Assert.NotEqual(firstAssociatedObject, firstAssociation);
+        }
+
+        private class InvocationRecordingTypeDescriptionProvider : TypeDescriptionProvider
+        {
+            public bool ReceivedCall { get; private set; } = false;
+
+            public void Reset() => ReceivedCall = false;
+
+            public override object CreateInstance(IServiceProvider provider, Type objectType, Type[] argTypes, object[] args)
+            {
+                ReceivedCall = true;
+                return base.CreateInstance(provider, objectType, argTypes, args);
+            }
+
+            public override IDictionary GetCache(object instance)
+            {
+                ReceivedCall = true;
+                return base.GetCache(instance);
+            }
+
+            public override ICustomTypeDescriptor GetExtendedTypeDescriptor(object instance)
+            {
+                ReceivedCall = true;
+                return base.GetExtendedTypeDescriptor(instance);
+            }
+
+            public override string GetFullComponentName(object component)
+            {
+                ReceivedCall = true;
+                return base.GetFullComponentName(component);
+            }
+
+            public override Type GetReflectionType(Type objectType, object instance)
+            {
+                ReceivedCall = true;
+                return base.GetReflectionType(objectType, instance);
+            }
+
+            protected override IExtenderProvider[] GetExtenderProviders(object instance)
+            {
+                ReceivedCall = true;
+                return base.GetExtenderProviders(instance);
+            }
+
+            public override Type GetRuntimeType(Type reflectionType)
+            {
+                ReceivedCall = true;
+                return base.GetRuntimeType(reflectionType);
+            }
+
+            public override ICustomTypeDescriptor GetTypeDescriptor(Type objectType, object instance)
+            {
+                ReceivedCall = true;
+                return base.GetTypeDescriptor(objectType, instance);
+            }
+
+            public override bool IsSupportedType(Type type)
+            {
+                ReceivedCall = true;
+                return base.IsSupportedType(type);
+            }
         }
 
         private static Tuple<Type, Type>[] s_typesWithConverters =


### PR DESCRIPTION
This brings ```System.ComponentModel.TypeConverter``` line coverage to 47% via some straightforward unit tests of ```EventDescriptor```, ```PropertyDescriptor```, and ```TypeDescriptor``` APIs.

@twsouthwick