### PR TITLE
Remove FileSystemWatcher dependency from Unix X509Store

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
@@ -448,7 +448,7 @@ namespace Internal.Cryptography.Pal
                 throw new CryptographicException(SR.Format(SR.Cryptography_OwnerNotCurrentUser, path));
             }
 
-            if ((dirStat.Mode & (int)Interop.Sys.Permissions.Mask) != (int)Interop.Sys.Permissions.S_IRWXU)
+            if ((dirStat.Mode & (int)Interop.Sys.Permissions.S_IRWXU) != (int)Interop.Sys.Permissions.S_IRWXU)
             {
                 throw new CryptographicException(SR.Format(SR.Cryptography_InvalidDirectoryPermissions, path));
             }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Security.Cryptography;
@@ -28,9 +27,6 @@ namespace Internal.Cryptography.Pal
         private static string s_userStoreRoot;
 
         private readonly string _storePath;
-        private readonly object _fileWatcherLock = new object();
-        private List<X509Certificate2> _certificates;
-        private FileSystemWatcher _watcher;
 
         private readonly bool _readOnly;
 
@@ -84,11 +80,6 @@ namespace Internal.Cryptography.Pal
 
         public void Dispose()
         {
-            if (_watcher != null)
-            {
-                _watcher.Dispose();
-                _watcher = null;
-            }
         }
 
         public byte[] Export(X509ContentType contentType, string password)
@@ -105,82 +96,22 @@ namespace Internal.Cryptography.Pal
         {
             Debug.Assert(collection != null);
 
-            // Copy the reference locally, any directory change operations
-            // will cause the field to be reset to null.
-            List<X509Certificate2> certificates = _certificates;
-
-            if (certificates == null)
-            {
-                // ReadDirectory will both load _certificates and return the answer, so this call
-                // will have stable results across multiple adds/deletes happening in parallel.
-                certificates = ReadDirectory();
-                Debug.Assert(certificates != null);
-            }
-
-            foreach (X509Certificate2 cert in certificates)
-            {
-                collection.Add(cert);
-            }
-        }
-
-        private List<X509Certificate2> ReadDirectory()
-        {
             if (!Directory.Exists(_storePath))
             {
-                // Don't assign the field here, because we don't have a FileSystemWatcher
-                // yet to tell us that something has been added.
-                return new List<X509Certificate2>(0);
+                return;
             }
 
-            List<X509Certificate2> certs = new List<X509Certificate2>();
-
-            lock (_fileWatcherLock)
+            foreach (string filePath in Directory.EnumerateFiles(_storePath, PfxWildcard))
             {
-                if (_watcher == null)
+                try
                 {
-                    _watcher = new FileSystemWatcher(_storePath, PfxWildcard)
-                    {
-                        NotifyFilter = NotifyFilters.LastWrite,
-                    };
-
-                    FileSystemEventHandler handler = FlushCache;
-                    _watcher.Changed += handler;
-                    _watcher.Created += handler;
-                    _watcher.Deleted += handler;
-                    // The Renamed event has a different delegate type
-                    _watcher.Renamed += FlushCache;
-                    _watcher.Error += FlushCache;
+                    collection.Add(new X509Certificate2(filePath));
                 }
-
-                // Start watching for change events to know that another instance
-                // has messed with the underlying store.  This keeps us aligned
-                // with the Windows implementation, which opens stores with change
-                // notifications.
-                _watcher.EnableRaisingEvents = true;
-
-                foreach (string filePath in Directory.EnumerateFiles(_storePath, PfxWildcard))
+                catch (CryptographicException)
                 {
-                    X509Certificate2 cert;
-
-                    try
-                    {
-                        cert = new X509Certificate2(filePath);
-                    }
-                    catch (CryptographicException)
-                    {
-                        // The file wasn't a certificate, move on to the next one.
-                        continue;
-                    }
-
-                    certs.Add(cert);
+                    // The file wasn't a certificate, move on to the next one.
                 }
-
-                // Don't release _fileWatcherLock until _certificates is assigned, otherwise
-                // we may be setting it to a stale value after the change event said to clear it
-                _certificates = certs;
             }
-
-            return certs;
         }
 
         public void Add(ICertificatePal certPal)
@@ -191,40 +122,16 @@ namespace Internal.Cryptography.Pal
                 throw new CryptographicException(SR.Cryptography_X509_StoreReadOnly);
             }
 
-            // Save the collection to a local so it's consistent for the whole method
-            List<X509Certificate2> certificates = _certificates;
+            // This may well be the first time that we've added something to this store.
+            Directory.CreateDirectory(_storePath);
+
+            uint userId = Interop.Sys.GetEUid();
+            EnsureDirectoryPermissions(_storePath, userId);
+
             OpenSslX509CertificateReader cert = (OpenSslX509CertificateReader)certPal;
 
             using (X509Certificate2 copy = new X509Certificate2(cert.DuplicateHandles()))
             {
-                // certificates will be null if anything has changed since the last call to
-                // get_Certificates; including Add being called without get_Certificates being
-                // called at all.
-                if (certificates != null)
-                {
-                    foreach (X509Certificate2 inCollection in certificates)
-                    {
-                        if (inCollection.Equals(copy))
-                        {
-                            if (!copy.HasPrivateKey || inCollection.HasPrivateKey)
-                            {
-                                // If the existing store only knows about a public key, but we're
-                                // adding a public+private pair, continue with the add.
-                                //
-                                // So, therefore, if we aren't adding a private key, or already have one,
-                                // we don't need to do anything.
-                                return;
-                            }
-                        }
-                    }
-                }
-
-                // This may well be the first time that we've added something to this store.
-                Directory.CreateDirectory(_storePath);
-
-                uint userId = Interop.Sys.GetEUid();
-                EnsureDirectoryPermissions(_storePath, userId);
-
                 string thumbprint = copy.Thumbprint;
                 bool findOpenSlot;
 
@@ -233,41 +140,26 @@ namespace Internal.Cryptography.Pal
 
                 if (existingFilename != null)
                 {
-                    bool dataExistsAlready = false;
-
-                    // If the file on disk is just a public key, but we're trying to add a private key,
-                    // we'll want to overwrite it.
-                    if (copy.HasPrivateKey)
+                    if (!copy.HasPrivateKey)
                     {
-                        try
+                        return;
+                    }
+
+                    try
+                    {
+                        using (X509Certificate2 fromFile = new X509Certificate2(existingFilename))
                         {
-                            using (X509Certificate2 fromFile = new X509Certificate2(existingFilename))
+                            if (fromFile.HasPrivateKey)
                             {
-                                if (fromFile.HasPrivateKey)
-                                {
-                                    // We have a private key, the file has a private key, we're done here.
-                                    dataExistsAlready = true;
-                                }
+                                // We have a private key, the file has a private key, we're done here.
+                                return;
                             }
                         }
-                        catch (CryptographicException)
-                        {
-                            // We can't read this file anymore, but a moment ago it was this certificate,
-                            // so go ahead and overwrite it.
-                        }
                     }
-                    else
+                    catch (CryptographicException)
                     {
-                        // If we're just a public key then the file has at least as much data as we do.
-                        dataExistsAlready = true;
-                    }
-
-                    if (dataExistsAlready)
-                    {
-                        // The file was added but our collection hasn't resynced yet.
-                        // Set _certificates to null to force a resync.
-                        _certificates = null;
-                        return;
+                        // We can't read this file anymore, but a moment ago it was this certificate,
+                        // so go ahead and overwrite it.
                     }
                 }
 
@@ -295,9 +187,6 @@ namespace Internal.Cryptography.Pal
                     stream.Write(pkcs12, 0, pkcs12.Length);
                 }
             }
-
-            // Null out _certificates so the next call to get_Certificates causes a re-scan.
-            _certificates = null;
         }
 
         public void Remove(ICertificatePal certPal)
@@ -320,9 +209,6 @@ namespace Internal.Cryptography.Pal
                     File.Delete(currentFilename);
                 }
             }
-
-            // Null out _certificates so the next call to get_Certificates causes a re-scan.
-            _certificates = null;
         }
 
         private static string FindExistingFilename(X509Certificate2 cert, string storePath, out bool hadCandidates)
@@ -381,25 +267,6 @@ namespace Internal.Cryptography.Pal
             }
 
             throw new CryptographicException(SR.Cryptography_X509_StoreNoFileAvailable);
-        }
-
-        private void FlushCache(object sender, EventArgs e)
-        {
-            lock (_fileWatcherLock)
-            {
-                // Events might end up not firing until after the object was disposed, which could cause
-                // problems consistently reading _watcher; so save it to a local.
-                FileSystemWatcher watcher = _watcher;
-
-                if (watcher != null)
-                {
-                    // Stop processing events until we read again, particularly because
-                    // there's nothing else we'll do until then.
-                    watcher.EnableRaisingEvents = false;
-                }
-
-                _certificates = null;
-            }
         }
 
         private static string GetDirectoryName(string storeName)

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -247,7 +247,7 @@
     <value>Unable to get file status.</value>
   </data>
   <data name="Cryptography_InvalidDirectoryPermissions" xml:space="preserve">
-    <value>Invalid directory permissions. The directory '{0}' must be readable, writable and executable by the owner. It must not be readable, writable or executable by anyone other than the owner.</value>
+    <value>Invalid directory permissions. The directory '{0}' must be readable, writable and executable by the owner.</value>
   </data>
   <data name="Cryptography_OwnerNotCurrentUser" xml:space="preserve">
     <value>The owner of '{0}' is not the current user.</value>

--- a/src/System.Security.Cryptography.X509Certificates/src/unix/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/unix/project.json
@@ -7,7 +7,6 @@
     "System.Globalization": "4.0.10",
     "System.Globalization.Calendars": "4.0.0",
     "System.IO.FileSystem": "4.0.0",
-    "System.IO.FileSystem.Watcher": "4.0.0-rc3-24012-00",
     "System.Resources.ResourceManager": "4.0.0",
     "System.Runtime": "4.0.20",
     "System.Runtime.Handles": "4.0.0",

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Xunit;
 
@@ -67,6 +69,54 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        public static void X509Store_OpenExisting_Fails()
+        {
+            RunX509StoreTest(
+                (store, storeDirectory) =>
+                {
+                    // Since the directory was explicitly deleted already, this should fail.
+                    Assert.Throws<CryptographicException>(
+                        () => store.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly));
+                });
+        }
+
+        [Fact]
+        private static void X509Store_AddReadOnly()
+        {
+            RunX509StoreTest(
+                (store, storeDirectory) =>
+                {
+                    using (var cert = new X509Certificate2(TestData.MsCertificate))
+                    {
+                        store.Open(OpenFlags.ReadOnly);
+
+                        // Adding a certificate when the store is ReadOnly should fail:
+                        Assert.Throws<CryptographicException>(() => store.Add(cert));
+
+                        // Since we haven't done anything yet, we shouldn't have polluted the hard drive.
+                        Assert.False(Directory.Exists(storeDirectory), "Directory.Exists(storeDirectory)");
+                    }
+                });
+        }
+
+        [Fact]
+        private static void X509Store_AddClosed()
+        {
+            RunX509StoreTest(
+                (store, storeDirectory) =>
+                {
+                    using (var cert = new X509Certificate2(TestData.MsCertificate))
+                    {
+                        // Adding a certificate when the store is closed should fail:
+                        Assert.Throws<CryptographicException>(() => store.Add(cert));
+
+                        // Since we haven't done anything yet, we shouldn't have polluted the hard drive.
+                        Assert.False(Directory.Exists(storeDirectory), "Directory.Exists(storeDirectory)");
+                    }
+                });
+        }
+
+        [Fact]
         [OuterLoop(/* Alters user/machine state */)]
         private static void X509Store_AddOne()
         {
@@ -94,6 +144,440 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 });
         }
 
+        [Fact]
+        [OuterLoop(/* Alters user/machine state */)]
+        private static void X509Store_AddOneAfterUpgrade()
+        {
+            RunX509StoreTest(
+                (store, storeDirectory) =>
+                {
+                    using (var cert = new X509Certificate2(TestData.MsCertificate))
+                    {
+                        store.Open(OpenFlags.ReadOnly);
+
+                        // Adding a certificate when the store is ReadOnly should fail:
+                        Assert.Throws<CryptographicException>(() => store.Add(cert));
+
+                        // Since we haven't done anything yet, we shouldn't have polluted the hard drive.
+                        Assert.False(Directory.Exists(storeDirectory), "Directory.Exists(storeDirectory)");
+
+                        // Calling Open on an open store changes the access rights:
+                        store.Open(OpenFlags.ReadWrite);
+
+                        store.Add(cert);
+                        Assert.True(Directory.Exists(storeDirectory), "Directory.Exists(storeDirectory)");
+                        Assert.Equal(1, Directory.GetFiles(storeDirectory).Length);
+
+                        X509Certificate2Collection storeCerts = store.Certificates;
+
+                        Assert.Equal(1, storeCerts.Count);
+
+                        using (X509Certificate2 storeCert = storeCerts[0])
+                        {
+                            Assert.Equal(cert, storeCert);
+                            Assert.NotSame(cert, storeCert);
+                        }
+                    }
+                });
+        }
+
+        [Fact]
+        [OuterLoop(/* Alters user/machine state */)]
+        private static void X509Store_DowngradePermissions()
+        {
+            RunX509StoreTest(
+                (store, storeDirectory) =>
+                {
+                    using (var certA = new X509Certificate2(TestData.MsCertificate))
+                    using (var certB = new X509Certificate2(TestData.DssCer))
+                    {
+                        store.Open(OpenFlags.ReadWrite);
+                        
+                        // Ensure that ReadWrite took effect.
+                        store.Add(certA);
+
+                        store.Open(OpenFlags.ReadOnly);
+
+                        // Adding a certificate when the store is ReadOnly should fail:
+                        Assert.Throws<CryptographicException>(() => store.Add(certB));
+                    }
+                });
+        }
+
+        [Fact]
+        private static void X509Store_AddAfterDispose()
+        {
+            RunX509StoreTest(
+                (store, storeDirectory) =>
+                {
+                    using (var certA = new X509Certificate2(TestData.MsCertificate))
+                    using (var certB = new X509Certificate2(TestData.DssCer))
+                    {
+                        store.Open(OpenFlags.ReadWrite);
+
+                        store.Add(certA);
+
+                        // Dispose returns the store to the pre-opened state.
+                        store.Dispose();
+
+                        // Adding a certificate when the store is closed should fail:
+                        Assert.Throws<CryptographicException>(() => store.Add(certB));
+                    }
+                });
+        }
+
+        [Fact]
+        [OuterLoop(/* Alters user/machine state */)]
+        private static void X509Store_AddAndClear()
+        {
+            RunX509StoreTest(
+                (store, storeDirectory) =>
+                {
+                    using (var cert = new X509Certificate2(TestData.MsCertificate))
+                    {
+                        store.Open(OpenFlags.ReadWrite);
+
+                        store.Add(cert);
+                        Assert.True(Directory.Exists(storeDirectory), "Directory.Exists(storeDirectory)");
+                        Assert.Equal(1, Directory.GetFiles(storeDirectory).Length);
+
+                        store.Remove(cert);
+
+                        // The directory should still exist.
+                        Assert.True(Directory.Exists(storeDirectory), "Store Directory Still Exists");
+                        Assert.Equal(0, Directory.GetFiles(storeDirectory).Length);
+                    }
+                });
+        }
+
+        [Fact]
+        [OuterLoop(/* Alters user/machine state */)]
+        private static void X509Store_AddDuplicate()
+        {
+            RunX509StoreTest(
+                (store, storeDirectory) =>
+                {
+                    using (var cert = new X509Certificate2(TestData.MsCertificate))
+                    using (var certClone = new X509Certificate2(cert.RawData))
+                    {
+                        store.Open(OpenFlags.ReadWrite);
+
+                        store.Add(cert);
+                        Assert.True(Directory.Exists(storeDirectory), "Directory.Exists(storeDirectory)");
+                        Assert.Equal(1, Directory.GetFiles(storeDirectory).Length);
+
+                        store.Add(certClone);
+                        Assert.Equal(1, Directory.GetFiles(storeDirectory).Length);
+                    }
+                });
+        }
+
+        [Fact]
+        [OuterLoop(/* Alters user/machine state */)]
+        private static void X509Store_AddTwo()
+        {
+            RunX509StoreTest(
+                (store, storeDirectory) =>
+                {
+                    using (var certA = new X509Certificate2(TestData.MsCertificate))
+                    using (var certB = new X509Certificate2(TestData.DssCer))
+                    {
+                        store.Open(OpenFlags.ReadWrite);
+
+                        store.Add(certA);
+                        store.Add(certB);
+                        Assert.True(Directory.Exists(storeDirectory), "Directory.Exists(storeDirectory)");
+                        Assert.Equal(2, Directory.GetFiles(storeDirectory).Length);
+
+                        X509Certificate2Collection storeCerts = store.Certificates;
+                        Assert.Equal(2, storeCerts.Count);
+
+                        X509Certificate2[] expectedCerts = { certA, certB };
+
+                        foreach (X509Certificate2 storeCert in storeCerts)
+                        {
+                            Assert.Contains(storeCert, expectedCerts);
+                            storeCert.Dispose();
+                        }
+                    }
+                });
+        }
+
+        [Fact]
+        [OuterLoop(/* Alters user/machine state */)]
+        private static void X509Store_AddTwo_UpgradePrivateKey()
+        {
+            RunX509StoreTest(
+                (store, storeDirectory) =>
+                {
+                    using (var certAPrivate = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
+                    using (var certAPublic = new X509Certificate2(certAPrivate.RawData))
+                    using (var certB = new X509Certificate2(TestData.DssCer))
+                    {
+                        store.Open(OpenFlags.ReadWrite);
+
+                        store.Add(certAPublic);
+                        store.Add(certB);
+                        Assert.True(Directory.Exists(storeDirectory), "Directory.Exists(storeDirectory)");
+
+                        string[] storeFiles = Directory.GetFiles(storeDirectory);
+                        Assert.Equal(2, storeFiles.Length);
+
+                        X509Certificate2Collection storeCerts = store.Certificates;
+                        Assert.Equal(2, storeCerts.Count);
+
+                        X509Certificate2[] expectedCerts = { certAPublic, certB };
+
+                        foreach (X509Certificate2 storeCert in storeCerts)
+                        {
+                            Assert.False(storeCert.HasPrivateKey, "storeCert.HasPrivateKey (before)");
+                            storeCert.Dispose();
+                        }
+
+                        store.Add(certAPrivate);
+                        // It replaces the existing file, the names should be unaffected.
+                        Assert.Equal(storeFiles, Directory.GetFiles(storeDirectory));
+
+                        storeCerts = store.Certificates;
+                        Assert.Equal(2, storeCerts.Count);
+
+                        bool foundCertA = false;
+
+                        foreach (X509Certificate2 storeCert in storeCerts)
+                        {
+                            // The public instance and private instance are .Equal
+                            if (storeCert.Equals(certAPublic))
+                            {
+                                Assert.True(storeCert.HasPrivateKey, "storeCert.HasPrivateKey (affected cert)");
+                                foundCertA = true;
+                            }
+                            else
+                            {
+                                Assert.False(storeCert.HasPrivateKey, "storeCert.HasPrivateKey (other cert)");
+                            }
+
+                            Assert.Contains(storeCert, expectedCerts);
+                            storeCert.Dispose();
+                        }
+
+                        Assert.True(foundCertA, "foundCertA");
+                    }
+                });
+        }
+
+        [Fact]
+        [OuterLoop(/* Alters user/machine state */)]
+        private static void X509Store_AddTwo_UpgradePrivateKey_NoDowngrade()
+        {
+            RunX509StoreTest(
+                (store, storeDirectory) =>
+                {
+                    using (var certAPrivate = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
+                    using (var certAPublic = new X509Certificate2(certAPrivate.RawData))
+                    using (var certB = new X509Certificate2(TestData.DssCer))
+                    {
+                        store.Open(OpenFlags.ReadWrite);
+
+                        store.Add(certAPublic);
+                        store.Add(certB);
+                        Assert.True(Directory.Exists(storeDirectory), "Directory.Exists(storeDirectory)");
+
+                        X509Certificate2Collection storeCerts = store.Certificates;
+                        Assert.Equal(2, storeCerts.Count);
+
+                        X509Certificate2[] expectedCerts = { certAPublic, certB };
+
+                        foreach (X509Certificate2 storeCert in storeCerts)
+                        {
+                            Assert.False(storeCert.HasPrivateKey, "storeCert.HasPrivateKey (before)");
+                            Assert.Contains(storeCert, expectedCerts);
+                            storeCert.Dispose();
+                        }
+
+                        // Add the private (checked in X509Store_AddTwo_UpgradePrivateKey)
+                        store.Add(certAPrivate);
+                        // Then add the public again, which shouldn't do anything.
+                        store.Add(certAPublic);
+
+                        storeCerts = store.Certificates;
+                        Assert.Equal(2, storeCerts.Count);
+
+                        bool foundCertA = false;
+
+                        foreach (X509Certificate2 storeCert in storeCerts)
+                        {
+                            if (storeCert.Equals(certAPublic))
+                            {
+                                Assert.True(storeCert.HasPrivateKey, "storeCert.HasPrivateKey (affected cert)");
+                                foundCertA = true;
+                            }
+                            else
+                            {
+                                Assert.False(storeCert.HasPrivateKey, "storeCert.HasPrivateKey (other cert)");
+                            }
+
+                            Assert.Contains(storeCert, expectedCerts);
+                            storeCert.Dispose();
+                        }
+                        
+                        Assert.True(foundCertA, "foundCertA");
+                    }
+                });
+        }
+
+        [Fact]
+        [OuterLoop(/* Alters user/machine state */)]
+        private static void X509Store_DistinctCollections()
+        {
+            RunX509StoreTest(
+                (store, storeDirectory) =>
+                {
+                    using (var certA = new X509Certificate2(TestData.MsCertificate))
+                    using (var certB = new X509Certificate2(TestData.DssCer))
+                    {
+                        store.Open(OpenFlags.ReadWrite);
+
+                        store.Add(certA);
+                        store.Add(certB);
+                        Assert.True(Directory.Exists(storeDirectory), "Directory.Exists(storeDirectory)");
+                        Assert.Equal(2, Directory.GetFiles(storeDirectory).Length);
+
+                        X509Certificate2Collection storeCertsA = store.Certificates;
+                        X509Certificate2Collection storeCertsB = store.Certificates;
+
+                        Assert.NotSame(storeCertsA, storeCertsB);
+                        Assert.Equal(storeCertsA.Count, storeCertsB.Count);
+
+                        foreach (X509Certificate2 collACert in storeCertsA)
+                        {
+                            int bIndex = storeCertsB.IndexOf(collACert);
+                            Assert.InRange(bIndex, 0, storeCertsB.Count);
+
+                            X509Certificate2 collBCert = storeCertsB[bIndex];
+                            // Equal is implied by IndexOf working.
+                            Assert.NotSame(collACert, collBCert);
+
+                            storeCertsB.RemoveAt(bIndex);
+
+                            collACert.Dispose();
+                            collBCert.Dispose();
+                        }
+                    }
+                });
+        }
+
+        [Fact]
+        [OuterLoop(/* Alters user/machine state */)]
+        private static void X509Store_Add4_Remove1()
+        {
+            RunX509StoreTest(
+                (store, storeDirectory) =>
+                {
+                    using (var certA = new X509Certificate2(TestData.MsCertificate))
+                    using (var certB = new X509Certificate2(TestData.DssCer))
+                    using (var certBClone = new X509Certificate2(certB.RawData))
+                    using (var certC = new X509Certificate2(TestData.ECDsa256Certificate))
+                    using (var certD = new X509Certificate2(TestData.MicrosoftDotComRootBytes))
+                    {
+                        store.Open(OpenFlags.ReadWrite);
+                        
+                        store.Add(certA);
+                        store.Add(certB);
+                        store.Add(certC);
+                        store.Add(certD);
+
+                        Assert.True(Directory.Exists(storeDirectory), "Directory.Exists(storeDirectory)");
+                        Assert.Equal(4, Directory.GetFiles(storeDirectory).Length);
+
+                        X509Certificate2[] expectedCerts = { certA, certB, certC, certD };
+                        X509Certificate2Collection storeCerts = store.Certificates;
+                        Assert.Equal(4, storeCerts.Count);
+
+                        foreach (X509Certificate2 storeCert in storeCerts)
+                        {
+                            Assert.Contains(storeCert, expectedCerts);
+                            storeCert.Dispose();
+                        }
+
+                        store.Remove(certBClone);
+                        Assert.Equal(3, Directory.GetFiles(storeDirectory).Length);
+
+                        expectedCerts = new[] { certA, certC, certD };
+                        storeCerts = store.Certificates;
+                        Assert.Equal(3, storeCerts.Count);
+
+                        foreach (X509Certificate2 storeCert in storeCerts)
+                        {
+                            Assert.Contains(storeCert, expectedCerts);
+                            storeCert.Dispose();
+                        }
+                    }
+                });
+        }
+
+        [Theory]
+        [OuterLoop(/* Alters user/machine state */)]
+        [InlineData(false)]
+        [InlineData(true)]
+        private static void X509Store_MultipleObjects(bool matchCase)
+        {
+            RunX509StoreTest(
+                (store, storeDirectory) =>
+                {
+                    using (var certA = new X509Certificate2(TestData.MsCertificate))
+                    using (var certB = new X509Certificate2(TestData.DssCer))
+                    using (var certC = new X509Certificate2(TestData.ECDsa256Certificate))
+                    using (var certD = new X509Certificate2(TestData.MicrosoftDotComRootBytes))
+                    {
+                        store.Open(OpenFlags.ReadWrite);
+
+                        store.Add(certA);
+                        store.Add(certB);
+                        Assert.True(Directory.Exists(storeDirectory), "Directory.Exists(storeDirectory)");
+
+                        string newName = store.Name;
+
+                        if (!matchCase)
+                        {
+                            newName = newName.ToUpperInvariant();
+                            Assert.NotEqual(store.Name, newName);
+                        }
+
+                        using (X509Store storeClone = new X509Store(newName, store.Location))
+                        {
+                            storeClone.Open(OpenFlags.ReadWrite);
+
+                            X509Certificate2Collection storeCerts = store.Certificates;
+                            X509Certificate2Collection storeCloneCerts = storeClone.Certificates;
+
+                            Assert.Equal(
+                                storeCerts.OfType<X509Certificate2>(),
+                                storeCloneCerts.OfType<X509Certificate2>());
+
+                            store.Add(certC);
+
+                            // The object was added to store, but should show up in both objects
+                            // after re-reading the Certificates property
+                            storeCerts = store.Certificates;
+                            storeCloneCerts = storeClone.Certificates;
+
+                            Assert.Equal(
+                                storeCerts.OfType<X509Certificate2>(),
+                                storeCloneCerts.OfType<X509Certificate2>());
+
+                            // Now add one to storeClone to prove bidirectionality.
+                            storeClone.Add(certD);
+                            storeCerts = store.Certificates;
+                            storeCloneCerts = storeClone.Certificates;
+
+                            Assert.Equal(
+                                storeCerts.OfType<X509Certificate2>(),
+                                storeCloneCerts.OfType<X509Certificate2>());
+                        }
+                    }
+                });
+        }
+        
         private static void RunX509StoreTest(Action<X509Store, string> testAction)
         {
             string certStoresFeaturePath = PersistedFiles.GetUserFeatureDirectory("cryptography", "x509stores");

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
@@ -66,6 +66,68 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+        [Fact]
+        [OuterLoop(/* Alters user/machine state */)]
+        private static void X509Store_AddOne()
+        {
+            RunX509StoreTest(
+                (store, storeDirectory) =>
+                {
+                    using (var cert = new X509Certificate2(TestData.MsCertificate))
+                    {
+                        store.Open(OpenFlags.ReadWrite);
+
+                        store.Add(cert);
+                        Assert.True(Directory.Exists(storeDirectory), "Directory.Exists(storeDirectory)");
+                        Assert.Equal(1, Directory.GetFiles(storeDirectory).Length);
+
+                        X509Certificate2Collection storeCerts = store.Certificates;
+
+                        Assert.Equal(1, storeCerts.Count);
+
+                        using (X509Certificate2 storeCert = storeCerts[0])
+                        {
+                            Assert.Equal(cert, storeCert);
+                            Assert.NotSame(cert, storeCert);
+                        }
+                    }
+                });
+        }
+
+        private static void RunX509StoreTest(Action<X509Store, string> testAction)
+        {
+            string certStoresFeaturePath = PersistedFiles.GetUserFeatureDirectory("cryptography", "x509stores");
+            string storeName = "TestStore" + Guid.NewGuid().ToString("N");
+            string storeDirectory = Path.Combine(certStoresFeaturePath, storeName.ToLowerInvariant());
+
+            if (Directory.Exists(storeDirectory))
+            {
+                Directory.Delete(storeDirectory, true);
+            }
+
+            try
+            {
+                using (X509Store store = new X509Store(storeName, StoreLocation.CurrentUser))
+                {
+                    testAction(store, storeDirectory);
+                }
+            }
+            finally
+            {
+                try
+                {
+                    if (Directory.Exists(storeDirectory))
+                    {
+                        Directory.Delete(storeDirectory, true);
+                    }
+                }
+                catch
+                {
+                    // Don't allow any (additional?) I/O errors to propagate.
+                }
+            }
+        }
+
         // `openssl crl -in [MicrosoftDotComRootCrlPem] -noout -hash`.crl
         private const string MicrosoftDotComRootCrlFilename = "b204d74a.crl";
 


### PR DESCRIPTION
The original impetus for change was to remove the FileSystemWatcher dependency for the Unix implementation of X509Store.  Since changes were being made, some tests were finally added to OuterLoop (since it involves making state changes on the filesystem).  This uncovered an issue that creating new stores fails due to the directory permissions check being overly restrictive (in a way that we explicitly concluded it wasn't doing at the time of the change).

So, with the two commits:
* Creating new stores works again
* There are a lot of X509Store tests on Unix
* The FSW dependency is removed, and all the associated caching and cache purge logic.

So, this reacts to #6797, fixes #6618, and fixes #3374.

cc: @stephentoub @weshaggard @AtsushiKan