### PR TITLE
Improve performance of WebUtility.Decode for non-escaped strings

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -427,13 +427,8 @@ namespace System.Net
                 else
                     helper.AddChar(ch);
             }
-
-            if (!needsDecoding)
-            {
-                // No decoding needed
-                return value;
-            }
-            return helper.GetString();
+            
+            return needsDecoding ? helper.GetString() : value;
         }
 
         private static byte[] UrlDecodeInternal(byte[] bytes, int offset, int count)

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -407,7 +407,6 @@ namespace System.Net
                 }
                 else if (ch == '%' && pos < count - 2)
                 {
-                    needsDecoding = true;
                     int h1 = HexToInt(value[pos + 1]);
                     int h2 = HexToInt(value[pos + 2]);
 
@@ -418,6 +417,7 @@ namespace System.Net
 
                         // don't add as char
                         helper.AddByte(b);
+                        needsDecoding = true;
                         continue;
                     }
                 }

--- a/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
@@ -54,10 +54,30 @@ namespace System.Net.Tests
 
         public static IEnumerable<Tuple<string, string>> UrlDecode_SharedTestData()
         {
-            // Recent change brings function inline with RFC 3986 to return hex-encoded chars in uppercase
+            // Escaping needed - case insensitive hex
             yield return Tuple.Create("%2F%5C%22%09Hello!+%E2%99%A5%3F%2F%5C%22%09World!+%E2%99%A5%3F%E2%99%A5", "/\\\"\tHello! \u2665?/\\\"\tWorld! \u2665?\u2665");
-            yield return Tuple.Create("Hello, world", "Hello, world"); // No special chars
-            yield return Tuple.Create("%F0%90%8F%BF", "\uD800\uDFFF"); // Surrogate pair
+            yield return Tuple.Create("%2f%5c%22%09Hello!+%e2%99%a5%3f%2f%5c%22%09World!+%e2%99%a5%3F%e2%99%a5", "/\\\"\tHello! \u2665?/\\\"\tWorld! \u2665?\u2665");
+
+            // Surrogate pair
+            yield return Tuple.Create("%F0%90%8F%BF", "\uD800\uDFFF");
+            yield return Tuple.Create("\uD800\uDFFF", "\uD800\uDFFF");
+
+            // Spaces
+            yield return Tuple.Create("abc+def", "abc def");
+            yield return Tuple.Create("++++", "    ");
+            yield return Tuple.Create("    ", "    ");
+
+            // No escaping needed
+            yield return Tuple.Create("abc", "abc");
+            yield return Tuple.Create("Hello, world", "Hello, world");
+            yield return Tuple.Create("\u1234\u2345", "\u1234\u2345");
+            yield return Tuple.Create("abc\u1234\u2345def\u1234", "abc\u1234\u2345def\u1234");
+
+            // Invalid percent encoding
+            yield return Tuple.Create("%", "%");
+            yield return Tuple.Create("%A", "%A");
+            yield return Tuple.Create("%G1", "%G1");
+            yield return Tuple.Create("%1G", "%1G");
         }
 
         public static IEnumerable<Tuple<string, string>> UrlEncode_SharedTestData()


### PR DESCRIPTION
- Cuts allocations down to 1/3 of the original
- Doubles performance (in time)

- We still allocate a little bit, as removing all allocations would harm the performance of strings that actually need escaping

## Benchmark - escaping needed
- No performance regressions

![benchmark escaping](https://cloud.githubusercontent.com/assets/1275900/14454716/c85fc7bc-0093-11e6-8c65-3eba5ce34729.png)


## Benchmark - no escaping needed
![benchmark no escaping](https://cloud.githubusercontent.com/assets/1275900/14454713/c5124e54-0093-11e6-983b-ad3ae9e654ff.png)

## Benchmark Code
<details>
<summary>Click here</summary>
```
static void Main(string[] args)
{
	// Escaping
    TimeAction("Old: ", () => Old.UrlDecode("%ABabc"));
    TimeAction("New: ", () => New.UrlDecode("%ABabc"));

    // No escaping
    TimeAction("Old: ", () => Old.UrlDecode("abc"));
    TimeAction("New: ", () => New.UrlDecode("abc"));

    Console.ReadLine();
}

public static void TimeAction(string prefix, Action action)
{
    var sw = new Stopwatch();
    for (int iter = 0; iter < 5; iter++)
    {
        int gen0 = GC.CollectionCount(0);
        sw.Restart();
        for (int i = 0; i < 10000000; i++)
        {
            action();
        }
        sw.Stop();
        Console.WriteLine($"{prefix}Time: {sw.Elapsed.TotalSeconds}\tGC0: {GC.CollectionCount(0) - gen0}");
    }
}
```
</details>

/cc @stephentoub @jamesqo @davidsh 
Fixes #6542 together with #7546