### PR TITLE
Remove some dead error-related code in System.Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -153,7 +153,7 @@
   <data name="SetterMustBeVoid" xml:space="preserve">
     <value>Setter should have void type.</value>
   </data>
-  <data name="PropertyTyepMustMatchSetter" xml:space="preserve">
+  <data name="PropertyTypeMustMatchSetter" xml:space="preserve">
     <value>Property type must match the value type of setter</value>
   </data>
   <data name="BothAccessorsMustBeStatic" xml:space="preserve">
@@ -482,9 +482,6 @@
   </data>
   <data name="ArgumentCannotBeOfTypeVoid" xml:space="preserve">
     <value>Argument type cannot be System.Void.</value>
-  </data>
-  <data name="InvalidOperation" xml:space="preserve">
-    <value>Invalid operation: '{0}'</value>
   </data>
   <data name="OutOfRange" xml:space="preserve">
     <value>{0} must be greater than or equal to {1}</value>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -899,10 +899,7 @@ namespace System.Linq.Expressions
                 {
                     var lastExpression = expressionList[expressionCount - 1];
 
-                    if (lastExpression == null)
-                    {
-                        throw Error.ArgumentNull(nameof(expressions));
-                    }
+                    ContractUtils.RequiresNotNull(lastExpression, nameof(expressions));
 
                     if (lastExpression.Type == type)
                     {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -98,9 +98,9 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "Property type must match the value type of setter"
         /// </summary>
-        internal static Exception PropertyTyepMustMatchSetter()
+        internal static Exception PropertyTypeMustMatchSetter()
         {
-            return new ArgumentException(Strings.PropertyTyepMustMatchSetter);
+            return new ArgumentException(Strings.PropertyTypeMustMatchSetter);
         }
         /// <summary>
         /// ArgumentException with message like "Both accessors must be static."
@@ -425,13 +425,6 @@ namespace System.Linq.Expressions
             return Dynamic.Utils.Error.ExpressionTypeDoesNotMatchMethodParameter(p0, p1, p2);
         }
         /// <summary>
-        /// ArgumentException with message like "Expression of type '{0}' cannot be used for parameter of type '{1}'"
-        /// </summary>
-        internal static Exception ExpressionTypeDoesNotMatchParameter(object p0, object p1)
-        {
-            return Dynamic.Utils.Error.ExpressionTypeDoesNotMatchParameter(p0, p1);
-        }
-        /// <summary>
         /// ArgumentException with message like "Expression of type '{0}' cannot be used for return type '{1}'"
         /// </summary>
         internal static Exception ExpressionTypeDoesNotMatchReturn(object p0, object p1)
@@ -486,13 +479,6 @@ namespace System.Linq.Expressions
         internal static Exception IncorrectNumberOfIndexes()
         {
             return new ArgumentException(Strings.IncorrectNumberOfIndexes);
-        }
-        /// <summary>
-        /// InvalidOperationException with message like "Incorrect number of arguments supplied for lambda invocation"
-        /// </summary>
-        internal static Exception IncorrectNumberOfLambdaArguments()
-        {
-            return Dynamic.Utils.Error.IncorrectNumberOfLambdaArguments();
         }
         /// <summary>
         /// ArgumentException with message like "Incorrect number of parameters supplied for lambda declaration"
@@ -839,13 +825,6 @@ namespace System.Linq.Expressions
             return new ArgumentException(Strings.ArgumentCannotBeOfTypeVoid);
         }
         /// <summary>
-        /// ArgumentException with message like "Invalid operation: '{0}'"
-        /// </summary>
-        internal static Exception InvalidOperation(object p0)
-        {
-            return new ArgumentException(Strings.InvalidOperation(p0));
-        }
-        /// <summary>
         /// ArgumentOutOfRangeException with message like "{0} must be greater than or equal to {1}"
         /// </summary>
         internal static Exception OutOfRange(object p0, object p1)
@@ -1069,14 +1048,6 @@ namespace System.Linq.Expressions
         internal static Exception PdbGeneratorNeedsExpressionCompiler()
         {
             return new NotSupportedException(Strings.PdbGeneratorNeedsExpressionCompiler);
-        }
-
-        /// <summary>
-        /// The exception that is thrown when a null reference (Nothing in Visual Basic) is passed to a method that does not accept it as a valid argument.
-        /// </summary>
-        internal static Exception ArgumentNull(string paramName)
-        {
-            return new ArgumentNullException(paramName);
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
@@ -411,7 +411,7 @@ namespace System.Linq.Expressions
                 Type valueType = setParameters[setParameters.Length - 1].ParameterType;
                 if (valueType.IsByRef) throw Error.PropertyCannotHaveRefType();
                 if (setter.ReturnType != typeof(void)) throw Error.SetterMustBeVoid();
-                if (property.PropertyType != valueType) throw Error.PropertyTyepMustMatchSetter();
+                if (property.PropertyType != valueType) throw Error.PropertyTypeMustMatchSetter();
 
                 if (getter != null)
                 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -146,11 +146,11 @@ namespace System.Linq.Expressions
         /// <summary>
         /// A string like "Property type must match the value type of setter"
         /// </summary>
-        internal static string PropertyTyepMustMatchSetter
+        internal static string PropertyTypeMustMatchSetter
         {
             get
             {
-                return SR.PropertyTyepMustMatchSetter;
+                return SR.PropertyTypeMustMatchSetter;
             }
         }
 
@@ -1123,14 +1123,6 @@ namespace System.Linq.Expressions
             {
                 return SR.ArgumentCannotBeOfTypeVoid;
             }
-        }
-
-        /// <summary>
-        /// A string like "Invalid operation: '{0}'"
-        /// </summary>
-        internal static string InvalidOperation(object p0)
-        {
-            return SR.Format(SR.InvalidOperation, p0);
         }
 
         /// <summary>


### PR DESCRIPTION
Also fix typo `PropertyTyepMustMatchSetter` to `PropertyTypeMustMatchSetter`

Contributes to #3836

Some of this is clearly related to the `CompileToMethod` method that desktop has and this doesn't. I don't know if there are long-term plans to support it, but they're currently dead methods.

Some are copies of methods in `System.Dynamic.Utils.Error` that are used from there.

One was an error thrown directly where most of the rest of the code goes through `ContractUtils` so I changed the single direct throw to do the same.

Some I don't know why the dead code was there.