### PR TITLE
Add a test for GetGroup never returning EmptyGroup

### DIFF
--- a/src/System.Text.RegularExpressions/tests/GroupCollectionTests.cs
+++ b/src/System.Text.RegularExpressions/tests/GroupCollectionTests.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class GroupCollectionTests
+{
+    [Fact]
+    public static void GetGroupTest()
+    {
+        string inputWithoutGroup = "Today is a great day for coding.";
+        string inputWithGroup = "I had had an accident.";
+        Regex regex = new Regex(@"(\w+)\s(\1)");
+        Match matchPos = regex.Match(inputWithGroup);
+        Match matchNeg = regex.Match(inputWithoutGroup);
+
+        //test if Success returns true with group(s) present
+        Assert.True(matchPos.Groups[0].Success);
+
+        //public [] operator calling internal GetGroup()
+        //should return internal _emptygroup thus making
+        //call to Success() false
+        Assert.False(matchNeg.Groups[0].Success);
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -21,6 +21,7 @@
     <Compile Include="CaptureTests.cs" />
     <Compile Include="EscapeUnescapeTests.cs" />
     <Compile Include="GroupNamesAndNumbers.cs" />
+    <Compile Include="GroupCollectionTests.cs" />
     <Compile Include="IsMatchMatchSplitTests.cs" />
     <Compile Include="MatchCollectionTests.cs" />
     <Compile Include="R2LGetGroupNamesMatchTests.cs" />


### PR DESCRIPTION
This will test previously fixed #253 via public API surface.

Also fix #914