### PR TITLE
Fix Process.ExitCode when used in conjunction with EnableRaisingEvents

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -63,6 +63,14 @@ namespace System.Diagnostics
             }
         }
 
+        /// <summary>Additional configuration when a process ID is set.</summary>
+        partial void ConfigureAfterProcessIdSet()
+        {
+            // Make sure that we configure the wait state holder for this process object, which we can only do once we have a process ID.
+            Debug.Assert(_haveProcessId, $"{nameof(ConfigureAfterProcessIdSet)} should only be called once a process ID is set");
+            GetWaitState(); // lazily initializes the wait state
+        }
+
         /// <summary>
         /// Instructs the Process component to wait the specified number of milliseconds for the associated process to exit.
         /// </summary>
@@ -243,8 +251,8 @@ namespace System.Diagnostics
 
             // Store the child's information into this Process object.
             Debug.Assert(childPid >= 0);
-            SetProcessHandle(new SafeProcessHandle(childPid));
             SetProcessId(childPid);
+            SetProcessHandle(new SafeProcessHandle(childPid));
 
             // Configure the parent's ends of the redirection streams.
             // We use UTF8 encoding without BOM by-default(instead of Console encoding as on Windows)

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1058,7 +1058,11 @@ namespace System.Diagnostics
         {
             _processId = processId;
             _haveProcessId = true;
+            ConfigureAfterProcessIdSet();
         }
+
+        /// <summary>Additional optional configuration hook after a process ID is set.</summary>
+        partial void ConfigureAfterProcessIdSet();
 
         /// <devdoc>
         ///    <para>


### PR DESCRIPTION
Our Process waiting/events implementation on Unix is complex due to the contraints of the underlying platform, e.g. you can only waitpid on a child once and then its state can be reclaimed by the OS, you can only waitpid on a child process, etc.  As a result, we maintain a shared table mapping process IDs to wait state information about that process.  To avoid leaks, we employ a reference counting system combined with dispose/finalization, such that entries are removed from the table when all consumers of the information have unregistered.  Exit code information is part of that wait state.

Today when you EnableRaisingEvents, we create and populate that table with wait state information, which will be filled in when the process exits.  However, if no one else has add-ref'd that wait state information, it'll then be removed from the table.  If someone else then comes along and asks for the wait state information, a new one is manufactured, and at this point we're unable to get some of the wait-related info, like exit code, because it can only be obtained from the underlying system once.  This means if you EnableRaisingEvents, allow the process to exit, and then after some period of time ask for the process' exit code, you'll likely get back 0 rather than the actual code.

The fix is to ensure that the Process itself maintains a ref on its own wait state information.  We already do this, but we only initialize that ref when waiting on the process, when asking whether its exited, etc.  We instead need to ensure it's done as early as possible, and the earliest it's possible is as soon as we have an ID for the process.

Fixes https://github.com/dotnet/corefx/issues/7658
cc: @Priya91, @pallavit, @joperezr, @rainersigwald