### PR TITLE
Hide several test libs from code coverage

### DIFF
--- a/src/Common/tests/System/Xml/BaseLibManaged/BaseLibManaged.csproj
+++ b/src/Common/tests/System/Xml/BaseLibManaged/BaseLibManaged.csproj
@@ -16,6 +16,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Globalization.cs" />
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Common/tests/System/Xml/BaseLibManaged/Globalization.cs
+++ b/src/Common/tests/System/Xml/BaseLibManaged/Globalization.cs
@@ -4,6 +4,8 @@
 
 using System;
 
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+
 namespace WebData.BaseLib
 {
     public class WebDataBaseLibException : System.Exception

--- a/src/System.Reflection/tests/TestExe/Program.cs
+++ b/src/System.Reflection/tests/TestExe/Program.cs
@@ -4,13 +4,12 @@
 
 using System;
 
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+
 namespace System.Reflection.Tests
 {
     public static class TestExe
     {
-        private static int Main()
-        {
-            return 42;
-        }
+        private static int Main() => 42;
     }
 }

--- a/src/System.Reflection/tests/TestExe/System.Reflection.Tests.TestExe.csproj
+++ b/src/System.Reflection/tests/TestExe/System.Reflection.Tests.TestExe.csproj
@@ -12,6 +12,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="Program.cs" />
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />


### PR DESCRIPTION
These are showing up and being counted in code coverage results.