### PR TITLE
Fix ConnectTimeout_TimesOut_Throws test

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Timeouts.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Timeouts.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Sockets;
 using System.Net.Test.Common;
@@ -61,13 +62,13 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [Theory]
+        [Fact]
         public async Task ConnectTimeout_TimesOut_Throws()
         {
             using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
                 s.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                s.Listen(0);
+                s.Listen(1);
 
                 IPEndPoint ep = (IPEndPoint)s.LocalEndPoint;
                 Uri uri = new Uri($"http://{ep.Address}:{ep.Port}");
@@ -75,15 +76,39 @@ namespace System.Net.Http.Functional.Tests
                 using (var handler = new HttpClientHandler())
                 using (var client = new HttpClient(handler))
                 {
-                    handler.ConnectTimeout = TimeSpan.FromMilliseconds(10);
+                    const int NumBacklogSockets = 16; // must be larger than OS' queue length when using Listen(1).
+                    var socketBacklog = new List<Socket>(NumBacklogSockets);
+                    try
+                    {
+                        handler.ConnectTimeout = TimeSpan.FromMilliseconds(10);
 
-                    var sw = Stopwatch.StartNew();
-                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.GetAsync(uri));
-                    sw.Stop();
+                        // Listen's backlog is only advisory; the OS may actually allow a larger backlog than that.
+                        // As such, create a bunch of clients to connect to the endpoint so that our actual request
+                        // will timeout while trying to connect.
+                        for (int i = 0; i < NumBacklogSockets; i++)
+                        {
+                            var tmpClient = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                            var ignored = tmpClient.ConnectAsync((IPEndPoint)s.LocalEndPoint);
+                            socketBacklog.Add(tmpClient);
+                        }
 
-                    Assert.InRange(sw.ElapsedMilliseconds, 1, 10*1000); // allow a very wide range
+                        // Make the actual connection.  It should timeout in connect.
+                        var sw = Stopwatch.StartNew();
+                        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.GetAsync(uri));
+                        sw.Stop();
+
+                        Assert.InRange(sw.ElapsedMilliseconds, 1, 10 * 1000); // allow a very wide range
+                    }
+                    finally
+                    {
+                        foreach (Socket c in socketBacklog)
+                        {
+                            c.Dispose();
+                        }
+                    }
                 }
             }
         }
+
     }
 }


### PR DESCRIPTION
This test wasn't actually running because it was incorrectly annotated as a [Theory] but without any data.  When changed to be a [Fact], it failed because the test depends on the Socket's listening backlog being filled so that a subsequent connect will time out, but Listen(1) doesn't actually force the OS to use a queue of max size of 1, it's just advisory.  The fix is to flood the server with requests that don't get accepted, filling the listen queue.

cc: @davidsh, @bartonjs