### PR TITLE
Add test for CultureInfo.CurrentCulture and LANG env var

### DIFF
--- a/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Globalization.Tests
 {
-    public class DateTimeFormatInfoCurrentCultureTests : RemoteExecutorTestBase
+    public class CurrentCultureTests : RemoteExecutorTestBase
     {
         [Fact]
         public void CurrentCulture()
@@ -97,6 +97,32 @@ namespace System.Globalization.Tests
         public void CurrentUICulture_Set_Null_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("value", () => CultureInfo.CurrentUICulture = null);
+        }
+
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        [Theory]
+        [InlineData("en-US.UTF-8", "en-US")]
+        [InlineData("en-US", "en-US")]
+        [InlineData("en_GB", "en-GB")]
+        [InlineData("fr-FR", "fr-FR")]
+        [InlineData("ru", "ru")]
+        [InlineData("", "en-US-POSIX")]
+        public void CurrentCulture_BasedOnLangEnvVar(string langEnvVar, string expectedCultureName)
+        {
+            var psi = new ProcessStartInfo();
+            psi.Environment.Clear();
+            psi.Environment["LANG"] = langEnvVar;
+
+            RemoteInvoke(expected =>
+            {
+                Assert.NotNull(CultureInfo.CurrentCulture);
+                Assert.NotNull(CultureInfo.CurrentUICulture);
+
+                Assert.Equal(expected, CultureInfo.CurrentCulture.Name);
+                Assert.Equal(expected, CultureInfo.CurrentUICulture.Name);
+
+                return SuccessExitCode;
+            }, expectedCultureName, new RemoteInvokeOptions { StartInfo = psi }).Dispose();
         }
     }
 }

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -99,7 +99,7 @@ namespace System.Globalization.Tests
             Assert.Throws<ArgumentNullException>("value", () => CultureInfo.CurrentUICulture = null);
         }
 
-        [PlatformSpecific(PlatformID.AnyUnix)]
+        [PlatformSpecific(Xunit.PlatformID.AnyUnix)]
         [Theory]
         [InlineData("en-US.UTF-8", "en-US")]
         [InlineData("en-US", "en-US")]


### PR DESCRIPTION
Verify that we pick up the right culture based on the LANG environment variable.

cc: @ellismg, @tarekgh 

@ellismg, I know you're contemplating changing the meaning of ```LANG=``` from ```en-US-POSIX``` to ```en-US.UTF-8``` or something like that.  I put the current one into the test case, but we can change it if/when the implementation changes.