### PR TITLE
SqlClient: Remove dependency on System.Collections.NonGeneric

### DIFF
--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/MetadataUtilsSmi.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/MetadataUtilsSmi.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-
-//------------------------------------------------------------------------------
-
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -77,57 +73,60 @@ namespace Microsoft.SqlServer.Server
             SqlDbType.DateTimeOffset,       // System.DateTimeOffset
         };
 
-        // Hash table to map from clr type object to ExtendedClrTypeCodeMap enum
-        // this HashTable should only be accessed from DetermineExtendedTypeCode and class ctor for setup.
-        private static readonly Hashtable s_typeToExtendedTypeCodeMap = CreateTypeToExtendedTypeCodeMap();
+        // Dictionary to map from clr type object to ExtendedClrTypeCodeMap enum.
+        // This dictionary should only be accessed from DetermineExtendedTypeCode and class ctor for setup.
+        private static readonly Dictionary<Type, ExtendedClrTypeCode> s_typeToExtendedTypeCodeMap = CreateTypeToExtendedTypeCodeMap();
 
-        private static Hashtable CreateTypeToExtendedTypeCodeMap()
+        private static Dictionary<Type, ExtendedClrTypeCode> CreateTypeToExtendedTypeCodeMap()
         {
-            // Set up type mapping hash table
+            int Count = 42;
             // Keep this initialization list in the same order as ExtendedClrTypeCode for ease in validating!
-            Hashtable ht = new Hashtable(42);
-            ht.Add(typeof(System.Boolean), ExtendedClrTypeCode.Boolean);
-            ht.Add(typeof(System.Byte), ExtendedClrTypeCode.Byte);
-            ht.Add(typeof(System.Char), ExtendedClrTypeCode.Char);
-            ht.Add(typeof(System.DateTime), ExtendedClrTypeCode.DateTime);
-            ht.Add(typeof(System.DBNull), ExtendedClrTypeCode.DBNull);
-            ht.Add(typeof(System.Decimal), ExtendedClrTypeCode.Decimal);
-            ht.Add(typeof(System.Double), ExtendedClrTypeCode.Double);
-            // lookup code will handle special-case null-ref, omitting the addition of ExtendedTypeCode.Empty
-            ht.Add(typeof(System.Int16), ExtendedClrTypeCode.Int16);
-            ht.Add(typeof(System.Int32), ExtendedClrTypeCode.Int32);
-            ht.Add(typeof(System.Int64), ExtendedClrTypeCode.Int64);
-            ht.Add(typeof(System.SByte), ExtendedClrTypeCode.SByte);
-            ht.Add(typeof(System.Single), ExtendedClrTypeCode.Single);
-            ht.Add(typeof(System.String), ExtendedClrTypeCode.String);
-            ht.Add(typeof(System.UInt16), ExtendedClrTypeCode.UInt16);
-            ht.Add(typeof(System.UInt32), ExtendedClrTypeCode.UInt32);
-            ht.Add(typeof(System.UInt64), ExtendedClrTypeCode.UInt64);
-            ht.Add(typeof(System.Object), ExtendedClrTypeCode.Object);
-            ht.Add(typeof(System.Byte[]), ExtendedClrTypeCode.ByteArray);
-            ht.Add(typeof(System.Char[]), ExtendedClrTypeCode.CharArray);
-            ht.Add(typeof(System.Guid), ExtendedClrTypeCode.Guid);
-            ht.Add(typeof(SqlBinary), ExtendedClrTypeCode.SqlBinary);
-            ht.Add(typeof(SqlBoolean), ExtendedClrTypeCode.SqlBoolean);
-            ht.Add(typeof(SqlByte), ExtendedClrTypeCode.SqlByte);
-            ht.Add(typeof(SqlDateTime), ExtendedClrTypeCode.SqlDateTime);
-            ht.Add(typeof(SqlDouble), ExtendedClrTypeCode.SqlDouble);
-            ht.Add(typeof(SqlGuid), ExtendedClrTypeCode.SqlGuid);
-            ht.Add(typeof(SqlInt16), ExtendedClrTypeCode.SqlInt16);
-            ht.Add(typeof(SqlInt32), ExtendedClrTypeCode.SqlInt32);
-            ht.Add(typeof(SqlInt64), ExtendedClrTypeCode.SqlInt64);
-            ht.Add(typeof(SqlMoney), ExtendedClrTypeCode.SqlMoney);
-            ht.Add(typeof(SqlDecimal), ExtendedClrTypeCode.SqlDecimal);
-            ht.Add(typeof(SqlSingle), ExtendedClrTypeCode.SqlSingle);
-            ht.Add(typeof(SqlString), ExtendedClrTypeCode.SqlString);
-            ht.Add(typeof(SqlChars), ExtendedClrTypeCode.SqlChars);
-            ht.Add(typeof(SqlBytes), ExtendedClrTypeCode.SqlBytes);
-            ht.Add(typeof(SqlXml), ExtendedClrTypeCode.SqlXml);
-            ht.Add(typeof(DbDataReader), ExtendedClrTypeCode.DbDataReader);
-            ht.Add(typeof(IEnumerable<SqlDataRecord>), ExtendedClrTypeCode.IEnumerableOfSqlDataRecord);
-            ht.Add(typeof(System.TimeSpan), ExtendedClrTypeCode.TimeSpan);
-            ht.Add(typeof(System.DateTimeOffset), ExtendedClrTypeCode.DateTimeOffset);
-            return ht;
+            var dictionary = new Dictionary<Type, ExtendedClrTypeCode>(Count)
+            {
+                { typeof(bool), ExtendedClrTypeCode.Boolean },
+                { typeof(byte), ExtendedClrTypeCode.Byte },
+                { typeof(char), ExtendedClrTypeCode.Char },
+                { typeof(DateTime), ExtendedClrTypeCode.DateTime },
+                { typeof(DBNull), ExtendedClrTypeCode.DBNull },
+                { typeof(decimal), ExtendedClrTypeCode.Decimal },
+                { typeof(double), ExtendedClrTypeCode.Double },
+                // lookup code will handle special-case null-ref, omitting the addition of ExtendedTypeCode.Empty
+                { typeof(short), ExtendedClrTypeCode.Int16 },
+                { typeof(int), ExtendedClrTypeCode.Int32 },
+                { typeof(long), ExtendedClrTypeCode.Int64 },
+                { typeof(sbyte), ExtendedClrTypeCode.SByte },
+                { typeof(float), ExtendedClrTypeCode.Single },
+                { typeof(string), ExtendedClrTypeCode.String },
+                { typeof(ushort), ExtendedClrTypeCode.UInt16 },
+                { typeof(uint), ExtendedClrTypeCode.UInt32 },
+                { typeof(ulong), ExtendedClrTypeCode.UInt64 },
+                { typeof(object), ExtendedClrTypeCode.Object },
+                { typeof(byte[]), ExtendedClrTypeCode.ByteArray },
+                { typeof(char[]), ExtendedClrTypeCode.CharArray },
+                { typeof(Guid), ExtendedClrTypeCode.Guid },
+                { typeof(SqlBinary), ExtendedClrTypeCode.SqlBinary },
+                { typeof(SqlBoolean), ExtendedClrTypeCode.SqlBoolean },
+                { typeof(SqlByte), ExtendedClrTypeCode.SqlByte },
+                { typeof(SqlDateTime), ExtendedClrTypeCode.SqlDateTime },
+                { typeof(SqlDouble), ExtendedClrTypeCode.SqlDouble },
+                { typeof(SqlGuid), ExtendedClrTypeCode.SqlGuid },
+                { typeof(SqlInt16), ExtendedClrTypeCode.SqlInt16 },
+                { typeof(SqlInt32), ExtendedClrTypeCode.SqlInt32 },
+                { typeof(SqlInt64), ExtendedClrTypeCode.SqlInt64 },
+                { typeof(SqlMoney), ExtendedClrTypeCode.SqlMoney },
+                { typeof(SqlDecimal), ExtendedClrTypeCode.SqlDecimal },
+                { typeof(SqlSingle), ExtendedClrTypeCode.SqlSingle },
+                { typeof(SqlString), ExtendedClrTypeCode.SqlString },
+                { typeof(SqlChars), ExtendedClrTypeCode.SqlChars },
+                { typeof(SqlBytes), ExtendedClrTypeCode.SqlBytes },
+                { typeof(SqlXml), ExtendedClrTypeCode.SqlXml },
+                { typeof(DbDataReader), ExtendedClrTypeCode.DbDataReader },
+                { typeof(IEnumerable<SqlDataRecord>), ExtendedClrTypeCode.IEnumerableOfSqlDataRecord },
+                { typeof(TimeSpan), ExtendedClrTypeCode.TimeSpan },
+                { typeof(DateTimeOffset), ExtendedClrTypeCode.DateTimeOffset },
+            };
+            Debug.Assert(dictionary.Count == Count);
+            return dictionary;
         }
 
         internal static bool IsCharOrXmlType(SqlDbType type)
@@ -358,35 +357,18 @@ namespace Microsoft.SqlServer.Server
         // Method to map from Type to ExtendedTypeCode
         static internal ExtendedClrTypeCode DetermineExtendedTypeCodeFromType(Type clrType)
         {
-            object result = s_typeToExtendedTypeCodeMap[clrType];
-
             ExtendedClrTypeCode resultCode;
-            if (null == result)
-            {
-                resultCode = ExtendedClrTypeCode.Invalid;
-            }
-            else
-            {
-                resultCode = (ExtendedClrTypeCode)result;
-            }
-
-            return resultCode;
+            return s_typeToExtendedTypeCodeMap.TryGetValue(clrType, out resultCode) ?
+                resultCode :
+                ExtendedClrTypeCode.Invalid;
         }
 
         // Returns the ExtendedClrTypeCode that describes the given value
         static internal ExtendedClrTypeCode DetermineExtendedTypeCode(object value)
         {
-            ExtendedClrTypeCode resultCode;
-            if (null == value)
-            {
-                resultCode = ExtendedClrTypeCode.Empty;
-            }
-            else
-            {
-                resultCode = DetermineExtendedTypeCodeFromType(value.GetType());
-            }
-
-            return resultCode;
+            return value != null ?
+                DetermineExtendedTypeCodeFromType(value.GetType()) :
+                ExtendedClrTypeCode.Empty;
         }
 
         // returns a sqldbtype for the given type code

--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -186,8 +186,17 @@
   <data name="ADP_NonPooledOpenTimeout" xml:space="preserve">
     <value>Timeout attempting to open the connection.  The time period elapsed prior to attempting to open the connection has been exceeded.  This may have occurred because of too many simultaneous non-pooled connection attempts.</value>
   </data>
+  <data name="Arg_ArrayPlusOffTooSmall" xml:space="preserve">
+    <value>Destination array is not long enough to copy all the items in the collection. Check array index and length.</value>
+  </data>
+  <data name="Arg_RankMultiDimNotSupported" xml:space="preserve">
+    <value>Only single dimensional arrays are supported for the requested action.</value>
+  </data>
   <data name="Arg_RemoveArgNotFound" xml:space="preserve">
     <value>Cannot remove the specified item because it was not found in the specified Collection.</value>
+  </data>
+  <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
+    <value>Non-negative number required.</value>
   </data>
   <data name="Data_InvalidOffsetLength" xml:space="preserve">
     <value>Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.</value>

--- a/src/System.Data.SqlClient/src/System/Data/Common/DbConnectionOptions.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/DbConnectionOptions.cs
@@ -530,7 +530,10 @@ namespace System.Data.Common
                     DebugTraceKeyValuePair(keyname, keyvalue, synonyms);
 
                     string synonym;
-                    string realkeyname = null != synonyms && synonyms.TryGetValue(keyname, out synonym) ? synonym : keyname;
+                    string realkeyname = null != synonyms ?
+                        (synonyms.TryGetValue(keyname, out synonym) ? synonym : null) :
+                        keyname;
+
                     if (!IsKeyNameValid(realkeyname))
                     {
                         throw ADP.KeywordNotSupported(keyname);
@@ -625,7 +628,10 @@ namespace System.Data.Common
                     Debug.Assert(IsValueValidInternal(keyvalue), "parse failure, invalid keyvalue");
 #endif
                     string synonym;
-                    string realkeyname = null != synonyms && synonyms.TryGetValue(keyname, out synonym) ? synonym : keyname;
+                    string realkeyname = null != synonyms ?
+                        (synonyms.TryGetValue(keyname, out synonym) ? synonym : null) :
+                        keyname;
+
                     if (!IsKeyNameValid(realkeyname))
                     {
                         throw ADP.KeywordNotSupported(keyname);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
@@ -65,38 +65,20 @@ namespace System.Data.SqlClient
     // the controlling class for one result (metadata + rows)
     sealed internal class Result
     {
-        private _SqlMetaDataSet _metadata;
-        private ArrayList _rowset;
+        private readonly _SqlMetaDataSet _metadata;
+        private readonly List<Row> _rowset;
 
         internal Result(_SqlMetaDataSet metadata)
         {
             _metadata = metadata;
-            _rowset = new ArrayList();
+            _rowset = new List<Row>();
         }
 
-        internal int Count
-        {
-            get
-            {
-                return _rowset.Count;
-            }
-        }
+        internal int Count => _rowset.Count;
 
-        internal _SqlMetaDataSet MetaData
-        {
-            get
-            {
-                return _metadata;
-            }
-        }
+        internal _SqlMetaDataSet MetaData => _metadata;
 
-        internal Row this[int index]
-        {
-            get
-            {
-                return (Row)_rowset[index];
-            }
-        }
+        internal Row this[int index] => _rowset[index];
 
         internal void AddRow(Row row)
         {
@@ -107,23 +89,17 @@ namespace System.Data.SqlClient
     // A wrapper object for metadata and rowsets returned by our initial queries
     sealed internal class BulkCopySimpleResultSet
     {
-        private ArrayList _results;                   // the list of results
+        private readonly List<Result> _results;        // the list of results
         private Result _resultSet;                     // the current result
         private int[] _indexmap;                       // associates columnids with indexes in the rowarray
 
         internal BulkCopySimpleResultSet()
         {
-            _results = new ArrayList();
+            _results = new List<Result>();
         }
 
         // indexer
-        internal Result this[int idx]
-        {
-            get
-            {
-                return (Result)_results[idx];
-            }
-        }
+        internal Result this[int idx] => _results[idx];
 
         // callback function for the tdsparser
         // note that setting the metadata adds a resultset

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -1160,11 +1160,11 @@ namespace System.Data.SqlClient
             if (null != Statistics)
             {
                 UpdateStatistics();
-                return Statistics.GetHashtable();
+                return Statistics.GetDictionary();
             }
             else
             {
-                return new SqlStatistics().GetHashtable();
+                return new SqlStatistics().GetDictionary();
             }
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Diagnostics;
 
@@ -152,7 +153,7 @@ namespace System.Data.SqlClient
         }
 
 
-        static private Hashtable s_sqlClientSynonyms;
+        static private Dictionary<string, string> s_sqlClientSynonyms;
 
         private readonly bool _integratedSecurity;
 
@@ -437,73 +438,76 @@ namespace System.Data.SqlClient
 
         internal TypeSystem TypeSystemVersion { get { return _typeSystemVersion; } }
 
-        // this hashtable is meant to be read-only translation of parsed string
-        // keywords/synonyms to a known keyword string
-        internal static Hashtable GetParseSynonyms()
+        // This dictionary is meant to be read-only translation of parsed string
+        // keywords/synonyms to a known keyword string.
+        internal static Dictionary<string, string> GetParseSynonyms()
         {
-            Hashtable hash = s_sqlClientSynonyms;
-            if (null == hash)
+            Dictionary<string, string> synonyms = s_sqlClientSynonyms;
+            if (null == synonyms)
             {
-                hash = new Hashtable(SqlConnectionStringBuilder.KeywordsCount + SqlConnectionStringBuilder.DeprecatedKeywordsCount + SynonymCount + DeprecatedSynonymCount);
-                hash.Add(KEY.ApplicationIntent, KEY.ApplicationIntent);
-                hash.Add(KEY.Application_Name, KEY.Application_Name);
-                hash.Add(KEY.AsynchronousProcessing, KEY.AsynchronousProcessing);
-                hash.Add(KEY.AttachDBFilename, KEY.AttachDBFilename);
-                hash.Add(KEY.Connect_Timeout, KEY.Connect_Timeout);
-                hash.Add(KEY.Connection_Reset, KEY.Connection_Reset);
-                hash.Add(KEY.Context_Connection, KEY.Context_Connection);
-                hash.Add(KEY.Current_Language, KEY.Current_Language);
-                hash.Add(KEY.Data_Source, KEY.Data_Source);
-                hash.Add(KEY.Encrypt, KEY.Encrypt);
-                hash.Add(KEY.Enlist, KEY.Enlist);
-                hash.Add(KEY.FailoverPartner, KEY.FailoverPartner);
-                hash.Add(KEY.Initial_Catalog, KEY.Initial_Catalog);
-                hash.Add(KEY.Integrated_Security, KEY.Integrated_Security);
-                hash.Add(KEY.Load_Balance_Timeout, KEY.Load_Balance_Timeout);
-                hash.Add(KEY.MARS, KEY.MARS);
-                hash.Add(KEY.Max_Pool_Size, KEY.Max_Pool_Size);
-                hash.Add(KEY.Min_Pool_Size, KEY.Min_Pool_Size);
-                hash.Add(KEY.MultiSubnetFailover, KEY.MultiSubnetFailover);
-                hash.Add(KEY.Network_Library, KEY.Network_Library);
-                hash.Add(KEY.Packet_Size, KEY.Packet_Size);
-                hash.Add(KEY.Password, KEY.Password);
-                hash.Add(KEY.Persist_Security_Info, KEY.Persist_Security_Info);
-                hash.Add(KEY.Pooling, KEY.Pooling);
-                hash.Add(KEY.Replication, KEY.Replication);
-                hash.Add(KEY.TrustServerCertificate, KEY.TrustServerCertificate);
-                hash.Add(KEY.TransactionBinding, KEY.TransactionBinding);
-                hash.Add(KEY.Type_System_Version, KEY.Type_System_Version);
-                hash.Add(KEY.User_ID, KEY.User_ID);
-                hash.Add(KEY.User_Instance, KEY.User_Instance);
-                hash.Add(KEY.Workstation_Id, KEY.Workstation_Id);
-                hash.Add(KEY.Connect_Retry_Count, KEY.Connect_Retry_Count);
-                hash.Add(KEY.Connect_Retry_Interval, KEY.Connect_Retry_Interval);
+                int count = SqlConnectionStringBuilder.KeywordsCount + SqlConnectionStringBuilder.DeprecatedKeywordsCount + SynonymCount + DeprecatedSynonymCount;
+                synonyms = new Dictionary<string, string>(count)
+                {
+                    { KEY.ApplicationIntent, KEY.ApplicationIntent },
+                    { KEY.Application_Name, KEY.Application_Name },
+                    { KEY.AsynchronousProcessing, KEY.AsynchronousProcessing },
+                    { KEY.AttachDBFilename, KEY.AttachDBFilename },
+                    { KEY.Connect_Timeout, KEY.Connect_Timeout },
+                    { KEY.Connection_Reset, KEY.Connection_Reset },
+                    { KEY.Context_Connection, KEY.Context_Connection },
+                    { KEY.Current_Language, KEY.Current_Language },
+                    { KEY.Data_Source, KEY.Data_Source },
+                    { KEY.Encrypt, KEY.Encrypt },
+                    { KEY.Enlist, KEY.Enlist },
+                    { KEY.FailoverPartner, KEY.FailoverPartner },
+                    { KEY.Initial_Catalog, KEY.Initial_Catalog },
+                    { KEY.Integrated_Security, KEY.Integrated_Security },
+                    { KEY.Load_Balance_Timeout, KEY.Load_Balance_Timeout },
+                    { KEY.MARS, KEY.MARS },
+                    { KEY.Max_Pool_Size, KEY.Max_Pool_Size },
+                    { KEY.Min_Pool_Size, KEY.Min_Pool_Size },
+                    { KEY.MultiSubnetFailover, KEY.MultiSubnetFailover },
+                    { KEY.Network_Library, KEY.Network_Library },
+                    { KEY.Packet_Size, KEY.Packet_Size },
+                    { KEY.Password, KEY.Password },
+                    { KEY.Persist_Security_Info, KEY.Persist_Security_Info },
+                    { KEY.Pooling, KEY.Pooling },
+                    { KEY.Replication, KEY.Replication },
+                    { KEY.TrustServerCertificate, KEY.TrustServerCertificate },
+                    { KEY.TransactionBinding, KEY.TransactionBinding },
+                    { KEY.Type_System_Version, KEY.Type_System_Version },
+                    { KEY.User_ID, KEY.User_ID },
+                    { KEY.User_Instance, KEY.User_Instance },
+                    { KEY.Workstation_Id, KEY.Workstation_Id },
+                    { KEY.Connect_Retry_Count, KEY.Connect_Retry_Count },
+                    { KEY.Connect_Retry_Interval, KEY.Connect_Retry_Interval },
 
-                hash.Add(SYNONYM.APP, KEY.Application_Name);
-                hash.Add(SYNONYM.Async, KEY.AsynchronousProcessing);
-                hash.Add(SYNONYM.EXTENDED_PROPERTIES, KEY.AttachDBFilename);
-                hash.Add(SYNONYM.INITIAL_FILE_NAME, KEY.AttachDBFilename);
-                hash.Add(SYNONYM.CONNECTION_TIMEOUT, KEY.Connect_Timeout);
-                hash.Add(SYNONYM.TIMEOUT, KEY.Connect_Timeout);
-                hash.Add(SYNONYM.LANGUAGE, KEY.Current_Language);
-                hash.Add(SYNONYM.ADDR, KEY.Data_Source);
-                hash.Add(SYNONYM.ADDRESS, KEY.Data_Source);
-                hash.Add(SYNONYM.NETWORK_ADDRESS, KEY.Data_Source);
-                hash.Add(SYNONYM.SERVER, KEY.Data_Source);
-                hash.Add(SYNONYM.DATABASE, KEY.Initial_Catalog);
-                hash.Add(SYNONYM.TRUSTED_CONNECTION, KEY.Integrated_Security);
-                hash.Add(SYNONYM.Connection_Lifetime, KEY.Load_Balance_Timeout);
-                hash.Add(SYNONYM.NET, KEY.Network_Library);
-                hash.Add(SYNONYM.NETWORK, KEY.Network_Library);
-                hash.Add(SYNONYM.Pwd, KEY.Password);
-                hash.Add(SYNONYM.PERSISTSECURITYINFO, KEY.Persist_Security_Info);
-                hash.Add(SYNONYM.UID, KEY.User_ID);
-                hash.Add(SYNONYM.User, KEY.User_ID);
-                hash.Add(SYNONYM.WSID, KEY.Workstation_Id);
-                Debug.Assert(SqlConnectionStringBuilder.KeywordsCount + SqlConnectionStringBuilder.DeprecatedKeywordsCount + SynonymCount + DeprecatedSynonymCount == hash.Count, "incorrect initial ParseSynonyms size");
-                s_sqlClientSynonyms = hash;
+                    { SYNONYM.APP, KEY.Application_Name },
+                    { SYNONYM.Async, KEY.AsynchronousProcessing },
+                    { SYNONYM.EXTENDED_PROPERTIES, KEY.AttachDBFilename },
+                    { SYNONYM.INITIAL_FILE_NAME, KEY.AttachDBFilename },
+                    { SYNONYM.CONNECTION_TIMEOUT, KEY.Connect_Timeout },
+                    { SYNONYM.TIMEOUT, KEY.Connect_Timeout },
+                    { SYNONYM.LANGUAGE, KEY.Current_Language },
+                    { SYNONYM.ADDR, KEY.Data_Source },
+                    { SYNONYM.ADDRESS, KEY.Data_Source },
+                    { SYNONYM.NETWORK_ADDRESS, KEY.Data_Source },
+                    { SYNONYM.SERVER, KEY.Data_Source },
+                    { SYNONYM.DATABASE, KEY.Initial_Catalog },
+                    { SYNONYM.TRUSTED_CONNECTION, KEY.Integrated_Security },
+                    { SYNONYM.Connection_Lifetime, KEY.Load_Balance_Timeout },
+                    { SYNONYM.NET, KEY.Network_Library },
+                    { SYNONYM.NETWORK, KEY.Network_Library },
+                    { SYNONYM.Pwd, KEY.Password },
+                    { SYNONYM.PERSISTSECURITYINFO, KEY.Persist_Security_Info },
+                    { SYNONYM.UID, KEY.User_ID },
+                    { SYNONYM.User, KEY.User_ID },
+                    { SYNONYM.WSID, KEY.Workstation_Id }
+                };
+                Debug.Assert(synonyms.Count == count, "incorrect initial ParseSynonyms size");
+                s_sqlClientSynonyms = synonyms;
             }
-            return hash;
+            return synonyms;
         }
 
         internal string ObtainWorkstationId()
@@ -534,8 +538,8 @@ namespace System.Data.SqlClient
 
         internal System.Data.SqlClient.ApplicationIntent ConvertValueToApplicationIntent()
         {
-            object value = base.Parsetable[KEY.ApplicationIntent];
-            if (value == null)
+            string value;
+            if (!TryGetParsetableValue(KEY.ApplicationIntent, out value))
             {
                 return DEFAULT.ApplicationIntent;
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlErrorCollection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlErrorCollection.cs
@@ -2,64 +2,36 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-
-//------------------------------------------------------------------------------
-
 using System.Collections;
-
+using System.Collections.Generic;
 
 namespace System.Data.SqlClient
 {
     public sealed class SqlErrorCollection : ICollection
     {
-        private ArrayList _errors = new ArrayList();
+        // Ideally this would be typed as List<SqlError>, but that would make the non-generic
+        // CopyTo behave differently than the full framework (which uses ArrayList), throwing
+        // ArgumentException instead of the expected InvalidCastException for incompatible types.
+        // Instead, we use List<object>, which makes the non-generic CopyTo behave like
+        // ArrayList.CopyTo.
+        private readonly List<object> _errors = new List<object>();
 
-        internal SqlErrorCollection()
-        {
-        }
+        internal SqlErrorCollection() { }
 
-        public void CopyTo(Array array, int index)
-        {
-            _errors.CopyTo(array, index);
-        }
+        public void CopyTo(Array array, int index) => ((ICollection)_errors).CopyTo(array, index);
 
-        public void CopyTo(SqlError[] array, int index)
-        {
-            _errors.CopyTo(array, index);
-        }
+        public void CopyTo(SqlError[] array, int index) => _errors.CopyTo(array, index);
 
-        public int Count
-        {
-            get { return _errors.Count; }
-        }
+        public int Count => _errors.Count;
 
-        object System.Collections.ICollection.SyncRoot
-        {
-            get { return this; }
-        }
+        object ICollection.SyncRoot => this;
 
-        bool System.Collections.ICollection.IsSynchronized
-        {
-            get { return false; }
-        }
+        bool ICollection.IsSynchronized => false;
 
-        public SqlError this[int index]
-        {
-            get
-            {
-                return (SqlError)_errors[index];
-            }
-        }
+        public SqlError this[int index] => (SqlError)_errors[index];
 
-        public IEnumerator GetEnumerator()
-        {
-            return _errors.GetEnumerator();
-        }
+        public IEnumerator GetEnumerator() => _errors.GetEnumerator();
 
-        internal void Add(SqlError error)
-        {
-            _errors.Add(error);
-        }
+        internal void Add(SqlError error) => _errors.Add(error);
     }
 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -645,7 +645,7 @@ namespace System.Data.SqlClient
         {
             // For implicit pooled connections, if connection reset behavior is specified,
             // reset the database and language properties back to default.  It is important
-            // to do this on activate so that the hashtable is correct before SqlConnection
+            // to do this on activate so that the dictionary is correct before SqlConnection
             // obtains a clone.
 
             Debug.Assert(!HasLocalTransactionFromAPI, "Upon ResetConnection SqlInternalConnectionTds has a currently ongoing local transaction.");
@@ -659,7 +659,7 @@ namespace System.Data.SqlClient
                 // to the server is made.
                 _parser.PrepareResetConnection();
 
-                // Reset hashtable values, since calling reset will not send us env_changes.
+                // Reset dictionary values, since calling reset will not send us env_changes.
                 CurrentDatabase = _originalDatabase;
                 _currentLanguage = _originalLanguage;
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlStatistics.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlStatistics.cs
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Diagnostics;
 
@@ -96,31 +97,33 @@ namespace System.Data.SqlClient
             _waitForReply = false;
         }
 
-        internal IDictionary GetHashtable()
+        internal IDictionary GetDictionary()
         {
-            Hashtable ht = new Hashtable();
+            const int Count = 18;
+            var dictionary = new StatisticsDictionary(Count)
+            {
+                { "BuffersReceived", _buffersReceived },
+                { "BuffersSent", _buffersSent },
+                { "BytesReceived", _bytesReceived },
+                { "BytesSent", _bytesSent },
+                { "CursorOpens", _cursorOpens },
+                { "IduCount", _iduCount },
+                { "IduRows", _iduRows },
+                { "PreparedExecs", _preparedExecs },
+                { "Prepares", _prepares },
+                { "SelectCount", _selectCount },
+                { "SelectRows", _selectRows },
+                { "ServerRoundtrips", _serverRoundtrips },
+                { "SumResultSets", _sumResultSets },
+                { "Transactions", _transactions },
+                { "UnpreparedExecs", _unpreparedExecs },
 
-            ht.Add("BuffersReceived", _buffersReceived);
-            ht.Add("BuffersSent", _buffersSent);
-            ht.Add("BytesReceived", _bytesReceived);
-            ht.Add("BytesSent", _bytesSent);
-            ht.Add("CursorOpens", _cursorOpens);
-            ht.Add("IduCount", _iduCount);
-            ht.Add("IduRows", _iduRows);
-            ht.Add("PreparedExecs", _preparedExecs);
-            ht.Add("Prepares", _prepares);
-            ht.Add("SelectCount", _selectCount);
-            ht.Add("SelectRows", _selectRows);
-            ht.Add("ServerRoundtrips", _serverRoundtrips);
-            ht.Add("SumResultSets", _sumResultSets);
-            ht.Add("Transactions", _transactions);
-            ht.Add("UnpreparedExecs", _unpreparedExecs);
-
-            ht.Add("ConnectionTime", ADP.TimerToMilliseconds(_connectionTime));
-            ht.Add("ExecutionTime", ADP.TimerToMilliseconds(_executionTime));
-            ht.Add("NetworkServerTime", ADP.TimerToMilliseconds(_networkServerTime));
-
-            return ht;
+                { "ConnectionTime", ADP.TimerToMilliseconds(_connectionTime) },
+                { "ExecutionTime", ADP.TimerToMilliseconds(_executionTime) },
+                { "NetworkServerTime", ADP.TimerToMilliseconds(_networkServerTime) }
+            };
+            Debug.Assert(dictionary.Count == Count);
+            return dictionary;
         }
 
         internal bool RequestExecutionTimer()
@@ -218,6 +221,100 @@ namespace System.Data.SqlClient
                 _connectionTime = long.MaxValue;
             }
         }
+
+        // We subclass Dictionary to provide our own implementation of CopyTo, Keys.CopyTo, and
+        // Values.CopyTo to match the behavior of Hashtable, which is used in the full framework.
+        // Ideally this would derive from Dictionary<string, long>, but that would break compatibility
+        // with the full framework, which allows adding keys/values of any type.
+        private sealed class StatisticsDictionary : Dictionary<object, object>, IDictionary
+        {
+            private Collection _keys;
+            private Collection _values;
+
+            public StatisticsDictionary(int capacity) : base(capacity) { }
+
+            ICollection IDictionary.Keys => _keys ?? (_keys = new Collection(this, Keys));
+
+            ICollection IDictionary.Values => _values ?? (_values = new Collection(this, Values));
+
+            void ICollection.CopyTo(Array array, int arrayIndex)
+            {
+                ValidateCopyToArguments(array, arrayIndex);
+
+                foreach (KeyValuePair<object, object> pair in this)
+                {
+                    var entry = new DictionaryEntry(pair.Key, pair.Value);
+                    array.SetValue(entry, arrayIndex++);
+                }
+            }
+
+            private void CopyKeys(Array array, int arrayIndex)
+            {
+                ValidateCopyToArguments(array, arrayIndex);
+
+                foreach (KeyValuePair<object, object> pair in this)
+                {
+                    array.SetValue(pair.Key, arrayIndex++);
+                }
+            }
+
+            private void CopyValues(Array array, int arrayIndex)
+            {
+                ValidateCopyToArguments(array, arrayIndex);
+
+                foreach (KeyValuePair<object, object> pair in this)
+                {
+                    array.SetValue(pair.Value, arrayIndex++);
+                }
+            }
+
+            private void ValidateCopyToArguments(Array array, int arrayIndex)
+            {
+                if (array == null)
+                    throw new ArgumentNullException(nameof(array));
+                if (array.Rank != 1)
+                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+                if (arrayIndex < 0)
+                    throw new ArgumentOutOfRangeException(nameof(arrayIndex), SR.ArgumentOutOfRange_NeedNonNegNum);
+                if (array.Length - arrayIndex < Count)
+                    throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
+            }
+
+            private sealed class Collection : ICollection
+            {
+                private readonly StatisticsDictionary _dictionary;
+                private readonly ICollection _collection;
+
+                public Collection(StatisticsDictionary dictionary, ICollection collection)
+                {
+                    Debug.Assert(dictionary != null);
+                    Debug.Assert(collection != null);
+                    Debug.Assert((collection is KeyCollection) || (collection is ValueCollection));
+
+                    _dictionary = dictionary;
+                    _collection = collection;
+                }
+
+                int ICollection.Count => _collection.Count;
+
+                bool ICollection.IsSynchronized => _collection.IsSynchronized;
+
+                object ICollection.SyncRoot => _collection.SyncRoot;
+
+                void ICollection.CopyTo(Array array, int arrayIndex)
+                {
+                    if (_collection is KeyCollection)
+                    {
+                        _dictionary.CopyKeys(array, arrayIndex);
+                    }
+                    else
+                    {
+                        _dictionary.CopyValues(array, arrayIndex);
+                    }
+                }
+
+                IEnumerator IEnumerable.GetEnumerator() => _collection.GetEnumerator();
+            }
+        }
     }
 }
-

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlStatistics.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlStatistics.cs
@@ -223,7 +223,21 @@ namespace System.Data.SqlClient
         }
 
         // We subclass Dictionary to provide our own implementation of CopyTo, Keys.CopyTo, and
-        // Values.CopyTo to match the behavior of Hashtable, which is used in the full framework.
+        // Values.CopyTo to match the behavior of Hashtable, which is used in the full framework:
+        //
+        //  - When arrayIndex > array.Length, Hashtable throws ArgumentException whereas Dictionary
+        //    throws ArgumentOutOfRangeException.
+        //
+        //  - Hashtable specifies the ArgumentOutOfRangeException paramName as "arrayIndex" whereas
+        //    Dictionary uses "index".
+        //
+        //  - When the array is of a mismatched type, Hashtable throws InvalidCastException whereas
+        //    Dictionary throws ArrayTypeMismatchException.
+        //
+        //  - Hashtable allows copying values to a long[] array via Values.CopyTo, whereas Dictionary
+        //    throws ArgumentException due to the "Target array type is not compatible with type of
+        //    items in the collection" (when Dictionary<object, object> is used).
+        //
         // Ideally this would derive from Dictionary<string, long>, but that would break compatibility
         // with the full framework, which allows adding keys/values of any type.
         private sealed class StatisticsDictionary : Dictionary<object, object>, IDictionary

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlStream.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlStream.cs
@@ -316,7 +316,7 @@ namespace System.Data.SqlClient
     sealed internal class SqlCachedStream : Stream
     {
         private int _currentPosition;   // Position within the current array byte
-        private int _currentArrayIndex; // Index into the _cachedBytes ArrayList
+        private int _currentArrayIndex; // Index into the _cachedBytes List
         private List<byte[]> _cachedBytes;
         private long _totalLength;
 

--- a/src/System.Data.SqlClient/src/project.json
+++ b/src/System.Data.SqlClient/src/project.json
@@ -7,7 +7,6 @@
         "Microsoft.Win32.Primitives": "4.0.0",
         "System.Collections": "4.0.10",
         "System.Collections.Concurrent": "4.0.0",
-        "System.Collections.NonGeneric": "4.0.0",
         "System.Data.Common": "4.0.1-rc3-24013-00",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",

--- a/src/System.Data.SqlClient/tests/FunctionalTests/ExceptionTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/ExceptionTest.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
 using System.Collections;
+
 using Xunit;
 
-namespace System.Data.SqlClient.Tests 
+namespace System.Data.SqlClient.Tests
 {
     public class ExceptionTest
     {
@@ -24,7 +26,7 @@ namespace System.Data.SqlClient.Tests
 
             // tests improper server name thrown from constructor of tdsparser
             SqlConnectionStringBuilder badBuilder = new SqlConnectionStringBuilder(builder.ConnectionString) { DataSource = badServer, ConnectTimeout = 1 };
-            
+
             VerifyConnectionFailure<SqlException>(() => GenerateConnectionException(badBuilder.ConnectionString), sqlsvrBadConn, VerifyException);
         }
 
@@ -33,7 +35,7 @@ namespace System.Data.SqlClient.Tests
         {
             // Test exceptions - makes sure they are only thrown from upper layers
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connectionString);
-            
+
             SqlConnectionStringBuilder badBuilder = new SqlConnectionStringBuilder(builder.ConnectionString) { DataSource = badServer, ConnectTimeout = 1 };
             using (var sqlConnection = new SqlConnection(badBuilder.ConnectionString))
             {
@@ -90,7 +92,7 @@ namespace System.Data.SqlClient.Tests
         private TException VerifyConnectionFailure<TException>(Action connectAction, string expectedExceptionMessage, Func<TException, bool> exVerifier) where TException : Exception
         {
             TException ex = Assert.Throws<TException>(connectAction);
-            Assert.True(ex.Message.Contains(expectedExceptionMessage), string.Format("FAILED SqlException did not contain expected error message. Actual message: {0}", ex.Message));
+            Assert.Contains(expectedExceptionMessage, ex.Message);
             Assert.True(exVerifier(ex), "FAILED Exception verifier failed on the exception.");
 
             return ex;
@@ -109,45 +111,38 @@ namespace System.Data.SqlClient.Tests
 
         private bool VerifyException(SqlException exception, int count, int? errorNumber = null, int? errorState = null, int? severity = null)
         {
-
-            // Verify that there are the correct number of errors in the exception
-            Assert.True(exception.Errors.Count == count, string.Format("FAILED Incorrect number of errors. Expected: {0}. Actual: {1}.", count, exception.Errors.Count));
+            Assert.NotEmpty(exception.Errors);
+            Assert.Equal(count, exception.Errors.Count);
 
             // Ensure that all errors have an error-level severity
             for (int i = 0; i < count; i++)
             {
-                Assert.True(exception.Errors[i].Class >= 10, "FAILED verification of Exception!  Exception contains a warning!");
+                Assert.InRange(exception.Errors[i].Class, 10, byte.MaxValue);
             }
 
             // Check the properties of the exception populated by the server are correct
             if (errorNumber.HasValue)
             {
-                Assert.True(errorNumber.Value == exception.Number, string.Format("FAILED Error number of exception is incorrect. Expected: {0}. Actual: {1}.", errorNumber.Value, exception.Number));
+                Assert.Equal(errorNumber.Value, exception.Number);
             }
 
             if (errorState.HasValue)
             {
-                Assert.True(errorState.Value == exception.State, string.Format("FAILED Error state of exception is incorrect. Expected: {0}. Actual: {1}.", errorState.Value, exception.State));
+                Assert.Equal(errorState.Value, exception.State);
             }
 
             if (severity.HasValue)
             {
-                Assert.True(severity.Value == exception.Class, string.Format("FAILED Severity of exception is incorrect. Expected: {0}. Actual: {1}.", severity.Value, exception.Class));
+                Assert.Equal(severity.Value, exception.Class);
             }
 
             if ((errorNumber.HasValue) && (errorState.HasValue) && (severity.HasValue))
             {
-                string detailsText = string.Format("Error Number:{0},State:{1},Class:{2}", errorNumber.Value, errorState.Value, severity.Value);
-                Assert.True(exception.ToString().Contains(detailsText), string.Format("FAILED SqlException.ToString does not contain the error number, state and severity information"));
+                string expected = $"Error Number:{errorNumber.Value},State:{errorState.Value},Class:{severity.Value}";
+                Assert.Contains(expected, exception.ToString());
             }
-
-            // verify that the this[] function on the collection works, as well as the All function
-            SqlError[] errors = new SqlError[exception.Errors.Count];
-            exception.Errors.CopyTo(errors, 0);
-            Assert.True((errors[0].Message).Equals(exception.Errors[0].Message), string.Format("FAILED verification of Exception! ErrorCollection indexer/CopyTo resulted in incorrect value."));
 
             return true;
         }
-
     }
 }

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.RetrieveStatistics.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.RetrieveStatistics.cs
@@ -1,0 +1,550 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Linq;
+
+using Xunit;
+
+namespace System.Data.SqlClient.Tests
+{
+    public partial class SqlConnectionTest
+    {
+        private static readonly string[] s_retrieveStatisticsKeys =
+        {
+            "BuffersReceived",
+            "BuffersSent",
+            "BytesReceived",
+            "BytesSent",
+            "CursorOpens",
+            "IduCount",
+            "IduRows",
+            "PreparedExecs",
+            "Prepares",
+            "SelectCount",
+            "SelectRows",
+            "ServerRoundtrips",
+            "SumResultSets",
+            "Transactions",
+            "UnpreparedExecs",
+            "ConnectionTime",
+            "ExecutionTime",
+            "NetworkServerTime"
+        };
+
+        [Fact]
+        public void RetrieveStatistics_Success()
+        {
+            var connection = new SqlConnection();
+            IDictionary d = connection.RetrieveStatistics();
+            Assert.NotNull(d);
+            Assert.NotSame(d, connection.RetrieveStatistics());
+        }
+
+        [Fact]
+        public void RetrieveStatistics_ExpectedKeysInDictionary_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+
+            Assert.NotEmpty(d);
+            Assert.Equal(s_retrieveStatisticsKeys.Length, d.Count);
+
+            Assert.NotEmpty(d.Keys);
+            Assert.Equal(s_retrieveStatisticsKeys.Length, d.Keys.Count);
+
+            Assert.NotEmpty(d.Values);
+            Assert.Equal(s_retrieveStatisticsKeys.Length, d.Values.Count);
+
+            foreach (string key in s_retrieveStatisticsKeys)
+            {
+                Assert.True(d.Contains(key));
+
+                object value = d[key];
+                Assert.NotNull(value);
+                Assert.IsType<long>(value);
+                Assert.Equal(0L, value);
+            }
+        }
+
+        [Fact]
+        public void RetrieveStatistics_UnexpectedKeysNotInDictionary_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            Assert.False(d.Contains("Foo"));
+            Assert.Null(d["Foo"]);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_IsSynchronized_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            Assert.False(d.IsSynchronized);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_SyncRoot_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            Assert.NotNull(d.SyncRoot);
+            Assert.Same(d.SyncRoot, d.SyncRoot);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_IsFixedSize_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            Assert.False(d.IsFixedSize);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_IsReadOnly_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            Assert.False(d.IsReadOnly);
+        }
+
+        public static readonly object[][] RetrieveStatisticsKeyValueData =
+        {
+            new object[] { "Foo", 100L },
+            new object[] { "Foo", null },
+            new object[] { "Blah", "Blah" },
+            new object[] { 100, "Value" }
+        };
+
+        [Theory]
+        [MemberData(nameof(RetrieveStatisticsKeyValueData))]
+        public void RetrieveStatistics_Add_Success(object key, object value)
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+
+            d.Add(key, value);
+
+            Assert.True(d.Contains(key));
+
+            object v = d[key];
+            Assert.Same(value, v);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Add_ExistingKey_Throws()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            string key = s_retrieveStatisticsKeys[0];
+            Assert.Throws<ArgumentException>(null, () => d.Add(key, 100L));
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Add_NullKey_Throws()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            Assert.Throws<ArgumentNullException>("key", () => d.Add(null, 100L));
+        }
+
+        [Theory]
+        [MemberData(nameof(RetrieveStatisticsKeyValueData))]
+        public void RetrieveStatistics_Setter_Success(object key, object value)
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+
+            d[key] = value;
+
+            Assert.True(d.Contains(key));
+
+            object v = d[key];
+            Assert.Same(value, v);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Setter_ExistingKey_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            string key = s_retrieveStatisticsKeys[0];
+
+            d[key] = 100L;
+            Assert.Equal(100L, d[key]);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Setter_NullKey_Throws()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            Assert.Throws<ArgumentNullException>("key", () => d[null] = 100L);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Clear_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+
+            d.Clear();
+
+            Assert.Empty(d);
+            Assert.Equal(0, d.Count);
+
+            Assert.Empty(d.Keys);
+            Assert.Equal(0, d.Keys.Count);
+
+            Assert.Empty(d.Values);
+            Assert.Equal(0, d.Values.Count);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Remove_ExistingKey_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+
+            string key = s_retrieveStatisticsKeys[0];
+
+            Assert.Equal(s_retrieveStatisticsKeys.Length, d.Count);
+            Assert.Equal(s_retrieveStatisticsKeys.Length, d.Keys.Count);
+            Assert.Equal(s_retrieveStatisticsKeys.Length, d.Values.Count);
+            Assert.True(d.Contains(key));
+            Assert.NotNull(d[key]);
+
+            d.Remove(key);
+
+            Assert.Equal(s_retrieveStatisticsKeys.Length - 1, d.Count);
+            Assert.Equal(s_retrieveStatisticsKeys.Length - 1, d.Keys.Count);
+            Assert.Equal(s_retrieveStatisticsKeys.Length - 1, d.Values.Count);
+            Assert.False(d.Contains(key));
+            Assert.Null(d[key]);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Remove_NonExistentKey_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+
+            const string key = "Foo";
+
+            Assert.Equal(s_retrieveStatisticsKeys.Length, d.Count);
+            Assert.Equal(s_retrieveStatisticsKeys.Length, d.Keys.Count);
+            Assert.Equal(s_retrieveStatisticsKeys.Length, d.Values.Count);
+            Assert.False(d.Contains(key));
+            Assert.Null(d[key]);
+
+            d.Remove(key);
+
+            Assert.Equal(s_retrieveStatisticsKeys.Length, d.Count);
+            Assert.Equal(s_retrieveStatisticsKeys.Length, d.Keys.Count);
+            Assert.Equal(s_retrieveStatisticsKeys.Length, d.Values.Count);
+            Assert.False(d.Contains(key));
+            Assert.Null(d[key]);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Remove_NullKey_Throws()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            Assert.Throws<ArgumentNullException>("key", () => d.Remove(null));
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Contains_NullKey_Throws()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            Assert.Throws<ArgumentNullException>("key", () => d.Contains(null));
+        }
+
+        [Fact]
+        public void RetrieveStatistics_CopyTo_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            DictionaryEntry[] destination = new DictionaryEntry[d.Count];
+
+            d.CopyTo(destination, 0);
+
+            int i = 0;
+            foreach (DictionaryEntry entry in d)
+            {
+                Assert.Equal(entry, destination[i]);
+                i++;
+            }
+        }
+
+        [Fact]
+        public void RetrieveStatistics_CopyTo_Throws()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+
+            Assert.Throws<ArgumentNullException>("array", () => d.CopyTo(null, 0));
+            Assert.Throws<ArgumentNullException>("array", () => d.CopyTo(null, -1));
+            Assert.Throws<ArgumentOutOfRangeException>("arrayIndex", () => d.CopyTo(new DictionaryEntry[20], -1));
+            Assert.Throws<ArgumentException>(null, () => d.CopyTo(new DictionaryEntry[20], 18));
+            Assert.Throws<ArgumentException>(null, () => d.CopyTo(new DictionaryEntry[20], 1000));
+            Assert.Throws<ArgumentException>(null, () => d.CopyTo(new DictionaryEntry[4, 3], 0));
+            Assert.Throws<InvalidCastException>(() => d.CopyTo(new string[20], 0));
+        }
+
+        [Fact]
+        public void RetrieveStatistics_GetEnumerator_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+
+            IDictionaryEnumerator e = d.GetEnumerator();
+
+            Assert.NotNull(e);
+            Assert.NotSame(e, d.GetEnumerator());
+
+            for (int i = 0; i < 2; i++)
+            {
+                Assert.Throws<InvalidOperationException>(() => e.Current);
+
+                foreach (string ignored in s_retrieveStatisticsKeys)
+                {
+                    Assert.True(e.MoveNext());
+
+                    Assert.NotNull(e.Current);
+                    Assert.NotNull(e.Entry.Key);
+                    Assert.NotNull(e.Entry.Value);
+
+                    Assert.Equal(e.Current, e.Entry);
+                    Assert.Same(e.Key, e.Entry.Key);
+                    Assert.Same(e.Value, e.Entry.Value);
+                }
+
+                Assert.False(e.MoveNext());
+                Assert.False(e.MoveNext());
+                Assert.False(e.MoveNext());
+
+                Assert.Throws<InvalidOperationException>(() => e.Current);
+
+                e.Reset();
+            }
+        }
+
+        [Fact]
+        public void RetrieveStatistics_GetEnumerator_ModifyCollection_Throws()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+
+            IDictionaryEnumerator e = d.GetEnumerator();
+
+            d.Add("Foo", 0L);
+
+            Assert.Throws<InvalidOperationException>(() => e.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => e.Reset());
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Keys_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            Assert.NotNull(d.Keys);
+            Assert.Same(d.Keys, d.Keys);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Keys_IsSynchronized_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            ICollection c = d.Keys;
+            Assert.False(c.IsSynchronized);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Keys_SyncRoot_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            ICollection c = d.Keys;
+            Assert.NotNull(c.SyncRoot);
+            Assert.Same(c.SyncRoot, c.SyncRoot);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Keys_CopyTo_ObjectArray_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            ICollection c = d.Keys;
+            object[] destination = new object[c.Count];
+
+            c.CopyTo(destination, 0);
+
+            Assert.Equal(c.Cast<object>().ToArray(), destination);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Keys_CopyTo_StringArray_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            ICollection c = d.Keys;
+            string[] destination = new string[c.Count];
+
+            c.CopyTo(destination, 0);
+
+            Assert.Equal(c.Cast<string>().ToArray(), destination);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Keys_CopyTo_Throws()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            ICollection c = d.Keys;
+
+            Assert.Throws<ArgumentNullException>("array", () => c.CopyTo(null, 0));
+            Assert.Throws<ArgumentNullException>("array", () => c.CopyTo(null, -1));
+            Assert.Throws<ArgumentOutOfRangeException>("arrayIndex", () => c.CopyTo(new string[20], -1));
+            Assert.Throws<ArgumentException>(null, () => c.CopyTo(new string[20], 18));
+            Assert.Throws<ArgumentException>(null, () => c.CopyTo(new string[20], 1000));
+            Assert.Throws<ArgumentException>(null, () => c.CopyTo(new string[4, 3], 0));
+            Assert.Throws<InvalidCastException>(() => c.CopyTo(new Version[20], 0));
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Keys_GetEnumerator_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            ICollection c = d.Keys;
+
+            IEnumerator e = c.GetEnumerator();
+
+            Assert.NotNull(e);
+            Assert.NotSame(e, c.GetEnumerator());
+
+            for (int i = 0; i < 2; i++)
+            {
+                Assert.Throws<InvalidOperationException>(() => e.Current);
+
+                foreach (string ignored in s_retrieveStatisticsKeys)
+                {
+                    Assert.True(e.MoveNext());
+                    Assert.NotNull(e.Current);
+                    Assert.True(s_retrieveStatisticsKeys.Contains(e.Current));
+                }
+
+                Assert.False(e.MoveNext());
+                Assert.False(e.MoveNext());
+                Assert.False(e.MoveNext());
+
+                Assert.Throws<InvalidOperationException>(() => e.Current);
+
+                e.Reset();
+            }
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Keys_GetEnumerator_ModifyCollection_Throws()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            ICollection c = d.Keys;
+
+            IEnumerator e = c.GetEnumerator();
+
+            d.Add("Foo", 0L);
+
+            Assert.Throws<InvalidOperationException>(() => e.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => e.Reset());
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Values_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            Assert.NotNull(d.Values);
+            Assert.Same(d.Values, d.Values);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Values_IsSynchronized_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            ICollection c = d.Values;
+            Assert.False(c.IsSynchronized);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Values_SyncRoot_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            ICollection c = d.Values;
+            Assert.NotNull(c.SyncRoot);
+            Assert.Same(c.SyncRoot, c.SyncRoot);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Values_CopyTo_ObjectArray_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            ICollection c = d.Values;
+            object[] destination = new object[c.Count];
+
+            c.CopyTo(destination, 0);
+
+            Assert.Equal(c.Cast<object>().ToArray(), destination);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Values_CopyTo_Int64Array_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            ICollection c = d.Values;
+            long[] destination = new long[c.Count];
+
+            c.CopyTo(destination, 0);
+
+            Assert.Equal(c.Cast<long>().ToArray(), destination);
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Values_CopyTo_Throws()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            ICollection c = d.Values;
+
+            Assert.Throws<ArgumentNullException>("array", () => c.CopyTo(null, 0));
+            Assert.Throws<ArgumentNullException>("array", () => c.CopyTo(null, -1));
+            Assert.Throws<ArgumentOutOfRangeException>("arrayIndex", () => c.CopyTo(new long[20], -1));
+            Assert.Throws<ArgumentException>(null, () => c.CopyTo(new long[20], 18));
+            Assert.Throws<ArgumentException>(null, () => c.CopyTo(new long[20], 1000));
+            Assert.Throws<ArgumentException>(null, () => c.CopyTo(new long[4, 3], 0));
+            Assert.Throws<InvalidCastException>(() => c.CopyTo(new Version[20], 0));
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Values_GetEnumerator_Success()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            ICollection c = d.Values;
+
+            IEnumerator e = c.GetEnumerator();
+
+            Assert.NotNull(e);
+            Assert.NotSame(e, c.GetEnumerator());
+
+            for (int i = 0; i < 2; i++)
+            {
+                Assert.Throws<InvalidOperationException>(() => e.Current);
+
+                foreach (string ignored in s_retrieveStatisticsKeys)
+                {
+                    Assert.True(e.MoveNext());
+                    Assert.NotNull(e.Current);
+                    Assert.Equal(0L, e.Current);
+                }
+
+                Assert.False(e.MoveNext());
+                Assert.False(e.MoveNext());
+                Assert.False(e.MoveNext());
+
+                Assert.Throws<InvalidOperationException>(() => e.Current);
+
+                e.Reset();
+            }
+        }
+
+        [Fact]
+        public void RetrieveStatistics_Values_GetEnumerator_ModifyCollection_Throws()
+        {
+            IDictionary d = new SqlConnection().RetrieveStatistics();
+            ICollection c = d.Values;
+
+            IEnumerator e = c.GetEnumerator();
+
+            d.Add("Foo", 0L);
+
+            Assert.Throws<InvalidOperationException>(() => e.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => e.Reset());
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlErrorCollectionTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlErrorCollectionTest.cs
@@ -1,0 +1,157 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+
+using Xunit;
+
+namespace System.Data.SqlClient.Tests
+{
+    public class SqlErrorCollectionTest
+    {
+        private const string badServer = "92B96911A0BD43E8ADA4451031F7E7CF";
+
+        [Fact]
+        public void IsSynchronized_Success()
+        {
+            ICollection c = CreateCollection();
+            Assert.False(c.IsSynchronized);
+        }
+
+        [Fact]
+        public void SyncRoot_Success()
+        {
+            ICollection c = CreateCollection();
+            Assert.Same(c, c.SyncRoot);
+        }
+
+        [Fact]
+        public void Indexer_Success()
+        {
+            SqlErrorCollection c = CreateCollection();
+            Assert.NotNull(c[0]);
+            Assert.Same(c[0], c[0]);
+        }
+
+        [Fact]
+        public void Indexer_Throws()
+        {
+            SqlErrorCollection c = CreateCollection();
+
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => c[-1]);
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => c[c.Count]);
+        }
+
+        [Fact]
+        public void CopyTo_Success()
+        {
+            ValidateCopyTo((collection, array, index) => collection.CopyTo(array, index));
+        }
+
+        [Fact]
+        public void CopyTo_NonGeneric_Success()
+        {
+            ValidateCopyTo((collection, array, index) => ((ICollection)collection).CopyTo(array, index));
+        }
+
+        private static void ValidateCopyTo(Action<SqlErrorCollection, SqlError[], int> copyTo)
+        {
+            SqlErrorCollection c = CreateCollection();
+            SqlError[] destination = new SqlError[5];
+
+            copyTo(c, destination, 2);
+
+            Assert.Null(destination[0]);
+            Assert.Null(destination[1]);
+            Assert.Same(c[0], destination[2]);
+            Assert.Null(destination[3]);
+            Assert.Null(destination[4]);
+        }
+
+        [Fact]
+        public void CopyTo_Throws()
+        {
+            ValidateCopyToThrows((collection, array, index) => collection.CopyTo(array, index));
+        }
+
+        [Fact]
+        public void CopyTo_NonGeneric_Throws()
+        {
+            ValidateCopyToThrows((collection, array, index) => ((ICollection)collection).CopyTo(array, index), c =>
+            {
+                ICollection ic = c;
+                Assert.Throws<ArgumentException>(null, () => ic.CopyTo(new SqlError[4, 3], 0));
+                Assert.Throws<InvalidCastException>(() => ic.CopyTo(new string[10], 0));
+            });
+        }
+
+        private static void ValidateCopyToThrows(
+            Action<SqlErrorCollection, SqlError[], int> copyTo,
+            Action<SqlErrorCollection> additionalValidation = null)
+        {
+            SqlErrorCollection c = CreateCollection();
+
+            Assert.Throws<ArgumentNullException>(() => copyTo(c, null, 0));
+            Assert.Throws<ArgumentNullException>(() => copyTo(c, null, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => copyTo(c, new SqlError[10], -1));
+            Assert.Throws<ArgumentException>(() => copyTo(c, new SqlError[10], 1000));
+
+            additionalValidation?.Invoke(c);
+        }
+
+        [Fact]
+        public void GetEnumerator_Success()
+        {
+            SqlErrorCollection c = CreateCollection();
+
+            IEnumerator e = c.GetEnumerator();
+
+            Assert.NotNull(e);
+            Assert.NotSame(e, c.GetEnumerator());
+
+            for (int i = 0; i < 2; i++)
+            {
+                Assert.Throws<InvalidOperationException>(() => e.Current);
+
+                Assert.True(e.MoveNext());
+                Assert.Same(c[0], e.Current);
+
+                Assert.False(e.MoveNext());
+                Assert.False(e.MoveNext());
+                Assert.False(e.MoveNext());
+
+                Assert.Throws<InvalidOperationException>(() => e.Current);
+
+                e.Reset();
+            }
+        }
+
+        private static SqlErrorCollection CreateCollection()
+        {
+            var builder = new SqlConnectionStringBuilder()
+            {
+                DataSource = badServer,
+                ConnectTimeout = 1,
+                Pooling = false
+            };
+
+            using (var connection = new SqlConnection(builder.ConnectionString))
+            {
+                try
+                {
+                    connection.Open();
+                }
+                catch (SqlException ex)
+                {
+                    Assert.NotNull(ex.Errors);
+                    Assert.Equal(1, ex.Errors.Count);
+
+                    return ex.Errors;
+                }
+            }
+
+            throw new InvalidOperationException("SqlException.Errors should have been returned.");
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -17,6 +17,8 @@
   <ItemGroup>
     <Compile Include="ExceptionTest.cs" />
     <Compile Include="SqlBulkCopyColumnMappingCollectionTest.cs" />
+    <Compile Include="SqlConnectionTest.RetrieveStatistics.cs" />
+    <Compile Include="SqlErrorCollectionTest.cs" />
     <Compile Include="SqlStringTest.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Two commits:

 1. The first commit adds some more tests, along with minor cleanup to existing tests. The tests pass on the full framework and before & after the changes in the second commit.

 2. The second commit removes SqlClient's dependency on the non-generic collections.

Fixes #7637

cc: @saurabh500, @stephentoub, @jamesqo 

---

Note: The change to `FieldNameLookup.cs` in this PR overlaps with changes in #7686, so I'll need to rebase this if #7686 is merged first.

---

@saurabh500, there were some changes that I couldn't easily write functional tests for... Would you mind running the manual tests before merging?