### PR TITLE
Fix Globalization tests running on Windows 7 using Desktop framework

### DIFF
--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>System.Globalization.Tests</RootNamespace>
     <AssemblyName>System.Globalization.Tests</AssemblyName>
     <IncludePerformanceTests>true</IncludePerformanceTests>
+    <DefineConstants Condition="'$(TargetGroup)' == 'net46'">$(DefineConstants);net46</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Globalization/tests/TextInfo/TextInfoToLower.cs
+++ b/src/System.Globalization/tests/TextInfo/TextInfoToLower.cs
@@ -39,9 +39,20 @@ namespace System.Globalization.Tests
 
                 // SNOWMAN, which does not have a lower case variant.
                 yield return new object[] { cultureName, "\u2603", "\u2603" };
-
+#if net46
+                if (PlatformDetection.IsWindows7)
+                {
+                    // on Windows 7, Desktop framework is using its own sorting DLL and not calling the OS except with Invariant culture
+                    yield return new object[] { cultureName, "\U00010400", cultureName == "" ? "\U00010400" : "\U00010428" };
+                }
+                else 
+                {
+                    yield return new object[] { cultureName, "\U00010400", "\U00010428" };
+                }
+#else //!net46
                 // DESERT CAPITAL LETTER LONG I has a lower case variant (but not on Windows 7).
                 yield return new object[] { cultureName, "\U00010400", PlatformDetection.IsWindows7 ? "\U00010400" : "\U00010428" };
+#endif // net46
 
                 // RAINBOW (outside the BMP and does not case)
                 yield return new object[] { cultureName, "\U0001F308", "\U0001F308" };

--- a/src/System.Globalization/tests/TextInfo/TextInfoToUpper.cs
+++ b/src/System.Globalization/tests/TextInfo/TextInfoToUpper.cs
@@ -40,8 +40,20 @@ namespace System.Globalization.Tests
                 // SNOWMAN, which does not have an upper case variant.
                 yield return new object[] { cultureName, "\u2603", "\u2603" };
 
+#if net46
+                if (PlatformDetection.IsWindows7)
+                {
+                    // on Windows 7, Desktop framework is using its own sorting DLL and not calling the OS except with Invariant culture
+                    yield return new object[] { cultureName, "\U00010428", cultureName == "" ? "\U00010428" : "\U00010400" };
+                }
+                else 
+                {
+                    yield return new object[] { cultureName, "\U00010428", "\U00010400" };
+                }
+#else //!net46
                 // DESERT SMALL LETTER LONG I has an upper case variant (but not on Windows 7).
                 yield return new object[] { cultureName, "\U00010428", PlatformDetection.IsWindows7 ? "\U00010428" : "\U00010400" };
+#endif // net46
 
                 // RAINBOW (outside the BMP and does not case)
                 yield return new object[] { cultureName, "\U0001F308", "\U0001F308" };


### PR DESCRIPTION
Desktop framework is using its own sorting Dll when running on Windows 7 This gives a different results than what the OS give. invariant culture is exception as the framework call the OS for invariant.