### PR TITLE
Minor System.Collections.NonGeneric test cleanup

### DIFF
--- a/src/System.Collections.NonGeneric/src/System/Collections/ArrayList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/ArrayList.cs
@@ -345,7 +345,7 @@ namespace System.Collections
         public virtual void CopyTo(Array array, int arrayIndex)
         {
             if ((array != null) && (array.Rank != 1))
-                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
             Contract.EndContractBlock();
             // Delegate rest of error checking to Array.Copy.
             Array.Copy(_items, 0, array, arrayIndex, _size);
@@ -360,7 +360,7 @@ namespace System.Collections
             if (_size - index < count)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
             if ((array != null) && (array.Rank != 1))
-                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
             Contract.EndContractBlock();
             // Delegate rest of error checking to Array.Copy.
             Array.Copy(_items, index, array, arrayIndex, count);
@@ -999,7 +999,7 @@ namespace System.Collections
                 if (array.Length - arrayIndex < count)
                     throw new ArgumentException(SR.Argument_InvalidOffLen);
                 if (array.Rank != 1)
-                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
                 Contract.EndContractBlock();
 
                 if (_list.Count - index < count)
@@ -2612,7 +2612,7 @@ namespace System.Collections
                 if (array == null)
                     throw new ArgumentNullException(nameof(array));
                 if (array.Rank != 1)
-                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
                 if (index < 0)
                     throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_NeedNonNegNum);
                 if (array.Length - index < _baseSize)
@@ -2628,7 +2628,7 @@ namespace System.Collections
                 if (array == null)
                     throw new ArgumentNullException(nameof(array));
                 if (array.Rank != 1)
-                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
                 if (index < 0 || count < 0)
                     throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
                 if (array.Length - arrayIndex < count)

--- a/src/System.Collections.NonGeneric/src/System/Collections/Hashtable.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Hashtable.cs
@@ -196,7 +196,7 @@ namespace System.Collections
 
             double rawsize = capacity / _loadFactor;
             if (rawsize > Int32.MaxValue)
-                throw new ArgumentException(SR.Arg_HTCapacityOverflow);
+                throw new ArgumentException(SR.Arg_HTCapacityOverflow, nameof(capacity));
 
             // Avoid awfully small sizes
             int hashsize = (rawsize > InitialSize) ? HashHelpers.GetPrime((int)rawsize) : InitialSize;
@@ -460,7 +460,7 @@ namespace System.Collections
             if (array == null)
                 throw new ArgumentNullException(nameof(array), SR.ArgumentNull_Array);
             if (array.Rank != 1)
-                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
             if (arrayIndex < 0)
                 throw new ArgumentOutOfRangeException(nameof(arrayIndex), SR.ArgumentOutOfRange_NeedNonNegNum);
             if (array.Length - arrayIndex < Count)
@@ -1022,7 +1022,7 @@ namespace System.Collections
                 if (array == null)
                     throw new ArgumentNullException(nameof(array));
                 if (array.Rank != 1)
-                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
                 if (arrayIndex < 0)
                     throw new ArgumentOutOfRangeException(nameof(arrayIndex), SR.ArgumentOutOfRange_NeedNonNegNum);
                 Contract.EndContractBlock();
@@ -1068,7 +1068,7 @@ namespace System.Collections
                 if (array == null)
                     throw new ArgumentNullException(nameof(array));
                 if (array.Rank != 1)
-                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
                 if (arrayIndex < 0)
                     throw new ArgumentOutOfRangeException(nameof(arrayIndex), SR.ArgumentOutOfRange_NeedNonNegNum);
                 Contract.EndContractBlock();

--- a/src/System.Collections.NonGeneric/src/System/Collections/Queue.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Queue.cs
@@ -147,7 +147,7 @@ namespace System.Collections
             if (array == null)
                 throw new ArgumentNullException(nameof(array));
             if (array.Rank != 1)
-                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
             Contract.EndContractBlock();

--- a/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
@@ -361,7 +361,7 @@ namespace System.Collections
             if (array == null)
                 throw new ArgumentNullException(nameof(array), SR.ArgumentNull_Array);
             if (array.Rank != 1)
-                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
             if (arrayIndex < 0)
                 throw new ArgumentOutOfRangeException(nameof(arrayIndex), SR.ArgumentOutOfRange_NeedNonNegNum);
             if (array.Length - arrayIndex < Count)
@@ -982,7 +982,7 @@ namespace System.Collections
             public virtual void CopyTo(Array array, int arrayIndex)
             {
                 if (array != null && array.Rank != 1)
-                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
                 Contract.EndContractBlock();
 
                 // defer error checking to Array.Copy
@@ -1086,7 +1086,7 @@ namespace System.Collections
             public virtual void CopyTo(Array array, int arrayIndex)
             {
                 if (array != null && array.Rank != 1)
-                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
                 Contract.EndContractBlock();
 
                 // defer error checking to Array.Copy

--- a/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
@@ -136,7 +136,7 @@ namespace System.Collections
             if (array == null)
                 throw new ArgumentNullException(nameof(array));
             if (array.Rank != 1)
-                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_NeedNonNegNum);
             if (array.Length - index < _size)

--- a/src/System.Collections.NonGeneric/tests/ArrayListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayListTests.cs
@@ -6,15 +6,14 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Threading.Tasks;
-
 using Xunit;
 
 namespace System.Collections.Tests
 {
-    public static partial class ArrayListTests
+    public static class ArrayListTests
     {
         [Fact]
-        public static void TestCtor_Empty()
+        public static void Ctor_Empty()
         {
             var arrList = new ArrayList();
             Assert.Equal(0, arrList.Count);
@@ -25,11 +24,13 @@ namespace System.Collections.Tests
             Assert.False(arrList.IsSynchronized);
         }
 
-        [Fact]
-        public static void TestCtor_Capacity()
+        [Theory]
+        [InlineData(16)]
+        [InlineData(0)]
+        public static void Ctor_Int(int capacity)
         {
-            var arrList = new ArrayList(16);
-            Assert.Equal(16, arrList.Capacity);
+            var arrList = new ArrayList(capacity);
+            Assert.Equal(capacity, arrList.Capacity);
 
             Assert.False(arrList.IsFixedSize);
             Assert.False(arrList.IsReadOnly);
@@ -37,18 +38,22 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_Capacity_Invalid()
+        public static void Ctor_Int_NegativeCapacity_ThrowsArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new ArrayList(-1)); // Capacity < 0
         }
 
         [Fact]
-        public static void TestCtor_ICollection()
+        public static void Ctor_ICollection()
         {
             ArrayList sourceList = Helpers.CreateIntArrayList(100);
             var arrList = new ArrayList(sourceList);
 
-            Assert.Equal(100, arrList.Count);
+            Assert.Equal(sourceList.Count, arrList.Count);
+            for (int i = 0; i < arrList.Count; i++)
+            {
+                Assert.Equal(sourceList[i], arrList[i]);
+            }
 
             Assert.False(arrList.IsFixedSize);
             Assert.False(arrList.IsReadOnly);
@@ -56,7 +61,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_ICollection_Empty()
+        public static void Ctor_ICollection_Empty()
         {
             ICollection arrListCollection = new ArrayList();
             ArrayList arrList = new ArrayList(arrListCollection);
@@ -69,13 +74,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_ICollection_Invalid()
+        public static void Ctor_ICollection_NullCollection_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("c", () => new ArrayList(null)); // Collection is null
         }
 
         [Fact]
-        public static void TestDebuggerAttribute()
+        public static void DebuggerAttribute()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new ArrayList());
             DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new ArrayList() { "a", 1, "b", 2 });
@@ -87,15 +92,14 @@ namespace System.Collections.Tests
             }
             catch (TargetInvocationException ex)
             {
-                ArgumentNullException nullException = ex.InnerException as ArgumentNullException;
-                threwNull = nullException != null;
+                threwNull = ex.InnerException is ArgumentNullException;
             }
 
             Assert.True(threwNull);
         }
 
         [Fact]
-        public static void TestAdapter_ArrayList()
+        public static void Adapter_ArrayList()
         {
             ArrayList arrList = ArrayList.Adapter(new ArrayList());
             Assert.False(arrList.IsFixedSize);
@@ -104,7 +108,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdapter_FixedSizeArrayList()
+        public static void Adapter_FixedSizeArrayList()
         {
             ArrayList arrList = ArrayList.Adapter(ArrayList.FixedSize(new ArrayList()));
             Assert.True(arrList.IsFixedSize);
@@ -113,7 +117,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdapter_ReadOnlyArrayList()
+        public static void Adapter_ReadOnlyArrayList()
         {
             ArrayList arrList = ArrayList.Adapter(ArrayList.ReadOnly(new ArrayList()));
             Assert.True(arrList.IsFixedSize);
@@ -122,7 +126,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdapter_SynchronizedArrayList()
+        public static void Adapter_SynchronizedArrayList()
         {
             ArrayList arrList = ArrayList.Adapter(ArrayList.Synchronized(new ArrayList()));
             Assert.False(arrList.IsFixedSize);
@@ -131,7 +135,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdapter_PopulateChangesToList()
+        public static void Adapter_PopulateChangesToList()
         {
             const string FromBefore = " from before";
 
@@ -149,7 +153,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdapter_ClearList()
+        public static void Adapter_ClearList()
         {
             // Make sure changes through list show up in listAdapter
             ArrayList arrList = Helpers.CreateIntArrayList(100);
@@ -159,7 +163,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdapter_Enumerators()
+        public static void Adapter_Enumerators()
         {
             // Test to see if enumerators are correctly enumerate through elements
             ArrayList arrList = Helpers.CreateIntArrayList(10);
@@ -183,7 +187,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdapter_EnumeratorsModifiedList()
+        public static void Adapter_EnumeratorsModifiedList()
         {
             // Test to see if enumerators are correctly getting invalidated with list modified through list
             ArrayList arrList = Helpers.CreateIntArrayList(10);
@@ -203,7 +207,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdapter_EnumeratorsModifiedAdapter()
+        public static void Adapter_EnumeratorsModifiedAdapter()
         {
             // Test to see if enumerators are correctly getting invalidated with list modified through listAdapter
             ArrayList arrList = Helpers.CreateStringArrayList(10);
@@ -223,7 +227,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdapter_InsertRange()
+        public static void Adapter_InsertRange()
         {
             // Test too see if listAdapator modified using InsertRange works
             // Populate the list
@@ -238,7 +242,7 @@ namespace System.Collections.Tests
         }
         
         [Fact]
-        public static void TestAdapter_Capacity_Set()
+        public static void Adapter_Capacity_Set()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             ArrayList adapter = ArrayList.Adapter(arrList);
@@ -248,13 +252,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdapter_Invalid()
+        public static void Adapter_NullList_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("list", () => ArrayList.Adapter(null)); // List is null
         }
 
         [Fact]
-        public static void TestAddRange_Basic()
+        public static void AddRange_Basic()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             ArrayList arrList2 = Helpers.CreateIntArrayList(20, 10);
@@ -263,7 +267,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAddRange_DifferentCollection()
+        public static void AddRange_DifferentCollection()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             Queue queue = new Queue();
@@ -275,7 +279,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAddRange_Self()
+        public static void AddRange_Self()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -325,7 +329,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAddRange_DifferentObjectTypes()
+        public static void AddRange_DifferentObjectTypes()
         {
             // Add an ICollection with different type objects
             ArrayList arrList1 = Helpers.CreateIntArrayList(10); // Array list contains only integers currently
@@ -355,7 +359,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAddRange_EmptyCollection()
+        public static void AddRange_EmptyCollection()
         {
             var emptyCollection = new Queue();
             ArrayList arrList1 = Helpers.CreateIntArrayList(100);
@@ -372,7 +376,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAddRange_Invalid()
+        public static void AddRange_NullCollection_ThrowsArgumentNullException()
         {
             var arrList1 = new ArrayList();
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -390,7 +394,7 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestAdd(int count)
+        public static void Add(int count)
         {
             VerifyAdd(new ArrayList(), count);
         }
@@ -399,7 +403,7 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestAdd_SmallCapacity(int count)
+        public static void Add_SmallCapacity(int count)
         {
             VerifyAdd(new ArrayList(1), count);
         }
@@ -432,7 +436,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestBinarySearch_Basic()
+        public static void BinarySearch_Basic()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -446,7 +450,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestBinarySearch_Basic_NotFoundReturnsNextElementIndex()
+        public static void BinarySearch_Basic_NotFoundReturnsNextElementIndex()
         {
             // The zero-based index of the value in the sorted ArrayList, if value is found; otherwise, a negative number,
             // which is the bitwise complement of the index of the next element.
@@ -461,7 +465,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestBinarySearch_Basic_NullObject()
+        public static void BinarySearch_Basic_NullObject()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(100);
             arrList1.Add(null);
@@ -473,7 +477,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestBinarySearch_Basic_DuplicateResults()
+        public static void BinarySearch_Basic_DuplicateResults()
         {
             // If we have duplicate results, return the first.
             var arrList1 = new ArrayList();
@@ -488,7 +492,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestBinarySearch_IComparer()
+        public static void BinarySearch_IComparer()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -502,7 +506,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestBinarySearch_IComparer_NotFoundReturnsNextElementIndex()
+        public static void BinarySearch_IComparer_NotFoundReturnsNextElementIndex()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(100);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -515,7 +519,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestBinarySearch_IComparer_NullObject()
+        public static void BinarySearch_IComparer_NullObject()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(100);
             arrList1.Add(null);
@@ -527,7 +531,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestBinarySearch_IComparer_DuplicateResults()
+        public static void BinarySearch_IComparer_DuplicateResults()
         {
             // If we have duplicate results, return the first.
             var arrList1 = new ArrayList();
@@ -542,7 +546,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestBinarySearch_Int_Int_IComparer()
+        public static void BinarySearch_Int_Int_IComparer()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -556,7 +560,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestBinarySearch_Int_Int_IComparer_ObjectOutsideIndex()
+        public static void BinarySearch_Int_Int_IComparer_ObjectOutsideIndex()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -572,7 +576,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestBinarySearch_Int_Int_IComparer_NullComparer()
+        public static void BinarySearch_Int_Int_IComparer_NullComparer()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -588,7 +592,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestBinarySearch_Int_Int_IComparer_Invalid()
+        public static void BinarySearch_Int_Int_IComparer_Invalid()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -606,7 +610,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCapacity_Get()
+        public static void Capacity_Get()
         {
             var arrList = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList, arrList2 =>
@@ -616,7 +620,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCapacity_Set()
+        public static void Capacity_Set()
         {
             var arrList = Helpers.CreateIntArrayList(10);
             int nCapacity = 2 * arrList.Capacity;
@@ -631,11 +635,11 @@ namespace System.Collections.Tests
             // Range ignores setter
             arrList = new ArrayList(Helpers.CreateIntArray(10)).GetRange(0, arrList.Count);
             arrList.Capacity = 1000;
-            Assert.NotEqual(100, arrList.Capacity);
+            Assert.NotEqual(1000, arrList.Capacity);
         }
 
         [Fact]
-        public static void TestCapacity_Set_Zero()
+        public static void Capacity_Set_Zero()
         {
             var arrList = new ArrayList(1);
 
@@ -650,7 +654,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCapacity_Set_One()
+        public static void Capacity_Set_One()
         {
             var arrList = new ArrayList(4);
 
@@ -665,7 +669,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCapacity_Set_Invalid()
+        public static void Capacity_Set_InvalidValue_ThrowsArgumentOutOfRangeException()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -681,7 +685,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestClear()
+        public static void Clear()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             arrList1.Add(null);
@@ -698,7 +702,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestClear_EmptyArrayList()
+        public static void Clear_EmptyArrayList()
         {
             var arrList1 = new ArrayList();
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -715,7 +719,7 @@ namespace System.Collections.Tests
 
 
         [Fact]
-        public static void TestClear_FixedSizeArrayList_Invalid()
+        public static void Clear_FixedSizeArrayList_ThrowsNotSupportedException()
         {
             IList sourceArrList = ArrayList.FixedSize(Helpers.CreateIntArrayList(10));
             ArrayList arrList = ArrayList.Adapter(sourceArrList);
@@ -727,7 +731,7 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestClone(int count)
+        public static void Clone(int count)
         {
             // Clone should exactly replicate a collection to another object reference
             // afterwards these 2 should not hold the same object references
@@ -750,7 +754,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestClone_IsShallowCopy()
+        public static void Clone_IsShallowCopy()
         {
             var arrList = new ArrayList();
             for (int i = 0; i < 10; i++)
@@ -786,7 +790,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestContains()
+        public static void Contains()
         {
             var data = new string[11];
             for (int i = 0; i < 10; i++)
@@ -818,7 +822,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestContains_NonExistentObject()
+        public static void Contains_NonExistentObject()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -830,7 +834,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestContains_EmptyArrayList()
+        public static void Contains_EmptyArrayList()
         {
             var arrList1 = new ArrayList();
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -842,7 +846,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Basic()
+        public static void CopyTo_Basic()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -858,7 +862,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Basic_EmptyArrayListToFilledArray()
+        public static void CopyTo_Basic_EmptyArrayListToFilledArray()
         {
             var arrList1 = new ArrayList();
             var arrCopy = new string[10];
@@ -879,7 +883,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Basic_EmptyArray()
+        public static void CopyTo_Basic_EmptyArray()
         {
             var arrList1 = new ArrayList();
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -891,14 +895,14 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Basic_Invalid()
+        public static void CopyTo_Basic_Invalid()
         {
-            Assert.Throws<ArgumentNullException>(() => new ArrayList().CopyTo(null)); // Array is null
-            Assert.Throws<ArgumentException>(() => new ArrayList().CopyTo(new object[10, 10])); // Array is multidimensional
+            Assert.Throws<ArgumentNullException>("dest", () => new ArrayList().CopyTo(null)); // Array is null
+            Assert.Throws<ArgumentException>("array", () => new ArrayList().CopyTo(new object[10, 10])); // Array is multidimensional
         }
 
         [Fact]
-        public static void TestCopyTo_Int()
+        public static void CopyTo_Int()
         {
             int index = 1;
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
@@ -924,7 +928,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Int_EqualToLength()
+        public static void CopyTo_Int_EqualToLength()
         {
             var arrList1 = new ArrayList();
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -935,7 +939,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Int_EmptyArrayListToFilledArray()
+        public static void CopyTo_Int_EmptyArrayListToFilledArray()
         {
             var arrList1 = new ArrayList();
             var arrCopy = new string[10];
@@ -956,7 +960,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Int_EmptyArray()
+        public static void CopyTo_Int_EmptyArray()
         {
             var arrList1 = new ArrayList();
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -968,7 +972,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Int_Invalid()
+        public static void CopyTo_Int_Invalid()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -976,7 +980,7 @@ namespace System.Collections.Tests
                 var arrCopy = new int[arrList2.Count];
 
                 Assert.Throws<ArgumentNullException>(() => arrList2.CopyTo(null)); // Array is null
-                Assert.Throws<ArgumentException>(() => arrList2.CopyTo(new object[10, 10])); // Array is multidimensional
+                Assert.Throws<ArgumentException>("array", () => arrList2.CopyTo(new object[10, 10])); // Array is multidimensional
 
                 Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.CopyTo(arrCopy, -1)); // Index < 0
                 Assert.Throws<ArgumentException>(() => arrList2.CopyTo(new object[11], 2)); // Invalid index and length
@@ -984,7 +988,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Int_Int()
+        public static void CopyTo_Int_Int()
         {
             int index = 3;
             int count = 3;
@@ -1002,7 +1006,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Int_Int_EmptyArrayListToFilledArray()
+        public static void CopyTo_Int_Int_EmptyArrayListToFilledArray()
         {
             var arrList1 = new ArrayList();
             var arrCopy = new string[10];
@@ -1023,7 +1027,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Int_Int_Invalid()
+        public static void CopyTo_Int_Int_Invalid()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -1033,14 +1037,14 @@ namespace System.Collections.Tests
                 Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.CopyTo(-1, arrCopy, 0, 1)); // Index < 0
                 Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.CopyTo(0, arrCopy, 0, -1)); // Count < 0
 
-                Assert.Throws<ArgumentException>(null, () =>
+                Assert.Throws<ArgumentException>(() =>
                 {
                     arrCopy = new string[100];
                     arrList2.CopyTo(arrList2.Count - 1, arrCopy, 0, 24);
                 });
 
                 Assert.Throws<ArgumentNullException>(() => arrList2.CopyTo(0, null, 3, 3)); // Array is null
-                Assert.Throws<ArgumentException>(() => arrList2.CopyTo(0, new object[arrList2.Count, arrList2.Count], 0, arrList2.Count)); // Array is multidimensional
+                Assert.Throws<ArgumentException>("array", () => arrList2.CopyTo(0, new object[arrList2.Count, arrList2.Count], 0, arrList2.Count)); // Array is multidimensional
 
                 // Array index and count is out of bounds
                 Assert.Throws<ArgumentException>(() =>
@@ -1054,7 +1058,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestFixedSize_ArrayList()
+        public static void FixedSize_ArrayList()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             ArrayList arrList2 = ArrayList.FixedSize(arrList1);
@@ -1071,7 +1075,7 @@ namespace System.Collections.Tests
 
             // Remove an object from the original list and verify the object underneath has been cut
             arrList1.RemoveAt(9);
-            Assert.Throws<ArgumentOutOfRangeException>(() => arrList2[9]);
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => arrList2[9]);
 
             // We cant remove or add to the fixed list
             Assert.Throws<NotSupportedException>(() => arrList2.RemoveAt(0));
@@ -1088,7 +1092,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestFixedSize_ReadOnlyArrayList()
+        public static void FixedSize_ReadOnlyArrayList()
         {
             ArrayList arrList = ArrayList.FixedSize(ArrayList.ReadOnly(new ArrayList()));
             Assert.True(arrList.IsFixedSize);
@@ -1097,7 +1101,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestFixedSize_SynchronizedArrayList()
+        public static void FixedSize_SynchronizedArrayList()
         {
             ArrayList arrList = ArrayList.FixedSize(ArrayList.Synchronized(new ArrayList()));
             Assert.True(arrList.IsFixedSize);
@@ -1106,14 +1110,14 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestFixedSize_RangeArrayList()
+        public static void FixedSize_RangeArrayList()
         {
             ArrayList arrList = ArrayList.FixedSize(new ArrayList()).GetRange(0, 0);
             Assert.True(arrList.IsFixedSize);
         }
 
         [Fact]
-        public static void TestFixedSize_ArrayList_CanChangeExistingItems()
+        public static void FixedSize_ArrayList_CanChangeExistingItems()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             ArrayList arrList2 = ArrayList.FixedSize(arrList1);
@@ -1123,13 +1127,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestFixedSize_ArrayList_Invalid()
+        public static void FixedSize_ArrayList_NullCollection_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("list", () => ArrayList.FixedSize(null)); // List is null
         }
 
         [Fact]
-        public static void TestFixedSize_IList()
+        public static void FixedSize_IList()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.FixedSize((IList)arrList);
@@ -1146,7 +1150,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestFixedSize_SynchronizedIList()
+        public static void FixedSize_SynchronizedIList()
         {
             IList iList = ArrayList.FixedSize((IList)ArrayList.Synchronized(new ArrayList()));
             Assert.True(iList.IsFixedSize);
@@ -1155,7 +1159,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestFixedSize_IList_Contains()
+        public static void FixedSize_IList_Contains()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.FixedSize((IList)arrList);
@@ -1166,7 +1170,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestFixedSize_IList_IndexOf()
+        public static void FixedSize_IList_IndexOf()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.FixedSize((IList)arrList);
@@ -1177,7 +1181,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestFixedSize_IList_SyncRoot()
+        public static void FixedSize_IList_SyncRoot()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.FixedSize((IList)arrList);
@@ -1186,7 +1190,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestFixedSize_IList_CopyTo()
+        public static void FixedSize_IList_CopyTo()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.FixedSize((IList)arrList);
@@ -1203,7 +1207,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestFixedSize_IList_GetEnumerator()
+        public static void FixedSize_IList_GetEnumerator()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.FixedSize((IList)arrList);
@@ -1220,7 +1224,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestFixedSizeIList_GetEnumerator_Invalid()
+        public static void FixedSizeIList_GetEnumerator_Invalid()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.FixedSize((IList)arrList);
@@ -1243,14 +1247,14 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestFixedSize_IList_NotSupportedMethods()
+        public static void FixedSize_IList_ModifyingCollection_ThrowsNotSupportedException()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.FixedSize((IList)arrList);
 
             // Remove an object from the original list. Verify the object underneath has been cut
             arrList.RemoveAt(9);
-            Assert.Throws<ArgumentOutOfRangeException>(() => iList[9]);
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => iList[9]);
 
             // We cant remove or add to the fixed list
             Assert.Throws<NotSupportedException>(() => iList.RemoveAt(0));
@@ -1261,7 +1265,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestFixedSize_IList_CanChangeExistingItems()
+        public static void FixedSize_IList_CanChangeExistingItems()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.FixedSize((IList)arrList1);
@@ -1272,13 +1276,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestFixedSize_IList_Invalid()
+        public static void FixedSize_IList_NullList_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => ArrayList.FixedSize((IList)null)); // List is null
+            Assert.Throws<ArgumentNullException>("list", () => ArrayList.FixedSize((IList)null)); // List is null
         }
 
         [Fact]
-        public static void TestGetEnumerator_Basic()
+        public static void GetEnumerator_Basic()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -1307,7 +1311,7 @@ namespace System.Collections.Tests
         }
         
         [Fact]
-        public static void TestGetEnumerator_Basic_ArrayListContainingItself()
+        public static void GetEnumerator_Basic_ArrayListContainingItself()
         {
             // Verify the enumerator works correctly when the ArrayList itself is in the ArrayList
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
@@ -1330,7 +1334,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetEnumerator_Basic_DerivedArrayList()
+        public static void GetEnumerator_Basic_DerivedArrayList()
         {
             // The enumerator for a derived (subclassed) ArrayList is different to a normal ArrayList as it does not run an optimized MoveNext() function
             var arrList = new DerivedArrayList(Helpers.CreateIntArrayList(10));
@@ -1348,7 +1352,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetEnumerator_Basic_Invalid()
+        public static void GetEnumerator_Basic_Invalid()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -1389,7 +1393,7 @@ namespace System.Collections.Tests
         }
         
         [Fact]
-        public static void TestGetEnumerator_Int_Int()
+        public static void GetEnumerator_Int_Int()
         {
             int index = 3;
             int count = 3;
@@ -1411,7 +1415,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetEnumerator_Int_Int_ArrayListContainingItself()
+        public static void GetEnumerator_Int_Int_ArrayListContainingItself()
         {
             // Verify the enumerator works correctly when the ArrayList itself is in the ArrayList
             int[] data = Helpers.CreateIntArray(10);
@@ -1468,7 +1472,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetEnumerator_Int_Int_ZeroCount()
+        public static void GetEnumerator_Int_Int_ZeroCount()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -1480,7 +1484,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetEnumerator_Int_Int_Invalid()
+        public static void GetEnumerator_Int_Int_Invalid()
         {
             int index = 3;
             int count = 3;
@@ -1518,15 +1522,15 @@ namespace System.Collections.Tests
                 Assert.Throws<InvalidOperationException>(() => enumerator.Current);
 
                 // Invalid parameters    
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.GetEnumerator(-1, arrList2.Count)); // Index < 0
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.GetEnumerator(0, -1)); // Count < 0
-                Assert.Throws<ArgumentException>(() => arrList2.GetEnumerator(0, arrList2.Count + 1)); // Count + list.Count
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.GetEnumerator(-1, arrList2.Count + 1)); // Index < 0 and count > list.Count
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => arrList2.GetEnumerator(-1, arrList2.Count)); // Index < 0
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => arrList2.GetEnumerator(0, -1)); // Count < 0
+                Assert.Throws<ArgumentException>(null, () => arrList2.GetEnumerator(0, arrList2.Count + 1)); // Count + list.Count
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => arrList2.GetEnumerator(-1, arrList2.Count + 1)); // Index < 0 and count > list.Count
             });
         }
 
         [Fact]
-        public static void TestGetRange()
+        public static void GetRange()
         {
             int index = 10;
             int count = 50;
@@ -1552,7 +1556,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetRange_ChangeUnderlyingCollection()
+        public static void GetRange_ChangeUnderlyingCollection()
         {
             int index = 10;
             int count = 50;
@@ -1598,7 +1602,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetRange_ChangeUnderlyingCollection_Invalid()
+        public static void GetRange_ChangeUnderlyingCollection_Invalid()
         {
             int index = 10;
             int count = 50;
@@ -1636,7 +1640,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetRange_Invalid()
+        public static void GetRange_Invalid()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(100);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -1650,7 +1654,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetRange_Empty()
+        public static void GetRange_Empty()
         {
             // We should be able to get a range of 0
             var arrList1 = new ArrayList();
@@ -1662,7 +1666,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSetRange()
+        public static void SetRange()
         {
             int index = 3;
 
@@ -1686,7 +1690,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSetRange_Invalid()
+        public static void SetRange_Invalid()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -1706,7 +1710,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSetRange_EmptyCollection()
+        public static void SetRange_EmptyCollection()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             ICollection emptyCollection = new ArrayList();
@@ -1727,7 +1731,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexOf_Basic()
+        public static void IndexOf_Basic()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -1740,7 +1744,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexOf_Basic_DuplicateItems()
+        public static void IndexOf_Basic_DuplicateItems()
         {
             var arrList1 = new ArrayList();
             arrList1.Add(null);
@@ -1754,7 +1758,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexOf_Basic_NonExistentObject()
+        public static void IndexOf_Basic_NonExistentObject()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -1766,7 +1770,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexOf_Int()
+        public static void IndexOf_Int()
         {
             int startIndex = 3;
 
@@ -1791,7 +1795,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexOf_Int_NonExistentObject()
+        public static void IndexOf_Int_NonExistentObject()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -1803,7 +1807,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexOf_Int_ExistentObjectNotInRange()
+        public static void IndexOf_Int_ExistentObjectNotInRange()
         {
             // Find an existing object before the index (expects -1)
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
@@ -1814,20 +1818,20 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexOf_Int_Invalid()
+        public static void IndexOf_Int_InvalidStartIndex_ThrowsArgumentOutOfRangeException()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.IndexOf("Batman", -1)); // Start index < 0                
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.IndexOf("Batman", arrList2.Count + 1)); // Start index > list.Count
+                Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => arrList2.IndexOf("Batman", -1)); // Start index < 0                
+                Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => arrList2.IndexOf("Batman", arrList2.Count + 1)); // Start index > list.Count
 
                 Assert.Equal(-1, arrList2.IndexOf("Batman", arrList2.Count, 0)); // Index = list.Count
             });
         }
 
         [Fact]
-        public static void TestIndexOf_Int_Int()
+        public static void IndexOf_Int_Int()
         {
             int startIndex = 0;
             int count = 5;
@@ -1853,7 +1857,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexOf_Int_Int_NonExistentObject()
+        public static void IndexOf_Int_Int_NonExistentObject()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -1865,7 +1869,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexOf_Int_Int_ExistentObjectNotInRange()
+        public static void IndexOf_Int_Int_ExistentObjectNotInRange()
         {
             // Find an existing object before the startIndex or after startIndex + count (expects -1)
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
@@ -1877,22 +1881,22 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexOf_Int_Int_Invalid()
+        public static void IndexOf_Int_Int_InvalidIndexCount_ThrowsArgumentOutOfRangeException()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.IndexOf("Batman", -1, arrList2.Count)); // Start index < 0
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.IndexOf("Batman", arrList2.Count + 1, arrList2.Count)); // Start index > Count
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.IndexOf("Batman", 0, -1)); // Count < 0
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.IndexOf("Batman", 3, arrList2.Count + 1)); // Count > list.Count
+                Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => arrList2.IndexOf("Batman", -1, arrList2.Count)); // Start index < 0
+                Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => arrList2.IndexOf("Batman", arrList2.Count + 1, arrList2.Count)); // Start index > Count
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => arrList2.IndexOf("Batman", 0, -1)); // Count < 0
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => arrList2.IndexOf("Batman", 3, arrList2.Count + 1)); // Count > list.Count
 
                 Assert.Equal(-1, arrList2.IndexOf("Batman", arrList2.Count, 0)); // Index = list.Count
             });
         }
 
         [Fact]
-        public static void TestInsertRange()
+        public static void InsertRange()
         {
             int index = 3;
 
@@ -1915,7 +1919,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestInsertRange_LargeCapacity()
+        public static void InsertRange_LargeCapacity()
         {
             // Add a range large enough to increase the capacity of the arrayList by more than a factor of two
             var arrList1 = new ArrayList();
@@ -1937,7 +1941,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestInsertRange_EmptyCollection()
+        public static void InsertRange_EmptyCollection()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             var emptyCollection = new Queue();
@@ -1954,7 +1958,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestInsertRange_WrappedNonArrayList()
+        public static void InsertRange_WrappedNonArrayList()
         {
             // Create an array list by wrapping a non-ArrayList object (e.g. List<T>)
             var list = new List<int>(Helpers.CreateIntArray(10));
@@ -1969,7 +1973,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestInsertRange_Itself()
+        public static void InsertRange_Itself()
         {
             int[] data = Helpers.CreateIntArray(10);
             var arrList1 = new ArrayList(data);
@@ -2038,7 +2042,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestInsert()
+        public static void Insert()
         {
             int start = 3;
 
@@ -2064,7 +2068,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestInsert_Invalid()
+        public static void Insert_InvalidIndex_ThrowsArguentOutOfRangeException()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2074,13 +2078,13 @@ namespace System.Collections.Tests
                     return;
                 }
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.Insert(-1, "Batman")); // Index < 0
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.Insert(arrList2.Count + 1, "Batman")); // Index > count
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => arrList2.Insert(-1, "Batman")); // Index < 0
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => arrList2.Insert(arrList2.Count + 1, "Batman")); // Index > count
             });
         }
 
         [Fact]
-        public static void TestItem_Get()
+        public static void Item_Get()
         {
             int[] data = Helpers.CreateIntArray(10);
             var arrList1 = new ArrayList(data);
@@ -2094,7 +2098,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestItem_Get_Invalid()
+        public static void Item_Get_InvalidIndex_ThrowsArgumentOutOfRangeException()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2105,7 +2109,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestItem_Set()
+        public static void Item_Set()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2124,7 +2128,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestItem_Set_Invalid()
+        public static void Item_Set_InvalidIndex_ThrowsArgumentOutOfRangeException()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2140,7 +2144,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestLastIndexOf_Basic()
+        public static void LastIndexOf_Basic()
         {
             var data = new string[20];
             for (int i = 0; i < 10; i++)
@@ -2164,7 +2168,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestLastIndexOf_Basic_EmptyArrayList()
+        public static void LastIndexOf_Basic_EmptyArrayList()
         {
             var arrList1 = new ArrayList();
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2174,7 +2178,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestLastIndexOf_Basic_NonExistentObject()
+        public static void LastIndexOf_Basic_NonExistentObject()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2186,7 +2190,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestLastIndexOf_Int()
+        public static void LastIndexOf_Int()
         {
             int startIndex = 3;
 
@@ -2213,7 +2217,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestLastIndexOf_Int_NonExistentObject()
+        public static void LastIndexOf_Int_NonExistentObject()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2225,7 +2229,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestLastIndexOf_Int_ObjectOutOfRange()
+        public static void LastIndexOf_Int_ObjectOutOfRange()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2236,18 +2240,18 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestLastIndexOf_Int_Invalid()
+        public static void LastIndexOf_Int_InvalidStartIndex_ThrowsArgumentOutOfRangeException()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.LastIndexOf(0, -1)); // Index < 0
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.LastIndexOf(0, arrList2.Count)); // Index >= list.Count
+                Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => arrList2.LastIndexOf(0, -1)); // StartIndex < 0
+                Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => arrList2.LastIndexOf(0, arrList2.Count)); // StartIndex >= list.Count
             });
         }
 
         [Fact]
-        public static void TestLastIndexOf_Int_Int()
+        public static void LastIndexOf_Int_Int()
         {
             int startIndex = 15;
             int count = 10;
@@ -2275,7 +2279,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestLastIndexOf_Int_Int_EmptyArrayList()
+        public static void LastIndexOf_Int_Int_EmptyArrayList()
         {
             var arrList1 = new ArrayList();
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2285,7 +2289,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestLastIndexOf_Int_Int_NonExistentObject()
+        public static void LastIndexOf_Int_Int_NonExistentObject()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2295,7 +2299,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestLastIndexOf_Int_Int_ObjectOutOfRange()
+        public static void LastIndexOf_Int_Int_ObjectOutOfRange()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2309,7 +2313,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestLastIndexOf_Int_Int_Invalid()
+        public static void LastIndexOf_Int_Int_InvalidStartIndexCount_ThrowsArgumentOutOfRangeException()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2324,7 +2328,7 @@ namespace System.Collections.Tests
             });
         }
         [Fact]
-        public static void TestReadOnly_ArrayList()
+        public static void ReadOnly_ArrayList()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             ArrayList arrList2 = ArrayList.ReadOnly(arrList1);
@@ -2341,7 +2345,7 @@ namespace System.Collections.Tests
 
             // Remove an object from the original list and verify the object underneath has been cut
             arrList1.RemoveAt(9);
-            Assert.Throws<ArgumentOutOfRangeException>(() => arrList2[9]);
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => arrList2[9]);
 
             // We cant remove, change or add to the readonly list
             Assert.Throws<NotSupportedException>(() => arrList2.RemoveAt(0));
@@ -2372,7 +2376,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestReadOnly_SynchronizedArrayList()
+        public static void ReadOnly_SynchronizedArrayList()
         {
             ArrayList arrList = ArrayList.ReadOnly(ArrayList.Synchronized(new ArrayList()));
             Assert.True(arrList.IsFixedSize);
@@ -2381,13 +2385,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestReadOnly_ArrayList_Invalid()
+        public static void ReadOnly_ArrayList_NullList_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("list", () => ArrayList.ReadOnly(null)); // List is null
         }
 
         [Fact]
-        public static void TestReadOnly_IList()
+        public static void ReadOnly_IList()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.ReadOnly((IList)arrList1);
@@ -2404,7 +2408,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestReadOnly_SynchronizedIList()
+        public static void ReadOnly_SynchronizedIList()
         {
             IList iList = ArrayList.ReadOnly((IList)ArrayList.Synchronized(new ArrayList()));
             Assert.True(iList.IsFixedSize);
@@ -2413,7 +2417,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestReadOnly_IList_Contains()
+        public static void ReadOnly_IList_Contains()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.ReadOnly((IList)arrList);
@@ -2424,7 +2428,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestReadOnly_IList_IndexOf()
+        public static void ReadOnly_IList_IndexOf()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.ReadOnly((IList)arrList);
@@ -2435,7 +2439,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestReadOnly_IList_SyncRoot()
+        public static void ReadOnly_IList_SyncRoot()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.ReadOnly((IList)arrList);
@@ -2444,7 +2448,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestReadOnly_IList_CopyTo()
+        public static void ReadOnly_IList_CopyTo()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.ReadOnly((IList)arrList);
@@ -2461,7 +2465,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestReadOnly_IList_GetEnumerator()
+        public static void ReadOnly_IList_GetEnumerator()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.ReadOnly((IList)arrList);
@@ -2478,7 +2482,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestReadOnly_IList_GetEnumerator_Invalid()
+        public static void ReadOnly_IList_GetEnumerator_Invalid()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.ReadOnly((IList)arrList);
@@ -2501,14 +2505,14 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestReadOnly_IList_NotSupportedMethods()
+        public static void ReadOnly_IList_NotSupportedMethods()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.ReadOnly((IList)arrList);
 
             // Remove an object from the original list. Verify the object underneath has been cut
             arrList.RemoveAt(9);
-            Assert.Throws<ArgumentOutOfRangeException>(() => iList[9]);
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => iList[9]);
 
             // We cant remove or add to the fixed list
             Assert.Throws<NotSupportedException>(() => iList.RemoveAt(0));
@@ -2523,13 +2527,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestReadOnly_IList_Invalid()
+        public static void ReadOnly_IList_NullList_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("list", () => ArrayList.ReadOnly((IList)null)); // List is null
         }
 
         [Fact]
-        public static void TestRemoveAt()
+        public static void RemoveAt()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2549,7 +2553,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemoveAt_Invalid()
+        public static void RemoveAt_InvalidIndex_ThrowsArgumentOutOfRangeException()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2565,7 +2569,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemoveRange()
+        public static void RemoveRange()
         {
             int index = 3;
             int count = 3;
@@ -2590,7 +2594,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemoveRange_ZeroCount()
+        public static void RemoveRange_ZeroCount()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2612,7 +2616,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemoveRange_Invalid()
+        public static void RemoveRange_Invalid()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2622,17 +2626,17 @@ namespace System.Collections.Tests
                     return;
                 }
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.RemoveRange(-1, 1)); // Index < 0
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.RemoveRange(1, -1)); // Count < 0
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => arrList2.RemoveRange(-1, 1)); // Index < 0
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => arrList2.RemoveRange(1, -1)); // Count < 0
 
-                Assert.Throws<ArgumentException>(() => arrList2.RemoveRange(arrList2.Count, 1)); // Index > list.Count
-                Assert.Throws<ArgumentException>(() => arrList2.RemoveRange(0, arrList2.Count + 1)); // Count > list.Count
-                Assert.Throws<ArgumentException>(() => arrList2.RemoveRange(5, arrList2.Count - 1)); // Index + count > list.Count
+                Assert.Throws<ArgumentException>(null, () => arrList2.RemoveRange(arrList2.Count, 1)); // Index > list.Count
+                Assert.Throws<ArgumentException>(null, () => arrList2.RemoveRange(0, arrList2.Count + 1)); // Count > list.Count
+                Assert.Throws<ArgumentException>(null, () => arrList2.RemoveRange(5, arrList2.Count - 1)); // Index + count > list.Count
             });
         }
 
         [Fact]
-        public static void TestRemove()
+        public static void Remove()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             arrList.Add(null);
@@ -2645,7 +2649,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemove_Null()
+        public static void Remove_Null()
         {
             var arrList = new ArrayList();
 
@@ -2660,7 +2664,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemove_NonExistentObject()
+        public static void Remove_NonExistentObject()
         {
             var arrList = new ArrayList();
             arrList.Remove(null);
@@ -2668,7 +2672,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRepeat()
+        public static void Repeat()
         {
             ArrayList arrList = ArrayList.Repeat(5, 100);
             for (int i = 0; i < arrList.Count; i++)
@@ -2678,7 +2682,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRepeat_Null()
+        public static void Repeat_Null()
         {
             ArrayList arrList = ArrayList.Repeat(null, 100);
             for (int i = 0; i < arrList.Count; i++)
@@ -2688,20 +2692,20 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRepeat_ZeroCount()
+        public static void Repeat_ZeroCount()
         {
             ArrayList arrList = ArrayList.Repeat(5, 0);
             Assert.Equal(0, arrList.Count);
         }
 
         [Fact]
-        public static void TestRepeat_Invalid()
+        public static void Repeat_NegativeCount_ThrowsArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>("count", () => ArrayList.Repeat(5, -1)); // Count < 0
         }
 
         [Fact]
-        public static void TestReverse_Basic()
+        public static void Reverse_Basic()
         {
             int[] expected = Helpers.CreateIntArray(10);
             var arrList1 = new ArrayList(expected);
@@ -2724,7 +2728,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestReverse_Basic_EmptyArrayList()
+        public static void Reverse_Basic_EmptyArrayList()
         {
             var arrList1 = new ArrayList();
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2740,7 +2744,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestReverse_Basic_SingleObjectArrayList()
+        public static void Reverse_Basic_SingleObjectArrayList()
         {
             var arrList1 = new ArrayList();
             arrList1.Add(0);
@@ -2760,7 +2764,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestReverse_Int_Int()
+        public static void Reverse_Int_Int()
         {
             int index = 5;
             int count = 4;
@@ -2786,7 +2790,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestReverse_Int_Int_ZeroCount()
+        public static void Reverse_Int_Int_ZeroCount()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2808,7 +2812,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestReverse_Int_Int_Invalid()
+        public static void Reverse_Int_Int_Invalid()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2825,7 +2829,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSort_Basic()
+        public static void Sort_Basic()
         {
             int[] expected = Helpers.CreateIntArray(10);
             var arrList1 = new ArrayList(expected);
@@ -2846,7 +2850,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSort_Basic_EmptyArrayList()
+        public static void Sort_Basic_EmptyArrayList()
         {
             var arrList1 = new ArrayList();
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2862,7 +2866,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSort_Basic_SingleObjectArrayList()
+        public static void Sort_Basic_SingleObjectArrayList()
         {
             var arrList1 = new ArrayList();
             arrList1.Add(1);
@@ -2879,7 +2883,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSort_IComparer()
+        public static void Sort_IComparer()
         {
             int[] data = Helpers.CreateIntArray(10);
             int[] ascendingData = Helpers.CreateIntArray(10);
@@ -2916,7 +2920,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSort_Int_Int_IComparer()
+        public static void Sort_Int_Int_IComparer()
         {
             int index = 3;
             int count = 5;
@@ -2940,7 +2944,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSort_Int_Int_IComparer_Invalid()
+        public static void Sort_Int_Int_IComparer_Invalid()
         {
             ArrayList arrList1 = Helpers.CreateIntArrayList(10);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -2950,16 +2954,16 @@ namespace System.Collections.Tests
                     return;
                 }
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.Sort(-1, arrList2.Count, null)); // Index < 0
-                Assert.Throws<ArgumentOutOfRangeException>(() => arrList2.Sort(0, -1, null)); // Count < 0
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => arrList2.Sort(-1, arrList2.Count, null)); // Index < 0
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => arrList2.Sort(0, -1, null)); // Count < 0
 
-                Assert.Throws<ArgumentException>(() => arrList2.Sort(arrList2.Count, arrList2.Count, null)); // Index >= list.Count
-                Assert.Throws<ArgumentException>(() => arrList2.Sort(0, arrList2.Count + 1, null)); // Count = list.Count
+                Assert.Throws<ArgumentException>(null, () => arrList2.Sort(arrList2.Count, arrList2.Count, null)); // Index >= list.Count
+                Assert.Throws<ArgumentException>(null, () => arrList2.Sort(0, arrList2.Count + 1, null)); // Count = list.Count
             });
         }
 
         [Fact]
-        public static void TestSort_MultipleDataTypes_ThrowsInvalidOperationException()
+        public static void Sort_MultipleDataTypes_ThrowsInvalidOperationException()
         {
             var arrList1 = new ArrayList();
             arrList1.Add((short)1);
@@ -2981,7 +2985,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_ArrayList()
+        public static void Synchronized_ArrayList()
         {
             ArrayList arrList = ArrayList.Synchronized(new ArrayList());
             Assert.False(arrList.IsFixedSize);
@@ -2990,7 +2994,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_FixedSizeArrayList()
+        public static void Synchronized_FixedSizeArrayList()
         {
             ArrayList arrList = ArrayList.Synchronized(ArrayList.FixedSize(new ArrayList()));
             Assert.True(arrList.IsFixedSize);
@@ -2999,7 +3003,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_ReadOnlyArrayList()
+        public static void Synchronized_ReadOnlyArrayList()
         {
             ArrayList arrList = ArrayList.Synchronized(ArrayList.ReadOnly(new ArrayList()));
             Assert.True(arrList.IsFixedSize);
@@ -3008,13 +3012,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_ArrayList_Invalid()
+        public static void Synchronized_ArrayList_NullList_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => ArrayList.Synchronized(null)); // List is null
+            Assert.Throws<ArgumentNullException>("list", () => ArrayList.Synchronized(null)); // List is null
         }
 
         [Fact]
-        public static void TestSynchronized_IList()
+        public static void Synchronized_IList()
         {
             IList iList = ArrayList.Synchronized((IList)new ArrayList());
             Assert.False(iList.IsFixedSize);
@@ -3023,7 +3027,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_FixedSizeIList()
+        public static void Synchronized_FixedSizeIList()
         {
             IList iList = ArrayList.Synchronized((IList)ArrayList.FixedSize(new ArrayList()));
             Assert.True(iList.IsFixedSize);
@@ -3032,7 +3036,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_ReadOnlyIList()
+        public static void Synchronized_ReadOnlyIList()
         {
             IList iList = ArrayList.Synchronized((IList)ArrayList.ReadOnly(new ArrayList()));
             Assert.True(iList.IsFixedSize);
@@ -3041,7 +3045,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_IList_Indexer()
+        public static void Synchronized_IList_Indexer()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.Synchronized((IList)arrList);
@@ -3055,7 +3059,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_IList_Add_Remove()
+        public static void Synchronized_IList_Add_Remove()
         {
             var arrList = new ArrayList();
             IList iList = ArrayList.Synchronized((IList)arrList);
@@ -3075,7 +3079,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_IList_InsertRemoveAt()
+        public static void Synchronized_IList_InsertRemoveAt()
         {
             var arrList = new ArrayList();
             IList iList = ArrayList.Synchronized((IList)arrList);
@@ -3095,7 +3099,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_IList_Clear()
+        public static void Synchronized_IList_Clear()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.Synchronized((IList)arrList);
@@ -3105,7 +3109,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_IList_Contains()
+        public static void Synchronized_IList_Contains()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.Synchronized((IList)arrList);
@@ -3116,7 +3120,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_IList_IndexOf()
+        public static void Synchronized_IList_IndexOf()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.Synchronized((IList)arrList);
@@ -3127,7 +3131,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_IList_SyncRoot()
+        public static void Synchronized_IList_SyncRoot()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.Synchronized((IList)arrList);
@@ -3136,7 +3140,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_IList_CopyTo()
+        public static void Synchronized_IList_CopyTo()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.Synchronized((IList)arrList);
@@ -3153,7 +3157,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_IList_GetEnumerator()
+        public static void Synchronized_IList_GetEnumerator()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.Synchronized((IList)arrList);
@@ -3170,7 +3174,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronizedIList_GetEnumerator_Invalid()
+        public static void SynchronizedIList_GetEnumerator_Invalid()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             IList iList = ArrayList.Synchronized((IList)arrList);
@@ -3193,13 +3197,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_IList_Invalid()
+        public static void Synchronized_IList_NullList_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => ArrayList.Synchronized((IList)null)); // List is null
+            Assert.Throws<ArgumentNullException>("list", () => ArrayList.Synchronized((IList)null)); // List is null
         }
 
         [Fact]
-        public static void TestToArray()
+        public static void ToArray()
         {
             // ToArray returns an array of this. We will not extensively test this method as
             // this is a thin wrapper on Array.Copy which is extensively tested
@@ -3218,7 +3222,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestToArray_EmptyArrayList()
+        public static void ToArray_EmptyArrayList()
         {
             var arrList1 = new ArrayList();
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
@@ -3232,20 +3236,19 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestToArray_Invalid()
+        public static void ToArray_Invalid()
         {
-
             ArrayList arrList1 = Helpers.CreateIntArrayList(100);
             Helpers.PerformActionOnAllArrayListWrappers(arrList1, arrList2 =>
             {
                 // This should be covered in Array.Copy, but lets do it for completion's sake
                 Assert.Throws<InvalidCastException>(() => arrList2.ToArray(typeof(string))); // Objects stored are not strings
-                Assert.Throws<ArgumentNullException>(() => arrList2.ToArray(null)); // Type is null
+                Assert.Throws<ArgumentNullException>("type", () => arrList2.ToArray(null)); // Type is null
             });
         }
 
         [Fact]
-        public static void TestTrimToSize()
+        public static void TrimToSize()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(10);
             arrList.Capacity = 2 * arrList.Count;
@@ -3285,12 +3288,7 @@ namespace System.Collections.Tests
 
         private class Foo
         {
-            private string _stringValue = "Hello World";
-            public string StringValue
-            {
-                get { return _stringValue; }
-                set { _stringValue = value; }
-            }
+            public string StringValue { get; set; } = "Hello World";
         }
 
         private class MyCollection : ICollection
@@ -3306,42 +3304,27 @@ namespace System.Collections.Tests
 
             public Array Array
             {
-                get
-                {
-                    return _array;
-                }
+                get { return _array; }
             }
 
             public int StartIndex
             {
-                get
-                {
-                    return _startIndex;
-                }
+                get { return _startIndex; }
             }
 
             public int Count
             {
-                get
-                {
-                    return _collection.Count;
-                }
+                get { return _collection.Count; }
             }
 
             public object SyncRoot
             {
-                get
-                {
-                    return _collection.SyncRoot;
-                }
+                get { return _collection.SyncRoot; }
             }
 
             public bool IsSynchronized
             {
-                get
-                {
-                    return _collection.IsSynchronized;
-                }
+                get {return _collection.IsSynchronized; }
             }
 
             public void CopyTo(Array array, int startIndex)
@@ -3359,18 +3342,12 @@ namespace System.Collections.Tests
 
         private class AscendingComparer : IComparer
         {
-            public virtual int Compare(object x, object y)
-            {
-                return ((int)x).CompareTo((int)y);
-            }
+            public virtual int Compare(object x, object y) => ((int)x).CompareTo((int)y);
         }
 
         private class DescendingComparer : IComparer
         {
-            public virtual int Compare(object x, object y)
-            {
-                return -((int)x).CompareTo((int)y);
-            }
+            public virtual int Compare(object x, object y) => -((int)x).CompareTo((int)y);
         }
 
         private class DerivedArrayList : ArrayList
@@ -3387,13 +3364,10 @@ namespace System.Collections.Tests
         private ArrayList _arrGrandDaughter;
 
         [Fact]
-        public void TestGetSyncRoot()
+        public void GetSyncRoot()
         {
-            int iNumberOfElements = 100;
-            int iValue;
-            bool fDescending;
-
-            int iNumberOfWorkers = 10;
+            const int NumberOfElements = 100;
+            const int NumberOfWorkers = 10;
 
             // Testing SyncRoot is not as simple as its implementation looks like. This is the working
             // scenrio we have in mind.
@@ -3403,7 +3377,7 @@ namespace System.Collections.Tests
             // 4) Get a synchronized wrapper of the mother from 1)
             // 5) all of these should SyncRoot to the mother earth
 
-            ArrayList arrMother1 = Helpers.CreateIntArrayList(iNumberOfElements);
+            ArrayList arrMother1 = Helpers.CreateIntArrayList(NumberOfElements);
             Helpers.PerformActionOnAllArrayListWrappers(arrMother1, arrMother2 =>
             {
                 ArrayList arrSon1 = ArrayList.FixedSize(arrMother2);
@@ -3420,7 +3394,7 @@ namespace System.Collections.Tests
                 Assert.False(_arrGrandDaughter.SyncRoot is ArrayList);
 
                 arrMother2 = new ArrayList();
-                for (int i = 0; i < iNumberOfElements; i++)
+                for (int i = 0; i < NumberOfElements; i++)
                 {
                     arrMother2.Add(i);
                 }
@@ -3431,10 +3405,10 @@ namespace System.Collections.Tests
                 _arrDaughter = ArrayList.Synchronized(arrMother2);
 
                 // We are going to rumble with the ArrayLists with 2 threads
-                var workers = new Task[iNumberOfWorkers];
+                var workers = new Task[NumberOfWorkers];
                 var action1 = new Action(SortElements);
                 var action2 = new Action(ReverseElements);
-                for (int iThreads = 0; iThreads < iNumberOfWorkers; iThreads += 2)
+                for (int iThreads = 0; iThreads < NumberOfWorkers; iThreads += 2)
                 {
                     workers[iThreads] = Task.Run(action1);
                     workers[iThreads + 1] = Task.Run(action2);
@@ -3446,35 +3420,27 @@ namespace System.Collections.Tests
                 // Now lets see how this is done.
                 // Reverse and sort - ascending more likely
                 // Sort followed up Reverse - descending
-                fDescending = false;
-                if (((int)arrMother2[0]).CompareTo((int)arrMother2[1]) > 0)
-                    fDescending = true;
+                bool fDescending = ((int)arrMother2[0]).CompareTo((int)arrMother2[1]) > 0;
 
-                iValue = (int)arrMother2[0];
-                for (int i = 1; i < iNumberOfElements; i++)
+                int valye = (int)arrMother2[0];
+                for (int i = 1; i < NumberOfElements; i++)
                 {
                     if (fDescending)
                     {
-                        Assert.True(iValue.CompareTo((int)arrMother2[i]) > 0);
+                        Assert.True(valye.CompareTo((int)arrMother2[i]) > 0);
                     }
                     else
                     {
-                        Assert.True(iValue.CompareTo((int)arrMother2[i]) < 0);
+                        Assert.True(valye.CompareTo((int)arrMother2[i]) < 0);
                     }
-                    iValue = (int)arrMother2[i];
+                    valye = (int)arrMother2[i];
                 }
             });
         }
 
-        private void SortElements()
-        {
-            _arrGrandDaughter.Sort();
-        }
+        private void SortElements() => _arrGrandDaughter.Sort();
 
-        private void ReverseElements()
-        {
-            _arrDaughter.Reverse();
-        }
+        private void ReverseElements() => _arrDaughter.Reverse();
     }
 
     public class ArrayList_SynchronizedTests
@@ -3681,14 +3647,14 @@ namespace System.Collections.Tests
         };
 
         private IList _iList;
-        private int _iNumberOfElements = 10;
-        private const string _prefix = "String_";
+        private const int NumberOfElements = 10;
+        private const string Prefix = "String_";
 
         public ArrayList _arrList;
         public Hashtable _hash; // This will verify that threads will only add elements the num of times they are specified to
 
         [Fact]
-        public void TestSynchronized_ArrayList()
+        public void Synchronized_ArrayList()
         {
             // Make 40 threads which add strHeroes to an ArrayList
             // the outcome is that the length of the ArrayList should be the same size as the strHeroes array
@@ -3710,7 +3676,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public void TestSynchronized_IList()
+        public void Synchronized_IList()
         {
             int iNumberOfWorkers = 10;
 
@@ -3727,14 +3693,14 @@ namespace System.Collections.Tests
             Task.WaitAll(workers);
 
             // Checking time
-            Assert.Equal(_iNumberOfElements * iNumberOfWorkers, _iList.Count);
+            Assert.Equal(NumberOfElements * iNumberOfWorkers, _iList.Count);
 
-            for (int i = 0; i < _iNumberOfElements; i++)
+            for (int i = 0; i < NumberOfElements; i++)
             {
                 int iNumberOfTimes = 0;
                 for (int j = 0; j < _iList.Count; j++)
                 {
-                    if (((string)_iList[j]).Equals(_prefix + i))
+                    if (((string)_iList[j]).Equals(Prefix + i))
                         iNumberOfTimes++;
                 }
 
@@ -3783,17 +3749,17 @@ namespace System.Collections.Tests
 
         private void AddElements()
         {
-            for (int i = 0; i < _iNumberOfElements; i++)
+            for (int i = 0; i < NumberOfElements; i++)
             {
-                _iList.Add(_prefix + i);
+                _iList.Add(Prefix + i);
             }
         }
 
         private void RemoveElements()
         {
-            for (int i = 0; i < _iNumberOfElements; i++)
+            for (int i = 0; i < NumberOfElements; i++)
             {
-                _iList.Remove(_prefix + i);
+                _iList.Remove(Prefix + i);
             }
         }
     }

--- a/src/System.Collections.NonGeneric/tests/ArrayListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayListTests.cs
@@ -3370,7 +3370,7 @@ namespace System.Collections.Tests
             const int NumberOfWorkers = 10;
 
             // Testing SyncRoot is not as simple as its implementation looks like. This is the working
-            // scenrio we have in mind.
+            // scenario we have in mind.
             // 1) Create your Down to earth mother ArrayList
             // 2) Get a Fixed wrapper from it
             // 3) Get a Synchronized wrapper from 2)

--- a/src/System.Collections.NonGeneric/tests/CaseInsentiveComparerTests.cs
+++ b/src/System.Collections.NonGeneric/tests/CaseInsentiveComparerTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
-
 using Xunit;
 
 namespace System.Collections.Tests
@@ -23,10 +22,10 @@ namespace System.Collections.Tests
         [InlineData(5, null, 1)]
         [InlineData(null, 5, -1)]
         [InlineData(null, null, 0)]
-        public static void TestCtor_Empty_Compare(object a, object b, int expected)
+        public static void Ctor_Empty_Compare(object a, object b, int expected)
         {
             CaseInsensitiveComparer comparer = new CaseInsensitiveComparer();
-            Assert.Equal(expected, Helpers.NormalizeCompare(comparer.Compare(a, b)));
+            Assert.Equal(expected, Math.Sign(comparer.Compare(a, b)));
         }
 
         [Theory]
@@ -42,7 +41,7 @@ namespace System.Collections.Tests
         [InlineData(5, null, 1)]
         [InlineData(null, 5, -1)]
         [InlineData(null, null, 0)]
-        public static void TestCtor_CultureInfo_Compare(object a, object b, int expected)
+        public static void Ctor_CultureInfo_Compare(object a, object b, int expected)
         {
             var cultureNames = new string[]
             {
@@ -66,12 +65,12 @@ namespace System.Collections.Tests
                 }
 
                 var comparer = new CaseInsensitiveComparer(culture);
-                Assert.Equal(expected, Helpers.NormalizeCompare(comparer.Compare(a, b)));
+                Assert.Equal(expected, Math.Sign(comparer.Compare(a, b)));
             }
         }
 
         [Fact]
-        public static void TestCtor_CultureInfo_Compare_TurkishI()
+        public static void Ctor_CultureInfo_Compare_TurkishI()
         {
             var cultureNames = new string[]
             {
@@ -110,9 +109,9 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_CultureInfo_Invalid()
+        public static void Ctor_CultureInfo_NullCulture_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new CaseInsensitiveComparer(null)); // Culture is null
+            Assert.Throws<ArgumentNullException>("culture", () => new CaseInsensitiveComparer(null)); // Culture is null
         }
 
         [Theory]
@@ -129,7 +128,7 @@ namespace System.Collections.Tests
         [InlineData(5, null, 1)]
         [InlineData(null, 5, -1)]
         [InlineData(null, null, 0)]
-        public static void TestDefaultInvariant_Compare(object a, object b, int expected)
+        public static void DefaultInvariant_Compare(object a, object b, int expected)
         {
             var cultureNames = new string[]
             {
@@ -161,7 +160,7 @@ namespace System.Collections.Tests
 
                 // All cultures should sort the same way, irrespective of the thread's culture
                 CaseInsensitiveComparer defaultInvComparer = CaseInsensitiveComparer.DefaultInvariant;
-                Assert.Equal(expected, Helpers.NormalizeCompare(defaultInvComparer.Compare(a, b)));
+                Assert.Equal(expected, Math.Sign(defaultInvComparer.Compare(a, b)));
             }
 
             CultureInfo.DefaultThreadCurrentCulture = culture1;
@@ -181,13 +180,13 @@ namespace System.Collections.Tests
         [InlineData(5, null, 1)]
         [InlineData(null, 5, -1)]
         [InlineData(null, null, 0)]
-        public static void TestDefault_Compare(object a, object b, int expected)
+        public static void Default_Compare(object a, object b, int expected)
         {
-            Assert.Equal(expected, Helpers.NormalizeCompare(CaseInsensitiveComparer.Default.Compare(a, b)));
+            Assert.Equal(expected, Math.Sign(CaseInsensitiveComparer.Default.Compare(a, b)));
         }
 
         [Fact]
-        public static void TestDefault_Compare_TurkishI()
+        public static void Default_Compare_TurkishI()
         {
             // Turkish has lower-case and upper-case version of the dotted "i", so the upper case of "i" (U+0069) isn't "I" (U+0049)
             // but rather "İ" (U+0130)

--- a/src/System.Collections.NonGeneric/tests/CollectionBaseTests.cs
+++ b/src/System.Collections.NonGeneric/tests/CollectionBaseTests.cs
@@ -9,7 +9,7 @@ namespace System.Collections.Tests
     public static class CollectionBaseTests
     {
         [Fact]
-        public static void TestCtor_Empty()
+        public static void Ctor_Empty()
         {
             var collBase = new MyCollection();
             var arrList = new ArrayList();
@@ -25,7 +25,7 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(1024)]
-        public static void TestCtor_Capacity(int capacity)
+        public static void Ctor_Capacity(int capacity)
         {
             var collBase = new MyCollection(capacity);
             var arrList = new ArrayList(capacity);
@@ -37,16 +37,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtorCapacity_Invalid()
+        public static void CtorCapacity_Invalid()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new MyCollection(-1)); // Capacity < 0
+            Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new MyCollection(-1)); // Capacity < 0
             Assert.Throws<OutOfMemoryException>(() => new MyCollection(int.MaxValue)); // Capacity is too large
         }
 
-        private static Foo CreateValue(int i)
-        {
-            return new Foo(i, i.ToString());
-        }
+        private static Foo CreateValue(int i) => new Foo(i, i.ToString());
 
         private static MyCollection CreateCollection(int count)
         {
@@ -59,7 +56,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdd()
+        public static void Add()
         {
             MyCollection collBase = new MyCollection();
             for (int i = 0; i < 100; i++)
@@ -77,7 +74,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemove()
+        public static void Remove()
         {
             MyCollection collBase = CreateCollection(100);
             for (int i = 0; i < 100; i++)
@@ -90,15 +87,15 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemove_Invalid()
+        public static void Remove_Invalid()
         {
             MyCollection collBase = CreateCollection(100);
-            Assert.Throws<ArgumentException>(() => collBase.Remove(new Foo())); // Non existent object
+            Assert.Throws<ArgumentException>(null, () => collBase.Remove(new Foo())); // Non existent object
             Assert.Equal(100, collBase.Count);
         }
 
         [Fact]
-        public static void TestInsert()
+        public static void Insert()
         {
             var collBase = new MyCollection();
             for (int i = 0; i < 100; i++)
@@ -116,17 +113,17 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestInsert_Invalid()
+        public static void Insert_InvalidIndex_ThrowsArgumentOutOfRangeException()
         {
             MyCollection collBase = CreateCollection(100);
-            Assert.Throws<ArgumentOutOfRangeException>(() => collBase.Insert(-1, new Foo())); // Index < 0
-            Assert.Throws<ArgumentOutOfRangeException>(() => collBase.Insert(collBase.Count + 1, new Foo())); // Index > collBase.Count
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => collBase.Insert(-1, new Foo())); // Index < 0
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => collBase.Insert(collBase.Count + 1, new Foo())); // Index > collBase.Count
 
             Assert.Equal(100, collBase.Count);
         }
 
         [Fact]
-        public static void TestRemoveAt()
+        public static void RemoveAt()
         {
             MyCollection collBase = CreateCollection(100);
             for (int i = 0; i < collBase.Count; i++)
@@ -137,16 +134,16 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemoveAt_Invalid()
+        public static void RemoveAt_InvalidIndex_ThrowsArgumentOutOfRangeException()
         {
             MyCollection collBase = CreateCollection(100);
-            Assert.Throws<ArgumentOutOfRangeException>(() => collBase.RemoveAt(-1)); // Index < 0
-            Assert.Throws<ArgumentOutOfRangeException>(() => collBase.RemoveAt(collBase.Count)); // Index > collBase.Count
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => collBase.RemoveAt(-1)); // Index < 0
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => collBase.RemoveAt(collBase.Count)); // Index > collBase.Count
             Assert.Equal(100, collBase.Count);
         }
 
         [Fact]
-        public static void TestClear()
+        public static void Clear()
         {
             MyCollection collBase = CreateCollection(100);
             collBase.Clear();
@@ -154,7 +151,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexOf()
+        public static void IndexOf()
         {
             MyCollection collBase = CreateCollection(100);
             for (int i = 0; i < collBase.Count; i++)
@@ -165,7 +162,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestContains()
+        public static void Contains()
         {
             MyCollection collBase = CreateCollection(100);
             for (int i = 0; i < collBase.Count; i++)
@@ -176,7 +173,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestItem_Get()
+        public static void Item_Get()
         {
             MyCollection collBase = CreateCollection(100);
             for (int i = 0; i < collBase.Count; i++)
@@ -186,15 +183,15 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestItem_Get_Invalid()
+        public static void Item_Get_InvalidIndex_ThrowsArgumentOutOfRangeException()
         {
             MyCollection collBase = CreateCollection(100);
-            Assert.Throws<ArgumentOutOfRangeException>(() => collBase[-1]); // Index < 0
-            Assert.Throws<ArgumentOutOfRangeException>(() => collBase[collBase.Count]); // Index >= InnerList.Count
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => collBase[-1]); // Index < 0
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => collBase[collBase.Count]); // Index >= InnerList.Count
         }
 
         [Fact]
-        public static void TestItem_Set()
+        public static void Item_Set()
         {
             MyCollection collBase = CreateCollection(100);
             for (int i = 0; i < collBase.Count; i++)
@@ -206,17 +203,17 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestItem_Set_Invalid()
+        public static void Item_Set_Invalid()
         {
             MyCollection collBase = CreateCollection(100);
-            Assert.Throws<ArgumentOutOfRangeException>(() => collBase[-1] = new Foo()); // Index < 0
-            Assert.Throws<ArgumentOutOfRangeException>(() => collBase[collBase.Count] = new Foo()); // Index >= InnerList.Count
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => collBase[-1] = new Foo()); // Index < 0
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => collBase[collBase.Count] = new Foo()); // Index >= InnerList.Count
 
-            Assert.Throws<ArgumentNullException>(() => collBase[0] = null); // Object is null
+            Assert.Throws<ArgumentNullException>("value", () => collBase[0] = null); // Object is null
         }
 
         [Fact]
-        public static void TestCopyTo()
+        public static void CopyTo()
         {
             MyCollection collBase = CreateCollection(100);
 
@@ -241,16 +238,16 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Invalid()
+        public static void CopyTo_Invalid()
         {
             MyCollection collBase = CreateCollection(100);
             var fooArr = new Foo[100];
-            Assert.Throws<ArgumentOutOfRangeException>(() => collBase.CopyTo(fooArr, -1)); // Index < 0
-            Assert.Throws<ArgumentException>(() => collBase.CopyTo(fooArr, 50)); // Index + fooArray.Length > collBase.Count
+            Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => collBase.CopyTo(fooArr, -1)); // Index < 0
+            Assert.Throws<ArgumentException>("", () => collBase.CopyTo(fooArr, 50)); // Index + fooArray.Length > collBase.Count
         }
 
         [Fact]
-        public static void TestGetEnumerator()
+        public static void GetEnumerator()
         {
             MyCollection collBase = CreateCollection(100);
             IEnumerator enumerator = collBase.GetEnumerator();
@@ -267,7 +264,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetEnumerator_Invalid()
+        public static void GetEnumerator_Invalid()
         {
             MyCollection collBase = CreateCollection(100);
             IEnumerator enumerator = collBase.GetEnumerator();
@@ -289,7 +286,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSyncRoot()
+        public static void SyncRoot()
         {
             // SyncRoot should be the reference to the underlying collection, not to MyCollection
             var collBase = new MyCollection();
@@ -299,7 +296,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIListProperties()
+        public static void IListProperties()
         {
             MyCollection collBase = CreateCollection(100);
             Assert.False(collBase.IsFixedSize);
@@ -308,7 +305,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCapacityGet()
+        public static void CapacityGet()
         {
             var collBase = new MyCollection(new string[10]);
             Assert.True(collBase.Capacity >= collBase.Count);
@@ -318,7 +315,7 @@ namespace System.Collections.Tests
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(44)]
-        public static void TestCapacitySet(int capacity)
+        public static void CapacitySet(int capacity)
         {
             var collBase = new MyCollection(0);
 
@@ -327,16 +324,16 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCapacity_SetInvalid()
+        public static void Capacity_Set_Invalid()
         {
             var collBase = new MyCollection(new string[10]);
-            Assert.Throws<ArgumentOutOfRangeException>(() => collBase.Capacity = -1); // Capacity < 0
+            Assert.Throws<ArgumentOutOfRangeException>("value", () => collBase.Capacity = -1); // Capacity < 0
             Assert.Throws<OutOfMemoryException>(() => collBase.Capacity = int.MaxValue); // Capacity is very large
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => collBase.Capacity = collBase.Count - 1); // Capacity < list.Count
+            Assert.Throws<ArgumentOutOfRangeException>("value", () => collBase.Capacity = collBase.Count - 1); // Capacity < list.Count
         }
         [Fact]
-        public static void TestAdd_Called()
+        public static void Add_Called()
         {
             var f = new Foo(0, "0");
             var collBase = new OnMethodCalledCollectionBase();
@@ -350,7 +347,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdd_Throws_Called()
+        public static void Add_Throws_Called()
         {
             var f = new Foo(0, "0");
 
@@ -377,7 +374,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestInsert_Called()
+        public static void Insert_Called()
         {
             var f = new Foo(0, "0");
             var collBase = new OnMethodCalledCollectionBase();
@@ -391,7 +388,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestInsert_Throws_Called()
+        public static void Insert_Throws_Called()
         {
             var f = new Foo(0, "0");
 
@@ -418,7 +415,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemove_Called()
+        public static void Remove_Called()
         {
             var f = new Foo(0, "0");
             var collBase = new OnMethodCalledCollectionBase();
@@ -435,7 +432,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemove_Throws_Called()
+        public static void Remove_Throws_Called()
         {
             var f = new Foo(0, "0");
 
@@ -465,7 +462,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemoveAt_Called()
+        public static void RemoveAt_Called()
         {
             var f = new Foo(0, "0");
             var collBase = new OnMethodCalledCollectionBase();
@@ -482,7 +479,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemoveAt_Throws_Called()
+        public static void RemoveAt_Throws_Called()
         {
             var f = new Foo(0, "0");
 
@@ -512,7 +509,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestClear_Called()
+        public static void Clear_Called()
         {
             var f = new Foo(0, "0");
             var collBase = new OnMethodCalledCollectionBase();
@@ -526,7 +523,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestClear_Throws_Called()
+        public static void Clear_Throws_Called()
         {
             var f = new Foo(0, "0");
 
@@ -556,7 +553,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSet_Called()
+        public static void Set_Called()
         {
             var f = new Foo(1, "1");
 
@@ -574,7 +571,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSet_Throws_Called()
+        public static void Set_Throws_Called()
         {
             var f1 = new Foo(0, "0");
             var f2 = new Foo(1, "1");
@@ -625,16 +622,10 @@ namespace System.Collections.Tests
 
             public int InnerListCapacity
             {
-                get
-                {
-                    return InnerList.Capacity;
-                }
+                get { return InnerList.Capacity; }
             }
 
-            public int Add(Foo f1)
-            {
-                return List.Add(f1);
-            }
+            public int Add(Foo f1) => List.Add(f1);
 
             public Foo this[int indx]
             {
@@ -642,30 +633,15 @@ namespace System.Collections.Tests
                 set { List[indx] = value; }
             }
 
-            public void CopyTo(Array array, int index)
-            {
-                List.CopyTo(array, index);
-            }
+            public void CopyTo(Array array, int index) => List.CopyTo(array, index);
 
-            public int IndexOf(Foo f)
-            {
-                return List.IndexOf(f);
-            }
+            public int IndexOf(Foo f) => List.IndexOf(f);
 
-            public bool Contains(Foo f)
-            {
-                return List.Contains(f);
-            }
+            public bool Contains(Foo f) => List.Contains(f);
 
-            public void Insert(int index, Foo f)
-            {
-                List.Insert(index, f);
-            }
+            public void Insert(int index, Foo f) => List.Insert(index, f);
 
-            public void Remove(Foo f)
-            {
-                List.Remove(f);
-            }
+            public void Remove(Foo f) => List.Remove(f);
 
             public bool IsSynchronized
             {
@@ -687,6 +663,7 @@ namespace System.Collections.Tests
                 get { return List.IsFixedSize; }
             }
         }
+
         private class OnMethodCalledCollectionBase : CollectionBase
         {
             public bool OnValidateCalled;
@@ -709,10 +686,7 @@ namespace System.Collections.Tests
             public bool OnRemoveThrow;
             public bool OnRemoveCompleteThrow;
 
-            public int Add(Foo f1)
-            {
-                return List.Add(f1);
-            }
+            public int Add(Foo f1) => List.Add(f1);
 
             public Foo this[int indx]
             {
@@ -720,30 +694,15 @@ namespace System.Collections.Tests
                 set { List[indx] = value; }
             }
 
-            public void CopyTo(Array array, int index)
-            {
-                List.CopyTo(array, index);
-            }
+            public void CopyTo(Array array, int index) => List.CopyTo(array, index);
 
-            public int IndexOf(Foo f)
-            {
-                return List.IndexOf(f);
-            }
+            public int IndexOf(Foo f) => List.IndexOf(f);
 
-            public bool Contains(Foo f)
-            {
-                return List.Contains(f);
-            }
+            public bool Contains(Foo f) => List.Contains(f);
 
-            public void Insert(int index, Foo f)
-            {
-                List.Insert(index, f);
-            }
+            public void Insert(int index, Foo f) => List.Insert(index, f);
 
-            public void Remove(Foo f)
-            {
-                List.Remove(f);
-            }
+            public void Remove(Foo f) => List.Remove(f);
 
             protected override void OnSet(int index, object oldValue, object newValue)
             {
@@ -852,39 +811,22 @@ namespace System.Collections.Tests
 
             public Foo(int intValue, string stringValue)
             {
-                _intValue = intValue;
-                _stringValue = stringValue;
+                IntValue = intValue;
+                StringValue = stringValue;
             }
-
-            private int _intValue;
-            public int IntValue
-            {
-                get { return _intValue; }
-                set { _intValue = value; }
-            }
-
-            private string _stringValue;
-            public string StringValue
-            {
-                get { return _stringValue; }
-                set { _stringValue = value; }
-            }
+            
+            public int IntValue { get; set; }
+            public string StringValue { get; set; }
 
             public override bool Equals(object obj)
             {
-                if (obj == null)
+                Foo foo = obj as Foo;
+                if (foo == null)
                     return false;
-                if (!(obj is Foo))
-                    return false;
-                if ((((Foo)obj).IntValue == _intValue) && (((Foo)obj).StringValue == _stringValue))
-                    return true;
-                return false;
+                return foo.IntValue == IntValue && foo.StringValue == StringValue;
             }
 
-            public override int GetHashCode()
-            {
-                return _intValue;
-            }
+            public override int GetHashCode() => IntValue;
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/CollectionBaseTests.cs
+++ b/src/System.Collections.NonGeneric/tests/CollectionBaseTests.cs
@@ -243,7 +243,7 @@ namespace System.Collections.Tests
             MyCollection collBase = CreateCollection(100);
             var fooArr = new Foo[100];
             Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => collBase.CopyTo(fooArr, -1)); // Index < 0
-            Assert.Throws<ArgumentException>("", () => collBase.CopyTo(fooArr, 50)); // Index + fooArray.Length > collBase.Count
+            Assert.Throws<ArgumentException>(string.Empty, () => collBase.CopyTo(fooArr, 50)); // Index + fooArray.Length > collBase.Count
         }
 
         [Fact]

--- a/src/System.Collections.NonGeneric/tests/CollectionsUtilTests.cs
+++ b/src/System.Collections.NonGeneric/tests/CollectionsUtilTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Specialized;
-
 using Xunit;
 
 namespace System.Collections.Tests
@@ -11,7 +10,7 @@ namespace System.Collections.Tests
     public static class CollectionsUtilTests
     {
         [Fact]
-        public static void TestCreateCaseInsensitiveHashtable()
+        public static void CreateCaseInsensitiveHashtable()
         {
             Hashtable hashtable = CollectionsUtil.CreateCaseInsensitiveHashtable();
             Assert.Equal(0, hashtable.Count);
@@ -19,11 +18,11 @@ namespace System.Collections.Tests
             hashtable.Add("key1", "value1");
             Assert.Equal("value1", hashtable["key1"]);
 
-            Assert.Throws<ArgumentException>(() => hashtable.Add("key1", "value1"));
+            Assert.Throws<ArgumentException>(null, () => hashtable.Add("key1", "value1"));
         }
 
         [Fact]
-        public static void TestCreateCaseInsensitiveHashtable_Capacity()
+        public static void CreateCaseInsensitiveHashtable_Capacity()
         {
             Hashtable hashtable = CollectionsUtil.CreateCaseInsensitiveHashtable(15);
             Assert.Equal(0, hashtable.Count);
@@ -32,11 +31,11 @@ namespace System.Collections.Tests
             Assert.Equal("value1", hashtable["key1"]);
             Assert.Equal(1, hashtable.Count);
 
-            Assert.Throws<ArgumentException>(() => hashtable.Add("key1", "value1"));
+            Assert.Throws<ArgumentException>(null, () => hashtable.Add("key1", "value1"));
         }
 
         [Fact]
-        public static void TestCreateCaseInsensitiveHashtable_IDictionary()
+        public static void CreateCaseInsensitiveHashtable_IDictionary()
         {
             Hashtable hashtable1 = CollectionsUtil.CreateCaseInsensitiveHashtable();
             hashtable1.Add("key1", "value1");
@@ -48,11 +47,11 @@ namespace System.Collections.Tests
             Assert.Equal("value1", hashtable2["key1"]);
             Assert.Equal(2, hashtable2.Count);
 
-            Assert.Throws<ArgumentException>(() => hashtable2.Add("key1", "value1"));
+            Assert.Throws<ArgumentException>(null, () => hashtable2.Add("key1", "value1"));
         }
 
         [Fact]
-        public static void TestCreateCaseInsensitiveSortedList()
+        public static void CreateCaseInsensitiveSortedList()
         {
             SortedList sortedList = CollectionsUtil.CreateCaseInsensitiveSortedList();
             Assert.Equal(0, sortedList.Count);
@@ -61,7 +60,7 @@ namespace System.Collections.Tests
             Assert.Equal("value1", sortedList["key1"]);
             Assert.Equal(1, sortedList.Count);
 
-            Assert.Throws<ArgumentException>(() => sortedList.Add("key1", "value1"));
+            Assert.Throws<ArgumentException>(null, () => sortedList.Add("key1", "value1"));
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/ComparerTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ComparerTests.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Globalization;
-
 using Xunit;
 
 namespace System.Collections.Tests
@@ -21,22 +20,22 @@ namespace System.Collections.Tests
         [InlineData(1, null, 1)]
         [InlineData(null, null, 0)]
         [InlineData(null, 1, -1)]
-        public static void TestCtor_CultureInfo(object a, object b, int expected)
+        public static void Ctor_CultureInfo(object a, object b, int expected)
         {
             var culture = new CultureInfo("en-US");
             var comparer = new Comparer(culture);
 
-            Assert.Equal(expected, Helpers.NormalizeCompare(comparer.Compare(a, b)));
+            Assert.Equal(expected, Math.Sign(comparer.Compare(a, b)));
         }
 
         [Fact]
-        public static void TestCtor_CultureInfo_Invalid()
+        public static void Ctor_CultureInfo_NullCulture_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new Comparer(null)); // Culture is null
+            Assert.Throws<ArgumentNullException>("culture", () => new Comparer(null)); // Culture is null
         }
 
         [Fact]
-        public static void TestDefaultInvariant_Compare()
+        public static void DefaultInvariant_Compare()
         {
             CultureInfo culture1 = CultureInfo.DefaultThreadCurrentCulture;
             CultureInfo culture2 = CultureInfo.DefaultThreadCurrentUICulture;
@@ -85,14 +84,14 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestDefaultInvariant_Compare_Invalid()
+        public static void DefaultInvariant_Compare_Invalid()
         {
             Comparer comp = Comparer.Default;
-            Assert.Throws<ArgumentException>(() => comp.Compare(new object(), 1)); // One object doesn't implement IComparable
-            Assert.Throws<ArgumentException>(() => comp.Compare(1, new object())); // One object doesn't implement IComparable
-            Assert.Throws<ArgumentException>(() => comp.Compare(new object(), new object())); // Both objects don't implement IComparable
+            Assert.Throws<ArgumentException>(null, () => comp.Compare(new object(), 1)); // One object doesn't implement IComparable
+            Assert.Throws<ArgumentException>(null, () => comp.Compare(1, new object())); // One object doesn't implement IComparable
+            Assert.Throws<ArgumentException>(null, () => comp.Compare(new object(), new object())); // Both objects don't implement IComparable
 
-            Assert.Throws<ArgumentException>(() => comp.Compare(1, 1L)); // Different types
+            Assert.Throws<ArgumentException>(null, () => comp.Compare(1, 1L)); // Different types
         }
 
         public static IEnumerable<object[]> CompareTestData()
@@ -116,20 +115,20 @@ namespace System.Collections.Tests
         [InlineData(null, 1, -1)]
         [InlineData(null, null, 0)]
         [MemberData(nameof(CompareTestData))]
-        public static void TestDefault_Compare(object a, object b, int expected)
+        public static void Default_Compare(object a, object b, int expected)
         {
-            Assert.Equal(expected, Helpers.NormalizeCompare(Comparer.Default.Compare(a, b)));
+            Assert.Equal(expected, Math.Sign(Comparer.Default.Compare(a, b)));
         }
         
         [Fact]
-        public static void TestDefault_Compare_Invalid()
+        public static void Default_Compare_Invalid()
         {
             Comparer comp = Comparer.Default;
-            Assert.Throws<ArgumentException>(() => comp.Compare(new object(), 1)); // One object doesn't implement IComparable
-            Assert.Throws<ArgumentException>(() => comp.Compare(1, new object())); // One object doesn't implement IComparable
-            Assert.Throws<ArgumentException>(() => comp.Compare(new object(), new object())); // Both objects don't implement IComparable
+            Assert.Throws<ArgumentException>(null, () => comp.Compare(new object(), 1)); // One object doesn't implement IComparable
+            Assert.Throws<ArgumentException>(null, () => comp.Compare(1, new object())); // One object doesn't implement IComparable
+            Assert.Throws<ArgumentException>(null, () => comp.Compare(new object(), new object())); // Both objects don't implement IComparable
 
-            Assert.Throws<ArgumentException>(() => comp.Compare(1, 1L)); // Different types
+            Assert.Throws<ArgumentException>(null, () => comp.Compare(1, 1L)); // Different types
         }
 
         private class Foo : IComparable

--- a/src/System.Collections.NonGeneric/tests/DictionaryBaseTests.cs
+++ b/src/System.Collections.NonGeneric/tests/DictionaryBaseTests.cs
@@ -8,15 +8,9 @@ namespace System.Collections.Tests
 {
     public static class DictionaryBaseTests
     {
-        private static FooKey CreateKey(int i)
-        {
-            return new FooKey(i, i.ToString());
-        }
+        private static FooKey CreateKey(int i) => new FooKey(i, i.ToString());
 
-        private static FooValue CreateValue(int i)
-        {
-            return new FooValue(i, i.ToString());
-        }
+        private static FooValue CreateValue(int i) => new FooValue(i, i.ToString());
 
         private static MyDictionary CreateDictionary(int count)
         {
@@ -29,7 +23,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdd()
+        public static void Add()
         {
             var dictBase = new MyDictionary();
             for (int i = 0; i < 100; i++)
@@ -51,7 +45,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemove()
+        public static void Remove()
         {
             MyDictionary dictBase = CreateDictionary(100);
             for (int i = 0; i < 100; i++)
@@ -65,7 +59,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestContains()
+        public static void Contains()
         {
             MyDictionary dictBase = CreateDictionary(100);
             for (int i = 0; i < dictBase.Count; i++)
@@ -76,7 +70,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestKeys()
+        public static void Keys()
         {
             MyDictionary dictBase = CreateDictionary(100);
             ICollection keys = dictBase.Keys;
@@ -89,7 +83,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestValues()
+        public static void Values()
         {
             MyDictionary dictBase = CreateDictionary(100);
             ICollection values = dictBase.Values;
@@ -103,7 +97,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexer_Get()
+        public static void Item_Get()
         {
             MyDictionary dictBase = CreateDictionary(100);
             for (int i = 0; i < dictBase.Count; i++)
@@ -114,14 +108,14 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexer_Get_Invalid()
+        public static void Item_Get_NullKey_ThrowsArgumentNullException()
         {
             var dictBase = new MyDictionary();
-            Assert.Throws<ArgumentNullException>(() => dictBase[null]);
+            Assert.Throws<ArgumentNullException>("key", () => dictBase[null]);
         }
 
         [Fact]
-        public static void TestIndexer_Set()
+        public static void Item_Set()
         {
             MyDictionary dictBase = CreateDictionary(100);
 
@@ -141,14 +135,14 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexer_Set_Invalid()
+        public static void Indexer_Set_NullKey_ThrowsArgumentNullException()
         {
             var dictBase = new MyDictionary();
-            Assert.Throws<ArgumentNullException>(() => dictBase[null] = new FooValue());
+            Assert.Throws<ArgumentNullException>("key", () => dictBase[null] = new FooValue());
         }
 
         [Fact]
-        public static void TestClear()
+        public static void Clear()
         {
             MyDictionary dictBase = CreateDictionary(100);
             dictBase.Clear();
@@ -156,7 +150,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo()
+        public static void CopyTo()
         {
             MyDictionary dictBase = CreateDictionary(100);
             // Basic
@@ -185,19 +179,20 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Invalid()
+        public static void CopyTo_Invalid()
         {
             MyDictionary dictBase = CreateDictionary(100);
-            Assert.Throws<ArgumentNullException>(() => dictBase.CopyTo(null, 0)); // Array is null
+            Assert.Throws<ArgumentNullException>("array", () => dictBase.CopyTo(null, 0)); // Array is null
+            Assert.Throws<ArgumentException>("array", () => dictBase.CopyTo(new object[100, 100], 0)); // Array is multidimensional
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => dictBase.CopyTo(new DictionaryEntry[100], -1)); // Index < 0
+            Assert.Throws<ArgumentOutOfRangeException>("arrayIndex", () => dictBase.CopyTo(new DictionaryEntry[100], -1)); // Index < 0
 
-            Assert.Throws<ArgumentException>(() => dictBase.CopyTo(new DictionaryEntry[100], 100)); // Index >= count
-            Assert.Throws<ArgumentException>(() => dictBase.CopyTo(new DictionaryEntry[100], 50)); // Index + array.Count >= count
+            Assert.Throws<ArgumentException>(null, () => dictBase.CopyTo(new DictionaryEntry[100], 100)); // Index >= count
+            Assert.Throws<ArgumentException>(null, () => dictBase.CopyTo(new DictionaryEntry[100], 50)); // Index + array.Count >= count
         }
 
         [Fact]
-        public static void TestGetEnumerator_IDictionaryEnumerator()
+        public static void GetEnumerator_IDictionaryEnumerator()
         {
             MyDictionary dictBase = CreateDictionary(100);
             IDictionaryEnumerator enumerator = dictBase.GetEnumerator();
@@ -223,7 +218,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetEnumerator_IDictionaryEnumerator_Invalid()
+        public static void GetEnumerator_IDictionaryEnumerator_Invalid()
         {
             MyDictionary dictBase = CreateDictionary(100);
             IDictionaryEnumerator enumerator = dictBase.GetEnumerator();
@@ -254,7 +249,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetEnumerator_IEnumerator()
+        public static void GetEnumerator_IEnumerator()
         {
             MyDictionary dictBase = CreateDictionary(100);
             IEnumerator enumerator = ((IEnumerable)dictBase).GetEnumerator();
@@ -272,7 +267,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetEnumerator_IEnumerator_Invalid()
+        public static void GetEnumerator_IEnumerator_Invalid()
         {
             MyDictionary dictBase = CreateDictionary(100);
             IEnumerator enumerator = ((IEnumerable)dictBase).GetEnumerator();
@@ -294,7 +289,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSyncRoot()
+        public static void SyncRoot()
         {
             // SyncRoot should be the reference to the underlying dictionary, not to MyDictionary
             var dictBase = new MyDictionary();
@@ -304,7 +299,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIDictionaryProperties()
+        public static void IDictionaryProperties()
         {
             var dictBase = new MyDictionary();
             Assert.False(dictBase.IsFixedSize);
@@ -313,7 +308,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdd_Called()
+        public static void Add_Called()
         {
             var f = new FooKey(0, "0");
             var dictBase = new OnMethodCalledDictionary();
@@ -326,7 +321,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdd_Throws_Called()
+        public static void Add_Throws_Called()
         {
             var f = new FooKey(0, "0");
 
@@ -353,7 +348,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemove_Called()
+        public static void Remove_Called()
         {
             var f = new FooKey(0, "0");
             var dictBase = new OnMethodCalledDictionary();
@@ -370,7 +365,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemove_Throws_Called()
+        public static void Remove_Throws_Called()
         {
             var f = new FooKey(0, "0");
 
@@ -400,7 +395,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestClear_Called()
+        public static void Clear_Called()
         {
             var f = new FooKey(0, "0");
             var dictBase = new OnMethodCalledDictionary();
@@ -414,7 +409,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestClear_Throws_Called()
+        public static void Clear_Throws_Called()
         {
             var f = new FooKey(0, "0");
 
@@ -444,7 +439,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSet_New_Called()
+        public static void Set_New_Called()
         {
             var f = new FooKey(1, "1");
 
@@ -462,7 +457,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSet_New_Throws_Called()
+        public static void Set_New_Throws_Called()
         {
             var f = new FooKey(0, "0");
 
@@ -489,7 +484,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSet_Existing_Called()
+        public static void Set_Existing_Called()
         {
             var f = new FooKey(1, "1");
 
@@ -507,7 +502,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSet_Existing_Throws_Called()
+        public static void Set_Existing_Throws_Called()
         {
             var f = new FooKey(0, "0");
 
@@ -539,10 +534,7 @@ namespace System.Collections.Tests
         // DictionaryBase is provided to be used as the base class for strongly typed collections. Lets use one of our own here
         private class MyDictionary : DictionaryBase
         {
-            public void Add(FooKey key, FooValue value)
-            {
-                Dictionary.Add(key, value);
-            }
+            public void Add(FooKey key, FooValue value) => Dictionary.Add(key, value);
 
             public FooValue this[FooKey key]
             {
@@ -560,15 +552,9 @@ namespace System.Collections.Tests
                 get { return Dictionary.SyncRoot; }
             }
 
-            public bool Contains(FooKey key)
-            {
-                return Dictionary.Contains(key);
-            }
+            public bool Contains(FooKey key) => Dictionary.Contains(key);
 
-            public void Remove(FooKey key)
-            {
-                Dictionary.Remove(key);
-            }
+            public void Remove(FooKey key) => Dictionary.Remove(key);
 
             public bool IsFixedSize
             {
@@ -599,51 +585,27 @@ namespace System.Collections.Tests
 
             public FooKey(int i, string str)
             {
-                _intValue = i;
-                _stringValue = str;
+                IntValue = i;
+                StringValue = str;
             }
 
-            private int _intValue;
-            public int IntValue
-            {
-                get { return _intValue; }
-                set { _intValue = value; }
-            }
-
-            private string _stringValue;
-            public string StringValue
-            {
-                get { return _stringValue; }
-                set { _stringValue = value; }
-            }
+            public int IntValue { get; set; }            
+            public string StringValue { get; set; }
 
             public override bool Equals(object obj)
             {
-                if (obj == null)
+                FooKey foo = obj as FooKey;
+                if (foo == null)
                     return false;
-                if (!(obj is FooKey))
-                    return false;
-                if ((((FooKey)obj).IntValue == _intValue) && (((FooKey)obj).StringValue == _stringValue))
-                    return true;
-                return false;
+                return foo.IntValue == IntValue && foo.StringValue == StringValue;
             }
 
-            public override int GetHashCode()
-            {
-                return _intValue;
-            }
+            public override int GetHashCode() =>IntValue;
 
             public int CompareTo(object obj)
             {
-                if (!(obj is FooKey))
-                    throw new ArgumentException("obj must be type FooKey");
                 FooKey temp = (FooKey)obj;
-                if (temp.IntValue > _intValue)
-                    return -1;
-                else if (temp.IntValue < _intValue)
-                    return 1;
-                else
-                    return 0;
+                return IntValue.CompareTo(temp.IntValue);
             }
         }
 
@@ -655,51 +617,27 @@ namespace System.Collections.Tests
 
             public FooValue(int intValue, string stringValue)
             {
-                _intValue = intValue;
-                _stringValue = stringValue;
+                IntValue = intValue;
+                StringValue = stringValue;
             }
-
-            private int _intValue;
-            public int IntValue
-            {
-                get { return _intValue; }
-                set { _intValue = value; }
-            }
-
-            private string _stringValue;
-            public string StringValue
-            {
-                get { return _stringValue; }
-                set { _stringValue = value; }
-            }
+            
+            public int IntValue { get; set; }
+            public string StringValue { get; set; }
 
             public override bool Equals(object obj)
             {
-                if (obj == null)
+                FooValue foo = obj as FooValue;
+                if (foo == null)
                     return false;
-                if (!(obj is FooValue))
-                    return false;
-                if ((((FooValue)obj).IntValue == _intValue) && (((FooValue)obj).StringValue == _stringValue))
-                    return true;
-                return false;
+                return foo.IntValue == IntValue && foo.StringValue == StringValue;
             }
 
-            public override int GetHashCode()
-            {
-                return _intValue;
-            }
+            public override int GetHashCode() => IntValue;
 
             public int CompareTo(object obj)
             {
-                if (!(obj is FooValue))
-                    throw new ArgumentException("obj must be type FooValue");
                 FooValue temp = (FooValue)obj;
-                if (temp.IntValue > _intValue)
-                    return -1;
-                else if (temp.IntValue < _intValue)
-                    return 1;
-                else
-                    return 0;
+                return IntValue.CompareTo(temp.IntValue);
             }
         }
 
@@ -726,32 +664,17 @@ namespace System.Collections.Tests
             public bool OnRemoveThrow;
             public bool OnRemoveCompleteThrow;
 
-            public void Add(FooKey key, string value)
-            {
-                Dictionary.Add(key, value);
-            }
+            public void Add(FooKey key, string value) => Dictionary.Add(key, value);
 
             public string this[FooKey key]
             {
-                get
-                {
-                    return (string)Dictionary[key];
-                }
-                set
-                {
-                    Dictionary[key] = value;
-                }
+                get { return (string)Dictionary[key]; }
+                set { Dictionary[key] = value; }
             }
 
-            public bool Contains(FooKey key)
-            {
-                return Dictionary.Contains(key);
-            }
+            public bool Contains(FooKey key) => Dictionary.Contains(key);
 
-            public void Remove(FooKey key)
-            {
-                Dictionary.Remove(key);
-            }
+            public void Remove(FooKey key) => Dictionary.Remove(key);
 
             protected override void OnSet(object key, object oldValue, object newValue)
             {

--- a/src/System.Collections.NonGeneric/tests/HashtableTests.cs
+++ b/src/System.Collections.NonGeneric/tests/HashtableTests.cs
@@ -1638,7 +1638,7 @@ namespace System.Collections.Tests
             Assert.NotEqual(hash1.SyncRoot, hash3.SyncRoot);
 
             // Testing SyncRoot is not as simple as its implementation looks like. This is the working
-            // scenrio we have in mind.
+            // scenario we have in mind.
             // 1) Create your Down to earth mother Hashtable
             // 2) Get a synchronized wrapper from it
             // 3) Get a Synchronized wrapper from 2)

--- a/src/System.Collections.NonGeneric/tests/HashtableTests.cs
+++ b/src/System.Collections.NonGeneric/tests/HashtableTests.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Xunit;
 
 namespace System.Collections.Tests
@@ -14,14 +13,14 @@ namespace System.Collections.Tests
     public static class HashtableTests
     {
         [Fact]
-        public static void TestCtor_Empty()
+        public static void Ctor_Empty()
         {
             var hash = new ComparableHashtable();
             VerifyHashtable(hash, null, null);
         }
 
         [Fact]
-        public static void TestCtor_IDictionary()
+        public static void Ctor_IDictionary()
         {
             // No exception
             var hash1 = new ComparableHashtable(new Hashtable());
@@ -37,13 +36,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_IDictionary_Invalid()
+        public static void Ctor_IDictionary_NullDictionary_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new Hashtable((IDictionary)null)); // Dictionary is null
+            Assert.Throws<ArgumentNullException>("d", () => new Hashtable((IDictionary)null)); // Dictionary is null
         }
 
         [Fact]
-        public static void TestCtor_IEqualityComparer()
+        public static void Ctor_IEqualityComparer()
         {
             // Null comparer
             var hash = new ComparableHashtable((IEqualityComparer)null);
@@ -62,21 +61,21 @@ namespace System.Collections.Tests
         [InlineData(0)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestCtor_Capacity(int capacity)
+        public static void Ctor_Int(int capacity)
         {
             var hash = new ComparableHashtable(capacity);
             VerifyHashtable(hash, null, null);
         }
 
         [Fact]
-        public static void TestCtor_Capacity_Invalid()
+        public static void Ctor_Int_Invalid()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(-1)); // Capacity < 0
-            Assert.Throws<ArgumentException>(() => new Hashtable(int.MaxValue)); // Capacity / load factor > int.MaxValue
+            Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new Hashtable(-1)); // Capacity < 0
+            Assert.Throws<ArgumentException>("capacity", () => new Hashtable(int.MaxValue)); // Capacity / load factor > int.MaxValue
         }
 
         [Fact]
-        public static void TestCtor_IDictionary_LoadFactor()
+        public static void Ctor_IDictionary_Int()
         {
             // No exception
             var hash1 = new ComparableHashtable(new Hashtable(), 1f);
@@ -92,19 +91,20 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_IDictionary_LoadFactor_Invalid()
+        public static void Ctor_IDictionary_Int_Invalid()
         {
-            Assert.Throws<ArgumentNullException>(() => new Hashtable(null, 1f)); // Dictionary is null
+            Assert.Throws<ArgumentNullException>("d", () => new Hashtable(null, 1f)); // Dictionary is null
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(new Hashtable(), 0.09f)); // Load factor < 0.1f
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(new Hashtable(), 1.01f)); // Load factor > 1f
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(new Hashtable(), 0.09f)); // Load factor < 0.1f
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(new Hashtable(), 1.01f)); // Load factor > 1f
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(new Hashtable(), float.NaN)); // Load factor is NaN
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(new Hashtable(), float.PositiveInfinity)); // Load factor is infinity
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(new Hashtable(), float.NaN)); // Load factor is NaN
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(new Hashtable(), float.PositiveInfinity)); // Load factor is infinity
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(new Hashtable(), float.NegativeInfinity)); // Load factor is infinity
         }
 
         [Fact]
-        public static void TestCtor_IDictionary_IEqualityComparer()
+        public static void Ctor_IDictionary_IEqualityComparer()
         {
             // No exception
             var hash1 = new ComparableHashtable(new Hashtable(), null);
@@ -129,9 +129,9 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_IDictionary_IEqualityComparer_Invalid()
+        public static void Ctor_IDictionary_IEqualityComparer_NullDictionary_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new Hashtable(null, null)); // Dictionary is null
+            Assert.Throws<ArgumentNullException>("d", () => new Hashtable(null, null)); // Dictionary is null
         }
 
         [Theory]
@@ -139,14 +139,14 @@ namespace System.Collections.Tests
         [InlineData(10, 0.2)]
         [InlineData(100, 0.3)]
         [InlineData(1000, 1)]
-        public static void TestCtor_Capacity_LoadFactor(int capacity, float loadFactor)
+        public static void Ctor_Int_Int(int capacity, float loadFactor)
         {
             var hash = new ComparableHashtable(capacity, loadFactor);
             VerifyHashtable(hash, null, null);
         }
 
         [Fact]
-        public static void TestCtor_Capacity_LoadFactor_GenerateNewPrime()
+        public static void Ctor_Int_Int_GenerateNewPrime()
         {
             // The ctor for Hashtable performs the following calculation:
             // rawSize = capacity / (loadFactor * 0.72)
@@ -166,16 +166,17 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_Capacity_LoadFactor_Invalid()
+        public static void Ctor_Int_Int_Invalid()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(-1, 1f)); // Capacity < 0
-            Assert.Throws<ArgumentException>(() => new Hashtable(int.MaxValue, 0.1f)); // Capacity / load factor > int.MaxValue
+            Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new Hashtable(-1, 1f)); // Capacity < 0
+            Assert.Throws<ArgumentException>("capacity", () => new Hashtable(int.MaxValue, 0.1f)); // Capacity / load factor > int.MaxValue
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(100, 0.09f)); // Load factor < 0.1f
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(100, 1.01f)); // Load factor > 1f
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(100, 0.09f)); // Load factor < 0.1f
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(100, 1.01f)); // Load factor > 1f
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(100, float.NaN)); // Load factor is NaN
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(100, float.PositiveInfinity)); // Load factor is infinity
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(100, float.NaN)); // Load factor is NaN
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(100, float.PositiveInfinity)); // Load factor is infinity
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(100, float.NegativeInfinity)); // Load factor is infinity
         }
 
         [Theory]
@@ -183,7 +184,7 @@ namespace System.Collections.Tests
         [InlineData(10)]
         [InlineData(100)]
         [InlineData(1000)]
-        public static void TestCtor_Capacity_IEqualityComparer(int capacity)
+        public static void Ctor_Int_IEqualityComparer(int capacity)
         {
             // Null comparer
             var hash = new ComparableHashtable(capacity, null);
@@ -199,14 +200,14 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_Capacity_IEqualityComparer_Invalid()
+        public static void Ctor_Int_IEqualityComparer_Invalid()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(-1, null)); // Capacity < 0
-            Assert.Throws<ArgumentException>(() => new Hashtable(int.MaxValue, null)); // Capacity / load factor > int.MaxValue
+            Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new Hashtable(-1, null)); // Capacity < 0
+            Assert.Throws<ArgumentException>("capacity", () => new Hashtable(int.MaxValue, null)); // Capacity / load factor > int.MaxValue
         }
 
         [Fact]
-        public static void TestCtor_IDictionary_LoadFactor_IEqualityComparer()
+        public static void Ctor_IDictionary_Int_IEqualityComparer()
         {
             // No exception
             var hash1 = new ComparableHashtable(new Hashtable(), 1f, null);
@@ -232,15 +233,16 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_IDictionary_LoadFactor_IEqualityComparer_Invalid()
+        public static void Ctor_IDictionary_LoadFactor_IEqualityComparer_Invalid()
         {
-            Assert.Throws<ArgumentNullException>(() => new Hashtable(null, 1f, null)); // Dictionary is null
+            Assert.Throws<ArgumentNullException>("d", () => new Hashtable(null, 1f, null)); // Dictionary is null
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(new Hashtable(), 0.09f, null)); // Load factor < 0.1f
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(new Hashtable(), 1.01f, null)); // Load factor > 1f
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(new Hashtable(), 0.09f, null)); // Load factor < 0.1f
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(new Hashtable(), 1.01f, null)); // Load factor > 1f
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(new Hashtable(), float.NaN, null)); // Load factor is NaN
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(new Hashtable(), float.PositiveInfinity, null)); // Load factor is infinity
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(new Hashtable(), float.NaN, null)); // Load factor is NaN
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(new Hashtable(), float.PositiveInfinity, null)); // Load factor is infinity
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(new Hashtable(), float.NegativeInfinity, null)); // Load factor is infinity
         }
 
         [Theory]
@@ -248,7 +250,7 @@ namespace System.Collections.Tests
         [InlineData(10, 0.2)]
         [InlineData(100, 0.3)]
         [InlineData(1000, 1)]
-        public static void TestCtor_Capacity_LoadFactor_IEqualityComparer(int capacity, float loadFactor)
+        public static void Ctor_Int_Int_IEqualityComparer(int capacity, float loadFactor)
         {
             // Null comparer
             var hash = new ComparableHashtable(capacity, loadFactor, null);
@@ -265,20 +267,21 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_Capacit_yLoadFactor_IEqualityComparer_Invalid()
+        public static void Ctor_Capacity_LoadFactor_IEqualityComparer_Invalid()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(-1, 1f, null)); // Capacity < 0
-            Assert.Throws<ArgumentException>(() => new Hashtable(int.MaxValue, 0.1f, null)); // Capacity / load factor > int.MaxValue
+            Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new Hashtable(-1, 1f, null)); // Capacity < 0
+            Assert.Throws<ArgumentException>("capacity", () => new Hashtable(int.MaxValue, 0.1f, null)); // Capacity / load factor > int.MaxValue
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(100, 0.09f, null)); // Load factor < 0.1f
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(100, 1.01f, null)); // Load factor > 1f
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(100, 0.09f, null)); // Load factor < 0.1f
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(100, 1.01f, null)); // Load factor > 1f
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(100, float.NaN, null)); // Load factor is NaN
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Hashtable(100, float.PositiveInfinity, null)); // Load factor is infinity
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(100, float.NaN, null)); // Load factor is NaN
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(100, float.PositiveInfinity, null)); // Load factor is infinity
+            Assert.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(100, float.NegativeInfinity, null)); // Load factor is infinity
         }
 
         [Fact]
-        public static void TestDebuggerAttribute()
+        public static void DebuggerAttribute()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new Hashtable());
 
@@ -293,8 +296,7 @@ namespace System.Collections.Tests
             }
             catch (TargetInvocationException ex)
             {
-                ArgumentNullException nullException = ex.InnerException as ArgumentNullException;
-                threwNull = nullException != null;
+                threwNull = ex.InnerException is ArgumentNullException;
             }
 
             Assert.True(threwNull);
@@ -305,7 +307,7 @@ namespace System.Collections.Tests
         [InlineData(10)]
         [InlineData(100)]
         [InlineData(1000)]
-        public static void TestAdd(int count)
+        public static void Add(int count)
         {
             var hash1 = new Hashtable();
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -326,7 +328,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdd_ReferenceType()
+        public static void Add_ReferenceType()
         {
             var hash1 = new Hashtable();
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -344,18 +346,18 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdd_Invalid()
+        public static void Add_Invalid()
         {
             Hashtable hash1 = Helpers.CreateStringHashtable(100);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
             {
-                Assert.Throws<ArgumentNullException>(() => hash2.Add(null, 1)); // Key is null
-                Assert.Throws<ArgumentException>(() => hash2.Add("Key_1", "Value_2")); // Key already exists
+                Assert.Throws<ArgumentNullException>("key", () => hash2.Add(null, 1)); // Key is null
+                Assert.Throws<ArgumentException>(null, () => hash2.Add("Key_1", "Value_2")); // Key already exists
             });
         }
 
         [Fact]
-        public static void TestAdd_ClearRepeatedly()
+        public static void Add_ClearRepeatedly()
         {
             const int Iterations = 2;
             const int Count = 2;
@@ -377,7 +379,7 @@ namespace System.Collections.Tests
 
         [Fact]
         [OuterLoop]
-        public static void TestAddRemove_LargeAmountNumbers()
+        public static void AddRemove_LargeAmountNumbers()
         {
             // Generate a random 100,000 array of ints as test data 
             var inputData = new int[100000];
@@ -413,7 +415,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestDuplicatedKeysWithInitialCapacity()
+        public static void DuplicatedKeysWithInitialCapacity()
         {
             // Make rehash get called because to many items with duplicated keys have been added to the hashtable
             var hash = new Hashtable(200);
@@ -440,7 +442,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestDuplicatedKeysWithDefaultCapacity()
+        public static void DuplicatedKeysWithDefaultCapacity()
         {
             // Make rehash get called because to many items with duplicated keys have been added to the hashtable
             var hash = new Hashtable();
@@ -469,7 +471,7 @@ namespace System.Collections.Tests
         [Theory]
         [InlineData(0)]
         [InlineData(100)]
-        public static void TestClear(int count)
+        public static void Clear(int count)
         {
             Hashtable hash1 = Helpers.CreateIntHashtable(count);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -490,7 +492,7 @@ namespace System.Collections.Tests
         [Theory]
         [InlineData(0)]
         [InlineData(100)]
-        public static void TestClone(int count)
+        public static void Clone(int count)
         {
             Hashtable hash1 = Helpers.CreateStringHashtable(count);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -515,7 +517,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestClone_IsShallowCopy()
+        public static void Clone_IsShallowCopy()
         {
             var hash = new Hashtable();
             for (int i = 0; i < 10; i++)
@@ -540,7 +542,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestClone_HashtableCastedToInterfaces()
+        public static void Clone_HashtableCastedToInterfaces()
         {
             // Try to cast the returned object from Clone() to different types
             Hashtable hash = Helpers.CreateIntHashtable(100);
@@ -553,7 +555,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestContainsKey()
+        public static void ContainsKey()
         {
             Hashtable hash1 = Helpers.CreateStringHashtable(100);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -579,7 +581,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestContainsKey_EqualObjects()
+        public static void ContainsKey_EqualObjects()
         {
             var hash1 = new Hashtable();
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -612,18 +614,18 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestContainsKey_Invalid()
+        public static void ContainsKey_NullKey_ThrowsArgumentNullException()
         {
             var hash1 = new Hashtable();
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
             {
-                Assert.Throws<ArgumentNullException>(() => hash2.ContainsKey(null)); // Key is null
-                Assert.Throws<ArgumentNullException>(() => hash2.Contains(null)); // Key is null
+                Assert.Throws<ArgumentNullException>("key", () => hash2.ContainsKey(null)); // Key is null
+                Assert.Throws<ArgumentNullException>("key", () => hash2.Contains(null)); // Key is null
             });
         }
 
         [Fact]
-        public static void TestContainsValue()
+        public static void ContainsValue()
         {
             Hashtable hash1 = Helpers.CreateStringHashtable(100);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -649,7 +651,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestContainsValue_EqualObjects()
+        public static void ContainsValue_EqualObjects()
         {
             var hash1 = new Hashtable();
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -664,7 +666,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo()
+        public static void CopyTo()
         {
             var hash1 = new Hashtable();
 
@@ -720,7 +722,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_EmptyHashtable()
+        public static void CopyTo_EmptyHashtable()
         {
             var hash1 = new Hashtable();
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -747,27 +749,27 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Invalid()
+        public static void CopyTo_Invalid()
         {
             Hashtable hash1 = Helpers.CreateIntHashtable(10);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
             {
-                Assert.Throws<ArgumentNullException>(() => hash2.CopyTo(null, 0)); // Array is null
+                Assert.Throws<ArgumentNullException>("array", () => hash2.CopyTo(null, 0)); // Array is null
 
-                Assert.Throws<ArgumentException>(() => hash2.CopyTo(new object[10, 10], 0)); // Array is multidimensional
+                Assert.Throws<ArgumentException>("array", () => hash2.CopyTo(new object[10, 10], 0)); // Array is multidimensional
                 Assert.Throws<InvalidCastException>(() => hash2.CopyTo(new object[10][], 0)); // Array is invalid
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => hash2.CopyTo(new object[10], -1)); // Index < 0
-                Assert.Throws<ArgumentException>(() => hash2.CopyTo(new object[9], 0)); // Hash.Count + index > array.Length
-                Assert.Throws<ArgumentException>(() => hash2.CopyTo(new object[11], 2)); // Hash.Count + index > array.Length
-                Assert.Throws<ArgumentException>(() => hash2.CopyTo(new object[0], 0)); // Hash.Count + index > array.Length
+                Assert.Throws<ArgumentOutOfRangeException>("arrayIndex", () => hash2.CopyTo(new object[10], -1)); // Index < 0
+                Assert.Throws<ArgumentException>(null,() => hash2.CopyTo(new object[9], 0)); // Hash.Count + index > array.Length
+                Assert.Throws<ArgumentException>(null, () => hash2.CopyTo(new object[11], 2)); // Hash.Count + index > array.Length
+                Assert.Throws<ArgumentException>(null, () => hash2.CopyTo(new object[0], 0)); // Hash.Count + index > array.Length
             });
         }
 
         [Theory]
         [InlineData(0)]
         [InlineData(100)]
-        public static void TestGetEnumerator_IDictionaryEnumerator(int count)
+        public static void GetEnumerator_IDictionaryEnumerator(int count)
         {
             Hashtable hash1 = Helpers.CreateIntHashtable(count);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -804,7 +806,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetEnumerator_IDictionaryEnumerator_Invalid()
+        public static void GetEnumerator_IDictionaryEnumerator_Invalid()
         {
             Hashtable hash1 = Helpers.CreateIntHashtable(100);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -851,7 +853,7 @@ namespace System.Collections.Tests
         [Theory]
         [InlineData(0)]
         [InlineData(100)]
-        public static void TestGetEnumerator_IEnumerator(int count)
+        public static void GetEnumerator_IEnumerator(int count)
         {
             Hashtable hash1 = Helpers.CreateStringHashtable(count);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -880,7 +882,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetEnumerator_IEnumerator_Invalid()
+        public static void GetEnumerator_IEnumerator_Invalid()
         {
             Hashtable hash1 = Helpers.CreateIntHashtable(100);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -913,7 +915,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetItem()
+        public static void GetItem()
         {
             Hashtable hash1 = Helpers.CreateStringHashtable(100);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -931,17 +933,17 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetItem_Invalid()
+        public static void GetItem_NullKey_ThrowsArgumentNullException()
         {
             var hash1 = new Hashtable();
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
             {
-                Assert.Throws<ArgumentNullException>(() => hash2[null]); // Key is null
+                Assert.Throws<ArgumentNullException>("key", () => hash2[null]); // Key is null
             });
         }
 
         [Fact]
-        public static void TestSetItem()
+        public static void SetItem()
         {
             var hash1 = new Hashtable();
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -968,17 +970,17 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSetItem_Invalid()
+        public static void SetItem_NullKey_ThrowsArgumentNullException()
         {
             var hash1 = new Hashtable();
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
             {
-                Assert.Throws<ArgumentNullException>(() => hash2[null] = "Value"); // Key is null
+                Assert.Throws<ArgumentNullException>("key", () => hash2[null] = "Value"); // Key is null
             });
         }
 
         [Fact]
-        public static void TestKeys_ICollectionProperties()
+        public static void Keys_ICollectionProperties()
         {
             Hashtable hash1 = Helpers.CreateStringHashtable(100);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -997,7 +999,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestKeys_GetEnumerator()
+        public static void Keys_GetEnumerator()
         {
             Hashtable hash1 = Helpers.CreateStringHashtable(100);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -1023,7 +1025,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestKeys_ModifyingHashtable_ModifiesCollection()
+        public static void Keys_ModifyingHashtable_ModifiesCollection()
         {
             Hashtable hash = Helpers.CreateStringHashtable(100);
             ICollection keys = hash.Keys;
@@ -1040,7 +1042,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestKeys_CopyTo()
+        public static void Keys_CopyTo()
         {
             Hashtable hash1 = Helpers.CreateStringHashtable(100);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -1071,25 +1073,25 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestKeys_CopyToInvalid()
+        public static void Keys_CopyTo_Invalid()
         {
             Hashtable hash1 = Helpers.CreateStringHashtable(100);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
             {
                 ICollection keys = hash2.Keys;
 
-                Assert.Throws<ArgumentNullException>(() => keys.CopyTo(null, 0)); // Array is null
-                Assert.Throws<ArgumentException>(() => keys.CopyTo(new object[100, 100], 0)); // Array is multidimensional
+                Assert.Throws<ArgumentNullException>("array", () => keys.CopyTo(null, 0)); // Array is null
+                Assert.Throws<ArgumentException>("array", () => keys.CopyTo(new object[100, 100], 0)); // Array is multidimensional
 
-                Assert.Throws<ArgumentException>(() => keys.CopyTo(new object[50], 0)); // Index + array.Length > hash.Count
-                Assert.Throws<ArgumentException>(() => keys.CopyTo(new object[100], 1)); // Index + array.Length > hash.Count
+                Assert.Throws<ArgumentException>(null, () => keys.CopyTo(new object[50], 0)); // Index + array.Length > hash.Count
+                Assert.Throws<ArgumentException>(null, () => keys.CopyTo(new object[100], 1)); // Index + array.Length > hash.Count
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => keys.CopyTo(new object[100], -1)); // Index < 0
+                Assert.Throws<ArgumentOutOfRangeException>("arrayIndex", () => keys.CopyTo(new object[100], -1)); // Index < 0
             });
         }
 
         [Fact]
-        public static void TestRemove()
+        public static void Remove()
         {
             Hashtable hash1 = Helpers.CreateStringHashtable(100);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -1106,7 +1108,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemove_SameHashcode()
+        public static void Remove_SameHashcode()
         {
             // We want to add and delete items (with the same hashcode) to the hashtable in such a way that the hashtable
             // does not expand but have to tread through collision bit set positions to insert the new elements. We do this
@@ -1149,17 +1151,17 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemove_Invalid()
+        public static void Remove_NullKey_ThrowsArgumentNullException()
         {
             var hash1 = new Hashtable();
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
             {
-                Assert.Throws<ArgumentNullException>(() => hash2.Remove(null));
+                Assert.Throws<ArgumentNullException>("key", () => hash2.Remove(null)); // Key is null
             });
         }
 
         [Fact]
-        public static void TestSynchronizedProperties()
+        public static void SynchronizedProperties()
         {
             // Ensure Synchronized correctly reflects a wrapped hashtable
             var hash1 = Helpers.CreateStringHashtable(100);
@@ -1178,13 +1180,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronizedInvalid()
+        public static void Synchronized_NullTable_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => Hashtable.Synchronized(null)); // Table is null
+            Assert.Throws<ArgumentNullException>("table", () => Hashtable.Synchronized(null)); // Table is null
         }
 
         [Fact]
-        public static void TestValues_ICollectionProperties()
+        public static void Values_ICollectionProperties()
         {
             Hashtable hash1 = Helpers.CreateStringHashtable(100);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -1203,7 +1205,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestValues_GetEnumerator()
+        public static void Values_GetEnumerator()
         {
             Hashtable hash1 = Helpers.CreateStringHashtable(100);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -1229,7 +1231,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestValues_ModifyingHashtable_ModifiesCollection()
+        public static void Values_ModifyingHashtable_ModifiesCollection()
         {
             Hashtable hash = Helpers.CreateStringHashtable(100);
             ICollection values = hash.Values;
@@ -1246,7 +1248,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestValues_CopyTo()
+        public static void Values_CopyTo()
         {
             Hashtable hash1 = Helpers.CreateStringHashtable(100);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
@@ -1277,20 +1279,20 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestValues_CopyToInvalid()
+        public static void Values_CopyTo_Invalid()
         {
             Hashtable hash1 = Helpers.CreateStringHashtable(100);
             Helpers.PerformActionOnAllHashtableWrappers(hash1, hash2 =>
             {
                 ICollection values = hash2.Values;
 
-                Assert.Throws<ArgumentNullException>(() => values.CopyTo(null, 0)); // Array is null
-                Assert.Throws<ArgumentException>(() => values.CopyTo(new object[100, 100], 0)); // Array is multidimensional
+                Assert.Throws<ArgumentNullException>("array", () => values.CopyTo(null, 0)); // Array is null
+                Assert.Throws<ArgumentException>("array", () => values.CopyTo(new object[100, 100], 0)); // Array is multidimensional
 
-                Assert.Throws<ArgumentException>(() => values.CopyTo(new object[50], 0)); // Index + array.Length > hash.Count
-                Assert.Throws<ArgumentException>(() => values.CopyTo(new object[100], 1)); // Index + array.Length > hash.Count
+                Assert.Throws<ArgumentException>(null, () => values.CopyTo(new object[50], 0)); // Index + array.Length > hash.Count
+                Assert.Throws<ArgumentException>(null, () => values.CopyTo(new object[100], 1)); // Index + array.Length > hash.Count
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => values.CopyTo(new object[100], -1)); // Index < 0
+                Assert.Throws<ArgumentOutOfRangeException>("arrayIndex", () => values.CopyTo(new object[100], -1)); // Index < 0
             });
         }
 
@@ -1379,10 +1381,7 @@ namespace System.Collections.Tests
 
             public new IEqualityComparer EqualityComparer
             {
-                get
-                {
-                    return base.EqualityComparer;
-                }
+                get { return base.EqualityComparer; }
             }
         }
 
@@ -1415,36 +1414,20 @@ namespace System.Collections.Tests
                 return 0;
             }
 
-            public override string ToString()
-            {
-                return Value.ToString();
-            }
+            public override string ToString() => Value.ToString();
         }
 
         private class Foo
         {
-            private string _stringValue = "Hello World";
-            public string StringValue
-            {
-                get { return _stringValue; }
-                set { _stringValue = value; }
-            }
+            public string StringValue { get; set; } = "Hello World";
 
             public override bool Equals(object obj)
             {
                 Foo foo = obj as Foo;
-                if (foo == null)
-                {
-                    return false;
-                }
-
-                return StringValue.Equals(foo.StringValue);
+                return foo != null && StringValue == foo.StringValue;
             }
 
-            public override int GetHashCode()
-            {
-                return StringValue.GetHashCode();
-            }
+            public override int GetHashCode() => StringValue.GetHashCode();
         }
     }
 
@@ -1473,7 +1456,7 @@ namespace System.Collections.Tests
 
         [Fact]
         [OuterLoop]
-        public void TestGetItem_ThreadSafety()
+        public void GetItem_ThreadSafety()
         {
             int i1 = 0x10;
             int i2 = 0x100;
@@ -1566,9 +1549,9 @@ namespace System.Collections.Tests
 
         [Fact]
         [OuterLoop]
-        public void TestSynchronizedThreadSafety()
+        public void SynchronizedThreadSafety()
         {
-            int iNumberOfWorkers = 3;
+            const int NumberOfWorkers = 3;
 
             // Synchronized returns a hashtable that is thread safe
             // We will try to test this by getting a number of threads to write some items
@@ -1576,7 +1559,7 @@ namespace System.Collections.Tests
             var hash1 = new Hashtable();
             _hash2 = Hashtable.Synchronized(hash1);
 
-            var workers = new Task[iNumberOfWorkers];
+            var workers = new Task[NumberOfWorkers];
             for (int i = 0; i < workers.Length; i++)
             {
                 var name = "Thread worker " + i;
@@ -1587,9 +1570,9 @@ namespace System.Collections.Tests
             Task.WaitAll(workers);
 
             // Check time
-            Assert.Equal(_hash2.Count, _iNumberOfElements * iNumberOfWorkers);
+            Assert.Equal(_hash2.Count, _iNumberOfElements * NumberOfWorkers);
 
-            for (int i = 0; i < iNumberOfWorkers; i++)
+            for (int i = 0; i < NumberOfWorkers; i++)
             {
                 for (int j = 0; j < _iNumberOfElements; j++)
                 {
@@ -1600,7 +1583,7 @@ namespace System.Collections.Tests
 
             // We cannot can make an assumption on the order of these items but
             // now we are going to remove all of these
-            workers = new Task[iNumberOfWorkers];
+            workers = new Task[NumberOfWorkers];
             for (int i = 0; i < workers.Length; i++)
             {
                 string name = "Thread worker " + i;
@@ -1634,10 +1617,10 @@ namespace System.Collections.Tests
     {
         private Hashtable _hashDaughter;
         private Hashtable _hashGrandDaughter;
-        private int _iNumberOfElements = 100;
+        private const int NumberOfElements = 100;
 
         [Fact]
-        public void TestSyncRoot()
+        public void SyncRoot()
         {
             // Different hashtables have different SyncRoots
             var hash1 = new Hashtable();
@@ -1663,7 +1646,7 @@ namespace System.Collections.Tests
             // 5) all of these should SyncRoot to the mother earth
 
             var hashMother = new Hashtable();
-            for (int i = 0; i < _iNumberOfElements; i++)
+            for (int i = 0; i < NumberOfElements; i++)
             {
                 hashMother.Add("Key_" + i, "Value_" + i);
             }
@@ -1696,7 +1679,7 @@ namespace System.Collections.Tests
             // Check:
             // Either there should be some elements (the new ones we added and/or the original ones) or none
             var hshPossibleValues = new Hashtable();
-            for (int i = 0; i < _iNumberOfElements; i++)
+            for (int i = 0; i < NumberOfElements; i++)
             {
                 hshPossibleValues.Add("Key_" + i, "Value_" + i);
             }

--- a/src/System.Collections.NonGeneric/tests/Helpers.cs
+++ b/src/System.Collections.NonGeneric/tests/Helpers.cs
@@ -219,13 +219,5 @@ namespace System.Collections.Tests
                 CultureInfo.DefaultThreadCurrentCulture = currentCulture;
             }
         }
-
-        public static int NormalizeCompare(int i)
-        {
-            return
-                i == 0 ? 0 :
-                i > 0 ? 1 :
-                -1;
-        }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/Performance/Perf.HashTable.cs
+++ b/src/System.Collections.NonGeneric/tests/Performance/Perf.HashTable.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Xunit.Performance;
-
 using Xunit;
 
 namespace System.Collections.Tests

--- a/src/System.Collections.NonGeneric/tests/QueueTests.cs
+++ b/src/System.Collections.NonGeneric/tests/QueueTests.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Xunit;
 
 namespace System.Collections.Tests
@@ -14,7 +13,7 @@ namespace System.Collections.Tests
     public static class QueueTests
     {
         [Fact]
-        public static void TestCtor_Empty()
+        public static void Ctor_Empty()
         {
             const int DefaultCapactiy = 32;
             var queue = new Queue();
@@ -33,7 +32,7 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(32)]
         [InlineData(77)]
-        public static void TestCtor_Capacity(int capacity)
+        public static void Ctor_Int(int capacity)
         {
             var queue = new Queue(capacity);
 
@@ -45,16 +44,16 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_Capacity_Invalid()
+        public static void Ctor_Int_NegativeCapacity_ThrowsArgumentOutOfRangeException()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Queue(-1)); // Capacity < 0
+            Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new Queue(-1)); // Capacity < 0
         }
 
         [Theory]
         [InlineData(1, 2.0)]
         [InlineData(32, 1.0)]
         [InlineData(77, 5.0)]
-        public static void TestCtor_Capacity_GrowFactor(int capacity, float growFactor)
+        public static void Ctor_Int_Int(int capacity, float growFactor)
         {
             var queue = new Queue(capacity, growFactor);
 
@@ -66,15 +65,15 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_Capactiy_GrowFactor_Invalid()
+        public static void Ctor_Int_Int_Invalid()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Queue(-1, 1)); // Capacity < 0
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Queue(1, (float)0.99)); // Grow factor < 1
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Queue(1, (float)10.01)); // Grow factor > 10
+            Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new Queue(-1, 1)); // Capacity < 0
+            Assert.Throws<ArgumentOutOfRangeException>("growFactor", () => new Queue(1, (float)0.99)); // Grow factor < 1
+            Assert.Throws<ArgumentOutOfRangeException>("growFactor", () => new Queue(1, (float)10.01)); // Grow factor > 10
         }
 
         [Fact]
-        public static void TestCtor_ICollection()
+        public static void Ctor_ICollection()
         {
             ArrayList arrList = Helpers.CreateIntArrayList(100);
             var queue = new Queue(arrList);
@@ -87,13 +86,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_ICollection_Invalid()
+        public static void Ctor_ICollection_NullCollection_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new Queue(null)); // Collection is null
+            Assert.Throws<ArgumentNullException>("col", () => new Queue(null)); // Collection is null
         }
 
         [Fact]
-        public static void TestDebuggerAttribute()
+        public static void DebuggerAttribute()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new Queue());
 
@@ -111,8 +110,7 @@ namespace System.Collections.Tests
             }
             catch (TargetInvocationException ex)
             {
-                ArgumentNullException nullException = ex.InnerException as ArgumentNullException;
-                threwNull = nullException != null;
+                threwNull = ex.InnerException is ArgumentNullException;
             }
 
             Assert.True(threwNull);
@@ -122,7 +120,7 @@ namespace System.Collections.Tests
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(32)]
-        public static void TestClear(int capacity)
+        public static void Clear(int capacity)
         {
             var queue1 = new Queue(capacity);
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -137,7 +135,7 @@ namespace System.Collections.Tests
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(32)]
-        public static void TestClearEmpty(int capacity)
+        public static void Clear_Empty(int capacity)
         {
             var queue1 = new Queue(capacity);
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -150,7 +148,7 @@ namespace System.Collections.Tests
             });
         }
         [Fact]
-        public static void TestClone()
+        public static void Clone()
         {
             Queue queue1 = Helpers.CreateIntQueue(100);
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -167,7 +165,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestClone_IsShallowCopy()
+        public static void Clone_IsShallowCopy()
         {
             var queue1 = new Queue();
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -184,7 +182,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestClone_Empty()
+        public static void Clone_Empty()
         {
             var queue1 = new Queue();
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -199,7 +197,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestClone_Clear()
+        public static void Clone_Clear()
         {
             Queue queue1 = Helpers.CreateIntQueue(100);
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -216,7 +214,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestClone_DequeueUntilEmpty()
+        public static void Clone_DequeueUntilEmpty()
         {
             Queue queue1 = Helpers.CreateIntQueue(100);
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -236,7 +234,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestClone_DequeueThenEnqueue()
+        public static void Clone_DequeueThenEnqueue()
         {
             var queue1 = new Queue(100);
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -268,7 +266,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestContains()
+        public static void Contains()
         {
             Queue queue1 = Helpers.CreateIntQueue(100);
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -284,7 +282,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestContains_NonExistentObject()
+        public static void Contains_NonExistentObject()
         {
             Queue queue1 = Helpers.CreateIntQueue(100);
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -299,7 +297,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestContains_EmptyQueue()
+        public static void Contains_EmptyQueue()
         {
             var queue1 = new Queue();
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -320,7 +318,7 @@ namespace System.Collections.Tests
         [InlineData(10, 50)]
         [InlineData(100, 50)]
         [InlineData(1000, 50)]
-        public static void TestCopyTo(int count, int index)
+        public static void CopyTo(int count, int index)
         {
             Queue queue1 = Helpers.CreateIntQueue(count);
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -336,7 +334,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_DequeueThenEnqueue()
+        public static void CopyTo_DequeueThenEnqueue()
         {
             var queue1 = new Queue(100);
             // Insert 50 items in the Queue
@@ -363,17 +361,17 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Invalid()
+        public static void CopyTo_Invalid()
         {
             Queue queue1 = Helpers.CreateIntQueue(100);
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
             {
-                Assert.Throws<ArgumentNullException>(() => queue2.CopyTo(null, 0)); // Array is null
-                Assert.Throws<ArgumentException>(() => queue2.CopyTo(new object[150, 150], 0)); // Array is multidimensional
+                Assert.Throws<ArgumentNullException>("array", () => queue2.CopyTo(null, 0)); // Array is null
+                Assert.Throws<ArgumentException>("array", () => queue2.CopyTo(new object[150, 150], 0)); // Array is multidimensional
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => queue2.CopyTo(new object[150], -1)); // Index < 0
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => queue2.CopyTo(new object[150], -1)); // Index < 0
 
-                Assert.Throws<ArgumentException>(() => queue2.CopyTo(new object[150], 51)); // Index + queue.Count > array.Length
+                Assert.Throws<ArgumentException>(null, () => queue2.CopyTo(new object[150], 51)); // Index + queue.Count > array.Length
             });
         }
 
@@ -382,7 +380,7 @@ namespace System.Collections.Tests
         [InlineData(10)]
         [InlineData(100)]
         [InlineData(1000)]
-        public static void TestDequeue(int count)
+        public static void Dequeue(int count)
         {
             Queue queue1 = Helpers.CreateIntQueue(count);
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -397,7 +395,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestDequeue_EmptyQueue()
+        public static void Dequeue_EmptyQueue_ThrowsInvalidOperationException()
         {
             var queue1 = new Queue();
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -411,7 +409,7 @@ namespace System.Collections.Tests
         [InlineData(10)]
         [InlineData(100)]
         [InlineData(1000)]
-        public static void TestDequeue_UntilEmpty(int count)
+        public static void Dequeue_UntilEmpty(int count)
         {
             Queue queue1 = Helpers.CreateIntQueue(count);
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -429,7 +427,7 @@ namespace System.Collections.Tests
         [InlineData(10)]
         [InlineData(100)]
         [InlineData(10000)]
-        public static void TestEnqueue(int count)
+        public static void Enqueue(int count)
         {
             var queue1 = new Queue();
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -444,7 +442,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestEnqueue_Null()
+        public static void Enqueue_Null()
         {
             var queue1 = new Queue();
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -459,32 +457,29 @@ namespace System.Collections.Tests
         [InlineData(10)]
         [InlineData(100)]
         [InlineData(1000)]
-        public static void TestGetEnumerator(int count)
+        public static void GetEnumerator(int count)
         {
             var queue1 = Helpers.CreateIntQueue(count);
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
             {
-                IEnumerator enumerator1 = queue2.GetEnumerator();
-                IEnumerator enumerator2 = queue2.GetEnumerator();
-
-                IEnumerator[] enumerators = { enumerator1, enumerator2 };
-                foreach (IEnumerator enumerator in enumerators)
+                Assert.NotSame(queue2.GetEnumerator(), queue2.GetEnumerator());
+                IEnumerator enumerator = queue2.GetEnumerator();
+                for (int i = 0; i < 2; i++)
                 {
-                    Assert.NotNull(enumerator);
-                    int i = 0;
+                    int counter = 0;
                     while (enumerator.MoveNext())
                     {
-                        Assert.Equal(i, enumerator.Current);
-                        i++;
+                        Assert.Equal(counter, enumerator.Current);
+                        counter++;
                     }
-                    Assert.Equal(count, i);
+                    Assert.Equal(count, counter);
                     enumerator.Reset();
                 }
             });
         }
 
         [Fact]
-        public static void TestGetEnumerator_Invalid()
+        public static void GetEnumerator_Invalid()
         {
             var queue1 = Helpers.CreateIntQueue(100);
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -520,7 +515,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestPeek()
+        public static void Peek()
         {
             string s1 = "hello";
             string s2 = "world";
@@ -580,7 +575,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestPeek_Invalid()
+        public static void Peek_EmptyQueue_ThrowsInvalidOperationException()
         {
             var queue1 = new Queue();
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -594,7 +589,7 @@ namespace System.Collections.Tests
         [InlineData(10)]
         [InlineData(100)]
         [InlineData(1000)]
-        public static void TestToArray(int count)
+        public static void ToArray(int count)
         {
             Queue queue1 = Helpers.CreateIntQueue(count);
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -609,7 +604,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestToArray_Wrapped()
+        public static void ToArray_Wrapped()
         {
             var queue1 = new Queue(1);
             queue1.Enqueue(1);
@@ -623,7 +618,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestToArrayDiffentObjectTypes()
+        public static void ToArrayDiffentObjectTypes()
         {
             string s1 = "hello";
             string s2 = "world";
@@ -665,7 +660,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestToArray_EmptyQueue()
+        public static void ToArray_EmptyQueue()
         {
             var queue1 = new Queue();
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -681,7 +676,7 @@ namespace System.Collections.Tests
         [InlineData(10)]
         [InlineData(100)]
         [InlineData(1000)]
-        public static void TestTrimToSize(int count)
+        public static void TrimToSize(int count)
         {
             Queue queue1 = Helpers.CreateIntQueue(count);
             Helpers.PerformActionOnAllQueueWrappers(queue1, queue2 =>
@@ -708,7 +703,7 @@ namespace System.Collections.Tests
         [InlineData(10)]
         [InlineData(100)]
         [InlineData(1000)]
-        public static void TestTrimToSize_DequeueAll(int count)
+        public static void TrimToSize_DequeueAll(int count)
         {
             Queue queue1 = Helpers.CreateIntQueue(count);
             for (int i = 0; i < count; i++)
@@ -728,7 +723,7 @@ namespace System.Collections.Tests
         }
         
         [Fact]
-        public static void TestTrimToSize_Wrapped()
+        public static void TrimToSize_Wrapped()
         {
             var queue = new Queue(100);
 
@@ -761,33 +756,24 @@ namespace System.Collections.Tests
             {
                 IntValue = intValue;
             }
-
-            private int _intValue;
-            public int IntValue
-            {
-                set { _intValue = value; }
-                get { return _intValue; }
-            }
+            
+            public int IntValue { get; set; }
         }
     }
 
     public class Queue_SyncRootTests
     {
-        Task[] workers;
-        Action action1;
-        Action action2;
-
-        int iNumberOfElements = 1000;
-        int iNumberOfWorkers = 1000;
+        private const int NumberOfElements = 1000;
+        private const int NumberOfWorkers = 1000;
 
         private Queue _queueDaughter;
         private Queue _queueGrandDaughter;
 
         [Fact]
-        public void TestSyncRoot()
+        public void SyncRoot()
         {
             var queueMother = new Queue();
-            for (int i = 0; i < iNumberOfElements; i++)
+            for (int i = 0; i < NumberOfElements; i++)
             {
                 queueMother.Enqueue(i);
             }
@@ -803,14 +789,13 @@ namespace System.Collections.Tests
             Assert.Equal(queueMother.SyncRoot, _queueGrandDaughter.SyncRoot);
             Assert.Equal(queueMother.SyncRoot, _queueDaughter.SyncRoot);
 
-
-            workers = new Task[iNumberOfWorkers];
-            action1 = SortElements;
-            action2 = ReverseElements;
-            for (int iThreads = 0; iThreads < iNumberOfWorkers; iThreads += 2)
+            Task[] workers = new Task[NumberOfWorkers];
+            Action action1 = SortElements;
+            Action action2 = ReverseElements;
+            for (int i = 0; i < NumberOfWorkers; i += 2)
             {
-                workers[iThreads] = Task.Run(action1);
-                workers[iThreads + 1] = Task.Run(action2);
+                workers[i] = Task.Run(action1);
+                workers[i + 1] = Task.Run(action2);
             }
 
             Task.WaitAll(workers);
@@ -819,7 +804,7 @@ namespace System.Collections.Tests
         private void SortElements()
         {
             _queueGrandDaughter.Clear();
-            for (int i = 0; i < iNumberOfElements; i++)
+            for (int i = 0; i < NumberOfElements; i++)
             {
                 _queueGrandDaughter.Enqueue(i);
             }
@@ -828,7 +813,7 @@ namespace System.Collections.Tests
         private void ReverseElements()
         {
             _queueDaughter.Clear();
-            for (int i = 0; i < iNumberOfElements; i++)
+            for (int i = 0; i < NumberOfElements; i++)
             {
                 _queueDaughter.Enqueue(i);
             }
@@ -837,16 +822,14 @@ namespace System.Collections.Tests
 
     public class Queue_SynchronizedTests
     {
-        public Queue m_Queue;
-        public int iCountTestcases = 0;
-        public int iCountErrors = 0;
-        public int m_ThreadsToUse = 8;
-        public int m_ThreadAge = 5; // 5000;
+        public Queue _queue;
+        public int _threadsToUse = 8;
+        public int _threadAge = 5; // 5000;
 
-        public int m_ThreadCount;
+        public int _threadCount;
 
         [Fact]
-        public static void TestSynchronized()
+        public static void Synchronized()
         {
             Queue queue = Helpers.CreateIntQueue(100);
             Queue syncQueue = Queue.Synchronized(queue);
@@ -860,96 +843,96 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public void TestSynchronizedEnqueue()
+        public void SynchronizedEnqueue()
         {
             // Enqueue
-            m_Queue = Queue.Synchronized(new Queue());
+            _queue = Queue.Synchronized(new Queue());
             PerformTest(StartEnqueueThread, 40);
 
             // Dequeue
-            Queue queue = Helpers.CreateIntQueue(m_ThreadAge);
-            m_Queue = Queue.Synchronized(queue);
+            Queue queue = Helpers.CreateIntQueue(_threadAge);
+            _queue = Queue.Synchronized(queue);
             PerformTest(StartDequeueThread, 0);
 
             // Enqueue, dequeue
-            m_Queue = Queue.Synchronized(new Queue());
+            _queue = Queue.Synchronized(new Queue());
             PerformTest(StartEnqueueDequeueThread, 0);
 
             // Dequeue, enqueue
-            queue = Helpers.CreateIntQueue(m_ThreadAge);
-            m_Queue = Queue.Synchronized(queue);
-            PerformTest(StartDequeueEnqueueThread, m_ThreadAge);
+            queue = Helpers.CreateIntQueue(_threadAge);
+            _queue = Queue.Synchronized(queue);
+            PerformTest(StartDequeueEnqueueThread, _threadAge);
         }
 
         private void PerformTest(Action action, int expected)
         {
-            var tasks = new Task[m_ThreadsToUse];
+            var tasks = new Task[_threadsToUse];
 
-            for (int i = 0; i < m_ThreadsToUse; i++)
+            for (int i = 0; i < _threadsToUse; i++)
             {
                 tasks[i] = Task.Factory.StartNew(action, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             }
 
-            m_ThreadCount = m_ThreadsToUse;
+            _threadCount = _threadsToUse;
             Task.WaitAll(tasks);
 
-            Assert.Equal(expected, m_Queue.Count);
+            Assert.Equal(expected, _queue.Count);
         }
 
         [Fact]
-        public static void TestSynchronizedInvalid()
+        public static void Synchronized_NullQueue_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => Queue.Synchronized(null)); // Queue is null
+            Assert.Throws<ArgumentNullException>("queue", () => Queue.Synchronized(null)); // Queue is null
         }
 
         public void StartEnqueueThread()
         {
-            int t_age = m_ThreadAge;
+            int t_age = _threadAge;
             while (t_age > 0)
             {
-                m_Queue.Enqueue(t_age);
+                _queue.Enqueue(t_age);
                 Interlocked.Decrement(ref t_age);
             }
-            Interlocked.Decrement(ref m_ThreadCount);
+            Interlocked.Decrement(ref _threadCount);
         }
 
         private void StartDequeueThread()
         {
-            int t_age = m_ThreadAge;
+            int t_age = _threadAge;
             while (t_age > 0)
             {
                 try
                 {
-                    m_Queue.Dequeue();
+                    _queue.Dequeue();
                 }
                 catch { }
                 Interlocked.Decrement(ref t_age);
             }
-            Interlocked.Decrement(ref m_ThreadCount);
+            Interlocked.Decrement(ref _threadCount);
         }
 
         private void StartEnqueueDequeueThread()
         {
-            int t_age = m_ThreadAge;
+            int t_age = _threadAge;
             while (t_age > 0)
             {
-                m_Queue.Enqueue(2);
-                m_Queue.Dequeue();
+                _queue.Enqueue(2);
+                _queue.Dequeue();
                 Interlocked.Decrement(ref t_age);
             }
-            Interlocked.Decrement(ref m_ThreadCount);
+            Interlocked.Decrement(ref _threadCount);
         }
 
         private void StartDequeueEnqueueThread()
         {
-            int t_age = m_ThreadAge;
+            int t_age = _threadAge;
             while (t_age > 0)
             {
-                m_Queue.Dequeue();
-                m_Queue.Enqueue(2);
+                _queue.Dequeue();
+                _queue.Enqueue(2);
                 Interlocked.Decrement(ref t_age);
             }
-            Interlocked.Decrement(ref m_ThreadCount);
+            Interlocked.Decrement(ref _threadCount);
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/ReadOnlyCollectionBaseTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ReadOnlyCollectionBaseTests.cs
@@ -20,7 +20,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSyncRoot()
+        public static void SyncRoot()
         {
             MyReadOnlyCollectionBase collection = CreateCollection();
             Assert.False(collection.SyncRoot is ArrayList);
@@ -28,14 +28,14 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAddRange_Count()
+        public static void AddRange_Count()
         {
             MyReadOnlyCollectionBase collection = CreateCollection();
             Assert.Equal(100, collection.Count);
         }
         
         [Fact]
-        public static void TestCopyTo_ZeroIndex()
+        public static void CopyTo_ZeroIndex()
         {
             MyReadOnlyCollectionBase collection = CreateCollection();
 
@@ -51,7 +51,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_NonZeroIndex()
+        public static void CopyTo_NonZeroIndex()
         {
             MyReadOnlyCollectionBase collection = CreateCollection();
 
@@ -67,18 +67,18 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Invalid()
+        public static void CopyTo_Invalid()
         {
             MyReadOnlyCollectionBase collection = CreateCollection();
 
-            Assert.Throws<ArgumentNullException>(() => collection.CopyTo(null, 0)); // Array is null
+            Assert.Throws<ArgumentNullException>("dest", () => collection.CopyTo(null, 0)); // Array is null
 
-            Assert.Throws<ArgumentException>(() => collection.CopyTo(new Foo[100], 50)); // Index + collection.Count > array.Length
-            Assert.Throws<ArgumentOutOfRangeException>(() => collection.CopyTo(new Foo[100], -1)); // Index < 0
+            Assert.Throws<ArgumentException>("", () => collection.CopyTo(new Foo[100], 50)); // Index + collection.Count > array.Length
+            Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => collection.CopyTo(new Foo[100], -1)); // Index < 0
         }
 
         [Fact]
-        public static void TestGetEnumerator()
+        public static void GetEnumerator()
         {
             MyReadOnlyCollectionBase collection = CreateCollection();
 
@@ -107,15 +107,14 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIsSynchronized()
+        public static void IsSynchronized()
         {
             MyReadOnlyCollectionBase collection = CreateCollection();
-
             Assert.False(((ICollection)collection).IsSynchronized);
         }
 
         [Fact]
-        public static void TestIListMethods()
+        public static void IListMethods()
         {
             MyReadOnlyCollectionBase collection = CreateCollection();
 
@@ -130,28 +129,25 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIListProperties()
+        public static void IListProperties()
         {
             MyReadOnlyCollectionBase collection = CreateCollection();
-
             Assert.True(collection.IsFixedSize);
             Assert.True(collection.IsReadOnly);
         }
 
         [Fact]
-        public static void TestVirtualMethods()
+        public static void VirtualMethods()
         {
             VirtualTestReadOnlyCollection collectionBase = new VirtualTestReadOnlyCollection();
             Assert.Equal(collectionBase.Count, int.MinValue);
-
             Assert.Null(collectionBase.GetEnumerator());
         }
 
-        // ReadOnlyCollectionBase is provided to be used as the base class for strongly typed collections. Lets use one of our own here.
-        // This collection only allows the type Foo
+        // ReadOnlyCollectionBase is provided to be used as the base class for strongly typed collections.
+        // Let's use one of our own here for the type Foo.
         private class MyReadOnlyCollectionBase : ReadOnlyCollectionBase
         {
-            //we need a way of initializing this collection
             public MyReadOnlyCollectionBase(Foo[] values)
             {
                 InnerList.AddRange(values);
@@ -162,28 +158,16 @@ namespace System.Collections.Tests
                 get { return (Foo)InnerList[indx]; }
             }
 
-            public void CopyTo(Array array, int index)
-            {
-                ((ICollection)this).CopyTo(array, index);// Use the base class explicit implementation of ICollection.CopyTo
-            }
+            public void CopyTo(Array array, int index) => ((ICollection)this).CopyTo(array, index);
 
             public virtual object SyncRoot
             {
-                get
-                {
-                    return ((ICollection)this).SyncRoot;// Use the base class explicit implementation of ICollection.SyncRoot
-                }
+                get { return ((ICollection)this).SyncRoot; }
             }
 
-            public int IndexOf(Foo f)
-            {
-                return ((IList)InnerList).IndexOf(f);
-            }
+            public int IndexOf(Foo f) => ((IList)InnerList).IndexOf(f);
 
-            public bool Contains(Foo f)
-            {
-                return ((IList)InnerList).Contains(f);
-            }
+            public bool Contains(Foo f) => ((IList)InnerList).Contains(f);
 
             public bool IsFixedSize
             {
@@ -200,16 +184,10 @@ namespace System.Collections.Tests
         {
             public override int Count
             {
-                get
-                {
-                    return int.MinValue;
-                }
+                get { return int.MinValue; }
             }
 
-            public override IEnumerator GetEnumerator()
-            {
-                return null;
-            }
+            public override IEnumerator GetEnumerator() => null;
         }
 
         private class Foo
@@ -220,39 +198,22 @@ namespace System.Collections.Tests
 
             public Foo(int intValue, string stringValue)
             {
-                _intValue = intValue;
-                _stringValue = stringValue;
+                IntValue = intValue;
+                StringValue = stringValue;
             }
-
-            private int _intValue;
-            public int IntValue
-            {
-                get { return _intValue; }
-                set { _intValue = value; }
-            }
-
-            private string _stringValue;
-            public string StringValue
-            {
-                get { return _stringValue; }
-                set { _stringValue = value; }
-            }
+            
+            public int IntValue { get; set; }
+            public string StringValue { get; set; }
 
             public override bool Equals(object obj)
             {
+                Foo foo = obj as Foo;
                 if (obj == null)
                     return false;
-                if (!(obj is Foo))
-                    return false;
-                if ((((Foo)obj).IntValue == _intValue) && (((Foo)obj).StringValue == _stringValue))
-                    return true;
-                return false;
+                return foo.IntValue == IntValue && foo.StringValue == StringValue;
             }
 
-            public override int GetHashCode()
-            {
-                return _intValue;
-            }
+            public override int GetHashCode() => IntValue;
         }
     }
 }

--- a/src/System.Collections.NonGeneric/tests/ReadOnlyCollectionBaseTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ReadOnlyCollectionBaseTests.cs
@@ -73,7 +73,7 @@ namespace System.Collections.Tests
 
             Assert.Throws<ArgumentNullException>("dest", () => collection.CopyTo(null, 0)); // Array is null
 
-            Assert.Throws<ArgumentException>("", () => collection.CopyTo(new Foo[100], 50)); // Index + collection.Count > array.Length
+            Assert.Throws<ArgumentException>(string.Empty, () => collection.CopyTo(new Foo[100], 50)); // Index + collection.Count > array.Length
             Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => collection.CopyTo(new Foo[100], -1)); // Index < 0
         }
 

--- a/src/System.Collections.NonGeneric/tests/SortedListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedListTests.cs
@@ -13,7 +13,7 @@ namespace System.Collections.Tests
     public static class SortedListTests
     {
         [Fact]
-        public static void TestCtor_Empty()
+        public static void Ctor_Empty()
         {
             var sortList = new SortedList();
             Assert.Equal(0, sortList.Count);
@@ -29,11 +29,11 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestCtor_Capacity(int capacity)
+        public static void Ctor_Int(int initialCapacity)
         {
-            var sortList = new SortedList(capacity);
+            var sortList = new SortedList(initialCapacity);
             Assert.Equal(0, sortList.Count);
-            Assert.Equal(capacity, sortList.Capacity);
+            Assert.Equal(initialCapacity, sortList.Capacity);
 
             Assert.False(sortList.IsFixedSize);
             Assert.False(sortList.IsReadOnly);
@@ -41,9 +41,9 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_Capcaity_Invalid()
+        public static void Ctor_Int_NegativeInitialCapacity_ThrowsArgumentOutOfRangeException()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new SortedList(-1)); // Capacity < 0
+            Assert.Throws<ArgumentOutOfRangeException>("initialCapacity", () => new SortedList(-1)); // InitialCapacity < 0
         }
 
         [Theory]
@@ -51,11 +51,11 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestCtor_IComparer_Capacity(int capacity)
+        public static void Ctor_IComparer_Int(int initialCapacity)
         {
-            var sortList = new SortedList(new CustomComparer(), capacity);
+            var sortList = new SortedList(new CustomComparer(), initialCapacity);
             Assert.Equal(0, sortList.Count);
-            Assert.Equal(capacity, sortList.Capacity);
+            Assert.Equal(initialCapacity, sortList.Capacity);
 
             Assert.False(sortList.IsFixedSize);
             Assert.False(sortList.IsReadOnly);
@@ -63,13 +63,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_IComparer_Capacity_Invalid()
+        public static void Ctor_IComparer_Int_NegativeInitialCapacity_ThrowsArgumentOutOfRangeException()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new SortedList(new CustomComparer(), -1)); // Capacity < 0
+            Assert.Throws<ArgumentOutOfRangeException>("value", () => new SortedList(new CustomComparer(), -1)); // InitialCapacity < 0
         }
 
         [Fact]
-        public static void TestCtor_IComparer()
+        public static void Ctor_IComparer()
         {
             var sortList = new SortedList(new CustomComparer());
             Assert.Equal(0, sortList.Count);
@@ -80,7 +80,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void Test_Ctor_IComparer_Null()
+        public static void Ctor_IComparer_Null()
         {
             var sortList = new SortedList((IComparer)null);
             Assert.Equal(0, sortList.Count);
@@ -99,7 +99,7 @@ namespace System.Collections.Tests
         [InlineData(1, false)]
         [InlineData(10, false)]
         [InlineData(100, false)]
-        public static void TestCtor_IDictionary(int count, bool sorted)
+        public static void Ctor_IDictionary(int count, bool sorted)
         {
             var hashtable = new Hashtable();
             if (sorted)
@@ -139,9 +139,9 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_IDictionary_Invalid()
+        public static void Ctor_IDictionary_NullDictionary_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new SortedList((IDictionary)null)); // Dictionary is null
+            Assert.Throws<ArgumentNullException>("d", () => new SortedList((IDictionary)null)); // Dictionary is null
         }
 
         [Theory]
@@ -153,7 +153,7 @@ namespace System.Collections.Tests
         [InlineData(1, false)]
         [InlineData(10, false)]
         [InlineData(100, false)]
-        public static void TestCtor_IDictionary_IComparer(int count, bool sorted)
+        public static void Ctor_IDictionary_IComparer(int count, bool sorted)
         {
             var hashtable = new Hashtable();
             if (sorted)
@@ -194,7 +194,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_IDictionary_IComparer_Null()
+        public static void Ctor_IDictionary_IComparer_Null()
         {
             var sortList = new SortedList(new Hashtable(), null);
             Assert.Equal(0, sortList.Count);
@@ -205,13 +205,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_IDictionary_IComparer_Invalid()
+        public static void Ctor_IDictionary_IComparer_NullDictionary_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new SortedList(null, new CustomComparer())); // Dictionary is null
+            Assert.Throws<ArgumentNullException>("d", () => new SortedList(null, new CustomComparer())); // Dictionary is null
         }
 
         [Fact]
-        public static void TestDebuggerAttribute()
+        public static void DebuggerAttribute()
         {
             var list = new SortedList() { { "a", 1 }, { "b", 2 } };
 
@@ -227,15 +227,14 @@ namespace System.Collections.Tests
             }
             catch (TargetInvocationException ex)
             {
-                ArgumentNullException nullException = ex.InnerException as ArgumentNullException;
-                threwNull = nullException != null;
+                threwNull = ex.InnerException is ArgumentNullException;
             }
 
             Assert.True(threwNull);
         }
 
         [Fact]
-        public static void TestAdd()
+        public static void Add()
         {
             var sortList1 = new SortedList();
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -258,14 +257,14 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestAdd_Invalid()
+        public static void Add_Invalid()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
-                Assert.Throws<ArgumentNullException>(() => sortList2.Add(null, 101)); // Key is null
+                Assert.Throws<ArgumentNullException>("key", () => sortList2.Add(null, 101)); // Key is null
 
-                Assert.Throws<ArgumentException>(() => sortList2.Add(1, 101)); // Key already exists
+                Assert.Throws<ArgumentException>(null, () => sortList2.Add(1, 101)); // Key already exists
             });
         }
 
@@ -274,7 +273,7 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestClear(int count)
+        public static void Clear(int count)
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(count);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -292,7 +291,7 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestClone(int count)
+        public static void Clone(int count)
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(count);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -311,7 +310,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestClone_IsShallowCopy()
+        public static void Clone_IsShallowCopy()
         {
             var sortList = new SortedList();
             for (int i = 0; i < 10; i++)
@@ -346,7 +345,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestContainsKey()
+        public static void ContainsKey()
         {
             var sortList1 = new SortedList();
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -372,18 +371,18 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestContainsKey_Invalid()
+        public static void ContainsKey_NullKey_ThrowsArgumentNullException()
         {
             var sortList1 = new SortedList();
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
-                Assert.Throws<ArgumentNullException>(() => sortList2.Contains(null)); // Key is null
-                Assert.Throws<ArgumentNullException>(() => sortList2.ContainsKey(null)); // Key is null
+                Assert.Throws<ArgumentNullException>("key", () => sortList2.Contains(null)); // Key is null
+                Assert.Throws<ArgumentNullException>("key", () => sortList2.ContainsKey(null)); // Key is null
             });
         }
 
         [Fact]
-        public static void TestContainsValue()
+        public static void ContainsValue()
         {
             var sortList1 = new SortedList();
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -412,7 +411,7 @@ namespace System.Collections.Tests
         [InlineData(1, 50)]
         [InlineData(10, 50)]
         [InlineData(100, 50)]
-        public static void TestCopyTo(int count, int index)
+        public static void CopyTo(int count, int index)
         {
             SortedList sortList1 = Helpers.CreateStringSortedList(count);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -435,21 +434,21 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Invalid()
+        public static void CopyTo_Invalid()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
-                Assert.Throws<ArgumentNullException>(() => sortList2.CopyTo(null, 0)); // Array is null
-                Assert.Throws<ArgumentException>(() => sortList2.CopyTo(new object[10, 10], 0)); // Array is multidimensional
+                Assert.Throws<ArgumentNullException>("array", () => sortList2.CopyTo(null, 0)); // Array is null
+                Assert.Throws<ArgumentException>("array", () => sortList2.CopyTo(new object[10, 10], 0)); // Array is multidimensional
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => sortList2.CopyTo(new object[100], -1)); // Index < 0
-                Assert.Throws<ArgumentException>(() => sortList2.CopyTo(new object[150], 51)); // Index + list.Count > array.Count
+                Assert.Throws<ArgumentOutOfRangeException>("arrayIndex", () => sortList2.CopyTo(new object[100], -1)); // Index < 0
+                Assert.Throws<ArgumentException>(null, () => sortList2.CopyTo(new object[150], 51)); // Index + list.Count > array.Count
             });
         }
 
         [Fact]
-        public static void TestGetByIndex()
+        public static void GetByIndex()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -467,13 +466,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetByIndex_Invalid()
+        public static void GetByIndex_InvalidIndex_ThrowsArgumentOutOfRangeException()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => sortList2.GetByIndex(-1)); // Index < 0
-                Assert.Throws<ArgumentOutOfRangeException>(() => sortList2.GetByIndex(sortList2.Count)); // Index >= list.Count
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => sortList2.GetByIndex(-1)); // Index < 0
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => sortList2.GetByIndex(sortList2.Count)); // Index >= list.Count
             });
         }
 
@@ -482,42 +481,35 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestGetEnumerator_IDictionaryEnumerator(int count)
+        public static void GetEnumerator_IDictionaryEnumerator(int count)
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(count);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
-                IDictionaryEnumerator enumerator1 = sortList2.GetEnumerator();
-                IDictionaryEnumerator enumerator2 = sortList2.GetEnumerator();
-
-                IDictionaryEnumerator[] enumerators = { enumerator1, enumerator2 };
-                foreach (IDictionaryEnumerator enumerator in enumerators)
+                Assert.NotSame(sortList2.GetEnumerator(), sortList2.GetEnumerator());
+                IDictionaryEnumerator enumerator = sortList2.GetEnumerator();
+                for (int i = 0; i < 2; i++)
                 {
-                    Assert.NotNull(enumerator);
-
-                    for (int i = 0; i < 2; i++)
+                    int counter = 0;
+                    while (enumerator.MoveNext())
                     {
-                        int counter = 0;
-                        while (enumerator.MoveNext())
-                        {
-                            Assert.Equal(enumerator.Current, enumerator.Entry);
-                            Assert.Equal(enumerator.Entry.Key, enumerator.Key);
-                            Assert.Equal(enumerator.Entry.Value, enumerator.Value);
+                        Assert.Equal(enumerator.Current, enumerator.Entry);
+                        Assert.Equal(enumerator.Entry.Key, enumerator.Key);
+                        Assert.Equal(enumerator.Entry.Value, enumerator.Value);
 
-                            Assert.Equal(sortList2.GetKey(counter), enumerator.Entry.Key);
-                            Assert.Equal(sortList2.GetByIndex(counter), enumerator.Entry.Value);
+                        Assert.Equal(sortList2.GetKey(counter), enumerator.Entry.Key);
+                        Assert.Equal(sortList2.GetByIndex(counter), enumerator.Entry.Value);
 
-                            counter++;
-                        }
-                        Assert.Equal(count, counter);
-                        enumerator.Reset();
+                        counter++;
                     }
+                    Assert.Equal(count, counter);
+                    enumerator.Reset();
                 }
             });
         }
 
         [Fact]
-        public static void TestGetEnumerator_IDictionaryEnumerator_Invalid()
+        public static void GetEnumerator_IDictionaryEnumerator_Invalid()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -567,36 +559,30 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestGetEnumerator_IEnumerator(int count)
+        public static void GetEnumerator_IEnumerator(int count)
         {
             SortedList sortList = Helpers.CreateIntSortedList(count);
-            IEnumerator enumerator1 = ((IEnumerable)sortList).GetEnumerator();
-            IEnumerator enumerator2 = ((IEnumerable)sortList).GetEnumerator();
-
-            IEnumerator[] enumerators = { enumerator1, enumerator2 };
-            foreach (IEnumerator enumerator in enumerators)
+            Assert.NotSame(sortList.GetEnumerator(), sortList.GetEnumerator());
+            IEnumerator enumerator = sortList.GetEnumerator();
+            for (int i = 0; i < 2; i++)
             {
-                Assert.NotNull(enumerator);
-                for (int i = 0; i < 2; i++)
+                int counter = 0;
+                while (enumerator.MoveNext())
                 {
-                    int counter = 0;
-                    while (enumerator.MoveNext())
-                    {
-                        DictionaryEntry dictEntry = (DictionaryEntry)enumerator.Current;
+                    DictionaryEntry dictEntry = (DictionaryEntry)enumerator.Current;
 
-                        Assert.Equal(sortList.GetKey(counter), dictEntry.Key);
-                        Assert.Equal(sortList.GetByIndex(counter), dictEntry.Value);
+                    Assert.Equal(sortList.GetKey(counter), dictEntry.Key);
+                    Assert.Equal(sortList.GetByIndex(counter), dictEntry.Value);
 
-                        counter++;
-                    }
-                    Assert.Equal(count, counter);
-                    enumerator.Reset();
+                    counter++;
                 }
+                Assert.Equal(count, counter);
+                enumerator.Reset();
             }
         }
 
         [Fact]
-        public static void TestGetEnumerator_IEnumerator_Invalid()
+        public static void GetEnumerator_IEnumerator_Invalid()
         {
             SortedList sortList = Helpers.CreateIntSortedList(100);
 
@@ -631,7 +617,7 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestGetKeyList(int count)
+        public static void GetKeyList(int count)
         {
             SortedList sortList1 = Helpers.CreateStringSortedList(count);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -655,14 +641,14 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetKeyList_IsSameAsKeysProperty()
+        public static void GetKeyList_IsSameAsKeysProperty()
         {
             var sortList = Helpers.CreateIntSortedList(10);
             Assert.Same(sortList.GetKeyList(), sortList.Keys);
         }
 
         [Fact]
-        public static void TestGetKeyList_IListProperties()
+        public static void GetKeyList_IListProperties()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -677,7 +663,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetKeyList_Contains()
+        public static void GetKeyList_Contains()
         {
             SortedList sortList1 = Helpers.CreateStringSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -695,7 +681,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetKeyList_Contains_Invalid()
+        public static void GetKeyList_Contains_InvalidValueType_ThrowsInvalidOperationException()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -707,7 +693,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetKeyList_IndexOf()
+        public static void GetKeyList_IndexOf()
         {
             SortedList sortList1 = Helpers.CreateStringSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -725,13 +711,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetKeyList_IndexOf_Invalid()
+        public static void GetKeyList_IndexOf_Invalid()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
                 IList keys = sortList2.GetKeyList();
-                Assert.Throws<ArgumentNullException>(() => keys.IndexOf(null)); // Value is null
+                Assert.Throws<ArgumentNullException>("key", () => keys.IndexOf(null)); // Value is null
                 Assert.Throws<InvalidOperationException>(() => keys.IndexOf("hello")); // Value is a different object type
             });
         }
@@ -745,7 +731,7 @@ namespace System.Collections.Tests
         [InlineData(1, 50)]
         [InlineData(10, 50)]
         [InlineData(100, 50)]
-        public static void TestGetKeyList_CopyTo(int count, int index)
+        public static void GetKeyList_CopyTo(int count, int index)
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(count);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -763,17 +749,17 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetKeyList_CopyTo_Invalid()
+        public static void GetKeyList_CopyTo_Invalid()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
                 IList keys = sortList2.GetKeyList();
-                Assert.Throws<ArgumentNullException>(() => keys.CopyTo(null, 0)); // Array is null
-                Assert.Throws<ArgumentException>(() => keys.CopyTo(new object[10, 10], 0)); // Array is multidimensional
+                Assert.Throws<ArgumentNullException>("dest", () => keys.CopyTo(null, 0)); // Array is null
+                Assert.Throws<ArgumentException>("array", () => keys.CopyTo(new object[10, 10], 0)); // Array is multidimensional
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => keys.CopyTo(new object[100], -1)); // Index < 0
-                Assert.Throws<ArgumentException>(() => keys.CopyTo(new object[150], 51)); // Index + list.Count > array.Count
+                Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => keys.CopyTo(new object[100], -1)); // Index < 0
+                Assert.Throws<ArgumentException>("", () => keys.CopyTo(new object[150], 51)); // Index + list.Count > array.Count
             });
         }
 
@@ -782,12 +768,13 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestGetKeyList_GetEnumerator(int count)
+        public static void GetKeyList_GetEnumerator(int count)
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(count);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
                 IList keys = sortList2.GetKeyList();
+                Assert.NotSame(keys.GetEnumerator(), keys.GetEnumerator());
                 IEnumerator enumerator = sortList2.GetEnumerator();
 
                 for (int i = 0; i < 2; i++)
@@ -802,14 +789,13 @@ namespace System.Collections.Tests
                         counter++;
                     }
                     Assert.Equal(count, counter);
-
                     enumerator.Reset();
                 }
             });
         }
 
         [Fact]
-        public static void TestGetKeyList_GetEnumerator_Invalid()
+        public static void GetKeyList_GetEnumerator_Invalid()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -844,7 +830,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetKeyList_TryingToModifyCollection_Throws()
+        public static void GetKeyList_TryingToModifyCollection_ThrowsNotSupportedException()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -863,7 +849,7 @@ namespace System.Collections.Tests
         [Theory]
         [InlineData(0)]
         [InlineData(100)]
-        public static void TestGetKey(int count)
+        public static void GetKey(int count)
         {
             SortedList sortList1 = Helpers.CreateStringSortedList(count);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -877,13 +863,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetKey_Invalid()
+        public static void GetKey_InvalidIndex_ThrowsArgumentOutOfRangeException()
         {
             SortedList sortList1 = Helpers.CreateStringSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => sortList2.GetKey(-1)); // Index < 0
-                Assert.Throws<ArgumentOutOfRangeException>(() => sortList2.GetKey(sortList2.Count)); // Index >= count
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => sortList2.GetKey(-1)); // Index < 0
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => sortList2.GetKey(sortList2.Count)); // Index >= count
             });
         }
 
@@ -892,7 +878,7 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestGetValueList(int count)
+        public static void GetValueList(int count)
         {
             SortedList sortList1 = Helpers.CreateStringSortedList(count);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -916,14 +902,14 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetValueList_IsSameAsValuesProperty()
+        public static void GetValueList_IsSameAsValuesProperty()
         {
             var sortList = Helpers.CreateIntSortedList(10);
             Assert.Same(sortList.GetValueList(), sortList.Values);
         }
 
         [Fact]
-        public static void TestGetValueList_IListProperties()
+        public static void GetValueList_IListProperties()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -938,7 +924,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetValueList_Contains()
+        public static void GetValueList_Contains()
         {
             SortedList sortList1 = Helpers.CreateStringSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -959,7 +945,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetValueList_IndexOf()
+        public static void GetValueList_IndexOf()
         {
             SortedList sortList1 = Helpers.CreateStringSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -985,7 +971,7 @@ namespace System.Collections.Tests
         [InlineData(1, 50)]
         [InlineData(10, 50)]
         [InlineData(100, 50)]
-        public static void TestGetValueList_CopyTo(int count, int index)
+        public static void GetValueList_CopyTo(int count, int index)
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(count);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -1003,17 +989,17 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetValueList_CopyTo_Invalid()
+        public static void GetValueList_CopyTo_Invalid()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
                 IList values = sortList2.GetValueList();
-                Assert.Throws<ArgumentNullException>(() => values.CopyTo(null, 0)); // Array is null
-                Assert.Throws<ArgumentException>(() => values.CopyTo(new object[10, 10], 0)); // Array is multidimensional
+                Assert.Throws<ArgumentNullException>("dest", () => values.CopyTo(null, 0)); // Array is null
+                Assert.Throws<ArgumentException>("array", () => values.CopyTo(new object[10, 10], 0)); // Array is multidimensional
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => values.CopyTo(new object[100], -1)); // Index < 0
-                Assert.Throws<ArgumentException>(() => values.CopyTo(new object[150], 51)); // Index + list.Count > array.Count
+                Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => values.CopyTo(new object[100], -1)); // Index < 0
+                Assert.Throws<ArgumentException>("", () => values.CopyTo(new object[150], 51)); // Index + list.Count > array.Count
             });
         }
 
@@ -1022,12 +1008,13 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestGetValueList_GetEnumerator(int count)
+        public static void GetValueList_GetEnumerator(int count)
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(count);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
                 IList values = sortList2.GetValueList();
+                Assert.NotSame(values.GetEnumerator(), values.GetEnumerator());
                 IEnumerator enumerator = sortList2.GetEnumerator();
 
                 for (int i = 0; i < 2; i++)
@@ -1042,14 +1029,13 @@ namespace System.Collections.Tests
                         counter++;
                     }
                     Assert.Equal(count, counter);
-
                     enumerator.Reset();
                 }
             });
         }
 
         [Fact]
-        public static void TestValueList_GetEnumerator_Invalid()
+        public static void ValueList_GetEnumerator_Invalid()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -1084,7 +1070,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetValueList_TryingToModifyCollection_Throws()
+        public static void GetValueList_TryingToModifyCollection_ThrowsNotSupportedException()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -1101,7 +1087,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexOfKey()
+        public static void IndexOfKey()
         {
             SortedList sortList1 = Helpers.CreateStringSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -1125,17 +1111,17 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexOfKey_Invalid()
+        public static void IndexOfKey_NullKey_ThrowsArgumentNullException()
         {
             SortedList sortList1 = Helpers.CreateStringSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
-                Assert.Throws<ArgumentNullException>(() => sortList2.IndexOfKey(null)); // Key is null
+                Assert.Throws<ArgumentNullException>("key", () => sortList2.IndexOfKey(null)); // Key is null
             });
         }
 
         [Fact]
-        public static void TestIndexOfValue()
+        public static void IndexOfValue()
         {
             SortedList sortList1 = Helpers.CreateStringSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -1163,7 +1149,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestIndexOfValue_SameValue()
+        public static void IndexOfValue_SameValue()
         {
             var sortList1 = new SortedList();
             sortList1.Add("Key_0", "Value_0");
@@ -1180,7 +1166,7 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(4)]
         [InlineData(5000)]
-        public static void TestGetSetCapacity(int capacity)
+        public static void Capacity_Get_Set(int capacity)
         {
             var sortList = new SortedList();
             sortList.Capacity = capacity;
@@ -1192,22 +1178,22 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSetCapacity_Shrink()
+        public static void Capacity_Set_ShrinkingCapacity_ThrowsArgumentOutOfRangeException()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => sortList2.Capacity = sortList2.Count - 1); // Capacity < count
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => sortList2.Capacity = sortList2.Count - 1); // Capacity < count
             });
         }
 
         [Fact]
-        public static void TestSetCapacity_Invalid()
+        public static void Capacity_Set_Invalid()
         {
             var sortList1 = new SortedList();
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => sortList2.Capacity = -1); // Capacity < 0
+                Assert.Throws<ArgumentOutOfRangeException>("value", () => sortList2.Capacity = -1); // Capacity < 0
                 Assert.Throws<OutOfMemoryException>(() => sortList2.Capacity = int.MaxValue); // Capacity is too large
             });
         }
@@ -1216,7 +1202,7 @@ namespace System.Collections.Tests
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(10)]
-        public static void TestGetObject(int count)
+        public static void Item_Get(int count)
         {
             SortedList sortList1 = Helpers.CreateStringSortedList(count);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -1236,7 +1222,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestGetObject_DifferentCulture()
+        public static void Item_Get_DifferentCulture()
         {
             var sortList = new SortedList();
 
@@ -1286,7 +1272,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSetObject()
+        public static void Item_Set()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -1312,17 +1298,17 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSetObject_Invalid()
+        public static void Item_Set_NullKey_ThrowsArgumentNullException()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
-                Assert.Throws<ArgumentNullException>(() => sortList2[null] = 101); // Key is null
+                Assert.Throws<ArgumentNullException>("key", () => sortList2[null] = 101); // Key is null
             });
         }
 
         [Fact]
-        public static void TestRemoveAt()
+        public static void RemoveAt()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -1339,18 +1325,18 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemoveAt_Invalid()
+        public static void RemoveAt_InvalidIndex_ThrowsArgumentOutOfRangeException()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => sortList2.RemoveAt(-1)); // Index < 0
-                Assert.Throws<ArgumentOutOfRangeException>(() => sortList2.RemoveAt(sortList2.Count)); // Index >= count
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => sortList2.RemoveAt(-1)); // Index < 0
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => sortList2.RemoveAt(sortList2.Count)); // Index >= count
             });
         }
 
         [Fact]
-        public static void TestRemove()
+        public static void Remove()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -1369,17 +1355,17 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestRemove_Invalid()
+        public static void Remove_NullKey_ThrowsArgumentNullException()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
-                Assert.Throws<ArgumentNullException>(() => sortList2.Remove(null)); // Key is null
+                Assert.Throws<ArgumentNullException>("key", () => sortList2.Remove(null)); // Key is null
             });
         }
 
         [Fact]
-        public static void TestSetByIndex()
+        public static void SetByIndex()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -1393,31 +1379,31 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSetByIndex_Invalid()
+        public static void SetByIndex_InvalidIndex_ThrowsArgumentOutOfRangeExeption()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => sortList2.SetByIndex(-1, 101)); // Index < 0
-                Assert.Throws<ArgumentOutOfRangeException>(() => sortList2.SetByIndex(sortList2.Count, 101)); // Index >= list.Count
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => sortList2.SetByIndex(-1, 101)); // Index < 0
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => sortList2.SetByIndex(sortList2.Count, 101)); // Index >= list.Count
             });
         }
         
         [Fact]
-        public static void TestSynchronized_IsSynchronized()
+        public static void Synchronized_IsSynchronized()
         {
             SortedList sortList = SortedList.Synchronized(new SortedList());
             Assert.True(sortList.IsSynchronized);
         }
 
         [Fact]
-        public static void TestSynchronized_Invalid()
+        public static void Synchronized_NullList_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => SortedList.Synchronized(null)); // List is null
+            Assert.Throws<ArgumentNullException>("list", () => SortedList.Synchronized(null)); // List is null
         }
 
         [Fact]
-        public static void TestTrimToSize()
+        public static void TrimToSize()
         {
             SortedList sortList1 = Helpers.CreateIntSortedList(100);
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
@@ -1437,20 +1423,12 @@ namespace System.Collections.Tests
 
         private class Foo
         {
-            private string _stringValue = "Hello World";
-            public string StringValue
-            {
-                get { return _stringValue; }
-                set { _stringValue = value; }
-            }
+            public string StringValue { get; set; } = "Hello World";
         }
 
         private class CustomComparer : IComparer
         {
-            public int Compare(object obj1, object obj2)
-            {
-                return -string.Compare(obj1.ToString(), obj2.ToString());
-            }
+            public int Compare(object obj1, object obj2) => -string.Compare(obj1.ToString(), obj2.ToString());
         }
     }
 
@@ -1458,11 +1436,11 @@ namespace System.Collections.Tests
     {
         private SortedList _sortListDaughter;
         private SortedList _sortListGrandDaughter;
-        private int _numElements = 100;
+        private const int NumberOfElements = 100;
 
         [Fact]
         [OuterLoop]
-        public void TestGetSyncRootBasic()
+        public void GetSyncRootBasic()
         {
             // Testing SyncRoot is not as simple as its implementation looks like. This is the working
             // scenrio we have in mind.
@@ -1473,7 +1451,7 @@ namespace System.Collections.Tests
             // 5) all of these should SyncRoot to the mother earth
 
             var sortListMother = new SortedList();
-            for (int i = 0; i < _numElements; i++)
+            for (int i = 0; i < NumberOfElements; i++)
             {
                 sortListMother.Add("Key_" + i, "Value_" + i);
             }
@@ -1510,7 +1488,7 @@ namespace System.Collections.Tests
             // Now lets see how this is done.
             // Either there are some elements or none
             var sortListPossible = new SortedList();
-            for (int i = 0; i < _numElements; i++)
+            for (int i = 0; i < NumberOfElements; i++)
             {
                 sortListPossible.Add("Key_" + i, "Value_" + i);
             }

--- a/src/System.Collections.NonGeneric/tests/SortedListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedListTests.cs
@@ -759,7 +759,7 @@ namespace System.Collections.Tests
                 Assert.Throws<ArgumentException>("array", () => keys.CopyTo(new object[10, 10], 0)); // Array is multidimensional
 
                 Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => keys.CopyTo(new object[100], -1)); // Index < 0
-                Assert.Throws<ArgumentException>("", () => keys.CopyTo(new object[150], 51)); // Index + list.Count > array.Count
+                Assert.Throws<ArgumentException>(string.Empty, () => keys.CopyTo(new object[150], 51)); // Index + list.Count > array.Count
             });
         }
 
@@ -999,7 +999,7 @@ namespace System.Collections.Tests
                 Assert.Throws<ArgumentException>("array", () => values.CopyTo(new object[10, 10], 0)); // Array is multidimensional
 
                 Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => values.CopyTo(new object[100], -1)); // Index < 0
-                Assert.Throws<ArgumentException>("", () => values.CopyTo(new object[150], 51)); // Index + list.Count > array.Count
+                Assert.Throws<ArgumentException>(string.Empty, () => values.CopyTo(new object[150], 51)); // Index + list.Count > array.Count
             });
         }
 
@@ -1443,7 +1443,7 @@ namespace System.Collections.Tests
         public void GetSyncRootBasic()
         {
             // Testing SyncRoot is not as simple as its implementation looks like. This is the working
-            // scenrio we have in mind.
+            // scenario we have in mind.
             // 1) Create your Down to earth mother SortedList
             // 2) Get a synchronized wrapper from it
             // 3) Get a Synchronized wrapper from 2)

--- a/src/System.Collections.NonGeneric/tests/StackTests.cs
+++ b/src/System.Collections.NonGeneric/tests/StackTests.cs
@@ -478,7 +478,7 @@ namespace System.Collections.Tests
         public void GetSyncRootBasic()
         {
             // Testing SyncRoot is not as simple as its implementation looks like. This is the working
-            // scenrio we have in mind.
+            // scenario we have in mind.
             // 1) Create your Down to earth mother Stack
             // 2) Get a Fixed wrapper from it
             // 3) Get a Synchronized wrapper from 2)

--- a/src/System.Collections.NonGeneric/tests/StackTests.cs
+++ b/src/System.Collections.NonGeneric/tests/StackTests.cs
@@ -5,7 +5,6 @@
 using System.Diagnostics;
 using System.Reflection;
 using System.Threading.Tasks;
-
 using Xunit;
 
 namespace System.Collections.Tests
@@ -13,7 +12,7 @@ namespace System.Collections.Tests
     public static class StackTests
     {
         [Fact]
-        public static void TestCtor_Empty()
+        public static void Ctor_Empty()
         {
             var stack = new Stack();
             Assert.Equal(0, stack.Count);
@@ -26,17 +25,17 @@ namespace System.Collections.Tests
         [InlineData(10)]
         [InlineData(100)]
         [InlineData(1000)]
-        public static void TestCtor_Capacity(int capacity)
+        public static void Ctor_Int(int initialCapacity)
         {
-            var stack = new Stack(capacity);
+            var stack = new Stack(initialCapacity);
             Assert.Equal(0, stack.Count);
             Assert.False(stack.IsSynchronized);
         }
 
         [Fact]
-        public static void TestCtor_Capacity_Invalid()
+        public static void Ctor_Int_NegativeInitialCapacity_ThrowsArgumentOutOfRangeException()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Stack(-1)); // Capacity < 0
+            Assert.Throws<ArgumentOutOfRangeException>("initialCapacity", () => new Stack(-1)); // InitialCapacity < 0
         }
 
         [Theory]
@@ -46,7 +45,7 @@ namespace System.Collections.Tests
         [InlineData(100)]
         [InlineData(1000)]
         [InlineData(10000)]
-        public static void TestCtor_ICollection(int count)
+        public static void Ctor_ICollection(int count)
         {
             var array = new object[count];
             for (int i = 0; i < count; i++)
@@ -65,13 +64,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCtor_ICollection_Invalid()
+        public static void Ctor_ICollection_NullCollection_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new Stack(null)); // Collection is null
+            Assert.Throws<ArgumentNullException>("col", () => new Stack(null)); // Collection is null
         }
 
         [Fact]
-        public static void TestDebuggerAttribute()
+        public static void DebuggerAttribute()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new Stack());
 
@@ -89,15 +88,14 @@ namespace System.Collections.Tests
             }
             catch (TargetInvocationException ex)
             {
-                ArgumentNullException nullException = ex.InnerException as ArgumentNullException;
-                threwNull = nullException != null;
+                threwNull = ex.InnerException is ArgumentNullException;
             }
 
             Assert.True(threwNull);
         }
 
         [Fact]
-        public static void TestClear()
+        public static void Clear()
         {
             Stack stack1 = Helpers.CreateIntStack(100);
             Helpers.PerformActionOnAllStackWrappers(stack1, stack2 =>
@@ -115,7 +113,7 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestClone(int count)
+        public static void Clone(int count)
         {
             Stack stack1 = Helpers.CreateIntStack(count);
             Helpers.PerformActionOnAllStackWrappers(stack1, stack2 =>
@@ -133,7 +131,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestClone_IsShallowCopy()
+        public static void Clone_IsShallowCopy()
         {
             var stack1 = new Stack();
             stack1.Push(new Foo(10));
@@ -150,7 +148,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestContains()
+        public static void Contains()
         {
             Stack stack1 = Helpers.CreateIntStack(100);
             Helpers.PerformActionOnAllStackWrappers(stack1, stack2 =>
@@ -180,7 +178,7 @@ namespace System.Collections.Tests
         [InlineData(10, 5)]
         [InlineData(100, 50)]
         [InlineData(1000, 500)]
-        public static void TestCopyTo_ObjectArray(int count, int index)
+        public static void CopyTo_ObjectArray(int count, int index)
         {
             Stack stack1 = Helpers.CreateIntStack(count);
             Helpers.PerformActionOnAllStackWrappers(stack1, stack2 =>
@@ -205,7 +203,7 @@ namespace System.Collections.Tests
         [InlineData(10, 5)]
         [InlineData(100, 50)]
         [InlineData(1000, 500)]
-        public static void TestCopyTo_IntArray(int count, int index)
+        public static void CopyTo_IntArray(int count, int index)
         {
             Stack stack1 = Helpers.CreateIntStack(count);
             Helpers.PerformActionOnAllStackWrappers(stack1, stack2 =>
@@ -221,18 +219,18 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestCopyTo_Invalid()
+        public static void CopyTo_Invalid()
         {
             Stack stack1 = Helpers.CreateIntStack(100);
             Helpers.PerformActionOnAllStackWrappers(stack1, stack2 =>
             {
-                Assert.Throws<ArgumentNullException>(() => stack2.CopyTo(null, 0)); // Array is null
-                Assert.Throws<ArgumentException>(() => stack2.CopyTo(new object[10, 10], 0)); // Array is multidimensional
+                Assert.Throws<ArgumentNullException>("array", () => stack2.CopyTo(null, 0)); // Array is null
+                Assert.Throws<ArgumentException>("array", () => stack2.CopyTo(new object[10, 10], 0)); // Array is multidimensional
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => stack2.CopyTo(new object[100], -1)); // Index < 0
-                Assert.Throws<ArgumentException>(() => stack2.CopyTo(new object[0], 0)); // Index >= array.Count
-                Assert.Throws<ArgumentException>(() => stack2.CopyTo(new object[100], 1)); // Index + array.Count > stack.Count
-                Assert.Throws<ArgumentException>(() => stack2.CopyTo(new object[150], 51)); // Index + array.Count > stack.Count
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => stack2.CopyTo(new object[100], -1)); // Index < 0
+                Assert.Throws<ArgumentException>(null, () => stack2.CopyTo(new object[0], 0)); // Index >= array.Count
+                Assert.Throws<ArgumentException>(null, () => stack2.CopyTo(new object[100], 1)); // Index + array.Count > stack.Count
+                Assert.Throws<ArgumentException>(null, () => stack2.CopyTo(new object[150], 51)); // Index + array.Count > stack.Count
             });
         }
 
@@ -241,35 +239,29 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestGetEnumerator(int count)
+        public static void GetEnumerator(int count)
         {
             Stack stack1 = Helpers.CreateIntStack(count);
             Helpers.PerformActionOnAllStackWrappers(stack1, stack2 =>
             {
-                IEnumerator enumerator1 = stack2.GetEnumerator();
-                IEnumerator enumerator2 = stack2.GetEnumerator();
-
-                IEnumerator[] enumerators = { enumerator1, enumerator2 };
-                foreach (IEnumerator enumerator in enumerators)
+                Assert.NotSame(stack2.GetEnumerator(), stack2.GetEnumerator());
+                IEnumerator enumerator = stack2.GetEnumerator();
+                for (int i = 0; i < 2; i++)
                 {
-                    for (int i = 0; i < 2; i++)
+                    int counter = 0;
+                    while (enumerator.MoveNext())
                     {
-                        int counter = 0;
-                        while (enumerator.MoveNext())
-                        {
-                            counter++;
-                            Assert.NotNull(enumerator.Current);
-                        }
-                        Assert.Equal(count, counter);
-
-                        enumerator.Reset();
+                        counter++;
+                        Assert.NotNull(enumerator.Current);
                     }
+                    Assert.Equal(count, counter);
+                    enumerator.Reset();
                 }
             });
         }
 
         [Fact]
-        public static void TestGetEnumerator_Invalid()
+        public static void GetEnumerator_Invalid()
         {
             Stack stack1 = Helpers.CreateIntStack(100);
             Helpers.PerformActionOnAllStackWrappers(stack1, stack2 =>
@@ -309,7 +301,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestPeek()
+        public static void Peek()
         {
             int count = 100;
             Stack stack1 = Helpers.CreateIntStack(count);
@@ -328,7 +320,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestPeek_Invalid()
+        public static void Peek_EmptyStack_ThrowsInvalidOperationException()
         {
             var stack1 = new Stack();
             Helpers.PerformActionOnAllStackWrappers(stack1, stack2 =>
@@ -357,7 +349,7 @@ namespace System.Collections.Tests
         [InlineData(10, 5)]
         [InlineData(100, 50)]
         [InlineData(1000, 500)]
-        public static void TestPop(int pushCount, int popCount)
+        public static void Pop(int pushCount, int popCount)
         {
             Stack stack1 = Helpers.CreateIntStack(pushCount);
             Helpers.PerformActionOnAllStackWrappers(stack1, stack2 =>
@@ -372,7 +364,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestPop_Null()
+        public static void Pop_Null()
         {
             var stack1 = new Stack();
             Helpers.PerformActionOnAllStackWrappers(stack1, stack2 =>
@@ -388,12 +380,12 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestPop_Invalid()
+        public static void Pop_EmptyStack_ThrowsInvalidOperationException()
         {
             var stack1 = new Stack();
             Helpers.PerformActionOnAllStackWrappers(stack1, stack2 =>
             {
-                Assert.Throws<InvalidOperationException>(() => stack2.Pop());
+                Assert.Throws<InvalidOperationException>(() => stack2.Pop()); // Empty stack
             });
         }
 
@@ -402,7 +394,7 @@ namespace System.Collections.Tests
         [InlineData(10)]
         [InlineData(100)]
         [InlineData(1000)]
-        public static void TestPush(int count)
+        public static void Push(int count)
         {
             var stack1 = new Stack();
             Helpers.PerformActionOnAllStackWrappers(stack1, stack2 =>
@@ -417,7 +409,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestPush_Null()
+        public static void Push_Null()
         {
             var stack1 = new Stack();
             Helpers.PerformActionOnAllStackWrappers(stack1, stack2 =>
@@ -432,16 +424,16 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void TestSynchronized_IsSynchronized()
+        public static void Synchronized_IsSynchronized()
         {
             Stack stack = Stack.Synchronized(new Stack());
             Assert.True(stack.IsSynchronized);
         }
 
         [Fact]
-        public static void TestSynchronizedInvalid()
+        public static void Synchronized_NullStack_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => Stack.Synchronized(null)); // Stack is null
+            Assert.Throws<ArgumentNullException>("stack", () => Stack.Synchronized(null)); // Stack is null
         }
 
         [Theory]
@@ -449,7 +441,7 @@ namespace System.Collections.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public static void TestToArray(int count)
+        public static void ToArray(int count)
         {
             Stack stack1 = Helpers.CreateIntStack(count);
             Helpers.PerformActionOnAllStackWrappers(stack1, stack2 =>
@@ -468,15 +460,10 @@ namespace System.Collections.Tests
         {
             public Foo(int intValue)
             {
-                _intValue = intValue;
+                IntValue = intValue;
             }
-
-            private int _intValue;
-            public int IntValue
-            {
-                set { _intValue = value; }
-                get { return _intValue; }
-            }
+            
+            public int IntValue { get; set; }
         }
     }
 
@@ -485,20 +472,20 @@ namespace System.Collections.Tests
         private Stack _stackDaughter;
         private Stack _stackGrandDaughter;
 
-        private const int iNumberOfElements = 100;
+        private const int NumberOfElements = 100;
 
         [Fact]
-        public void TestGetSyncRootBasic()
+        public void GetSyncRootBasic()
         {
             // Testing SyncRoot is not as simple as its implementation looks like. This is the working
-            //scenrio we have in mind.
+            // scenrio we have in mind.
             // 1) Create your Down to earth mother Stack
             // 2) Get a Fixed wrapper from it
             // 3) Get a Synchronized wrapper from 2)
             // 4) Get a synchronized wrapper of the mother from 1)
             // 5) all of these should SyncRoot to the mother earth
             var stackMother = new Stack();
-            for (int i = 0; i < iNumberOfElements; i++)
+            for (int i = 0; i < NumberOfElements; i++)
             {
                 stackMother.Push(i);
             }
@@ -530,7 +517,7 @@ namespace System.Collections.Tests
         private void SortElements()
         {
             _stackGrandDaughter.Clear();
-            for (int i = 0; i < iNumberOfElements; i++)
+            for (int i = 0; i < NumberOfElements; i++)
             {
                 _stackGrandDaughter.Push(i);
             }
@@ -539,7 +526,7 @@ namespace System.Collections.Tests
         private void ReverseElements()
         {
             _stackDaughter.Clear();
-            for (int i = 0; i < iNumberOfElements; i++)
+            for (int i = 0; i < NumberOfElements; i++)
             {
                 _stackDaughter.Push(i);
             }


### PR DESCRIPTION
I was having a nostaligic through some of my first PRs to corefx, and checked out the System.Collections.NonGeneric tests
- Rename tests to remove the Test prefix
--> Is it worth removing the `static` keyword for these tests or not?
--> Sorry, this makes the diff a tad lengthy
- Add tests for the parameter name for `ArgumentExceptions`
- Cleans up some ctor and enumerator tests
- Adds some missing parameters to the production code (separate commit)

/cc @ianhays (I think you reviewed my original PR in this test lib)