### PR TITLE
Revert "Avoid specific contract versions in light-up code"

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.cs
@@ -12,7 +12,7 @@ namespace System.Reflection.Internal
     {
         internal static Lazy<Type> FileStreamType = new Lazy<Type>(() =>
         {
-            const string systemIOFileSystem = "System.IO.FileSystem, Version=0.0.0.0, Culture=neutral, PublicKeyToken = b03f5f7f11d50a3a";
+            const string systemIOFileSystem = "System.IO.FileSystem, Version=4.0.0.0, Culture=neutral, PublicKeyToken = b03f5f7f11d50a3a";
             const string mscorlib = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
 
             return LightUpHelper.GetType("System.IO.FileStream", systemIOFileSystem, mscorlib);

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryMapLightUp.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryMapLightUp.cs
@@ -53,8 +53,8 @@ namespace System.Reflection.Internal
 
         private static bool TryLoadTypes()
         {
-            const string systemIOMemoryMappedFiles = "System.IO.MemoryMappedFiles, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
-            const string systemRuntimeHandles = "System.Runtime.Handles, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
+            const string systemIOMemoryMappedFiles = "System.IO.MemoryMappedFiles, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
+            const string systemRuntimeHandles = "System.Runtime.Handles, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
             const string systemCore = "System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
 
             TryLoadType("System.IO.MemoryMappedFiles.MemoryMappedFileSecurity", systemIOMemoryMappedFiles, systemCore, out s_lazyMemoryMappedFileSecurityType);


### PR DESCRIPTION
This reverts commit 0c0efd1fca0aafd3ace1f738a7dce7b26c8b76e9.

Using 0.0.0.0 didn't help anything. Nick pointed out that it's desirable to indicate a minimum version known to have the functionality we need.