### PR TITLE
Fix HttpClient dependencies on desktop

### DIFF
--- a/src/System.Net.Http/pkg/System.Net.Http.pkgproj
+++ b/src/System.Net.Http/pkg/System.Net.Http.pkgproj
@@ -2,6 +2,9 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Version>4.1.0.0</Version>
+
+    <!-- we need to add a dependency on the unix shims, but only for the targetframework used by unix implementation -->
+    <UnixTargetFramework>netstandard1.4</UnixTargetFramework>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
@@ -12,14 +15,17 @@
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Net.Http.builds" />
-    <ProjectReference Include="$(NativePackagePath)\runtime.native.System\runtime.native.System.pkgproj" />
-    <ProjectReference Include="$(NativePackagePath)\runtime.native.System.Net.Http\runtime.native.System.Net.Http.pkgproj" />
-    <ProjectReference Include="$(NativePackagePath)\runtime.native.System.Security.Cryptography\runtime.native.System.Security.Cryptography.pkgproj" />
+    <ProjectReference Include="$(NativePackagePath)\runtime.native.System\runtime.native.System.pkgproj">
+      <TargetFramework>$(UnixTargetFramework)</TargetFramework>
+    </ProjectReference>
+    <ProjectReference Include="$(NativePackagePath)\runtime.native.System.Net.Http\runtime.native.System.Net.Http.pkgproj">
+      <TargetFramework>$(UnixTargetFramework)</TargetFramework>
+    </ProjectReference>
+    <ProjectReference Include="$(NativePackagePath)\runtime.native.System.Security.Cryptography\runtime.native.System.Security.Cryptography.pkgproj">
+      <TargetFramework>$(UnixTargetFramework)</TargetFramework>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <!-- We treat net46 as out-of-band, using the PCL reference assembly and PCL implementation. -->
-    <OutOfBoxFramework Include="net46" />
-
     <InboxOnTargetFramework Include="monoandroid10">
       <AsFrameworkReference>true</AsFrameworkReference>
     </InboxOnTargetFramework>

--- a/src/System.Net.Http/ref/System.Net.Http.csproj
+++ b/src/System.Net.Http/ref/System.Net.Http.csproj
@@ -4,9 +4,16 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageDestination Include="ref/netstandard1.3">
+      <TargetFramework>netstandard1.3</TargetFramework>
+    </PackageDestination>
+    <PackageDestination Include="ref/net46">
+      <TargetFramework>net46</TargetFramework>
+    </PackageDestination>
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="System.Net.Http.cs" />
   </ItemGroup>

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -11,10 +11,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Net.Http</AssemblyName>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(AssemblyVersionTransition)' == 'true'">4.1.0.0</AssemblyVersion>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
     <PackageTargetFramework Condition="'$(TargetsUnix)' == 'true'">netstandard1.4</PackageTargetFramework>
-    <PackageTargetRuntime Condition="'$(TargetsWindows)' == 'true'">win</PackageTargetRuntime>
     <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
     <NuGetTargetMoniker Condition="'$(TargetsUnix)' == 'true'">.NETStandard,Version=v1.4</NuGetTargetMoniker>
@@ -23,6 +20,15 @@
     <ProjectJson>unix/project.json</ProjectJson>
     <ProjectLockJson>unix/project.lock.json</ProjectLockJson>
   </PropertyGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+    <PackageDestination Include="runtimes/win/lib/netstandard1.3">
+      <TargetFramework>netstandard1.3</TargetFramework>
+    </PackageDestination>
+    <PackageDestination Include="lib/net46">
+      <TargetFramework>net46</TargetFramework>
+    </PackageDestination>
+  </ItemGroup>
+  
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />


### PR DESCRIPTION
The latest changes to make HttpClient an OOB implementation on desktop
were not getting the correct dependency set.  This has to do with the
the way that EnsureOOBFrameworks evaluates assets to duplicate.  It does
so by seeing if any placeholders are obscuring the netstandard asset and
copying the netstandard asset if that is the case.  This worked fine for
the reference assembly, but not the implementation since it wasn't
actually obscured.  The result was that NuGet selects the correct
assets, but is missing implementation dependencies.

For now I'm fixing this by changing the package structure to explicitly
break out the net46 implementations into their own folders.  This is
essentially what we were trying to make happen automatically with
EnsureOOBFrameworks.

Longer term we might want to refactor how we generate dependencies
to do an actual nuget-asset selection in order to harvest from the
actual assemblies that NuGet will choose.

For now I'm also working around the problem that the unix shims are
being referenced everywhere even though they're only needed for Unix.

There's still a problem with this package in that we have two different
netstandard dependency groups (one meant for Windows and one meant for
Unix) but because we can't express that in a fat package the Unix one
will win, even on a windows machine, if the target framework supports
NETStandard1.4 or higher.  This doesn't cause a problem at the moment
because the unix implementation is using a superset of the Windows
dependencies but we need to see about how to better handle
in lieu of the NuGet feature for RID-specific dependencies.

/cc @davidsh @weshaggard @chcosta