### PR TITLE
Remove dead code from CopyTo in Queue

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -134,7 +134,7 @@ namespace System.Collections.Generic
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
             }
 
-            int numToCopy = (arrayLen - arrayIndex < _size) ? (arrayLen - arrayIndex) : _size;
+            int numToCopy = _size;
             if (numToCopy == 0) return;
 
             int firstPart = (_array.Length - _head < numToCopy) ? _array.Length - _head : numToCopy;
@@ -174,7 +174,7 @@ namespace System.Collections.Generic
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
             }
 
-            int numToCopy = (arrayLen - index < _size) ? arrayLen - index : _size;
+            int numToCopy =  _size;
             if (numToCopy == 0) return;
 
             try


### PR DESCRIPTION
- We throw an exception if `arrayLen - index < _size` so this is dead
code
- Brings branch coverage to 100% in Queue

### `CopyTo<T>(T[] array, int arrayIndex)`
- The check [here](https://github.com/dotnet/corefx/blob/master/src/System.Collections/src/System/Collections/Generic/Queue.cs#L132) ensures that an exception is thrown

### `CopyTo(Array array, int arrayIndex)`
- The check [here](https://github.com/dotnet/corefx/blob/master/src/System.Collections/src/System/Collections/Generic/Queue.cs#L174) ensures that an exception is thrown

/cc @ianhays 