### PR TITLE
Add non-generic ICollection tests to SortedSet

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -2178,7 +2178,6 @@ namespace System.Collections.Generic
 
             private Stack<SortedSet<T>.Node> _stack;
             private SortedSet<T>.Node _current;
-            private static SortedSet<T>.Node s_dummyNode = new SortedSet<T>.Node(default(T));
 
             private bool _reverse;
 

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -283,4 +283,31 @@ namespace System.Collections.Tests
 
         #endregion
     }
+
+    public class SortedSet_ICollection_NonGeneric_Tests : ICollection_NonGeneric_Tests
+    {
+        protected override bool ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowsArgumentException { get { return true; } }
+        protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
+
+        protected override void AddToCollection(ICollection collection, int numberOfItemsToAdd)
+        {
+            int seed = numberOfItemsToAdd * 34;
+            for (int i = 0; i < numberOfItemsToAdd; i++)
+                ((SortedSet<string>)collection).Add(CreateT(seed++));
+        }
+
+        protected override ICollection NonGenericICollectionFactory()
+        {
+            return new SortedSet<string>();
+        }
+
+        protected string CreateT(int seed)
+        {
+            int stringLength = seed % 10 + 5;
+            Random rand = new Random(seed);
+            byte[] bytes = new byte[stringLength];
+            rand.NextBytes(bytes);
+            return Convert.ToBase64String(bytes);
+        }
+    }
 }

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -283,31 +283,4 @@ namespace System.Collections.Tests
 
         #endregion
     }
-
-    public class SortedSet_ICollection_NonGeneric_Tests : ICollection_NonGeneric_Tests
-    {
-        protected override bool ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowsArgumentException { get { return true; } }
-        protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
-
-        protected override void AddToCollection(ICollection collection, int numberOfItemsToAdd)
-        {
-            int seed = numberOfItemsToAdd * 34;
-            for (int i = 0; i < numberOfItemsToAdd; i++)
-                ((SortedSet<string>)collection).Add(CreateT(seed++));
-        }
-
-        protected override ICollection NonGenericICollectionFactory()
-        {
-            return new SortedSet<string>();
-        }
-
-        protected string CreateT(int seed)
-        {
-            int stringLength = seed % 10 + 5;
-            Random rand = new Random(seed);
-            byte[] bytes = new byte[stringLength];
-            rand.NextBytes(bytes);
-            return Convert.ToBase64String(bytes);
-        }
-    }
 }

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Tests.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.Collections.Tests
+{
+    public class SortedSet_ICollection_NonGeneric_Tests : ICollection_NonGeneric_Tests
+    {
+        protected override bool ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowsArgumentException { get { return true; } }
+        protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
+
+        protected override void AddToCollection(ICollection collection, int numberOfItemsToAdd)
+        {
+            int seed = numberOfItemsToAdd * 34;
+            for (int i = 0; i < numberOfItemsToAdd; i++)
+                ((SortedSet<string>)collection).Add(CreateT(seed++));
+        }
+
+        protected override ICollection NonGenericICollectionFactory()
+        {
+            return new SortedSet<string>();
+        }
+
+        protected string CreateT(int seed)
+        {
+            int stringLength = seed % 10 + 5;
+            Random rand = new Random(seed);
+            byte[] bytes = new byte[stringLength];
+            rand.NextBytes(bytes);
+            return Convert.ToBase64String(bytes);
+        }
+    }
+}

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Generic\SortedList\SortedList.Generic.Tests.cs" />
     <Compile Include="Generic\SortedSet\SortedSet.Generic.cs" />
     <Compile Include="Generic\SortedSet\SortedSet.Generic.Tests.cs" />
+    <Compile Include="Generic\SortedSet\SortedSet.Tests.cs" />
     <Compile Include="Generic\Stack\Stack.Tests.cs" />
     <Compile Include="Generic\Stack\Stack.Generic.cs" />
     <Compile Include="Generic\Stack\Stack.Generic.Tests.cs" />


### PR DESCRIPTION
Slight increase of ~0.2% in line CC, but mainly unifies SortedSet with the rest of the tests