### PR TITLE
Run only dnxcore50 tests on nano.

### DIFF
--- a/run-test.cmd
+++ b/run-test.cmd
@@ -6,9 +6,12 @@
 pushd %1
 
 FOR /D %%F IN (*.Tests) DO (
-pushd %%F\dnxcore50
-@echo "corerun.exe xunit.console.netcore.exe %%F.dll -xml testResults.xml -notrait category=outerloop -notrait category=failing -notrait category=nonwindowstests -notrait Benchmark=true"
-corerun.exe xunit.console.netcore.exe %%F.dll -xml testResults.xml -notrait category=outerloop -notrait category=failing -notrait category=nonwindowstests -notrait Benchmark=true
-popd )
+	IF EXIST %%F\dnxcore50 (
+		pushd %%F\dnxcore50
+		@echo "corerun.exe xunit.console.netcore.exe %%F.dll -xml testResults.xml -notrait category=outerloop -notrait category=failing -notrait category=nonwindowstests -notrait Benchmark=true"
+		corerun.exe xunit.console.netcore.exe %%F.dll -xml testResults.xml -notrait category=outerloop -notrait category=failing -notrait category=nonwindowstests -notrait Benchmark=true
+		popd
+	)
+)
 
 popd


### PR DESCRIPTION
After adding builds file, the net46 tests are dropped in Windows_NT.AnyCPU folder, and the dnxcore50 in AnyOS folder. So check first if dnxcore50 test config is there for the given test assembly, then attempt to run those tests.

Will fix failure in Windows Nano runs.

cc @joshfree