### PR TITLE
Build.sh change from uname -p to uname -m

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -195,7 +195,7 @@ __buildnative=false
 __TestNugetRuntimeId=win7-x64
 
 # Use uname to determine what the CPU is.
-CPUName=$(uname -p)
+CPUName=$(uname -m)
 # Some Linux platforms report unknown for platform, but the arch for machine.
 if [ $CPUName == "unknown" ]; then
     CPUName=$(uname -m)


### PR DESCRIPTION
On OSX (MBA Mid 2013) uname -p incorrectly returns i836, which is processed by the build script as an unknown processor type.

Note: before the change the build still builds x86_64 correctly because that x64 is the default. This change is mostly just to get rid of a warning and safeguard an incorrect build if the default changes later.