### PR TITLE
Remove unnecessary dependencies on non-generic and specialized collections from tests

### DIFF
--- a/src/System.Data.Common/tests/project.json
+++ b/src/System.Data.Common/tests/project.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24013-00",
     "System.Collections": "4.0.11-rc3-24013-00",
-    "System.Collections.NonGeneric": "4.0.1-rc3-24013-00",
     "System.Diagnostics.Tools": "4.0.1-rc3-24013-00",
     "System.Globalization": "4.0.11-rc3-24013-00",
     "System.IO": "4.1.0-rc3-24013-00",

--- a/src/System.Data.SqlClient/tests/ManualTests/project.json
+++ b/src/System.Data.SqlClient/tests/ManualTests/project.json
@@ -10,7 +10,6 @@
     "Microsoft.Win32.Primitives": "4.0.1-rc3-24013-00",
     "System.Collections": "4.0.11-rc3-24013-00",
     "System.Collections.Concurrent": "4.0.12-rc3-24013-00",
-    "System.Collections.NonGeneric": "4.0.1-rc3-24013-00",
     "System.ComponentModel": "4.0.1-rc3-24013-00",
     "System.ComponentModel.TypeConverter": "4.0.1-rc3-24013-00",
     "System.Console": "4.0.0-rc3-24013-00",

--- a/src/System.Net.NameResolution/tests/PalTests/project.json
+++ b/src/System.Net.NameResolution/tests/PalTests/project.json
@@ -3,7 +3,6 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24013-00",
     "Microsoft.Win32.Primitives": "4.0.1-rc3-24013-00",
     "System.Collections": "4.0.11-rc3-24013-00",
-    "System.Collections.NonGeneric": "4.0.1-rc3-24013-00",
     "System.ComponentModel.EventBasedAsync": "4.0.11-rc3-24013-00",
     "System.Console": "4.0.0-rc3-24013-00",
     "System.Diagnostics.Contracts": "4.0.1-rc3-24013-00",

--- a/src/System.Net.Sockets/tests/FunctionalTests/SelectTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SelectTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -50,8 +49,8 @@ namespace System.Net.Sockets.Tests
                     pair.Value.Send(new byte[1] { 42 });
                 }
 
-                ArrayList readList = new ArrayList(readPairs.Select(p => p.Key).ToArray());
-                ArrayList writeList = new ArrayList(writePairs.Select(p => p.Key).ToArray());
+                var readList = new List<Socket>(readPairs.Select(p => p.Key).ToArray());
+                var writeList = new List<Socket>(writePairs.Select(p => p.Key).ToArray());
 
                 Socket.Select(readList, writeList, null, FailTimeoutMicroseconds);
 
@@ -97,8 +96,8 @@ namespace System.Net.Sockets.Tests
             var errorPairs = Enumerable.Range(0, errors).Select(_ => CreateConnectedSockets()).ToArray();
             try
             {
-                ArrayList readList = new ArrayList(readPairs.Select(p => p.Key).ToArray());
-                ArrayList errorList = new ArrayList(errorPairs.Select(p => p.Key).ToArray());
+                var readList = new List<Socket>(readPairs.Select(p => p.Key).ToArray());
+                var errorList = new List<Socket>(errorPairs.Select(p => p.Key).ToArray());
 
                 Socket.Select(readList, null, errorList, SmallTimeoutMicroseconds);
 
@@ -131,7 +130,7 @@ namespace System.Net.Sockets.Tests
                     int next = rand.Next(0, readPairs.Count);
                     readPairs[next].Value.Send(new byte[1] { 42 });
 
-                    IList readList = new ArrayList(readPairs.Select(p => p.Key).ToArray());
+                    var readList = new List<Socket>(readPairs.Select(p => p.Key).ToArray());
                     Socket.Select(readList, null, null, FailTimeoutMicroseconds);
 
                     Assert.Equal(1, readList.Count);
@@ -160,7 +159,7 @@ namespace System.Net.Sockets.Tests
                     int next = rand.Next(0, errorPairs.Count);
                     errorPairs[next].Value.Send(new byte[1] { 42 }, SocketFlags.OutOfBand);
 
-                    IList errorList = new ArrayList(errorPairs.Select(p => p.Key).ToArray());
+                    var errorList = new List<Socket>(errorPairs.Select(p => p.Key).ToArray());
                     Socket.Select(null, null, errorList, FailTimeoutMicroseconds);
 
                     Assert.Equal(1, errorList.Count);

--- a/src/System.Net.Sockets/tests/FunctionalTests/project.json
+++ b/src/System.Net.Sockets/tests/FunctionalTests/project.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24013-00",
     "System.Collections": "4.0.11-rc3-24013-00",
-    "System.Collections.NonGeneric": "4.0.1-rc3-24013-00",
     "System.Diagnostics.Debug": "4.0.11-rc3-24013-00",
     "System.Diagnostics.Tracing": "4.1.0-rc3-24013-00",
     "System.IO.FileSystem": "4.0.1-rc3-24013-00",

--- a/src/System.Net.WebHeaderCollection/tests/project.json
+++ b/src/System.Net.WebHeaderCollection/tests/project.json
@@ -1,11 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24013-00",
-    "System.Collections.Specialized": "4.0.1-rc3-24013-00",
-    "System.Linq.Expressions": "4.0.11-rc3-24013-00",
-    "System.ObjectModel": "4.0.12-rc3-24013-00",
-    "System.Runtime": "4.1.0-rc3-24013-00",
-    "System.Text.RegularExpressions": "4.0.12-rc3-24013-00",
+    "System.Runtime": "4.0.0",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
     "test-runtime": {


### PR DESCRIPTION
There are a small number of remaining projects that still depend on the non-generic and specialized collections, that don't need to.

After this, the only remaining projects that depend on `System.Collections.NonGeneric`:
 - src/System.Collections.Specialized/src/project.json
 - src/System.Collections.Specialized/tests/project.json
 - src/System.Runtime.Serialization.Json/tests/Performance/project.json
 - src/System.Runtime.Serialization.Json/tests/project.json
 - src/System.Runtime.Serialization.Xml/tests/Performance/project.json
 - src/System.Runtime.Serialization.Xml/tests/project.json

And no projects depend on `System.Collections.Specialized`.

cc: @stephentoub, @davidsh, @saurabh500