### PR TITLE
Expose some implementation details of LowLevelList

### DIFF
--- a/src/Common/src/System/Collections/Generic/LowLevelList.cs
+++ b/src/Common/src/System/Collections/Generic/LowLevelList.cs
@@ -14,6 +14,9 @@
 ** (but any portion it does implement should match the real List<T>'s
 ** behavior.)
 **
+** It also exposes some of its implementation details to avoid
+** making copies, e.g. GetOrToArray() and GetArraySegment().
+**
 ** This file is a subset of System.Collections\System\Collections\Generics\List.cs
 ** and should be kept in sync with that file.
 ** 
@@ -215,6 +218,36 @@ namespace System.Collections.Generic
                 Capacity = newCapacity;
             }
         }
+        
+        // Returns the ArraySegment that contains the items of this list.
+        //
+        // Please use this instead of GetOrToArray if you
+        // don't need to return an array from your method
+        // (e.g. refactoring an internal API).
+        public ArraySegment<T> GetArraySegment() =>
+            new ArraySegment<T>(_items, 0, _size);
+        
+        // Returns the underlying array if the count/capacity
+        // are the same, otherwise makes a copy into a new array.
+        // Useful in e.g. public APIs where you have something like
+        // this:
+        //
+        // public T[] CreateFooArray()
+        // {
+        //     var list = new LowLevelList<T>();
+        //     <call list.Add() some number of times...>
+        //     return list.ToArray();
+        // }
+        //
+        // If we replace ToArray() with GetOrToArray(),
+        // we can avoid making an extra copy if the count
+        // and capacity of the list happen to be the same.
+        //
+        // This is invisible to the caller of the CreateFooArray
+        // method, since the array is not modified afterwards
+        // within the callee.
+        public T[] GetOrToArray() =>
+            Count == Capacity ? _items : ToArray();
 
 #if !TYPE_LOADER_IMPLEMENTATION
         // Adds the elements of the given collection to the end of this list. If


### PR DESCRIPTION
It looks like a common pattern with `List` and `LowLevelList` is to instantiate a new one, call `Add` on it a bunch of times, and then call `ToArray` on it. ([example](https://github.com/dotnet/corefx/blob/d0dc5fc099946adc1035b34a8b1f6042eddb0c75/src/Common/src/System/Linq/LowLevelEnumerable.cs#L43)) This is kinda wasteful, especially if the list's capacity == its count, since you can just return the underlying buffer if you're not planning to modify the list anymore.

This PR adds two new methods to `LowLevelList`:

- `GetOrToArray`
- `GetArraySegment`

The first one returns the underlying array if the capacity and count are the same, and the second one returns an `ArraySegment` of the underlying array behind the list (similar to `TryGetBuffer` in `MemoryStream`).

cc @JonHanna @stephentoub @hughbe