### PR TITLE
Disabling KerberosTest.NegotiateStream failing test in outerloop

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/KerberosTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/KerberosTest.cs
@@ -159,6 +159,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact, OuterLoop]
+        [ActiveIssue(7707)]
         [PlatformSpecific(PlatformID.Linux)]
         public void NegotiateStream_StreamToStream_AuthToHttpTarget_Success()
         {


### PR DESCRIPTION
I am disabling this test for time being , Since setup-kdc script has been modified in RHEL image , this test has started failing. In PR #7647 this test is already fixed to make it run with the updated script.
I will take care of removing this "ActiveIssue" in #7647 PR.
cc: @stephentoub @kapilash 
fix for #7707 