### PR TITLE
Fix CI jobs to also work for release/1.0.0-rc2

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -650,8 +650,8 @@ branchList.each { branchName ->
         def osGroup = osGroupMap[os]
         def configurationGroup = 'Debug'
 
-        def fullNativeCompBuildJobName = Utilities.getFolderName(project) + '/' + getJobName(Utilities.getFullJobName("nativecomp_${os.toLowerCase()}_${configurationGroup.toLowerCase()}", isPR), branchName)
-        def fullCoreFXBuildJobName = Utilities.getFolderName(project) + '/' + getJobName(Utilities.getFullJobName("${os.toLowerCase()}_${configurationGroup.toLowerCase()}_bld", isPR), branchName)
+        def fullNativeCompBuildJobName = Utilities.getFolderName(project) + '/' + getJobName(Utilities.getFullJobName(project, "nativecomp_${os.toLowerCase()}_${configurationGroup.toLowerCase()}", isPR), branchName)
+        def fullCoreFXBuildJobName = Utilities.getFolderName(project) + '/' + getJobName(Utilities.getFullJobName(project, "${os.toLowerCase()}_${configurationGroup.toLowerCase()}_bld", isPR), branchName)
 
         def newTestJobName = "outerloop_${os.toLowerCase()}_${configurationGroup.toLowerCase()}_checked_coreclr_tst"
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -458,7 +458,7 @@ def static addCopyCoreClrAndRunTestSteps(def job, String os, String osGroup, Str
             ${isOuterLoop ? 'sudo' : '' } ./run-test.sh \\
                 --configurationGroup ${configurationGroup} \\
                 --os ${osGroup} \\
-                --corefx-tests \${WORKSPACE}/bin/tests/ \\
+                --corefx-tests \${WORKSPACE}/bin/tests/${osGroup}.AnyCPU.${configurationGroup}/ \\
                 --coreclr-bins \${WORKSPACE}/bin/Product/${osGroup}.x64.${coreClrConfigurationGroup}/ \\
                 --mscorlib-bins \${WORKSPACE}/bin/Product/${osGroup}.x64.${coreClrConfigurationGroup}/ \\
                 ${useServerGC ? '--serverGc' : ''} ${isOuterLoop ? '--outerloop' : ''}

--- a/run-test.sh
+++ b/run-test.sh
@@ -345,8 +345,15 @@ then
     CoreClrObjs="$ProjectRoot/bin/obj/$OS.x64.$ConfigurationGroup"
 fi
 
-# Until netci.groovy is updated, if the CoreFxTests folder that was passed includes a specific
-# OS flavor, get the parent directory.
+# The CI system shares PR build job definitions between RC2 and master.  In RC2, we expected
+# that CoreFxTests was the path to the root folder containing the tests for a specific platform
+# (since all tests were rooted under a path like tests/Linux.AnyCPU.$ConfigurationGroup). In
+# master, we instead want CoreFxTests to point at the root of the tests folder, since tests
+# are now split across tests/AnyOS.AnyCPU.$ConfigruationGroup,
+# tests/Unix.AnyCPU.$ConfigruationGroup and tests/$OS.AnyCPU.$ConfigurationGroup.
+#
+# Until we can split the CI definitions up, we need them to pass a platform specific folder (so
+# the jobs work on RC2), so here we detect that case and use the parent folder instead.
 if [[ `basename $CoreFxTests` =~ ^(Linux|OSX|FreeBSD|NetBSD) ]]
 then
     CoreFxTests=`dirname $CoreFxTests`


### PR DESCRIPTION
The PR job definitions are shared between release/1.0.0-rc2 and master
However, in release/1.0.0-rc2, the way you invoke run-test.sh differs
from master because we don't have the .builds changes there and hence
the test layouts are different. Update the job definitions to use the
release/1.0.0-rc2 way of invoking run-test.sh and then update the
comment in run-test.sh that explains why we strip some stuff from
the test paths in some cases.