### PR TITLE
[RC2] Allow SslStreamPal.EncryptMessage to resize the output buffer

### DIFF
--- a/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
@@ -152,19 +152,19 @@ internal static partial class Interop
             return stateOk;
         }
 
-        internal static int Encrypt(SafeSslHandle context, byte[] buffer, int offset, int count, out Ssl.SslErrorCode errorCode)
+        internal static int Encrypt(SafeSslHandle context, byte[] input, int offset, int count, ref byte[] output, out Ssl.SslErrorCode errorCode)
         {
-            Debug.Assert(buffer != null);
+            Debug.Assert(input != null);
             Debug.Assert(offset >= 0);
             Debug.Assert(count >= 0);
-            Debug.Assert(buffer.Length >= offset + count);
+            Debug.Assert(input.Length >= offset + count);
 
             errorCode = Ssl.SslErrorCode.SSL_ERROR_NONE;
 
             int retVal;
             unsafe
             {
-                fixed (byte* fixedBuffer = buffer)
+                fixed (byte* fixedBuffer = input)
                 {
                     retVal = Ssl.SslWrite(context, fixedBuffer + offset, count);
                 }
@@ -191,10 +191,12 @@ internal static partial class Interop
             {
                 int capacityNeeded = Crypto.BioCtrlPending(context.OutputBio);
 
-                Debug.Assert(buffer.Length >= capacityNeeded, "Input buffer of size " + buffer.Length +
-                                                              " bytes is insufficient since encryption needs " + capacityNeeded + " bytes.");
+                if (output == null || output.Length < capacityNeeded)
+                {
+                    output = new byte[capacityNeeded];
+                }
 
-                retVal = BioRead(context.OutputBio, buffer, capacityNeeded);
+                retVal = BioRead(context.OutputBio, output, capacityNeeded);
             }
 
             return retVal;

--- a/src/Common/src/Interop/Unix/libssl/StreamSizes.cs
+++ b/src/Common/src/Interop/Unix/libssl/StreamSizes.cs
@@ -12,9 +12,17 @@ namespace System.Net
 
         internal StreamSizes()
         {
+            // Since the header and trailer values aren't being calculated anyways just
+            // report them as 0.
+            int ignoredHeader;
+            int ignoredTrailer;
+
+            header = 0;
+            trailer = 0;
+
             Interop.Ssl.GetStreamSizes(
-                out header,
-                out trailer,
+                out ignoredHeader,
+                out ignoredTrailer,
                 out maximumMessage);
         }
     }

--- a/src/System.Net.Security/src/System/Net/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/SecureChannel.cs
@@ -1043,7 +1043,8 @@ namespace System.Net.Security
                 GlobalLog.Dump(buffer, Math.Min(buffer.Length, 128));
             }
 
-            byte[] writeBuffer;
+            byte[] writeBuffer = output;
+
             try
             {
                 if (offset < 0 || offset > (buffer == null ? 0 : buffer.Length))
@@ -1059,16 +1060,12 @@ namespace System.Net.Security
                 resultSize = 0;
 
                 int bufferSizeNeeded = checked(size + _headerSize + _trailerSize);
-                if (output != null && bufferSizeNeeded <= output.Length)
-                {
-                    writeBuffer = output;
-                }
-                else
+
+                if (SslStreamPal.PresizeEncryptBuffer &&
+                    (output == null || output.Length < bufferSizeNeeded))
                 {
                     writeBuffer = new byte[bufferSizeNeeded];
                 }
-
-                Buffer.BlockCopy(buffer, offset, writeBuffer, _headerSize, size);
             }
             catch (Exception e)
             {
@@ -1085,7 +1082,15 @@ namespace System.Net.Security
                 throw;
             }
 
-            SecurityStatusPal secStatus = SslStreamPal.EncryptMessage(_securityContext, writeBuffer, size, _headerSize, _trailerSize, out resultSize);
+            SecurityStatusPal secStatus = SslStreamPal.EncryptMessage(
+                _securityContext,
+                buffer,
+                offset,
+                size,
+                _headerSize,
+                _trailerSize,
+                ref writeBuffer,
+                out resultSize);
 
             if (secStatus.ErrorCode != SecurityStatusPalErrorCode.OK)
             {

--- a/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
@@ -22,6 +22,7 @@ namespace System.Net
         }
 
         internal const bool StartMutualAuthAsAnonymous = false;
+        internal const bool PresizeEncryptBuffer = false;
 
         public static void VerifyPackageInfo()
         {
@@ -51,17 +52,16 @@ namespace System.Net
         {
             return new SafeFreeSslCredentials(certificate, protocols, policy);
         }
-        
-        public static SecurityStatusPal EncryptMessage(SafeDeleteContext securityContext, byte[] buffer, int size, int headerSize, int trailerSize, out int resultSize)
+
+        public static SecurityStatusPal EncryptMessage(SafeDeleteContext securityContext, byte[] input, int offset, int size, int headerSize, int trailerSize, ref byte[] output, out int resultSize)
         {
-            // Unencrypted data starts at an offset of headerSize
-            return EncryptDecryptHelper(securityContext, buffer, headerSize, size, headerSize, trailerSize, true, out resultSize);
+            return EncryptDecryptHelper(securityContext, input, offset, size, true, ref output, out resultSize);
         }
 
         public static SecurityStatusPal DecryptMessage(SafeDeleteContext securityContext, byte[] buffer, ref int offset, ref int count)
         {
             int resultSize;
-            SecurityStatusPal retVal = EncryptDecryptHelper(securityContext, buffer, offset, count, 0, 0, false, out resultSize);
+            SecurityStatusPal retVal = EncryptDecryptHelper(securityContext, buffer, offset, count, false, ref buffer, out resultSize);
             if (retVal.ErrorCode == SecurityStatusPalErrorCode.OK || 
                 retVal.ErrorCode == SecurityStatusPalErrorCode.Renegotiate)
             {
@@ -124,7 +124,7 @@ namespace System.Net
             }
         }
 
-        private static SecurityStatusPal EncryptDecryptHelper(SafeDeleteContext securityContext, byte[] buffer, int offset, int size, int headerSize, int trailerSize, bool encrypt, out int resultSize)
+        private static SecurityStatusPal EncryptDecryptHelper(SafeDeleteContext securityContext, byte[] input, int offset, int size, bool encrypt, ref byte[] output, out int resultSize)
         {
             resultSize = 0;
             try
@@ -134,12 +134,13 @@ namespace System.Net
 
                 if (encrypt)
                 {
-                    resultSize = Interop.OpenSsl.Encrypt(scHandle, buffer, offset, size, out errorCode);
+                    resultSize = Interop.OpenSsl.Encrypt(scHandle, input, offset, size, ref output, out errorCode);
                 }
                 else
                 {
                     Debug.Assert(offset == 0, "Expected offset 0 when decrypting");
-                    resultSize = Interop.OpenSsl.Decrypt(scHandle, buffer, size, out errorCode);
+                    Debug.Assert(ReferenceEquals(input, output), "Expected input==output when decrypting");
+                    resultSize = Interop.OpenSsl.Decrypt(scHandle, input, size, out errorCode);
                 }
 
                 switch (errorCode)

--- a/src/System.Net.Security/src/System/Net/SslStreamPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/SslStreamPal.Windows.cs
@@ -33,6 +33,7 @@ namespace System.Net
         }
 
         internal const bool StartMutualAuthAsAnonymous = true;
+        internal const bool PresizeEncryptBuffer = true;
 
         public static void VerifyPackageInfo()
         {
@@ -126,8 +127,13 @@ namespace System.Net
             return AcquireCredentialsHandle(direction, secureCredential);
         }
 
-        public static SecurityStatusPal EncryptMessage(SafeDeleteContext securityContext, byte[] writeBuffer, int size, int headerSize, int trailerSize, out int resultSize)
+        public static SecurityStatusPal EncryptMessage(SafeDeleteContext securityContext, byte[] input, int offset, int size, int headerSize, int trailerSize, ref byte[] output, out int resultSize)
         {
+            byte[] writeBuffer = output;
+
+            // Copy the input into the output buffer to prepare for SCHANNEL's expectations
+            Buffer.BlockCopy(input, offset, writeBuffer, headerSize, size);
+
             // Encryption using SCHANNEL requires 4 buffers: header, payload, trailer, empty.
             SecurityBuffer[] securityBuffer = new SecurityBuffer[4];
 


### PR DESCRIPTION
SecureChannel tried precalculating the size of the ouput buffer, because that's
how you interact with the Windows SChannel provider. Since OpenSSL has
the BIO type to handle payload buffering it isn't set up to report the header
and footer sizes the same way SChannel is.

So, let the PAL implementation change the output buffer if it wants it to be
bigger. The Windows implementation is largely unchanged, the only difference
being that the Buffer.BlockCopy that aligns the data for SChannel interpretation
has moved into the PAL. The Unix implementation doesn't need that extra
copy to happen, so there's even a mild perf gain here.

(RC2 port of #7725)
Fixes #7599.