### PR TITLE
[RC2] Fix Unix X509Store directory permissions check

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
@@ -448,7 +448,7 @@ namespace Internal.Cryptography.Pal
                 throw new CryptographicException(SR.Format(SR.Cryptography_OwnerNotCurrentUser, path));
             }
 
-            if ((dirStat.Mode & (int)Interop.Sys.Permissions.Mask) != (int)Interop.Sys.Permissions.S_IRWXU)
+            if ((dirStat.Mode & (int)Interop.Sys.Permissions.S_IRWXU) != (int)Interop.Sys.Permissions.S_IRWXU)
             {
                 throw new CryptographicException(SR.Format(SR.Cryptography_InvalidDirectoryPermissions, path));
             }

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -247,7 +247,7 @@
     <value>Unable to get file status.</value>
   </data>
   <data name="Cryptography_InvalidDirectoryPermissions" xml:space="preserve">
-    <value>Invalid directory permissions. The directory '{0}' must be readable, writable and executable by the owner. It must not be readable, writable or executable by anyone other than the owner.</value>
+    <value>Invalid directory permissions. The directory '{0}' must be readable, writable and executable by the owner.</value>
   </data>
   <data name="Cryptography_OwnerNotCurrentUser" xml:space="preserve">
     <value>The owner of '{0}' is not the current user.</value>


### PR DESCRIPTION
Users who create their first X509Store on build 23910 or later will get an exception that the directory has the wrong permissions. No test existed at the
time, and manual testing failed to identify the distinction between "continued
use" and "initial creation".

This changes the permissions check to ensure that the user permissions are
correct, and ignores the group and other permissions.  The files are explicitly
tested for rw?--?--?, and set to rw------- on mismatch, so there is no major
concern with the directory being overly readable.  It also adjusts the exception message to match the adjusted requirement, and adds a test.

This test will still suffer from the x509stores directory already existing on
established machines, since otherwise that runs the risk of breaking the
user's my and root stores if test cleanup goes awry.

(RC2 port of commit https://github.com/dotnet/corefx/pull/7655/commits/acee0a2414ca0898165d889783927d0a707abea4 from #7655)