### PR TITLE
Create xplat and Windows native symbol packages

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -99,6 +99,114 @@ if (CMAKE_SYSTEM_NAME STREQUAL Linux)
    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,--noexecstack")
 endif ()
 
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+    set(CLR_CMAKE_PLATFORM_UNIX 1)
+endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
+
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(CLR_CMAKE_PLATFORM_UNIX 1)
+endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+
+if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+    set(CLR_CMAKE_PLATFORM_UNIX 1)
+endif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+
+if(CMAKE_SYSTEM_NAME STREQUAL OpenBSD)
+    set(CLR_CMAKE_PLATFORM_UNIX 1)
+endif(CMAKE_SYSTEM_NAME STREQUAL OpenBSD)
+
+if(CMAKE_SYSTEM_NAME STREQUAL NetBSD)
+    set(CLR_CMAKE_PLATFORM_UNIX 1)
+endif(CMAKE_SYSTEM_NAME STREQUAL NetBSD)
+
+if(CMAKE_SYSTEM_NAME STREQUAL SunOS)
+    set(CLR_CMAKE_PLATFORM_UNIX 1)
+endif(CMAKE_SYSTEM_NAME STREQUAL SunOS)
+
+if (NOT WIN32)
+    if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+        # Ensure that dsymutil and strip is present
+        find_program(DSYMUTIL dsymutil)
+        if (DSYMUTIL STREQUAL "DSYMUTIL-NOTFOUND")
+            message(FATAL_ERROR "dsymutil not found")
+        endif()
+        find_program(STRIP strip)
+        if (STRIP STREQUAL "STRIP-NOTFOUND")
+            message(FATAL_ERROR "strip not found")
+        endif()
+    else (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+        # Ensure that objcopy is present
+        find_program(OBJCOPY objcopy)
+        if (OBJCOPY STREQUAL "OBJCOPY-NOTFOUND")
+            message(FATAL_ERROR "objcopy not found")
+        endif()
+    endif (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+endif ()
+
+
+function(strip_symbols targetName outputFilename)
+    if(CLR_CMAKE_PLATFORM_UNIX)
+        if(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
+
+            # On the older version of cmake (2.8.12) used on Ubuntu 14.04 the TARGET_FILE
+            # generator expression doesn't work correctly returning the wrong path and on
+            # the newer cmake versions the LOCATION property isn't supported anymore.
+            if(CMAKE_VERSION VERSION_EQUAL 3.0 OR CMAKE_VERSION VERSION_GREATER 3.0)
+                set(strip_source_file $<TARGET_FILE:${targetName}>)
+            else()
+                get_property(strip_source_file TARGET ${targetName} PROPERTY LOCATION)
+            endif()
+
+            if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+                set(strip_destination_file ${strip_source_file}.dwarf)
+
+                add_custom_command(
+                    TARGET ${targetName}
+                    POST_BUILD
+                    VERBATIM 
+                    COMMAND ${DSYMUTIL} --flat --minimize ${strip_source_file}
+                    COMMAND ${STRIP} -u -r ${strip_source_file}
+                    COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
+                )
+            else(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+                set(strip_destination_file ${strip_source_file}.dbg)
+
+                add_custom_command(
+                    TARGET ${targetName}
+                    POST_BUILD
+                    VERBATIM 
+                    COMMAND ${OBJCOPY} --only-keep-debug ${strip_source_file} ${strip_destination_file}
+                    COMMAND ${OBJCOPY} --strip-unneeded ${strip_source_file}
+                    COMMAND ${OBJCOPY} --add-gnu-debuglink=${strip_destination_file} ${strip_source_file}
+                    COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
+                )
+            endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+
+            set(${outputFilename} ${strip_destination_file} PARENT_SCOPE)
+        endif(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
+    endif(CLR_CMAKE_PLATFORM_UNIX)
+endfunction()
+
+function(install_library_and_symbols targetName)
+    strip_symbols(${targetName} strip_destination_file)
+
+    # On the older version of cmake (2.8.12) used on Ubuntu 14.04 the TARGET_FILE
+    # generator expression doesn't work correctly returning the wrong path and on
+    # the newer cmake versions the LOCATION property isn't supported anymore.
+    if(CMAKE_VERSION VERSION_EQUAL 3.0 OR CMAKE_VERSION VERSION_GREATER 3.0)
+        set(install_source_file $<TARGET_FILE:${targetName}>)
+    else()
+        get_property(install_source_file TARGET ${targetName} PROPERTY LOCATION)
+    endif()
+
+    install(PROGRAMS ${install_source_file} DESTINATION .)
+    if(WIN32)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${targetName}.pdb DESTINATION PDB)
+    else()
+        install(FILES ${strip_destination_file} DESTINATION .)
+    endif()
+endfunction()
+
 include(configure.cmake)
 
 add_subdirectory(System.IO.Compression.Native)

--- a/src/Native/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/Native/System.IO.Compression.Native/CMakeLists.txt
@@ -16,4 +16,4 @@ target_link_libraries(System.IO.Compression.Native
     ${ZLIB_LIBRARIES}
 )
 
-install (TARGETS System.IO.Compression.Native DESTINATION .)
+install_library_and_symbols (System.IO.Compression.Native)

--- a/src/Native/System.Native/CMakeLists.txt
+++ b/src/Native/System.Native/CMakeLists.txt
@@ -46,5 +46,5 @@ if (CMAKE_SYSTEM_NAME STREQUAL Linux)
     target_link_libraries(System.Native rt)
 endif ()
 
-install (TARGETS System.Native DESTINATION .)
+install_library_and_symbols (System.Native)
 install (TARGETS System.Native-Static DESTINATION .)

--- a/src/Native/System.Net.Http.Native/CMakeLists.txt
+++ b/src/Native/System.Net.Http.Native/CMakeLists.txt
@@ -25,4 +25,4 @@ target_link_libraries(System.Net.Http.Native
   ${CURL_LIBRARIES}
 )
 
-install (TARGETS System.Net.Http.Native DESTINATION .)
+install_library_and_symbols (System.Net.Http.Native)

--- a/src/Native/System.Net.Security.Native/CMakeLists.txt
+++ b/src/Native/System.Net.Security.Native/CMakeLists.txt
@@ -37,4 +37,4 @@ target_link_libraries(System.Net.Security.Native
     ${LIBGSS}
 )
 
-install (TARGETS System.Net.Security.Native DESTINATION .)
+install_library_and_symbols (System.Net.Security.Native)

--- a/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
@@ -71,4 +71,4 @@ endif()
 
 include(configure.cmake)
 
-install (TARGETS System.Security.Cryptography.Native DESTINATION .)
+install_library_and_symbols (System.Security.Cryptography.Native)

--- a/src/Native/pkg/dir.props
+++ b/src/Native/pkg/dir.props
@@ -1,5 +1,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.props))\dir.props" />
+
   <!-- coalesce RIDs into the correct build output directory -->
   <PropertyGroup>
     <OSGroupPath Condition="$(OSGroup.StartsWith('windows', StringComparison.OrdinalIgnoreCase))">Windows_NT</OSGroupPath>
@@ -10,6 +11,17 @@
     <OSGroupPath Condition="$(OSGroup.StartsWith('ubuntu'))">Linux</OSGroupPath>
     <OSGroupPath Condition="$(OSGroup.StartsWith('opensuse'))">Linux</OSGroupPath>
   </PropertyGroup>
+
+  <!-- Determine extensions of binary and symbol files on this OS. -->
+  <PropertyGroup>
+    <LibraryFileExtension Condition="'$(OSGroupPath)'=='Linux'">.so</LibraryFileExtension>
+    <LibraryFileExtension Condition="'$(OSGroupPath)'=='OSX'">.dylib</LibraryFileExtension>
+
+    <SymbolFileExtension>.pdb</SymbolFileExtension>
+    <SymbolFileExtension Condition="'$(OSGroupPath)'=='Linux'">.dbg</SymbolFileExtension>
+    <SymbolFileExtension Condition="'$(OSGroupPath)'=='OSX'">.dwarf</SymbolFileExtension>
+  </PropertyGroup>
+
   <PropertyGroup>
     <!-- common properties that point to output of native build.  Can be overriden in case of 
          a coordinating build that produces all packages from OS-specific native builds -->
@@ -24,4 +36,10 @@
     <Ubuntu1604NativePath Condition="'$(Ubuntu1604NativePath)' == ''">$(BuildNativePath)</Ubuntu1604NativePath>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
   </PropertyGroup>
+
+  <!-- Add path globs specific to native binaries to exclude unnecessary files from packages. -->
+  <ItemGroup Condition="'$(OSGroupPath)'=='Linux' OR '$(OSGroupPath)'=='OSX'">
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A$(SymbolFileExtension)" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.a;%2A%2A\%2A$(LibraryFileExtension)" />
+  </ItemGroup>
 </Project>

--- a/src/Native/pkg/dir.targets
+++ b/src/Native/pkg/dir.targets
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <File Include="@(NativeFile)" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <!-- Xplat builds strip symbols into a separate file in release mode. -->
+    <FindNeighboringSymbols Condition="'$(OSGroup)'!='Windows_NT' AND '$(ConfigurationGroup)'=='Release'">true</FindNeighboringSymbols>
+    <!-- Windows builds only emit pdbs in debug mode. -->
+    <FindNeighboringSymbols Condition="'$(OSGroup)'=='Windows_NT'">true</FindNeighboringSymbols>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(FindNeighboringSymbols)'=='true'">
+    <!-- On Windows, trim ".dll" before adding ".pdb". On xplat, the symbol extension is simply appended. -->
+    <NativeFileWithoutExtension Include="@(NativeFile)" Condition="'$(OSGroup)'!='Windows_NT'" />
+    <NativeFileWithoutExtension Include="@(NativeFile -> '%(RootDir)%(Directory)%(Filename)')" Condition="'$(OSGroup)'=='Windows_NT'" />
+
+    <File Include="@(NativeFileWithoutExtension -> '%(Identity)$(SymbolFileExtension)')">
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+
+    <!-- Include placeholder pdb on non-Windows platforms to ensure package is treated like a symbol package. -->
+    <File Include="$(MSBuildThisFileDirectory)\_.pdb" Condition="'$(PackageTargetRuntime)'!='' AND '$(OSGroup)'!='Windows_NT'">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/win/runtime.native.System.Data.SqlClient.sni.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/win/runtime.native.System.Data.SqlClient.sni.pkgproj
@@ -14,9 +14,9 @@
 
   <!-- These paths are not built in CoreFx, enable when fixing https://github.com/dotnet/corefx/issues/826 -->
   <ItemGroup>
-    <File Include="$(WinNativePath)sni.dll">
+    <NativeFile Include="$(WinNativePath)sni.dll">
       <TargetPath>runtimes/win7-$(PackagePlatform)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.IO.Compression/debian/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/debian/runtime.native.System.IO.Compression.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(DebianNativePath)System.IO.Compression.Native.so">
+    <NativeFile Include="$(DebianNativePath)System.IO.Compression.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.IO.Compression/fedora/23/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/fedora/23/runtime.native.System.IO.Compression.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(Fedora23NativePath)System.IO.Compression.Native.so">
+    <NativeFile Include="$(Fedora23NativePath)System.IO.Compression.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.IO.Compression/opensuse/13.2/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/opensuse/13.2/runtime.native.System.IO.Compression.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(OpenSuse132NativePath)System.IO.Compression.Native.so">
+    <NativeFile Include="$(OpenSuse132NativePath)System.IO.Compression.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.IO.Compression/osx/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/osx/runtime.native.System.IO.Compression.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(OSXNativePath)System.IO.Compression.Native.dylib">
+    <NativeFile Include="$(OSXNativePath)System.IO.Compression.Native.dylib">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.IO.Compression/rhel/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/rhel/runtime.native.System.IO.Compression.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(RHELNativePath)System.IO.Compression.Native.so">
+    <NativeFile Include="$(RHELNativePath)System.IO.Compression.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.IO.Compression/ubuntu/14.04/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/ubuntu/14.04/runtime.native.System.IO.Compression.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(Ubuntu1404NativePath)System.IO.Compression.Native.so">
+    <NativeFile Include="$(Ubuntu1404NativePath)System.IO.Compression.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.IO.Compression/ubuntu/16.04/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/ubuntu/16.04/runtime.native.System.IO.Compression.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(Ubuntu1604NativePath)System.IO.Compression.Native.so">
+    <NativeFile Include="$(Ubuntu1604NativePath)System.IO.Compression.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.IO.Compression/win10/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/win10/runtime.native.System.IO.Compression.pkgproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(WinNativePath)..\..\NetCoreForCoreCLR\native\clrcompression.dll">
+    <NativeFile Include="$(WinNativePath)..\..\NetCoreForCoreCLR\native\clrcompression.dll">
       <TargetPath>runtimes/win10-$(PackagePlatform)/lib/netcore50</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.IO.Compression/win7/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/win7/runtime.native.System.IO.Compression.pkgproj
@@ -8,9 +8,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <File Include="$(WinNativePath)\clrcompression.dll">
+        <NativeFile Include="$(WinNativePath)\clrcompression.dll">
             <TargetPath>runtimes/win7-$(PackagePlatform)/native</TargetPath>
-        </File>
+        </NativeFile>
     </ItemGroup>
 
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.IO.Compression/win8/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/win8/runtime.native.System.IO.Compression.pkgproj
@@ -8,9 +8,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <File Include="$(WinNativePath)\clrcompression.dll">
+        <NativeFile Include="$(WinNativePath)\clrcompression.dll">
             <TargetPath>runtimes/win8-$(PackagePlatform)/native</TargetPath>
-        </File>
+        </NativeFile>
     </ItemGroup>
 
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Net.Http/debian/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/debian/runtime.native.System.Net.Http.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(DebianNativePath)System.Net.Http.Native.so">
+    <NativeFile Include="$(DebianNativePath)System.Net.Http.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Net.Http/fedora/23/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/fedora/23/runtime.native.System.Net.Http.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(Fedora23NativePath)System.Net.Http.Native.so">
+    <NativeFile Include="$(Fedora23NativePath)System.Net.Http.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Net.Http/opensuse/13.2/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/opensuse/13.2/runtime.native.System.Net.Http.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(OpenSuse132NativePath)System.Net.Http.Native.so">
+    <NativeFile Include="$(OpenSuse132NativePath)System.Net.Http.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Net.Http/osx/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/osx/runtime.native.System.Net.Http.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(OSXNativePath)System.Net.Http.Native.dylib">
+    <NativeFile Include="$(OSXNativePath)System.Net.Http.Native.dylib">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Net.Http/rhel/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/rhel/runtime.native.System.Net.Http.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(RHELNativePath)System.Net.Http.Native.so">
+    <NativeFile Include="$(RHELNativePath)System.Net.Http.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Net.Http/ubuntu/14.04/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/ubuntu/14.04/runtime.native.System.Net.Http.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(Ubuntu1404NativePath)System.Net.Http.Native.so">
+    <NativeFile Include="$(Ubuntu1404NativePath)System.Net.Http.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Net.Http/ubuntu/16.04/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/ubuntu/16.04/runtime.native.System.Net.Http.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(Ubuntu1604NativePath)System.Net.Http.Native.so">
+    <NativeFile Include="$(Ubuntu1604NativePath)System.Net.Http.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Net.Security/debian/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/debian/runtime.native.System.Net.Security.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(DebianNativePath)\System.Net.Security.Native.so">
+    <NativeFile Include="$(DebianNativePath)\System.Net.Security.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Net.Security/fedora/23/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/fedora/23/runtime.native.System.Net.Security.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(Fedora23NativePath)\System.Net.Security.Native.so">
+    <NativeFile Include="$(Fedora23NativePath)\System.Net.Security.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Net.Security/opensuse/13.2/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/opensuse/13.2/runtime.native.System.Net.Security.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(OpenSuse132NativePath)\System.Net.Security.Native.so">
+    <NativeFile Include="$(OpenSuse132NativePath)\System.Net.Security.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Net.Security/osx/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/osx/runtime.native.System.Net.Security.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(OSXNativePath)\System.Net.Security.Native.dylib">
+    <NativeFile Include="$(OSXNativePath)\System.Net.Security.Native.dylib">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Net.Security/rhel/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/rhel/runtime.native.System.Net.Security.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(RHELNativePath)\System.Net.Security.Native.so">
+    <NativeFile Include="$(RHELNativePath)\System.Net.Security.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Net.Security/ubuntu/14.04/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/ubuntu/14.04/runtime.native.System.Net.Security.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(Ubuntu1404NativePath)\System.Net.Security.Native.so">
+    <NativeFile Include="$(Ubuntu1404NativePath)\System.Net.Security.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Net.Security/ubuntu/16.04/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/ubuntu/16.04/runtime.native.System.Net.Security.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(Ubuntu1604NativePath)\System.Net.Security.Native.so">
+    <NativeFile Include="$(Ubuntu1604NativePath)\System.Net.Security.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/debian/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/debian/runtime.native.System.Security.Cryptography.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(DebianNativePath)System.Security.Cryptography.Native.so">
+    <NativeFile Include="$(DebianNativePath)System.Security.Cryptography.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/23/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/fedora/23/runtime.native.System.Security.Cryptography.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(Fedora23NativePath)System.Security.Cryptography.Native.so">
+    <NativeFile Include="$(Fedora23NativePath)System.Security.Cryptography.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/13.2/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/opensuse/13.2/runtime.native.System.Security.Cryptography.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(OpenSuse132NativePath)System.Security.Cryptography.Native.so">
+    <NativeFile Include="$(OpenSuse132NativePath)System.Security.Cryptography.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/osx/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/osx/runtime.native.System.Security.Cryptography.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(OSXNativePath)System.Security.Cryptography.Native.dylib">
+    <NativeFile Include="$(OSXNativePath)System.Security.Cryptography.Native.dylib">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/rhel/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/rhel/runtime.native.System.Security.Cryptography.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(RHELNativePath)System.Security.Cryptography.Native.so">
+    <NativeFile Include="$(RHELNativePath)System.Security.Cryptography.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/14.04/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/14.04/runtime.native.System.Security.Cryptography.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(Ubuntu1404NativePath)System.Security.Cryptography.Native.so">
+    <NativeFile Include="$(Ubuntu1404NativePath)System.Security.Cryptography.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/16.04/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/16.04/runtime.native.System.Security.Cryptography.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(Ubuntu1604NativePath)System.Security.Cryptography.Native.so">
+    <NativeFile Include="$(Ubuntu1604NativePath)System.Security.Cryptography.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System/debian/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/debian/runtime.native.System.pkgproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(DebianNativePath)System.Native.so">
+    <NativeFile Include="$(DebianNativePath)System.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-    <File Include="$(DebianNativePath)System.Native.a">
+    </NativeFile>
+    <NativeFile Include="$(DebianNativePath)System.Native.a">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System/debian/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/debian/runtime.native.System.pkgproj
@@ -13,9 +13,9 @@
     <NativeFile Include="$(DebianNativePath)System.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
     </NativeFile>
-    <NativeFile Include="$(DebianNativePath)System.Native.a">
+    <File Include="$(DebianNativePath)System.Native.a">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </NativeFile>
+    </File>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System/fedora/23/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/fedora/23/runtime.native.System.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(Fedora23NativePath)System.Native.so">
+    <NativeFile Include="$(Fedora23NativePath)System.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
     <File Include="$(Fedora23NativePath)System.Native.a">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
     </File>

--- a/src/Native/pkg/runtime.native.System/opensuse/13.2/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/opensuse/13.2/runtime.native.System.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(OpenSuse132NativePath)System.Native.so">
+    <NativeFile Include="$(OpenSuse132NativePath)System.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
     <File Include="$(OpenSuse132NativePath)System.Native.a">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
     </File>

--- a/src/Native/pkg/runtime.native.System/osx/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/osx/runtime.native.System.pkgproj
@@ -13,9 +13,9 @@
     <NativeFile Include="$(OSXNativePath)System.Native.dylib">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
     </NativeFile>
-    <NativeFile Include="$(OSXNativePath)System.Native.a">
+    <File Include="$(OSXNativePath)System.Native.a">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </NativeFile>
+    </File>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System/osx/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/osx/runtime.native.System.pkgproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(OSXNativePath)System.Native.dylib">
+    <NativeFile Include="$(OSXNativePath)System.Native.dylib">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-    <File Include="$(OSXNativePath)System.Native.a">
+    </NativeFile>
+    <NativeFile Include="$(OSXNativePath)System.Native.a">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System/rhel/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/rhel/runtime.native.System.pkgproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(RHELNativePath)System.Native.so">
+    <NativeFile Include="$(RHELNativePath)System.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-    <File Include="$(RHELNativePath)System.Native.a">
+    </NativeFile>
+    <NativeFile Include="$(RHELNativePath)System.Native.a">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System/rhel/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/rhel/runtime.native.System.pkgproj
@@ -13,9 +13,9 @@
     <NativeFile Include="$(RHELNativePath)System.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
     </NativeFile>
-    <NativeFile Include="$(RHELNativePath)System.Native.a">
+    <File Include="$(RHELNativePath)System.Native.a">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </NativeFile>
+    </File>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System/ubuntu/14.04/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/ubuntu/14.04/runtime.native.System.pkgproj
@@ -13,9 +13,9 @@
     <NativeFile Include="$(Ubuntu1404NativePath)System.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
     </NativeFile>
-    <NativeFile Include="$(Ubuntu1404NativePath)System.Native.a">
+    <File Include="$(Ubuntu1404NativePath)System.Native.a">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </NativeFile>
+    </File>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System/ubuntu/14.04/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/ubuntu/14.04/runtime.native.System.pkgproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(Ubuntu1404NativePath)System.Native.so">
+    <NativeFile Include="$(Ubuntu1404NativePath)System.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-    <File Include="$(Ubuntu1404NativePath)System.Native.a">
+    </NativeFile>
+    <NativeFile Include="$(Ubuntu1404NativePath)System.Native.a">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System/ubuntu/16.04/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/ubuntu/16.04/runtime.native.System.pkgproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(Ubuntu1604NativePath)System.Native.so">
+    <NativeFile Include="$(Ubuntu1604NativePath)System.Native.so">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    </NativeFile>
     <File Include="$(Ubuntu1604NativePath)System.Native.a">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
     </File>


### PR DESCRIPTION
On Windows, in Debug configuration, creates symbol packages with the `.pdb` from the native build.

On Linux/OSX, in Release configuration, creates symbol packages with symbols that have been stripped from the release library. On Linux the symbol files are `.so.dbg`, on OSX `.dylib.dwarf`.

The symbol stripping code is from https://github.com/dotnet/coreclr/blob/afdce3a592e/CMakeLists.txt#L279-L340 as well as some simplified platform detection logic from earlier in that file. I also looked at the PRs for stripping coreclr symbols (https://github.com/dotnet/coreclr/pull/3872) and creating coreclr symbol packages (https://github.com/dotnet/coreclr/pull/4218) a lot while making these changes.

I've tested on Win10, OSX 10.11, and Ubuntu 14.04.4. I've uploaded the resulting native symbol packages to https://www.myget.org/gallery/dagood-test-native-symbols-corefx.

I had to rig a few things to test this out (I'll be looking into them further):
* On OSX, I had to force my `RuntimeOS` to `osx.10.10` in `build-packages.sh`. It's being used to filter which packages are created, and my `osx.10.11` resulted in no runtime packages being made.
* On all platforms I passed `/p:ConfigurationGroup=Release` (or `Debug`) to `build-packages`. The command should probably have a switch built in.

/cc @ericstj @weshaggard @brianrob