### PR TITLE
Restrict number of fallback levels in ArrayPool

### DIFF
--- a/src/System.Buffers/src/System/Buffers/DefaultArrayPool.cs
+++ b/src/System.Buffers/src/System/Buffers/DefaultArrayPool.cs
@@ -47,9 +47,19 @@ namespace System.Buffers
             int index = Utilities.SelectBucketIndex(minimumLength);
             if (index < _buckets.Length)
             {
-                // Search for an array starting at the 'index' bucket. If the bucket
-                // is empty, bump up to the next higher bucket and try that one.
-                for (int i = index; i < _buckets.Length; i++)
+                // Search for an array starting at the 'index' bucket. If the bucket is empty, bump up to the
+                // next higher bucket and try that one. Only try a max number of buckets, e.g. a max of 2 will
+                // guarantee that for a request that maps to a bucket of size N, we'll not return a buffer larger
+                // than N*2, and for a max of 3, we'll not return a buffer larger than N*4, etc.
+
+                const int MaxBucketsToTry = 2;
+                int maxIndex = index + MaxBucketsToTry;
+                if (maxIndex >= _buckets.Length)
+                {
+                    maxIndex = _buckets.Length;
+                }
+
+                for (int i = index; i < maxIndex; i++)
                 {
                     buffer = _buckets[i].Rent();
 


### PR DESCRIPTION
The current implementation of ArrayPool tries to get a buffer from the appropriate bucket for the requested size.  If it's unable to because the bucket has been exhausted, it then tries the next size up.  If that one's exhausted, it tries the next size up.  And so on, until the max size, and if everything is exhausted, the original bucket's size is then allocated.

The theory behind this is that it's better to give back an existing buffer rather than allocating a new one, even if it means giving back a buffer that's larger than requested, and similarly that it's better to allocate a buffer that could potentially be returned and stored later, even if it's larger than requested.  However, in a situation where lots of requests come in to rent a small size, they could actually end up allocating a significant amount of memory.  For example, with the default settings, if 650 requests came in for a 256 element object[], we'd end up exhausting all potential buffers in the pool, and allocating ~800MB of arrays, compared to the expected ~1.2MB of arrays.

This commit addresses this by limiting the number of levels we try before falling back to just allocating the original bucket's size.  This ensures we're not overly wasteful in giving back a much larger array than the one requested.  With the limit set in this commit, you'll never get back an array more than twice what was requested; we can tweak that in the future as needed.  We can explore increasing that fallback level as needed, and potentially making it configurable in the future.

cc: @rynowak, @sokket, @KrzysztofCwalina, @benaadams 

@rynowak, can you help putting this through its paces, making sure that it addresses the issues you were hitting and doesn't noticeably and negatively impact others?

Related issue: https://github.com/aspnet/Mvc/issues/3516