### PR TITLE
Add Http redirect tests

### DIFF
--- a/src/Common/tests/System/Net/HttpTestServers.cs
+++ b/src/Common/tests/System/Net/HttpTestServers.cs
@@ -91,42 +91,45 @@ namespace System.Net.Test.Common
                     statusDescription));
         }
 
-        public static Uri RedirectUriForDestinationUri(bool secure, Uri destinationUri, int hops)
+        public static Uri RedirectUriForDestinationUri(bool secure, int statusCode, Uri destinationUri, int hops)
         {
             string uriString;
             string destination = Uri.EscapeDataString(destinationUri.AbsoluteUri);
-            
+
             if (hops > 1)
             {
-                uriString = string.Format("{0}://{1}/{2}?uri={3}&hops={4}",
+                uriString = string.Format("{0}://{1}/{2}?statuscode={3}&uri={4}&hops={5}",
                     secure ? HttpsScheme : HttpScheme,
                     Host,
                     RedirectHandler,
+                    statusCode,
                     destination,
                     hops);
             }
             else
             {
-                uriString = string.Format("{0}://{1}/{2}?uri={3}",
+                uriString = string.Format("{0}://{1}/{2}?statuscode={3}&uri={4}",
                     secure ? HttpsScheme : HttpScheme,
                     Host,
                     RedirectHandler,
+                    statusCode,
                     destination);
             }
             
             return new Uri(uriString);
         }
 
-        public static Uri RedirectUriForCreds(bool secure, string userName, string password)
+        public static Uri RedirectUriForCreds(bool secure, int statusCode, string userName, string password)
         {
-                Uri destinationUri = BasicAuthUriForCreds(secure, userName, password);
-                string destination = Uri.EscapeDataString(destinationUri.AbsoluteUri);
-                
-                return new Uri(string.Format("{0}://{1}/{2}?uri={3}",
-                    secure ? HttpsScheme : HttpScheme,
-                    Host,
-                    RedirectHandler,
-                    destination));
+            Uri destinationUri = BasicAuthUriForCreds(secure, userName, password);
+            string destination = Uri.EscapeDataString(destinationUri.AbsoluteUri);
+            
+            return new Uri(string.Format("{0}://{1}/{2}?statuscode={3}&uri={4}",
+                secure ? HttpsScheme : HttpScheme,
+                Host,
+                RedirectHandler,
+                statusCode,
+                destination));
         }
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -57,7 +57,13 @@ namespace System.Net.Http.Functional.Tests
             foreach (bool checkRevocation in new[] { true, false })
             {
                 yield return new object[] { HttpTestServers.SecureRemoteEchoServer, checkRevocation };
-                yield return new object[] { HttpTestServers.RedirectUriForDestinationUri(true, HttpTestServers.SecureRemoteEchoServer, 1), checkRevocation };
+                yield return new object[] {
+                    HttpTestServers.RedirectUriForDestinationUri(
+                        secure:true,
+                        statusCode:302,
+                        destinationUri:HttpTestServers.SecureRemoteEchoServer,
+                        hops:1),
+                    checkRevocation };
             }
         }
 


### PR DESCRIPTION
Now that the Azure test endpoint has been updated, we can add more redirect tests that use different redirect status codes.

It isn't necessary to modify every existing test to use different codes. But I modified the important ones especially those using credentials.

Fixes #7505