### PR TITLE
Remove uses of MakeCompletedTask in System.IO

### DIFF
--- a/src/System.IO/src/System/IO/StreamWriter.cs
+++ b/src/System.IO/src/System/IO/StreamWriter.cs
@@ -516,7 +516,7 @@ namespace System.IO
             }
             else
             {
-                return MakeCompletedTask();
+                return Task.CompletedTask;
             }
         }
 
@@ -840,23 +840,13 @@ namespace System.IO
             set { _haveWrittenPreamble = value; }
         }
 
-
-#pragma warning disable 1998 // async method with no await
-        private async Task MakeCompletedTask()
-        {
-            // do nothing.  We're taking advantage of the async infrastructure's optimizations, one of which is to
-            // return a cached already-completed Task when possible.
-        }
-#pragma warning restore 1998
-
-
         private Task FlushAsyncInternal(bool flushStream, bool flushEncoder,
                                         char[] sCharBuffer, int sCharPos)
         {
             // Perf boost for Flush on non-dirty writers.
             if (sCharPos == 0 && !flushStream && !flushEncoder)
             {
-                return MakeCompletedTask();
+                return Task.CompletedTask;
             }
 
             Task flushTask = FlushAsyncInternal(this, flushStream, flushEncoder, sCharBuffer, sCharPos, _haveWrittenPreamble,

--- a/src/System.IO/src/System/IO/StringWriter.cs
+++ b/src/System.IO/src/System/IO/StringWriter.cs
@@ -136,56 +136,49 @@ namespace System.IO
             }
         }
 
-
         #region Task based Async APIs
-#pragma warning disable 1998 // async method with no await
-        private async Task MakeCompletedTask()
-        {
-            // do nothing.  We're taking advantage of the async infrastructure's optimizations, one of which is to
-            // return a cached already-completed Task when possible.
-        }
-#pragma warning restore 1998
-
+        
         public override Task WriteAsync(char value)
         {
             Write(value);
-            return MakeCompletedTask();
+            return Task.CompletedTask;
         }
 
         public override Task WriteAsync(string value)
         {
             Write(value);
-            return MakeCompletedTask();
+            return Task.CompletedTask;
         }
 
         public override Task WriteAsync(char[] buffer, int index, int count)
         {
             Write(buffer, index, count);
-            return MakeCompletedTask();
+            return Task.CompletedTask;
         }
 
         public override Task WriteLineAsync(char value)
         {
             WriteLine(value);
-            return MakeCompletedTask();
+            return Task.CompletedTask;
         }
 
         public override Task WriteLineAsync(string value)
         {
             WriteLine(value);
-            return MakeCompletedTask();
+            return Task.CompletedTask;
         }
 
         public override Task WriteLineAsync(char[] buffer, int index, int count)
         {
             WriteLine(buffer, index, count);
-            return MakeCompletedTask();
+            return Task.CompletedTask;
         }
 
         public override Task FlushAsync()
         {
-            return MakeCompletedTask();
+            return Task.CompletedTask;
         }
+        
         #endregion
 
         // Returns a string containing the characters written to this TextWriter

--- a/src/System.IO/src/System/IO/TextWriter.cs
+++ b/src/System.IO/src/System/IO/TextWriter.cs
@@ -489,19 +489,11 @@ namespace System.IO
         {
             if (buffer == null)
             {
-                return MakeCompletedTask();
+                return Task.CompletedTask;
             }
 
             return WriteAsync(buffer, 0, buffer.Length);
         }
-
-#pragma warning disable 1998 // async method with no await
-        private async Task MakeCompletedTask()
-        {
-            // do nothing.  We're taking advantage of the async infrastructure's optimizations, one of which is to
-            // return a cached already-completed Task when possible.
-        }
-#pragma warning restore 1998
 
         public virtual Task WriteAsync(char[] buffer, int index, int count)
         {
@@ -540,7 +532,7 @@ namespace System.IO
         {
             if (buffer == null)
             {
-                return MakeCompletedTask();
+                return Task.CompletedTask;
             }
 
             return WriteLineAsync(buffer, 0, buffer.Length);


### PR DESCRIPTION
Since `System.IO` uses a newer version of `System.Runtime` which supports `Task.CompletedTask`, there's no longer a need for a method which returns a cached task.

cc @stephentoub