### PR TITLE
Change the minimum target framework for System.Data.SqlClient to net 451

### DIFF
--- a/src/System.Data.SqlClient/pkg/System.Data.SqlClient.pkgproj
+++ b/src/System.Data.SqlClient/pkg/System.Data.SqlClient.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\4.0\System.Data.SqlClient.csproj">
-      <SupportedFramework>net45;</SupportedFramework>
+      <SupportedFramework>net451;</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.Data.SqlClient.csproj">
       <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>

--- a/src/System.Data.SqlClient/ref/4.0/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/ref/4.0/System.Data.SqlClient.csproj
@@ -4,8 +4,8 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.1</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.1</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.2</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.2</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Data.SqlClient.cs" />

--- a/src/System.Data.SqlClient/ref/4.0/project.json
+++ b/src/System.Data.SqlClient/ref/4.0/project.json
@@ -8,9 +8,9 @@
     "System.Xml.ReaderWriter": "4.0.0"
   },
   "frameworks": {
-    "netstandard1.1": {
+    "netstandard1.2": {
       "imports": [
-        "dotnet5.2"
+        "dotnet5.3"
       ]
     }
   }

--- a/src/System.Data.SqlClient/src/ApiCompatBaseline.net45.txt
+++ b/src/System.Data.SqlClient/src/ApiCompatBaseline.net45.txt
@@ -1,4 +1,0 @@
-MembersMustExist : Member 'System.Data.SqlClient.SqlConnectionStringBuilder.ConnectRetryCount.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Data.SqlClient.SqlConnectionStringBuilder.ConnectRetryCount.set(System.Int32)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Data.SqlClient.SqlConnectionStringBuilder.ConnectRetryInterval.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Data.SqlClient.SqlConnectionStringBuilder.ConnectRetryInterval.set(System.Int32)' does not exist in the implementation but it does exist in the contract.

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.builds
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.builds
@@ -9,7 +9,7 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="System.Data.SqlClient.csproj">
-      <TargetGroup>net45</TargetGroup>
+      <TargetGroup>net451</TargetGroup>
     </Project>
     <Project Include="System.Data.SqlClient.csproj">
       <TargetGroup>net46</TargetGroup>

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -7,10 +7,11 @@
   <PropertyGroup>
     <ProjectGuid>{D4550556-4745-457F-BA8F-3EBF3836D6B4}</ProjectGuid>
     <AssemblyName>System.Data.SqlClient</AssemblyName>
-    <AssemblyVersion Condition="'$(TargetGroup)' == 'net45'">4.0.0.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(TargetGroup)' != 'net45'">4.1.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)' == 'net451'">4.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)' != 'net451'">4.1.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net45' OR '$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net451' OR '$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(TargetGroup)' == 'net451'">net451</PackageTargetFramework>
     <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
     <UsePackageTargetRuntimeDefaults Condition="'$(TargetGroup)' == ''">true</UsePackageTargetRuntimeDefaults>
@@ -22,8 +23,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net451_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net451_Release|AnyCPU'" />
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="Microsoft\SqlServer\Server\ITypedGetters.cs" />
     <Compile Include="Microsoft\SqlServer\Server\ITypedGettersV3.cs" />

--- a/src/System.Data.SqlClient/src/project.json
+++ b/src/System.Data.SqlClient/src/project.json
@@ -41,9 +41,9 @@
         "System.Xml.ReaderWriter": "4.0.0"
       }
     },
-    "net45": {
+    "net451": {
       "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.5": "1.0.1"
+        "Microsoft.TargetingPack.NETFramework.v4.5.1": "1.0.1"
       }
     },
     "net46": {


### PR DESCRIPTION
The changes contains 
1. Upgrade of SqlClient min target framework to .Net 4.5.1
2. Remove the Api Compat baseline file. Since there is no difference emitted by msbuild /p:RunApiCompat=true the baseline file is no longer required.

Fixes #6938 