### PR TITLE
Remove SslStreamPal.PresizeEncryptBuffer

### DIFF
--- a/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
@@ -159,7 +159,8 @@ internal static partial class Interop
             Debug.Assert(input != null);
             Debug.Assert(offset >= 0);
             Debug.Assert(count >= 0);
-            Debug.Assert(input.Length >= offset + count);
+            Debug.Assert(offset <= input.Length);
+            Debug.Assert(input.Length - offset >= count);
 
             errorCode = Ssl.SslErrorCode.SSL_ERROR_NONE;
 

--- a/src/System.Net.Security/src/System/Net/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/SecureChannel.cs
@@ -1058,14 +1058,6 @@ namespace System.Net.Security
                 }
 
                 resultSize = 0;
-
-                int bufferSizeNeeded = checked(size + _headerSize + _trailerSize);
-
-                if (SslStreamPal.PresizeEncryptBuffer &&
-                    (output == null || output.Length < bufferSizeNeeded))
-                {
-                    writeBuffer = new byte[bufferSizeNeeded];
-                }
             }
             catch (Exception e)
             {

--- a/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
@@ -22,7 +22,6 @@ namespace System.Net
         }
 
         internal const bool StartMutualAuthAsAnonymous = false;
-        internal const bool PresizeEncryptBuffer = false;
 
         public static void VerifyPackageInfo()
         {


### PR DESCRIPTION
* Move the Windows buffer (p)resizing code into the Windows PAL
* Remove the consts from the PAL interface
* Harden an assert in the Unix PAL TLS Encrypt method

Addresses feedback from #7725.
cc: @CIPop @stephentoub