### PR TITLE
Async improvements to System.IO

### DIFF
--- a/src/Common/src/System/Threading/Tasks/TaskCache.cs
+++ b/src/Common/src/System/Threading/Tasks/TaskCache.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Threading.Tasks
+{
+    internal static class TaskCache
+    {
+        private static Task<int> s_zero;
+        private static Task<string> s_nullString;
+        private static Task<string> s_emptyString;
+        
+        public static Task<int> Zero =>
+            s_zero ?? (s_zero = Task.FromResult(0));
+        
+        public static Task<string> NullString =>
+            s_nullString ?? (s_nullString = Task.FromResult<string>(null));
+        
+        public static Task<string> EmptyString =>
+            s_emptyString ?? (s_emptyString = Task.FromResult(string.Empty));
+    }
+}

--- a/src/System.IO/src/System.IO.csproj
+++ b/src/System.IO/src/System.IO.csproj
@@ -58,6 +58,9 @@
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
       <Link>Common\System\IO\StringBuilderCache.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskCache.cs">
+      <Link>Common\System\Threading\Tasks\TaskCache.cs</Link>
+    </Compile>
     <Compile Include="$(Commonpath)\System\SR.Core.cs" Condition="'$(TargetGroup)' == 'netcore50aot'">
       <Link>Common\System\SR.Core.cs</Link>
     </Compile>

--- a/src/System.IO/src/System.IO.csproj
+++ b/src/System.IO/src/System.IO.csproj
@@ -37,6 +37,10 @@
   <ItemGroup Condition="'$(TargetGroup)' != 'net462'">
     <Compile Include="System\IO\BufferedStream.cs" />
     <Compile Include="System\IO\InvalidDataException.cs" />
+    <!-- Common -->
+    <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskCache.cs">
+      <Link>Common\System\Threading\Tasks\TaskCache.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcore50aot' or '$(TargetGroup)' == 'netstandard13aot'">
     <Compile Include="System\IO\BinaryReader.cs" />
@@ -57,9 +61,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
       <Link>Common\System\IO\StringBuilderCache.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskCache.cs">
-      <Link>Common\System\Threading\Tasks\TaskCache.cs</Link>
     </Compile>
     <Compile Include="$(Commonpath)\System\SR.Core.cs" Condition="'$(TargetGroup)' == 'netcore50aot'">
       <Link>Common\System\SR.Core.cs</Link>

--- a/src/System.IO/src/System/IO/BufferedStream.cs
+++ b/src/System.IO/src/System/IO/BufferedStream.cs
@@ -509,7 +509,9 @@ namespace System.IO
             if (t != null && t.Result == val)
                 return t;
 
-            t = Task.FromResult<int>(val);
+            t = val == 0 ?
+                TaskCache.Zero : // Return a cached Task if EOF has been reached
+                Task.FromResult<int>(val);
             _lastSyncCompletedReadTask = t;
             return t;
         }

--- a/src/System.IO/src/System/IO/MemoryStream.cs
+++ b/src/System.IO/src/System/IO/MemoryStream.cs
@@ -22,7 +22,7 @@ namespace System.IO
         private byte[] _buffer;    // Either allocated internally or externally.
         private int _origin;       // For user-provided arrays, start at this origin
         private int _position;     // read/write head.
-        [ContractPublicPropertyName("Length")]
+        [ContractPublicPropertyName(nameof(Length))]
         private int _length;       // Number of bytes within the memory stream
         private int _capacity;     // length of usable portion of buffer for stream
         // Note that _capacity == _buffer.Length for non-user-provided byte[]'s
@@ -193,14 +193,12 @@ namespace System.IO
         {
         }
 
-#pragma warning disable 1998 //async method with no await operators
         public override async Task FlushAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-
             Flush();
+            return Task.CompletedTask;
         }
-#pragma warning restore 1998
 
         public virtual bool TryGetBuffer(out ArraySegment<byte> buffer)
         {
@@ -439,15 +437,14 @@ namespace System.IO
             return ReadAsyncImpl(buffer, offset, count, cancellationToken);
         }
 
-#pragma warning disable 1998 //async method with no await operators
-        private async Task<int> ReadAsyncImpl(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        private Task<int> ReadAsyncImpl(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-
-            return Read(buffer, offset, count);
+            int read = Read(buffer, offset, count);
+            return read == 0 ?
+                TaskCache.Zero : // Return a cached Task if the end has been reached
+                Task.FromResult(read);
         }
-#pragma warning restore 1998
-
 
         public override int ReadByte()
         {
@@ -507,7 +504,7 @@ namespace System.IO
             return CopyToAsyncImpl(destination, bufferSize, cancellationToken);
         }
 
-        private async Task CopyToAsyncImpl(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        private Task CopyToAsyncImpl(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -522,11 +519,12 @@ namespace System.IO
             MemoryStream memStrDest = destination as MemoryStream;
             if (memStrDest == null)
             {
-                await destination.WriteAsync(_buffer, pos, n, cancellationToken).ConfigureAwait(false);
+                return destination.WriteAsync(_buffer, pos, n, cancellationToken);
             }
             else
             {
                 memStrDest.Write(_buffer, pos, n);
+                return Task.CompletedTask;
             }
         }
 
@@ -724,14 +722,12 @@ namespace System.IO
             return WriteAsyncImpl(buffer, offset, count, cancellationToken);
         }
 
-#pragma warning disable 1998 //async method with no await operators
-        private async Task WriteAsyncImpl(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        private Task WriteAsyncImpl(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-
             Write(buffer, offset, count);
+            return Task.CompletedTask;
         }
-#pragma warning restore 1998
 
         public override void WriteByte(byte value)
         {

--- a/src/System.IO/src/System/IO/Stream.cs
+++ b/src/System.IO/src/System/IO/Stream.cs
@@ -399,6 +399,12 @@ namespace System.IO
                 set { }
             }
 
+            public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return Task.CompletedTask;
+            }
+
             protected override void Dispose(bool disposing)
             {
                 // Do nothing - we don't want NullStream singleton (static) to be closable
@@ -407,26 +413,23 @@ namespace System.IO
             public override void Flush()
             {
             }
-
-#pragma warning disable 1998 // async method with no await
-            public override async Task FlushAsync(CancellationToken cancellationToken)
+            
+            public override Task FlushAsync(CancellationToken cancellationToken)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                return Task.CompletedTask;
             }
-#pragma warning restore 1998
 
             public override int Read(byte[] buffer, int offset, int count)
             {
                 return 0;
             }
 
-#pragma warning disable 1998 // async method with no await
             public override async Task<int> ReadAsync(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                return 0;
+                return Task.FromResult(0);
             }
-#pragma warning restore 1998
 
             public override int ReadByte()
             {
@@ -436,13 +439,12 @@ namespace System.IO
             public override void Write(byte[] buffer, int offset, int count)
             {
             }
-
-#pragma warning disable 1998 // async method with no await
-            public override async Task WriteAsync(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            
+            public override Task WriteAsync(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                return Task.CompletedTask;
             }
-#pragma warning restore 1998
 
             public override void WriteByte(byte value)
             {

--- a/src/System.IO/src/System/IO/Stream.cs
+++ b/src/System.IO/src/System/IO/Stream.cs
@@ -428,7 +428,7 @@ namespace System.IO
             public override async Task<int> ReadAsync(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                return Task.FromResult(0);
+                return TaskCache.Zero;
             }
 
             public override int ReadByte()

--- a/src/System.IO/src/System/IO/StreamReader.cs
+++ b/src/System.IO/src/System/IO/StreamReader.cs
@@ -1360,14 +1360,39 @@ namespace System.IO
                 return 0;
             }
 
+            public override Task<int> ReadAsync(char[] buffer, int index, int count)
+            {
+                return Task.FromResult(0);
+            }
+
+            public override int ReadBlock(char[] buffer, int index, int count)
+            {
+                return 0;
+            }
+
+            public override Task<int> ReadBlockAsync(char[] buffer, int index, int count)
+            {
+                return Task.FromResult(0);
+            }
+
             public override string ReadLine()
             {
                 return null;
             }
 
+            public override Task<string> ReadLineAsync()
+            {
+                return Task.FromResult<string>(null);
+            }
+
             public override string ReadToEnd()
             {
                 return string.Empty;
+            }
+
+            public override Task<string> ReadToEndAsync()
+            {
+                return Task.FromResult(string.Empty);
             }
 
             internal override int ReadBuffer()

--- a/src/System.IO/src/System/IO/StreamReader.cs
+++ b/src/System.IO/src/System/IO/StreamReader.cs
@@ -1362,7 +1362,7 @@ namespace System.IO
 
             public override Task<int> ReadAsync(char[] buffer, int index, int count)
             {
-                return Task.FromResult(0);
+                return TaskCache.Zero;
             }
 
             public override int ReadBlock(char[] buffer, int index, int count)
@@ -1372,7 +1372,7 @@ namespace System.IO
 
             public override Task<int> ReadBlockAsync(char[] buffer, int index, int count)
             {
-                return Task.FromResult(0);
+                return TaskCache.Zero;
             }
 
             public override string ReadLine()
@@ -1382,7 +1382,7 @@ namespace System.IO
 
             public override Task<string> ReadLineAsync()
             {
-                return Task.FromResult<string>(null);
+                return TaskCache.NullString;
             }
 
             public override string ReadToEnd()
@@ -1392,7 +1392,7 @@ namespace System.IO
 
             public override Task<string> ReadToEndAsync()
             {
-                return Task.FromResult(string.Empty);
+                return TaskCache.EmptyString;
             }
 
             internal override int ReadBuffer()

--- a/src/System.IO/src/System/IO/StringReader.cs
+++ b/src/System.IO/src/System/IO/StringReader.cs
@@ -203,7 +203,10 @@ namespace System.IO
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
             }
 
-            return Task.FromResult(ReadBlock(buffer, index, count));
+            int read = ReadBlock(buffer, index, count);
+            return read == 0 ?
+                TaskCache.Zero : // Return a cached Task if the end has been reached
+                Task.FromResult(read);
         }
 
         public override Task<int> ReadAsync(char[] buffer, int index, int count)
@@ -221,7 +224,10 @@ namespace System.IO
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
             }
 
-            return Task.FromResult(Read(buffer, index, count));
+            int read = Read(buffer, index, count);
+            return read == 0 ?
+                TaskCache.Zero : // Return a cached Task if the end has been reached
+                Task.FromResult(read);
         }
         #endregion
     }

--- a/src/System.IO/src/System/IO/TextReader.cs
+++ b/src/System.IO/src/System/IO/TextReader.cs
@@ -257,7 +257,7 @@ namespace System.IO
 
             public override Task<int> ReadAsync(char[] buffer, int index, int count)
             {
-                return Task.FromResult(0);
+                return TaskCache.Zero;
             }
 
             public override int ReadBlock(char[] buffer, int index, int count)
@@ -267,7 +267,7 @@ namespace System.IO
 
             public override Task<int> ReadBlockAsync(char[] buffer, int index, int count)
             {
-                return Task.FromResult(0);
+                return TaskCache.Zero;
             }
 
             public override string ReadLine()
@@ -277,7 +277,7 @@ namespace System.IO
 
             public override Task<string> ReadLineAsync()
             {
-                return Task.FromResult<string>(null);
+                return TaskCache.NullString;
             }
 
             public override string ReadToEnd()
@@ -287,7 +287,7 @@ namespace System.IO
 
             public override Task<string> ReadToEndAsync()
             {
-                return Task.FromResult(string.Empty);
+                return TaskCache.EmptyString;
             }
         }
     }

--- a/src/System.IO/src/System/IO/TextReader.cs
+++ b/src/System.IO/src/System/IO/TextReader.cs
@@ -255,9 +255,39 @@ namespace System.IO
                 return 0;
             }
 
+            public override Task<int> ReadAsync(char[] buffer, int index, int count)
+            {
+                return Task.FromResult(0);
+            }
+
+            public override int ReadBlock(char[] buffer, int index, int count)
+            {
+                return 0;
+            }
+
+            public override Task<int> ReadBlockAsync(char[] buffer, int index, int count)
+            {
+                return Task.FromResult(0);
+            }
+
             public override string ReadLine()
             {
                 return null;
+            }
+
+            public override Task<string> ReadLineAsync()
+            {
+                return Task.FromResult<string>(null);
+            }
+
+            public override string ReadToEnd()
+            {
+                return string.Empty;
+            }
+
+            public override Task<string> ReadToEndAsync()
+            {
+                return Task.FromResult(string.Empty);
             }
         }
     }

--- a/src/System.IO/src/System/IO/TextWriter.cs
+++ b/src/System.IO/src/System/IO/TextWriter.cs
@@ -570,40 +570,65 @@ namespace System.IO
             {
             }
 
-            public override Encoding Encoding
-            {
-                get
-                {
-                    return Encoding.Unicode;
-                }
-            }
+            public override Encoding Encoding => Encoding.Unicode;
+
+            public override Task FlushAsync() => Task.CompletedTask;
 
             [SuppressMessage("Microsoft.Contracts", "CC1055")]  // Skip extra error checking to avoid *potential* AppCompat problems.
             public override void Write(char[] buffer, int index, int count)
             {
             }
 
-            public override void Write(string value)
-            {
-            }
+            // These overrides for Write and WriteLine
+            // aren't strictly necessary, but we do so
+            // for perf reasons (nooping instead of e.g.
+            // allocating a new string in Write(int),
+            // which by default calls int.ToString).
 
-            // Not strictly necessary, but for perf reasons
-            public override void WriteLine()
-            {
-            }
+            public override void Write(bool value) { }
+            public override void Write(char value) { }
+            public override void Write(char[] buffer) { }
+            public override void Write(decimal value) { }
+            public override void Write(double value) { }
+            public override void Write(float value) { }
+            public override void Write(int value) { }
+            public override void Write(long value) { }
+            public override void Write(object value) { }
+            public override void Write(string format, object arg0) { }
+            public override void Write(string format, object arg0, object arg1) { }
+            public override void Write(string format, object arg0, object arg1, object arg2) { }
+            public override void Write(string format, params object[] arg) { }
+            public override void Write(string value) { }
+            public override void Write(uint value) { }
+            public override void Write(ulong value) { }
 
-            // Not strictly necessary, but for perf reasons
-            public override void WriteLine(string value)
-            {
-            }
+            public override Task WriteAsync(char value) => Task.CompletedTask;
+            public override Task WriteAsync(char[] buffer, int index, int count) => Task.CompletedTask;
+            public override Task WriteAsync(string value) => Task.CompletedTask;
 
-            public override void WriteLine(object value)
-            {
-            }
+            public override void WriteLine() { }
+            public override void WriteLine(bool value) { }
+            public override void WriteLine(char value) { }
+            public override void WriteLine(char[] buffer) { }
+            public override void WriteLine(char[] buffer, int index, int count) {  }
+            public override void WriteLine(decimal value) { }
+            public override void WriteLine(double value) { }
+            public override void WriteLine(float value) { }
+            public override void WriteLine(int value) { }
+            public override void WriteLine(long value) { }
+            public override void WriteLine(object value) { }
+            public override void WriteLine(string format, object arg0) { }
+            public override void WriteLine(string format, object arg0, object arg1) { }
+            public override void WriteLine(string format, object arg0, object arg1, object arg2) { }
+            public override void WriteLine(string format, params object[] arg) { }
+            public override void WriteLine(string value) { }
+            public override void WriteLine(uint value) { }
+            public override void WriteLine(ulong value) { }
 
-            public override void Write(char value)
-            {
-            }
+            public override Task WriteLineAsync() => Task.CompletedTask;
+            public override Task WriteLineAsync(char value) => Task.CompletedTask;
+            public override Task WriteLineAsync(char[] buffer, int index, int count) => Task.CompletedTask;
+            public override Task WriteLineAsync(string value) => Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
This PR introduces the following changes:

- The null-object Stream, StreamReader, TextReader, and TextWriters now have better performance.
  - `Stream.Null` overrides `CopyToAsync`, and now returns cached tasks for async flush/read/write.
  - `StreamReader.Null` overrides `ReadBlock` and `ReadToEnd`, and returns cached tasks in async methods.
    - Ditto for `TextReader.Null`.
  - `TextWriter.Null` now overrides a bunch of `Write` and `WriteLine` (both sync and async) methods to either noop or return a cached task.
- A `TaskCache` class has been introduced in `Common` that holds completed tasks for the following values:
  - `Task<int>` with result 0
  - `Task<string>` with a null result
  - `Task<string>` for the empty string
- `MemoryStream` now returns cached tasks instead of using `async` where it isn't needed.
- `BufferedStream` and `StringReader` now make use of `TaskCache.Zero` in `Read`-related methods where they were previously using `Task.FromResult`.

cc @hughbe  @JonHanna @justinvp @stephentoub