### PR TITLE
Respect CspParameters.ParentWindowHandle

### DIFF
--- a/src/System.Security.Cryptography.Csp/System.Security.Cryptography.Csp.sln
+++ b/src/System.Security.Cryptography.Csp/System.Security.Cryptography.Csp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.Cryptography.Csp", "src\System.Security.Cryptography.Csp.csproj", "{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}"
 EndProject
@@ -17,10 +17,10 @@ Global
 		{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Security.Cryptography.Csp/src/PinvokeAnalyzerExceptionList.analyzerdata
+++ b/src/System.Security.Cryptography.Csp/src/PinvokeAnalyzerExceptionList.analyzerdata
@@ -17,3 +17,4 @@ Advapi32.dll!CryptSignHashW
 Advapi32.dll!CryptVerifySignatureW
 Advapi32.dll!CryptDestroyKey
 Advapi32.dll!CryptDestroyHash
+Advapi32.dll!CryptSetProvParam


### PR DESCRIPTION
The meat of this change is to call CryptSetProvParam(PP_CLIENT_HWND) if a ParentWindowHandle was provided.

* `CryptGetProvParamFlags` was misnamed, it's not Flags, just an enum.
* The PInvoke checker didn't like my new call to CryptSetProvParam.  But since nothing in this library is using the apiset yet I matched the current style.  (Switching to the apiset is #7550)
* I got tired of telling VS it wasn't allowed to resave the .sln; so I let it this time.

Why is no test included?
* In order to measure the impact you have to have a smartcard (PIN protected) or software protected key.
* And I'd need a good way of asking for the address of said smartcard key.
* In order to see the impact you have to allow UI to pop.
    * And now you have to dismiss it.
* While I'm sure there's a good way to ask what a dialog's parent is, the only way I know is to click and get the flashy-window response from the modal dialog.
* I tested this with `GetConsoleWindow()`, which works when invoked via corerun.  It doesn't work when invoked via msbuild. (Because now it's a console program from a console program, so GetConsoleWindow() returns 0)

Fixes #7666.
cc: @AtsushiKan @stephentoub