### PR TITLE
Remove a closure allocation from WinHttpResponseStream

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -124,44 +124,49 @@ namespace System.Net.Http
 
             _state.TcsQueryDataAvailable =
                 new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-            _state.TcsQueryDataAvailable.Task.ContinueWith((previousTask) => 
+            
+            _state.TcsQueryDataAvailable.Task.ContinueWith((previousTask, state) => 
+            {
+                var self = (WinHttpResponseStream)state;
+                WinHttpRequestState requestState = self._state;
+                SafeWinHttpHandle requestHandle = self._requestHandle;
+                
+                if (previousTask.IsFaulted)
                 {
-                    if (previousTask.IsFaulted)
+                    requestState.TcsReadFromResponseStream.TrySetException(previousTask.Exception.InnerException);
+                }
+                else if (previousTask.IsCanceled || token.IsCancellationRequested)
+                {
+                    requestState.TcsReadFromResponseStream.TrySetCanceled(token);
+                }
+                else
+                {
+                    int bytesToRead;
+                    int bytesAvailable = previousTask.Result;
+                    if (bytesAvailable > count)
                     {
-                        _state.TcsReadFromResponseStream.TrySetException(previousTask.Exception.InnerException);
-                    }
-                    else if (previousTask.IsCanceled || token.IsCancellationRequested)
-                    {
-                        _state.TcsReadFromResponseStream.TrySetCanceled(token);
+                        bytesToRead = count;
                     }
                     else
                     {
-                        int bytesToRead;
-                        int bytesAvailable = previousTask.Result;
-                        if (bytesAvailable > count)
+                        bytesToRead = bytesAvailable;
+                    }
+                    
+                    lock (requestState.Lock)
+                    {
+                        if (!Interop.WinHttp.WinHttpReadData(
+                            requestHandle,
+                            Marshal.UnsafeAddrOfPinnedArrayElement(buffer, offset),
+                            (uint)bytesToRead,
+                            IntPtr.Zero))
                         {
-                            bytesToRead = count;
-                        }
-                        else
-                        {
-                            bytesToRead = bytesAvailable;
-                        }
-                        
-                        lock (_state.Lock)
-                        {
-                            if (!Interop.WinHttp.WinHttpReadData(
-                                _requestHandle,
-                                Marshal.UnsafeAddrOfPinnedArrayElement(buffer, offset),
-                                (uint)bytesToRead,
-                                IntPtr.Zero))
-                            {
-                                _state.TcsReadFromResponseStream.TrySetException(
-                                    new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError()));
-                            }
+                            requestState.TcsReadFromResponseStream.TrySetException(
+                                new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError()));
                         }
                     }
-                }, 
-                CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+                }
+            },
+            this, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
 
             // TODO: Issue #2165. Register callback on cancellation token to cancel WinHTTP operation.
                 


### PR DESCRIPTION
Pass in the current `WinHttpResponseStream` as a state parameter to the continuation, so we avoid a closure. Also unindented the code.

cc @davidsh @stephentoub

---

**edit:** Just updated it to pass in the method parameters as state, as well.