### PR TITLE
Avoid a closure allocation in MessageProcessingHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/MessageProcessingHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/MessageProcessingHandler.cs
@@ -126,8 +126,8 @@ namespace System.Net.Http
         // a closure, while simultaneously avoiding a tuple allocation.
         private sealed class SendState : TaskCompletionSource<HttpResponseMessage>
         {
-            public readonly MessageProcessingHandler _handler;
-            public readonly CancellationToken _token;
+            internal readonly MessageProcessingHandler _handler;
+            internal readonly CancellationToken _token;
             
             public SendState(MessageProcessingHandler handler, CancellationToken token)
             {

--- a/src/System.Net.Http/src/System/Net/Http/MessageProcessingHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/MessageProcessingHandler.cs
@@ -40,7 +40,7 @@ namespace System.Net.Http
             // to catch the exception since the caller doesn't expect exceptions when calling SendAsync(): The 
             // expectation is that the returned task will get faulted on errors, but the async call to SendAsync() 
             // should complete.
-            SendState tcs = new SendState(this, cancellationToken);
+            var tcs = new SendState(this, cancellationToken);
             try
             {
                 HttpRequestMessage newRequestMessage = ProcessRequest(request, cancellationToken);


### PR DESCRIPTION
Contributes to #7787 by removing a closure allocation from `MessageProcessingHandler.SendAsync`.

cc @davidsh @stephentoub