### PR TITLE
Avoid char[] allocation in WriteCharEntityAsync

### DIFF
--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlRawWriterAsync.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/XmlRawWriterAsync.cs
@@ -114,7 +114,7 @@ namespace System.Xml
         // Forward call to WriteString(string).
         public override Task WriteCharEntityAsync(char ch)
         {
-            return WriteStringAsync(new string(new char[] { ch }));
+            return WriteStringAsync(ch.ToString());
         }
 
         // Forward call to WriteString(string).


### PR DESCRIPTION
Small change to avoid a `char[]` allocation in `WriteCharEntityAsync`.

cc @khdang @zhenlan