### PR TITLE
Implement fault blocks in interpreted expressions

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -372,9 +372,6 @@
   <data name="UnsupportedExpressionType" xml:space="preserve">
     <value>The expression type '{0}' is not supported</value>
   </data>
-  <data name="FaultBlockNotSupported" xml:space="preserve">
-    <value>Fault blocks are not supported</value>
-  </data>
   <data name="ParameterExpressionNotValidAsDelegate" xml:space="preserve">
     <value>ParameterExpression of type '{0}' cannot be used for delegate parameter of type '{1}'</value>
   </data>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -1102,6 +1102,13 @@ namespace System.Linq.Expressions.Interpreter
             Emit(EnterTryCatchFinallyInstruction.CreateTryCatch());
         }
 
+        public EnterTryFaultInstruction EmitEnterTryFault(BranchLabel tryEnd)
+        {
+            var instruction = new EnterTryFaultInstruction(EnsureLabelIndex(tryEnd));
+            Emit(instruction);
+            return instruction;
+        }
+
         public void EmitEnterFinally(BranchLabel finallyStartLabel)
         {
             Emit(EnterFinallyInstruction.Create(EnsureLabelIndex(finallyStartLabel)));
@@ -1110,6 +1117,16 @@ namespace System.Linq.Expressions.Interpreter
         public void EmitLeaveFinally()
         {
             Emit(LeaveFinallyInstruction.Instance);
+        }
+
+        public void EmitEnterFault(BranchLabel faultStartLabel)
+        {
+            Emit(EnterFaultInstruction.Create(EnsureLabelIndex(faultStartLabel)));
+        }
+
+        public void EmitLeaveFault()
+        {
+            Emit(LeaveFaultInstruction.Instance);
         }
 
         public void EmitEnterExceptionFilter()

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -1112,11 +1112,6 @@ namespace System.Linq.Expressions.Interpreter
             Emit(LeaveFinallyInstruction.Instance);
         }
 
-        public void EmitLeaveFault(bool hasValue)
-        {
-            Emit(hasValue ? LeaveFaultInstruction.NonVoid : LeaveFaultInstruction.Void);
-        }
-
         public void EmitEnterExceptionFilter()
         {
             Emit(EnterExceptionFilterInstruction.Instance);

--- a/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -76,6 +76,46 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public void CannotRethrowWithinFinallyWithinCatch(bool useInterpreter)
+        {
+            LambdaExpression rethrowFinally = Expression.Lambda<Action>(
+                Expression.TryCatch(
+                    Expression.Empty(),
+                    Expression.Catch(
+                        typeof(Exception),
+                        Expression.TryFinally(
+                            Expression.Empty(),
+                            Expression.Rethrow()
+                            )
+                        )
+                    )
+                );
+            Assert.Throws<InvalidOperationException>(() => rethrowFinally.Compile(useInterpreter));
+        }
+
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        [ActiveIssue(3838)]
+        [ActiveIssue(3840)]
+        public void CannotRethrowWithinFaultWithinCatch(bool useInterpreter)
+        {
+            LambdaExpression rethrowFinally = Expression.Lambda<Action>(
+                Expression.TryCatch(
+                    Expression.Empty(),
+                    Expression.Catch(
+                        typeof(Exception),
+                        Expression.TryFault(
+                            Expression.Empty(),
+                            Expression.Rethrow()
+                            )
+                        )
+                    )
+                );
+            Assert.Throws<InvalidOperationException>(() => rethrowFinally.Compile(useInterpreter));
+        }
+
+        [Theory]
         [InlineData(false)]
         public void CanCatchAndThrowNonExceptions(bool useInterpreter)
         {


### PR DESCRIPTION
Fixes #3840

The interpreter had the beginning of an attempt to replicate fault blocks using exception handlers. This can't work as the execution order will be wrong, so add tests hitting this code to guard against regressions, then remove it, allowing the normal code paths to be taken in those cases.

Then remove some dead code from the light compiler, as this mostly relates to the existing interpretation of exception-related expressions, and so simplifies further work there.

Then add some more tests for invalid use of rethrow expressions that should fail at the compilation stage, as this includes within fault blocks and so must be tested for in that case.

Finally, actually implement support for fault blocks, fixing #3840.

cc @stephentoub, @VSadov