### PR TITLE
Add more Assign and OpAssign expression tests

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -355,11 +355,7 @@ namespace System.Linq.Expressions
 
         internal static Expression Create(ExpressionType nodeType, Expression left, Expression right, Type type, MethodInfo method, LambdaExpression conversion)
         {
-            if (nodeType == ExpressionType.Assign)
-            {
-                Debug.Assert(method == null && TypeUtils.AreEquivalent(type, left.Type));
-                return new AssignBinaryExpression(left, right);
-            }
+            Debug.Assert(nodeType != ExpressionType.Assign);
             if (conversion != null)
             {
                 Debug.Assert(method == null && TypeUtils.AreEquivalent(type, right.Type) && nodeType == ExpressionType.Coalesce);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalVariables.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalVariables.cs
@@ -40,15 +40,10 @@ namespace System.Linq.Expressions.Interpreter
             get { return (_flags & InClosureFlag) != 0; }
         }
 
-        public bool InClosureOrBoxed
-        {
-            get { return InClosure | IsBoxed; }
-        }
-
-        internal LocalVariable(int index, bool closure, bool boxed)
+        internal LocalVariable(int index, bool closure)
         {
             Index = index;
-            _flags = (closure ? InClosureFlag : 0) | (boxed ? IsBoxedFlag : 0);
+            _flags = (closure ? InClosureFlag : 0);
         }
 
         internal Expression LoadFromArray(Expression frameData, Expression closure, Type parameterType)
@@ -134,7 +129,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public LocalDefinition DefineLocal(ParameterExpression variable, int start)
         {
-            LocalVariable result = new LocalVariable(_localCount++, false, false);
+            LocalVariable result = new LocalVariable(_localCount++, false);
             _maxLocalCount = System.Math.Max(_localCount, _maxLocalCount);
 
             VariableScope existing, newScope;
@@ -274,7 +269,7 @@ namespace System.Linq.Expressions.Interpreter
             {
                 _closureVariables = new Dictionary<ParameterExpression, LocalVariable>();
             }
-            LocalVariable result = new LocalVariable(_closureVariables.Count, true, false);
+            LocalVariable result = new LocalVariable(_closureVariables.Count, true);
             _closureVariables.Add(variable, result);
             return result;
         }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
@@ -2,13 +2,82 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
 {
     public class Assign
     {
+        private class PropertyAndFields
+        {
+#pragma warning disable 649 // Assigned through expressions.
+            public string StringProperty { get; set; }
+            public string StringField;
+            public readonly string ReadonlyStringField;
+            public string ReadonlyStringProperty { get { return ""; } }
+            public static string StaticStringProperty { get; set; }
+            public static string StaticStringField;
+            public static readonly string ReadonlyStaticStringField;
+            public static string ReadonlyStaticStringProperty { get { return ""; } }
+            public const string ConstantString = "Constant";
+            public string WriteOnlyString { set { } }
+            public static string WriteOnlyStaticString { set { } }
+
+            public int Int32Property { get; set; }
+            public int Int32Field;
+            public readonly int ReadonlyInt32Field;
+            public int ReadonlyInt32Property { get { return 42; } }
+            public static int StaticInt32Property { get; set; }
+            public static int StaticInt32Field;
+            public static readonly int ReadonlyStaticInt32Field;
+            public static int ReadonlyStaticInt32Property { get { return 321; } }
+            public const int ConstantInt32 = 12;
+            public int WriteOnlyInt32 { set { } }
+            public static int WriteOnlyStaticInt32 { set { } }
+#pragma warning restore 649
+        }
+
+        private static IEnumerable<object[]> ReadOnlyExpressions()
+        {
+            Expression obj = Expression.Constant(new PropertyAndFields());
+            yield return new object[] { Expression.Field(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.ReadonlyInt32Field)) };
+            yield return new object[] { Expression.Property(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.ReadonlyInt32Property)) };
+            yield return new object[] { Expression.Field(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.ReadonlyStringField)) };
+            yield return new object[] { Expression.Property(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.ReadonlyStringProperty)) };
+            yield return new object[] { Expression.Field(null, typeof(PropertyAndFields), nameof(PropertyAndFields.ConstantInt32)) };
+            yield return new object[] { Expression.Field(null, typeof(PropertyAndFields), nameof(PropertyAndFields.ConstantString)) };
+            yield return new object[] { Expression.Field(null, typeof(PropertyAndFields), nameof(PropertyAndFields.ReadonlyStaticInt32Field)) };
+            yield return new object[] { Expression.Property(null, typeof(PropertyAndFields), nameof(PropertyAndFields.ReadonlyStaticInt32Property)) };
+            yield return new object[] { Expression.Field(null, typeof(PropertyAndFields), nameof(PropertyAndFields.ReadonlyStaticStringField)) };
+            yield return new object[] { Expression.Property(null, typeof(PropertyAndFields), nameof(PropertyAndFields.ReadonlyStaticStringProperty)) };
+            yield return new object[] { Expression.Default(typeof(int)) };
+            yield return new object[] { Expression.Default(typeof(string)) };
+            yield return new object[] { Expression.Default(typeof(DateTime)) };
+        }
+
+        private static IEnumerable<object> WriteOnlyExpressions()
+        {
+            Expression obj = Expression.Constant(new PropertyAndFields());
+            yield return new object[] { Expression.Property(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.WriteOnlyInt32)) };
+            yield return new object[] { Expression.Property(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.WriteOnlyString)) };
+            yield return new object[] { Expression.Property(null, typeof(PropertyAndFields), nameof(PropertyAndFields.WriteOnlyStaticInt32)) };
+            yield return new object[] { Expression.Property(null, typeof(PropertyAndFields), nameof(PropertyAndFields.WriteOnlyStaticString)) };
+        }
+
+        private static IEnumerable<object> MemberAssignments()
+        {
+            Expression obj = Expression.Constant(new PropertyAndFields());
+            yield return new object[] { Expression.Field(null, typeof(PropertyAndFields), nameof(PropertyAndFields.StaticInt32Field)), 1 };
+            yield return new object[] { Expression.Property(null, typeof(PropertyAndFields), nameof(PropertyAndFields.StaticInt32Property)), 2 };
+            yield return new object[] { Expression.Field(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.Int32Field)), 3 };
+            yield return new object[] { Expression.Property(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.Int32Property)), 4 };
+            yield return new object[] { Expression.Field(null, typeof(PropertyAndFields), nameof(PropertyAndFields.StaticStringField)), "a" };
+            yield return new object[] { Expression.Property(null, typeof(PropertyAndFields), nameof(PropertyAndFields.StaticStringProperty)), "b" };
+            yield return new object[] { Expression.Field(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.StringField)), "c" };
+            yield return new object[] { Expression.Property(obj, typeof(PropertyAndFields), nameof(PropertyAndFields.StringProperty)), "d" };
+        }
+
         [Theory, ClassData(typeof(CompilationTypes))]
         public void SimpleAssignment(bool useInterpreter)
         {
@@ -32,6 +101,18 @@ namespace System.Linq.Expressions.Tests
                 Expression.Assign(variable, Expression.Constant(42))
                 );
             Assert.Equal(42, Expression.Lambda<Func<int>>(exp).Compile(useInterpreter)());
+        }
+
+        [Theory, PerCompilationType(nameof(MemberAssignments))]
+        public void AssignToMember(Expression memberExp, object value, bool useInterpreter)
+        {
+            Func<bool> func = Expression.Lambda<Func<bool>>(
+                Expression.Block(
+                    Expression.Assign(memberExp, Expression.Constant(value)),
+                    Expression.Equal(memberExp, Expression.Constant(value))
+                    )
+                ).Compile(useInterpreter);
+            Assert.True(func());
         }
 
         [Fact]
@@ -87,25 +168,17 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("Hello", Expression.Lambda<Func<object>>(exp).Compile(useInterpreter)());
         }
 
-        [Fact]
-        public void AttemptToAssignToNonWritable()
+        [Theory, MemberData(nameof(ReadOnlyExpressions))]
+        public void AttemptToAssignToNonWritable(Expression readonlyExp)
         {
-            Assert.Throws<ArgumentException>(() => Expression.Assign(Expression.Default(typeof(int)), Expression.Default(typeof(int))));
-        }
-        private static class Unreadable<T>
-        {
-            public static T WriteOnly
-            {
-                set { }
-            }
+            Assert.Throws<ArgumentException>(() => Expression.Assign(readonlyExp, Expression.Default(readonlyExp.Type)));
         }
 
-        [Fact]
-        public static void AttemptToAssignFromNonReadable()
+        [Theory, MemberData(nameof(WriteOnlyExpressions))]
+        public static void AttemptToAssignFromNonReadable(Expression writeOnlyExp)
         {
-            Expression value = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
-            ParameterExpression variable = Expression.Variable(typeof(int));
-            Assert.Throws<ArgumentException>("right", () => Expression.Assign(variable, value));
+            ParameterExpression variable = Expression.Variable(writeOnlyExp.Type);
+            Assert.Throws<ArgumentException>("right", () => Expression.Assign(variable, writeOnlyExp));
         }
     }
 }


### PR DESCRIPTION
Consider assignment to static members.

Consider both value type and reference type assignments.

Remove dead code:

`LocalVariable` is never constructed boxed. Remove option for doing so.

`BinaryExpression.Create` is never called with `nodeType` of `ExpressionType.Assign`. Replace path for this case with assertion.

(`Create` is only called from `StackSpiller.RewriteLogicalBinaryExpression` or from `StackSpiller.RewriteBinaryExpression`, and those are only called from `StackSpiller.RewriteExpression` after a test on `NodeType`, which for `ExpressionType.Assign` calls `RewriteAssignBinaryExpression`).

cc: @VSadov