### PR TITLE
Add System.ValueTuple library

### DIFF
--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -1649,6 +1649,21 @@
         ]
     },
     {
+        "Name": "System.ValueTuple",
+        "Description": "Provides the System.ValueTuple structs, which implement the underlying types for C# 7 tuples.",
+        "CommonTypes": [
+            "System.ValueTuple",
+            "System.ValueTuple<T1>",
+            "System.ValueTuple<T1, T2>",
+            "System.ValueTuple<T1, T2, T3>",
+            "System.ValueTuple<T1, T2, T3, T4>",
+            "System.ValueTuple<T1, T2, T3, T4, T5>",
+            "System.ValueTuple<T1, T2, T3, T4, T5, T6>",
+            "System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>",
+            "System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>"
+        ]
+    },
+    {
         "Name": "System.Xml.ReaderWriter",
         "Description": "Provides provides a fast, non-cached, forward-only way to read and write Extensible Markup Language (XML) data.",
         "CommonTypes": [

--- a/src/System.ValueTuple/System.ValueTuple.sln
+++ b/src/System.ValueTuple/System.ValueTuple.sln
@@ -1,0 +1,27 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.ValueTuple", "src\System.ValueTuple.csproj", "{4C2655DB-BD9E-4C86-83A6-744ECDDBDF29}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.ValueTuple.Tests", "tests\System.ValueTuple.Tests.csproj", "{CBD5AE8D-8595-48E2-848F-1A3492A28FDB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4C2655DB-BD9E-4C86-83A6-744ECDDBDF29}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C2655DB-BD9E-4C86-83A6-744ECDDBDF29}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C2655DB-BD9E-4C86-83A6-744ECDDBDF29}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C2655DB-BD9E-4C86-83A6-744ECDDBDF29}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CBD5AE8D-8595-48E2-848F-1A3492A28FDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CBD5AE8D-8595-48E2-848F-1A3492A28FDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CBD5AE8D-8595-48E2-848F-1A3492A28FDB}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{CBD5AE8D-8595-48E2-848F-1A3492A28FDB}.Release|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/System.ValueTuple/pkg/System.ValueTuple.builds
+++ b/src/System.ValueTuple/pkg/System.ValueTuple.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.ValueTuple.pkgproj"/>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.ValueTuple/pkg/System.ValueTuple.pkgproj
+++ b/src/System.ValueTuple/pkg/System.ValueTuple.pkgproj
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.ValueTuple.builds">
+      <SupportedFramework>net45;netcore45;netstandardapp1.5;wpa81</SupportedFramework>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.ValueTuple/src/Resources/Strings.resx
+++ b/src/System.ValueTuple/src/Resources/Strings.resx
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ArgumentException_ValueTupleIncorrectType" xml:space="preserve">
+    <value>The parameter should be a ValueTuple type of appropriate arity.</value>
+  </data>
+  <data name="ArgumentException_ValueTupleLastArgumentNotAValueTuple" xml:space="preserve">
+    <value>The TRest type argument of ValueTuple`8 must be a ValueTuple.</value>
+  </data>
+</root>

--- a/src/System.ValueTuple/src/System.ValueTuple.builds
+++ b/src/System.ValueTuple/src/System.ValueTuple.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.ValueTuple.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.ValueTuple/src/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/src/System.ValueTuple.csproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <ProjectGuid>{4C2655DB-BD9E-4C86-83A6-744ECDDBDF29}</ProjectGuid>
+    <PackageTargetFramework>netstandard1.1</PackageTargetFramework>
+    <UseOpenKey Condition="'$(UseOpenKey)'==''">true</UseOpenKey>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.1</NuGetTargetMoniker>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the options -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup>
+    <RootNamespace>System</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="System\ValueTuple\ValueTuple.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.ValueTuple/src/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/src/System.ValueTuple.csproj
@@ -5,6 +5,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <ProjectGuid>{4C2655DB-BD9E-4C86-83A6-744ECDDBDF29}</ProjectGuid>
     <PackageTargetFramework>netstandard1.1</PackageTargetFramework>
+    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <UseOpenKey Condition="'$(UseOpenKey)'==''">true</UseOpenKey>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.1</NuGetTargetMoniker>
   </PropertyGroup>

--- a/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
@@ -28,11 +28,19 @@ namespace System
     public struct ValueTuple
         : IEquatable<ValueTuple>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple>, ITupleInternal
     {
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if <paramref name="obj"/> is a <see cref="ValueTuple"/>.</returns>
         public override bool Equals(object obj)
         {
             return obj is ValueTuple;
         }
 
+        /// <summary>Returns a value indicating whether this instance is equal to a specified value.</summary>
+        /// <param name="other">An instance to compare to this instance.</param>
+        /// <returns>true if <paramref name="other"/> has the same value as this instance; otherwise, false.</returns>
         public bool Equals(ValueTuple other)
         {
             return true;
@@ -55,6 +63,14 @@ namespace System
             return 0;
         }
 
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
         public int CompareTo(ValueTuple other)
         {
             return 0;
@@ -72,6 +88,8 @@ namespace System
             return 0;
         }
 
+        /// <summary>Returns the hash code for this instance.</summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
             return 0;
@@ -87,6 +105,13 @@ namespace System
             return 0;
         }
 
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>()</c>.
+        /// </remarks>
         public override string ToString()
         {
             return "()";
@@ -94,30 +119,120 @@ namespace System
 
         int ITupleInternal.Size => 0;
 
+        /// <summary>Creates a new struct 0-tuple.</summary>
+        /// <returns>A 0-tuple.</returns>
         public static ValueTuple Create() =>
             new ValueTuple();
 
+        /// <summary>Creates a new struct 1-tuple, or singleton.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <returns>A 1-tuple (singleton) whose value is (item1).</returns>
         public static ValueTuple<T1> Create<T1>(T1 item1) =>
             new ValueTuple<T1>(item1);
 
+        /// <summary>Creates a new struct 2-tuple, or pair.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <returns>A 2-tuple (pair) whose value is (item1, item2).</returns>
         public static ValueTuple<T1, T2> Create<T1, T2>(T1 item1, T2 item2) =>
             new ValueTuple<T1, T2>(item1, item2);
 
+        /// <summary>Creates a new struct 3-tuple, or triple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <returns>A 3-tuple (triple) whose value is (item1, item2, item3).</returns>
         public static ValueTuple<T1, T2, T3> Create<T1, T2, T3>(T1 item1, T2 item2, T3 item3) =>
             new ValueTuple<T1, T2, T3>(item1, item2, item3);
 
+        /// <summary>Creates a new struct 4-tuple, or quadruple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <typeparam name="T4">The type of the fourth component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <param name="item4">The value of the fourth component of the tuple.</param>
+        /// <returns>A 4-tuple (quadruple) whose value is (item1, item2, item3, item4).</returns>
         public static ValueTuple<T1, T2, T3, T4> Create<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4) =>
             new ValueTuple<T1, T2, T3, T4>(item1, item2, item3, item4);
 
+        /// <summary>Creates a new struct 5-tuple, or quintuple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <typeparam name="T4">The type of the fourth component of the tuple.</typeparam>
+        /// <typeparam name="T5">The type of the fifth component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <param name="item4">The value of the fourth component of the tuple.</param>
+        /// <param name="item5">The value of the fifth component of the tuple.</param>
+        /// <returns>A 5-tuple (quintuple) whose value is (item1, item2, item3, item4, item5).</returns>
         public static ValueTuple<T1, T2, T3, T4, T5> Create<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5) =>
             new ValueTuple<T1, T2, T3, T4, T5>(item1, item2, item3, item4, item5);
 
+        /// <summary>Creates a new struct 6-tuple, or sextuple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <typeparam name="T4">The type of the fourth component of the tuple.</typeparam>
+        /// <typeparam name="T5">The type of the fifth component of the tuple.</typeparam>
+        /// <typeparam name="T6">The type of the sixth component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <param name="item4">The value of the fourth component of the tuple.</param>
+        /// <param name="item5">The value of the fifth component of the tuple.</param>
+        /// <param name="item6">The value of the sixth component of the tuple.</param>
+        /// <returns>A 6-tuple (sextuple) whose value is (item1, item2, item3, item4, item5, item6).</returns>
         public static ValueTuple<T1, T2, T3, T4, T5, T6> Create<T1, T2, T3, T4, T5, T6>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6) =>
             new ValueTuple<T1, T2, T3, T4, T5, T6>(item1, item2, item3, item4, item5, item6);
 
+        /// <summary>Creates a new struct 7-tuple, or septuple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <typeparam name="T4">The type of the fourth component of the tuple.</typeparam>
+        /// <typeparam name="T5">The type of the fifth component of the tuple.</typeparam>
+        /// <typeparam name="T6">The type of the sixth component of the tuple.</typeparam>
+        /// <typeparam name="T7">The type of the seventh component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <param name="item4">The value of the fourth component of the tuple.</param>
+        /// <param name="item5">The value of the fifth component of the tuple.</param>
+        /// <param name="item6">The value of the sixth component of the tuple.</param>
+        /// <param name="item7">The value of the seventh component of the tuple.</param>
+        /// <returns>A 7-tuple (septuple) whose value is (item1, item2, item3, item4, item5, item6, item7).</returns>
         public static ValueTuple<T1, T2, T3, T4, T5, T6, T7> Create<T1, T2, T3, T4, T5, T6, T7>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7) =>
             new ValueTuple<T1, T2, T3, T4, T5, T6, T7>(item1, item2, item3, item4, item5, item6, item7);
 
+        /// <summary>Creates a new struct 8-tuple, or octuple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <typeparam name="T4">The type of the fourth component of the tuple.</typeparam>
+        /// <typeparam name="T5">The type of the fifth component of the tuple.</typeparam>
+        /// <typeparam name="T6">The type of the sixth component of the tuple.</typeparam>
+        /// <typeparam name="T7">The type of the seventh component of the tuple.</typeparam>
+        /// <typeparam name="TRest">The type of the eigth component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <param name="item4">The value of the fourth component of the tuple.</param>
+        /// <param name="item5">The value of the fifth component of the tuple.</param>
+        /// <param name="item6">The value of the sixth component of the tuple.</param>
+        /// <param name="item7">The value of the seventh component of the tuple.</param>
+        /// <param name="rest">The value of the eighth component of the tuple.</param>
+        /// <returns>An 8-tuple (octuple) whose value is (item1, item2, item3, item4, item5, item6, item7, rest).</returns>
         public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> Create<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) =>
             new ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, rest);
 
@@ -158,21 +273,53 @@ namespace System
         }
     }
 
+    /// <summary>Represents a 1-tuple, or singleton, as a value type.</summary>
+    /// <typeparam name="T1">The type of the tuple's only component.</typeparam>
     public struct ValueTuple<T1>
         : IEquatable<ValueTuple<T1>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1>>, ITupleInternal
     {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1}"/> instance's first component.
+        /// </summary>
         public T1 Item1;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
         public ValueTuple(T1 item1)
         {
             Item1 = item1;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
         public override bool Equals(object obj)
         {
             return obj is ValueTuple<T1> && Equals((ValueTuple<T1>)obj);
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its field
+        /// is equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
         public bool Equals(ValueTuple<T1> other)
         {
             return EqualityComparer<T1>.Default.Equals(Item1, other.Item1);
@@ -201,6 +348,14 @@ namespace System
             return Comparer<T1>.Default.Compare(Item1, objTuple.Item1);
         }
 
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
         public int CompareTo(ValueTuple<T1> other)
         {
             return Comparer<T1>.Default.Compare(Item1, other.Item1);
@@ -220,6 +375,10 @@ namespace System
             return comparer.Compare(Item1, objTuple.Item1);
         }
 
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
             return EqualityComparer<T1>.Default.GetHashCode(Item1);
@@ -235,6 +394,15 @@ namespace System
             return comparer.GetHashCode(Item1);
         }
 
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1)</c>,
+        /// where <c>Item1</c> represents the value of <see cref="Item1"/>. If the field is <see langword="null"/>,
+        /// it is represented as <see cref="string.Empty"/>.
+        /// </remarks>
         public override string ToString()
         {
             return "(" + Item1 + ")";
@@ -244,7 +412,7 @@ namespace System
     }
 
     /// <summary>
-    /// Represents a 2-tuple, or pair as a struct.
+    /// Represents a 2-tuple, or pair, as a value type.
     /// </summary>
     /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
     /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
@@ -252,17 +420,17 @@ namespace System
         : IEquatable<ValueTuple<T1, T2>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2>>, ITupleInternal
     {
         /// <summary>
-        /// The current <seealso cref="ValueTuple{T1, T2}"/> instance's first component.
+        /// The current <see cref="ValueTuple{T1, T2}"/> instance's first component.
         /// </summary>
         public T1 Item1;
 
         /// <summary>
-        /// The current <seealso cref="ValueTuple{T1, T2}"/> instance's first component.
+        /// The current <see cref="ValueTuple{T1, T2}"/> instance's first component.
         /// </summary>
         public T2 Item2;
 
         /// <summary>
-        /// Initializes a new instance of the <seealso cref="ValueTuple{T1, T2}"/> struct.
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2}"/> value type.
         /// </summary>
         /// <param name="item1">The value of the tuple's first component.</param>
         /// <param name="item2">The value of the tuple's second component.</param>
@@ -273,17 +441,17 @@ namespace System
         }
 
         /// <summary>
-        /// Returns a value that indicates whether the current <seealso cref="ValueTuple{T1, T2}"/> instance is equal to a specified object.
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2}"/> instance is equal to a specified object.
         /// </summary>
-        /// <param name="other">The object to compare with this instance.</param>
+        /// <param name="obj">The object to compare with this instance.</param>
         /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
         ///
         /// <remarks>
-        /// The <paramref name="other"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
         /// <list type="bullet">
-        ///     <item><description>It is a <seealso cref="ValueTuple{T1, T2}"/> struct.</description></item>
-        ///     <item><description>Its two components are of the same types as those of the current instance.</description></item>
-        ///     <item><description>Its two components are equal to those of the current instance.Equality is determined by the default object equality comparer for each component.</description></item>
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
         /// </list>
         /// </remarks>
         public override bool Equals(object obj)
@@ -292,18 +460,13 @@ namespace System
         }
 
         /// <summary>
-        /// Returns a value that indicates whether the current <seealso cref="ValueTuple{T1, T2}"/> instance is equal to a specified <seealso cref="ValueTuple{T1, T2}"/>.
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2}"/> instance is equal to a specified <see cref="ValueTuple{T1, T2}"/>.
         /// </summary>
-        /// <param name="other">The object to compare with this instance.</param>
-        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
-        ///
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
         /// <remarks>
-        /// The <paramref name="other"/> parameter is considered to be equal to the current instance under the following conditions:
-        /// <list type="bullet">
-        ///     <item><description>It is a <seealso cref="ValueTuple{T1, T2}"/> struct.</description></item>
-        ///     <item><description>Its two components are of the same types as those of the current instance.</description></item>
-        ///     <item><description>Its two components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
-        /// </list>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
         /// </remarks>
         public bool Equals(ValueTuple<T1, T2> other)
         {
@@ -312,7 +475,7 @@ namespace System
         }
 
         /// <summary>
-        /// Returns a value that indicates whether the current <seealso cref="ValueTuple{T1, T2}"/> instance is equal to a specified object based on a specified comparison method.
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2}"/> instance is equal to a specified object based on a specified comparison method.
         /// </summary>
         /// <param name="other">The object to compare with this instance.</param>
         /// <param name="comparer">An object that defines the method to use to evaluate whether the two objects are equal.</param>
@@ -320,14 +483,14 @@ namespace System
         ///
         /// <remarks>
         /// This member is an explicit interface member implementation. It can be used only when the
-        ///  <seealso cref="ValueTuple{T1, T2}"/> instance is cast to an <see cref="IStructuralEquatable"/> interface.
+        ///  <see cref="ValueTuple{T1, T2}"/> instance is cast to an <see cref="IStructuralEquatable"/> interface.
         ///
         /// The <see cref="IEqualityComparer.Equals"/> implementation is called only if <c>other</c> is not <see langword="null"/>,
-        ///  and if it can be successfully cast (in C#) or converted (in Visual Basic) to a <seealso cref="ValueTuple{T1, T2}"/>
+        ///  and if it can be successfully cast (in C#) or converted (in Visual Basic) to a <see cref="ValueTuple{T1, T2}"/>
         ///  whose components are of the same types as those of the current instance. The IStructuralEquatable.Equals(Object, IEqualityComparer) method
-        ///  first passes the <see cref="Item1"/> values of the <seealso cref="ValueTuple{T1, T2}"/> objects to be compared to the
+        ///  first passes the <see cref="Item1"/> values of the <see cref="ValueTuple{T1, T2}"/> objects to be compared to the
         ///  <see cref="IEqualityComparer.Equals"/> implementation. If this method call returns <see langword="true"/>, the method is
-        ///  called again and passed the <see cref="Item2"/> values of the two <seealso cref="ValueTuple{T1, T2}"/> instances.
+        ///  called again and passed the <see cref="Item2"/> values of the two <see cref="ValueTuple{T1, T2}"/> instances.
         /// </remarks>
         bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
         {
@@ -351,6 +514,14 @@ namespace System
             return CompareTo((ValueTuple<T1, T2>)other);
         }
 
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
         public int CompareTo(ValueTuple<T1, T2> other)
         {
             int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
@@ -377,7 +548,7 @@ namespace System
         }
 
         /// <summary>
-        /// Returns the hash code for the current <seealso cref="ValueTuple{T1, T2}"/> instance.
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2}"/> instance.
         /// </summary>
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
@@ -403,15 +574,14 @@ namespace System
         }
 
         /// <summary>
-        /// Returns a string that represents the value of this <seealso cref="ValueTuple{T1, T2}"/> instance.
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2}"/> instance.
         /// </summary>
-        /// <returns>The string representation of this <seealso cref="ValueTuple{T1, T2}"/> instance.</returns>
-        ///
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2}"/> instance.</returns>
         /// <remarks>
         /// The string returned by this method takes the form <c>(Item1, Item2)</c>,
-        ///  where <c>Item1</c> and <c>Item2</c> represent the values of the <see cref="Item1"/>
-        ///  and <see cref="Item2"/> properties. If either property value is <see langword="null"/>,
-        ///  it is represented as <see cref="String.Empty"/>.
+        /// where <c>Item1</c> and <c>Item2</c> represent the values of the <see cref="Item1"/>
+        /// and <see cref="Item2"/> fields. If either field value is <see langword="null"/>,
+        /// it is represented as <see cref="String.Empty"/>.
         /// </remarks>
         public override string ToString()
         {
@@ -421,13 +591,34 @@ namespace System
         int ITupleInternal.Size => 2;
     }
 
+    /// <summary>
+    /// Represents a 3-tuple, or triple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
     public struct ValueTuple<T1, T2, T3>
         : IEquatable<ValueTuple<T1, T2, T3>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3>>, ITupleInternal
     {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3}"/> instance's first component.
+        /// </summary>
         public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3}"/> instance's second component.
+        /// </summary>
         public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3}"/> instance's third component.
+        /// </summary>
         public T3 Item3;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
         public ValueTuple(T1 item1, T2 item2, T3 item3)
         {
             Item1 = item1;
@@ -435,11 +626,34 @@ namespace System
             Item3 = item3;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
         public override bool Equals(object obj)
         {
             return obj is ValueTuple<T1, T2, T3> && Equals((ValueTuple<T1, T2, T3>)obj);
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
         public bool Equals(ValueTuple<T1, T2, T3> other)
         {
             return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
@@ -470,6 +684,14 @@ namespace System
             return CompareTo((ValueTuple<T1, T2, T3>)other);
         }
 
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
         public int CompareTo(ValueTuple<T1, T2, T3> other)
         {
             int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
@@ -501,6 +723,10 @@ namespace System
             return comparer.Compare(Item3, objTuple.Item3);
         }
 
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
             return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
@@ -525,6 +751,14 @@ namespace System
             return GetHashCodeCore(comparer);
         }
 
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
         public override string ToString()
         {
             return "(" + Item1 + ", " + Item2 + ", " + Item3 + ")";
@@ -533,14 +767,40 @@ namespace System
         int ITupleInternal.Size => 3;
     }
 
+    /// <summary>
+    /// Represents a 4-tuple, or quadruple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
     public struct ValueTuple<T1, T2, T3, T4>
         : IEquatable<ValueTuple<T1, T2, T3, T4>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4>>, ITupleInternal
     {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance's first component.
+        /// </summary>
         public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance's second component.
+        /// </summary>
         public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance's third component.
+        /// </summary>
         public T3 Item3;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance's fourth component.
+        /// </summary>
         public T4 Item4;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3, T4}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        /// <param name="item4">The value of the tuple's fourth component.</param>
         public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4)
         {
             Item1 = item1;
@@ -549,11 +809,34 @@ namespace System
             Item4 = item4;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3, T4}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
         public override bool Equals(object obj)
         {
             return obj is ValueTuple<T1, T2, T3, T4> && Equals((ValueTuple<T1, T2, T3, T4>)obj);
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3, T4}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
         public bool Equals(ValueTuple<T1, T2, T3, T4> other)
         {
             return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
@@ -586,6 +869,14 @@ namespace System
             return CompareTo((ValueTuple<T1, T2, T3, T4>)other);
         }
 
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
         public int CompareTo(ValueTuple<T1, T2, T3, T4> other)
         {
             int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
@@ -623,6 +914,10 @@ namespace System
             return comparer.Compare(Item4, objTuple.Item4);
         }
 
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
             return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
@@ -649,6 +944,14 @@ namespace System
             return GetHashCodeCore(comparer);
         }
 
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3, T4}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3, T4}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
         public override string ToString()
         {
             return "(" + Item1 + ", " + Item2 + ", " + Item3 + ", " + Item4 + ")";
@@ -657,15 +960,46 @@ namespace System
         int ITupleInternal.Size => 4;
     }
 
+    /// <summary>
+    /// Represents a 5-tuple, or quintuple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
+    /// <typeparam name="T5">The type of the tuple's fifth component.</typeparam>
     public struct ValueTuple<T1, T2, T3, T4, T5>
         : IEquatable<ValueTuple<T1, T2, T3, T4, T5>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5>>, ITupleInternal
     {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's first component.
+        /// </summary>
         public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's second component.
+        /// </summary>
         public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's third component.
+        /// </summary>
         public T3 Item3;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's fourth component.
+        /// </summary>
         public T4 Item4;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's fifth component.
+        /// </summary>
         public T5 Item5;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        /// <param name="item4">The value of the tuple's fourth component.</param>
+        /// <param name="item5">The value of the tuple's fifth component.</param>
         public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
         {
             Item1 = item1;
@@ -675,11 +1009,34 @@ namespace System
             Item5 = item5;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
         public override bool Equals(object obj)
         {
             return obj is ValueTuple<T1, T2, T3, T4, T5> && Equals((ValueTuple<T1, T2, T3, T4, T5>)obj);
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3, T4, T5}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
         public bool Equals(ValueTuple<T1, T2, T3, T4, T5> other)
         {
             return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
@@ -714,6 +1071,14 @@ namespace System
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5>)other);
         }
 
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
         public int CompareTo(ValueTuple<T1, T2, T3, T4, T5> other)
         {
             int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
@@ -757,6 +1122,10 @@ namespace System
             return comparer.Compare(Item5, objTuple.Item5);
         }
 
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
             return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
@@ -785,6 +1154,14 @@ namespace System
             return GetHashCodeCore(comparer);
         }
 
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4, Item5)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
         public override string ToString()
         {
             return "(" + Item1 + ", " + Item2 + ", " + Item3 + ", " + Item4 + ", " + Item5 + ")";
@@ -793,16 +1170,52 @@ namespace System
         int ITupleInternal.Size => 5;
     }
 
+    /// <summary>
+    /// Represents a 6-tuple, or sixtuple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
+    /// <typeparam name="T5">The type of the tuple's fifth component.</typeparam>
+    /// <typeparam name="T6">The type of the tuple's sixth component.</typeparam>
     public struct ValueTuple<T1, T2, T3, T4, T5, T6>
         : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6>>, ITupleInternal
     {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's first component.
+        /// </summary>
         public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's second component.
+        /// </summary>
         public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's third component.
+        /// </summary>
         public T3 Item3;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's fourth component.
+        /// </summary>
         public T4 Item4;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's fifth component.
+        /// </summary>
         public T5 Item5;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's sixth component.
+        /// </summary>
         public T6 Item6;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        /// <param name="item4">The value of the tuple's fourth component.</param>
+        /// <param name="item5">The value of the tuple's fifth component.</param>
+        /// <param name="item6">The value of the tuple's sixth component.</param>
         public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
         {
             Item1 = item1;
@@ -813,11 +1226,34 @@ namespace System
             Item6 = item6;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
         public override bool Equals(object obj)
         {
             return obj is ValueTuple<T1, T2, T3, T4, T5, T6> && Equals((ValueTuple<T1, T2, T3, T4, T5, T6>)obj);
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
         public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6> other)
         {
             return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
@@ -854,6 +1290,14 @@ namespace System
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6>)other);
         }
 
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
         public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6> other)
         {
             int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
@@ -903,6 +1347,10 @@ namespace System
             return comparer.Compare(Item6, objTuple.Item6);
         }
 
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
             return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
@@ -933,6 +1381,14 @@ namespace System
             return GetHashCodeCore(comparer);
         }
 
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4, Item5, Item6)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
         public override string ToString()
         {
             return "(" + Item1 + ", " + Item2 + ", " + Item3 + ", " + Item4 + ", " + Item5 + ", " + Item6 + ")";
@@ -941,17 +1397,58 @@ namespace System
         int ITupleInternal.Size => 6;
     }
 
+    /// <summary>
+    /// Represents a 7-tuple, or sentuple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
+    /// <typeparam name="T5">The type of the tuple's fifth component.</typeparam>
+    /// <typeparam name="T6">The type of the tuple's sixth component.</typeparam>
+    /// <typeparam name="T7">The type of the tuple's seventh component.</typeparam>
     public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7>
         : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, ITupleInternal
     {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's first component.
+        /// </summary>
         public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's second component.
+        /// </summary>
         public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's third component.
+        /// </summary>
         public T3 Item3;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's fourth component.
+        /// </summary>
         public T4 Item4;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's fifth component.
+        /// </summary>
         public T5 Item5;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's sixth component.
+        /// </summary>
         public T6 Item6;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's seventh component.
+        /// </summary>
         public T7 Item7;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        /// <param name="item4">The value of the tuple's fourth component.</param>
+        /// <param name="item5">The value of the tuple's fifth component.</param>
+        /// <param name="item6">The value of the tuple's sixth component.</param>
+        /// <param name="item7">The value of the tuple's seventh component.</param>
         public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7)
         {
             Item1 = item1;
@@ -963,11 +1460,34 @@ namespace System
             Item7 = item7;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
         public override bool Equals(object obj)
         {
             return obj is ValueTuple<T1, T2, T3, T4, T5, T6, T7> && Equals((ValueTuple<T1, T2, T3, T4, T5, T6, T7>)obj);
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
         public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6, T7> other)
         {
             return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
@@ -1006,6 +1526,14 @@ namespace System
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other);
         }
 
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
         public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6, T7> other)
         {
             int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
@@ -1061,6 +1589,10 @@ namespace System
             return comparer.Compare(Item7, objTuple.Item7);
         }
 
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
             return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
@@ -1093,6 +1625,14 @@ namespace System
             return GetHashCodeCore(comparer);
         }
 
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4, Item5, Item6, Item7)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
         public override string ToString()
         {
             return "(" + Item1 + ", " + Item2 + ", " + Item3 + ", " + Item4 + ", " + Item5 + ", " + Item6 + ", " + Item7 + ")";
@@ -1101,18 +1641,64 @@ namespace System
         int ITupleInternal.Size => 7;
     }
 
+    /// <summary>
+    /// Represents an 8-tuple, or octuple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
+    /// <typeparam name="T5">The type of the tuple's fifth component.</typeparam>
+    /// <typeparam name="T6">The type of the tuple's sixth component.</typeparam>
+    /// <typeparam name="T7">The type of the tuple's seventh component.</typeparam>
+    /// <typeparam name="TRest">The type of the tuple's eigth component.</typeparam>
     public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
         : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, ITupleInternal
     {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's first component.
+        /// </summary>
         public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's second component.
+        /// </summary>
         public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's third component.
+        /// </summary>
         public T3 Item3;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's fourth component.
+        /// </summary>
         public T4 Item4;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's fifth component.
+        /// </summary>
         public T5 Item5;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's sixth component.
+        /// </summary>
         public T6 Item6;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's seventh component.
+        /// </summary>
         public T7 Item7;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's eigth component.
+        /// </summary>
         public TRest Rest;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        /// <param name="item4">The value of the tuple's fourth component.</param>
+        /// <param name="item5">The value of the tuple's fifth component.</param>
+        /// <param name="item6">The value of the tuple's sixth component.</param>
+        /// <param name="item7">The value of the tuple's seventh component.</param>
+        /// <param name="rest">The value of the tuple's eight component.</param>
         public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest)
         {
             if (!(rest is ITupleInternal))
@@ -1130,11 +1716,34 @@ namespace System
             Rest = rest;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
         public override bool Equals(object obj)
         {
             return obj is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> && Equals((ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)obj);
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
         public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other)
         {
             return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
@@ -1175,6 +1784,14 @@ namespace System
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other);
         }
 
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
         public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other)
         {
             int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
@@ -1236,6 +1853,10 @@ namespace System
             return comparer.Compare(Rest, objTuple.Rest);
         }
 
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
             // We want to have a limited hash in this case.  We'll use the last 8 elements of the tuple
@@ -1363,6 +1984,14 @@ namespace System
             return GetHashCodeCore(comparer);
         }
 
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4, Item5, Item6, Item7, Rest)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
         public override string ToString()
         {
             return "(" + Item1 + ", " + Item2 + ", " + Item3 + ", " + Item4 + ", " + Item5 + ", " + Item6 + ", " + Item7 + ", " + Rest + ")";

--- a/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
@@ -1,0 +1,1379 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System
+{
+    /// <summary>
+    /// Helper so we can call some tuple methods recursively without knowing the underlying types.
+    /// </summary>
+    internal interface ITupleInternal
+    {
+        int GetHashCode(IEqualityComparer comparer);
+        int Size { get; }
+    }
+
+    /// <summary>
+    /// The ValueTuple types (from arity 0 to 8) comprise the runtime implementation that underlies tuples in C# and struct tuples in F#.
+    /// Aside from created via language syntax, they are most easily created via the ValueTuple.Create factory methods.
+    /// The Value Tuple types differ from the System.Tuple types in that:
+    /// - they are structs rather than classes,
+    /// - they are mutable rather than readonly, and
+    /// - their members (such as Item1, Item2, etc) are fields rather than properties.
+    /// </summary>
+    public struct ValueTuple
+        : IEquatable<ValueTuple>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple>, ITupleInternal
+    {
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple;
+        }
+
+        public bool Equals(ValueTuple other)
+        {
+            return true;
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            return other is ValueTuple;
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return 0;
+        }
+
+        public int CompareTo(ValueTuple other)
+        {
+            return 0;
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return 0;
+        }
+
+        public override int GetHashCode()
+        {
+            return 0;
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return 0;
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return 0;
+        }
+
+        public override string ToString()
+        {
+            return "()";
+        }
+
+        int ITupleInternal.Size => 0;
+
+        public static ValueTuple Create() =>
+            new ValueTuple();
+
+        public static ValueTuple<T1> Create<T1>(T1 item1) =>
+            new ValueTuple<T1>(item1);
+
+        public static ValueTuple<T1, T2> Create<T1, T2>(T1 item1, T2 item2) =>
+            new ValueTuple<T1, T2>(item1, item2);
+
+        public static ValueTuple<T1, T2, T3> Create<T1, T2, T3>(T1 item1, T2 item2, T3 item3) =>
+            new ValueTuple<T1, T2, T3>(item1, item2, item3);
+
+        public static ValueTuple<T1, T2, T3, T4> Create<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4) =>
+            new ValueTuple<T1, T2, T3, T4>(item1, item2, item3, item4);
+
+        public static ValueTuple<T1, T2, T3, T4, T5> Create<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5) =>
+            new ValueTuple<T1, T2, T3, T4, T5>(item1, item2, item3, item4, item5);
+
+        public static ValueTuple<T1, T2, T3, T4, T5, T6> Create<T1, T2, T3, T4, T5, T6>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6) =>
+            new ValueTuple<T1, T2, T3, T4, T5, T6>(item1, item2, item3, item4, item5, item6);
+
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7> Create<T1, T2, T3, T4, T5, T6, T7>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7) =>
+            new ValueTuple<T1, T2, T3, T4, T5, T6, T7>(item1, item2, item3, item4, item5, item6, item7);
+
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> Create<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) =>
+            new ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, rest);
+
+        // From System.Web.Util.HashCodeCombiner
+        internal static int CombineHashCodes(int h1, int h2)
+        {
+            return (((h1 << 5) + h1) ^ h2);
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3)
+        {
+            return CombineHashCodes(CombineHashCodes(h1, h2), h3);
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4)
+        {
+            return CombineHashCodes(CombineHashCodes(h1, h2), CombineHashCodes(h3, h4));
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5)
+        {
+            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), h5);
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6)
+        {
+            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6));
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7)
+        {
+            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6, h7));
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7, int h8)
+        {
+            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6, h7, h8));
+        }
+    }
+
+    public struct ValueTuple<T1>
+        : IEquatable<ValueTuple<T1>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1>>, ITupleInternal
+    {
+        public T1 Item1;
+
+        public ValueTuple(T1 item1)
+        {
+            Item1 = item1;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1> && Equals((ValueTuple<T1>)obj);
+        }
+
+        public bool Equals(ValueTuple<T1> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1>)) return false;
+
+            var objTuple = (ValueTuple<T1>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1>)other;
+
+            return Comparer<T1>.Default.Compare(Item1, objTuple.Item1);
+        }
+
+        public int CompareTo(ValueTuple<T1> other)
+        {
+            return Comparer<T1>.Default.Compare(Item1, other.Item1);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1>)other;
+
+            return comparer.Compare(Item1, objTuple.Item1);
+        }
+
+        public override int GetHashCode()
+        {
+            return EqualityComparer<T1>.Default.GetHashCode(Item1);
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return comparer.GetHashCode(Item1);
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return comparer.GetHashCode(Item1);
+        }
+
+        public override string ToString()
+        {
+            return "(" + Item1 + ")";
+        }
+
+        int ITupleInternal.Size => 1;
+    }
+
+    /// <summary>
+    /// Represents a 2-tuple, or pair as a struct.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    public struct ValueTuple<T1, T2>
+        : IEquatable<ValueTuple<T1, T2>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2>>, ITupleInternal
+    {
+        /// <summary>
+        /// The current <seealso cref="ValueTuple{T1, T2}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+
+        /// <summary>
+        /// The current <seealso cref="ValueTuple{T1, T2}"/> instance's first component.
+        /// </summary>
+        public T2 Item2;
+
+        /// <summary>
+        /// Initializes a new instance of the <seealso cref="ValueTuple{T1, T2}"/> struct.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            Item1 = item1;
+            Item2 = item2;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <seealso cref="ValueTuple{T1, T2}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="other">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        ///
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <seealso cref="ValueTuple{T1, T2}"/> struct.</description></item>
+        ///     <item><description>Its two components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its two components are equal to those of the current instance.Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2> && Equals((ValueTuple<T1, T2>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <seealso cref="ValueTuple{T1, T2}"/> instance is equal to a specified <seealso cref="ValueTuple{T1, T2}"/>.
+        /// </summary>
+        /// <param name="other">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        ///
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <seealso cref="ValueTuple{T1, T2}"/> struct.</description></item>
+        ///     <item><description>Its two components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its two components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public bool Equals(ValueTuple<T1, T2> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <seealso cref="ValueTuple{T1, T2}"/> instance is equal to a specified object based on a specified comparison method.
+        /// </summary>
+        /// <param name="other">The object to compare with this instance.</param>
+        /// <param name="comparer">An object that defines the method to use to evaluate whether the two objects are equal.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        ///
+        /// <remarks>
+        /// This member is an explicit interface member implementation. It can be used only when the
+        ///  <seealso cref="ValueTuple{T1, T2}"/> instance is cast to an <see cref="IStructuralEquatable"/> interface.
+        ///
+        /// The <see cref="IEqualityComparer.Equals"/> implementation is called only if <c>other</c> is not <see langword="null"/>,
+        ///  and if it can be successfully cast (in C#) or converted (in Visual Basic) to a <seealso cref="ValueTuple{T1, T2}"/>
+        ///  whose components are of the same types as those of the current instance. The IStructuralEquatable.Equals(Object, IEqualityComparer) method
+        ///  first passes the <see cref="Item1"/> values of the <seealso cref="ValueTuple{T1, T2}"/> objects to be compared to the
+        ///  <see cref="IEqualityComparer.Equals"/> implementation. If this method call returns <see langword="true"/>, the method is
+        ///  called again and passed the <see cref="Item2"/> values of the two <seealso cref="ValueTuple{T1, T2}"/> instances.
+        /// </remarks>
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2>)other);
+        }
+
+        public int CompareTo(ValueTuple<T1, T2> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            return Comparer<T2>.Default.Compare(Item2, other.Item2);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item2, objTuple.Item2);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <seealso cref="ValueTuple{T1, T2}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <seealso cref="ValueTuple{T1, T2}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <seealso cref="ValueTuple{T1, T2}"/> instance.</returns>
+        ///
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2)</c>,
+        ///  where <c>Item1</c> and <c>Item2</c> represent the values of the <see cref="Item1"/>
+        ///  and <see cref="Item2"/> properties. If either property value is <see langword="null"/>,
+        ///  it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "(" + Item1 + ", " + Item2 + ")";
+        }
+
+        int ITupleInternal.Size => 2;
+    }
+
+    public struct ValueTuple<T1, T2, T3>
+        : IEquatable<ValueTuple<T1, T2, T3>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3>>, ITupleInternal
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+
+        public ValueTuple(T1 item1, T2 item2, T3 item3)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3> && Equals((ValueTuple<T1, T2, T3>)obj);
+        }
+
+        public bool Equals(ValueTuple<T1, T2, T3> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3>)other);
+        }
+
+        public int CompareTo(ValueTuple<T1, T2, T3> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            return Comparer<T3>.Default.Compare(Item3, other.Item3);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item3, objTuple.Item3);
+        }
+
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                               EqualityComparer<T3>.Default.GetHashCode(Item3));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2),
+                                               comparer.GetHashCode(Item3));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        public override string ToString()
+        {
+            return "(" + Item1 + ", " + Item2 + ", " + Item3 + ")";
+        }
+
+        int ITupleInternal.Size => 3;
+    }
+
+    public struct ValueTuple<T1, T2, T3, T4>
+        : IEquatable<ValueTuple<T1, T2, T3, T4>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4>>, ITupleInternal
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3, T4> && Equals((ValueTuple<T1, T2, T3, T4>)obj);
+        }
+
+        public bool Equals(ValueTuple<T1, T2, T3, T4> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3)
+                && EqualityComparer<T4>.Default.Equals(Item4, other.Item4);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3, T4>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3)
+                && comparer.Equals(Item4, objTuple.Item4);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3, T4>)other);
+        }
+
+        public int CompareTo(ValueTuple<T1, T2, T3, T4> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            c = Comparer<T3>.Default.Compare(Item3, other.Item3);
+            if (c != 0) return c;
+
+            return Comparer<T4>.Default.Compare(Item4, other.Item4);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item3, objTuple.Item3);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item4, objTuple.Item4);
+        }
+
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                               EqualityComparer<T4>.Default.GetHashCode(Item4));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2),
+                                               comparer.GetHashCode(Item3),
+                                               comparer.GetHashCode(Item4));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        public override string ToString()
+        {
+            return "(" + Item1 + ", " + Item2 + ", " + Item3 + ", " + Item4 + ")";
+        }
+
+        int ITupleInternal.Size => 4;
+    }
+
+    public struct ValueTuple<T1, T2, T3, T4, T5>
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5>>, ITupleInternal
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+        public T5 Item5;
+
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3, T4, T5> && Equals((ValueTuple<T1, T2, T3, T4, T5>)obj);
+        }
+
+        public bool Equals(ValueTuple<T1, T2, T3, T4, T5> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3)
+                && EqualityComparer<T4>.Default.Equals(Item4, other.Item4)
+                && EqualityComparer<T5>.Default.Equals(Item5, other.Item5);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3, T4, T5>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3)
+                && comparer.Equals(Item4, objTuple.Item4)
+                && comparer.Equals(Item5, objTuple.Item5);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3, T4, T5>)other);
+        }
+
+        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            c = Comparer<T3>.Default.Compare(Item3, other.Item3);
+            if (c != 0) return c;
+
+            c = Comparer<T4>.Default.Compare(Item4, other.Item4);
+            if (c != 0) return c;
+
+            return Comparer<T5>.Default.Compare(Item5, other.Item5);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item3, objTuple.Item3);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item4, objTuple.Item4);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item5, objTuple.Item5);
+        }
+
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                               EqualityComparer<T5>.Default.GetHashCode(Item5));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2),
+                                               comparer.GetHashCode(Item3),
+                                               comparer.GetHashCode(Item4),
+                                               comparer.GetHashCode(Item5));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        public override string ToString()
+        {
+            return "(" + Item1 + ", " + Item2 + ", " + Item3 + ", " + Item4 + ", " + Item5 + ")";
+        }
+
+        int ITupleInternal.Size => 5;
+    }
+
+    public struct ValueTuple<T1, T2, T3, T4, T5, T6>
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6>>, ITupleInternal
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+        public T5 Item5;
+        public T6 Item6;
+
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+            Item6 = item6;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3, T4, T5, T6> && Equals((ValueTuple<T1, T2, T3, T4, T5, T6>)obj);
+        }
+
+        public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3)
+                && EqualityComparer<T4>.Default.Equals(Item4, other.Item4)
+                && EqualityComparer<T5>.Default.Equals(Item5, other.Item5)
+                && EqualityComparer<T6>.Default.Equals(Item6, other.Item6);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3, T4, T5, T6>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3)
+                && comparer.Equals(Item4, objTuple.Item4)
+                && comparer.Equals(Item5, objTuple.Item5)
+                && comparer.Equals(Item6, objTuple.Item6);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6>)other);
+        }
+
+        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            c = Comparer<T3>.Default.Compare(Item3, other.Item3);
+            if (c != 0) return c;
+
+            c = Comparer<T4>.Default.Compare(Item4, other.Item4);
+            if (c != 0) return c;
+
+            c = Comparer<T5>.Default.Compare(Item5, other.Item5);
+            if (c != 0) return c;
+
+            return Comparer<T6>.Default.Compare(Item6, other.Item6);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item3, objTuple.Item3);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item4, objTuple.Item4);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item5, objTuple.Item5);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item6, objTuple.Item6);
+        }
+
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                               EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                               EqualityComparer<T6>.Default.GetHashCode(Item6));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2),
+                                               comparer.GetHashCode(Item3),
+                                               comparer.GetHashCode(Item4),
+                                               comparer.GetHashCode(Item5),
+                                               comparer.GetHashCode(Item6));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        public override string ToString()
+        {
+            return "(" + Item1 + ", " + Item2 + ", " + Item3 + ", " + Item4 + ", " + Item5 + ", " + Item6 + ")";
+        }
+
+        int ITupleInternal.Size => 6;
+    }
+
+    public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7>
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, ITupleInternal
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+        public T5 Item5;
+        public T6 Item6;
+        public T7 Item7;
+
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+            Item6 = item6;
+            Item7 = item7;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3, T4, T5, T6, T7> && Equals((ValueTuple<T1, T2, T3, T4, T5, T6, T7>)obj);
+        }
+
+        public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6, T7> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3)
+                && EqualityComparer<T4>.Default.Equals(Item4, other.Item4)
+                && EqualityComparer<T5>.Default.Equals(Item5, other.Item5)
+                && EqualityComparer<T6>.Default.Equals(Item6, other.Item6)
+                && EqualityComparer<T7>.Default.Equals(Item7, other.Item7);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3)
+                && comparer.Equals(Item4, objTuple.Item4)
+                && comparer.Equals(Item5, objTuple.Item5)
+                && comparer.Equals(Item6, objTuple.Item6)
+                && comparer.Equals(Item7, objTuple.Item7);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other);
+        }
+
+        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6, T7> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            c = Comparer<T3>.Default.Compare(Item3, other.Item3);
+            if (c != 0) return c;
+
+            c = Comparer<T4>.Default.Compare(Item4, other.Item4);
+            if (c != 0) return c;
+
+            c = Comparer<T5>.Default.Compare(Item5, other.Item5);
+            if (c != 0) return c;
+
+            c = Comparer<T6>.Default.Compare(Item6, other.Item6);
+            if (c != 0) return c;
+
+            return Comparer<T7>.Default.Compare(Item7, other.Item7);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item3, objTuple.Item3);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item4, objTuple.Item4);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item5, objTuple.Item5);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item6, objTuple.Item6);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item7, objTuple.Item7);
+        }
+
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                               EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                               EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                               EqualityComparer<T7>.Default.GetHashCode(Item7));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2),
+                                               comparer.GetHashCode(Item3),
+                                               comparer.GetHashCode(Item4),
+                                               comparer.GetHashCode(Item5),
+                                               comparer.GetHashCode(Item6),
+                                               comparer.GetHashCode(Item7));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        public override string ToString()
+        {
+            return "(" + Item1 + ", " + Item2 + ", " + Item3 + ", " + Item4 + ", " + Item5 + ", " + Item6 + ", " + Item7 + ")";
+        }
+
+        int ITupleInternal.Size => 7;
+    }
+
+    public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, ITupleInternal
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+        public T5 Item5;
+        public T6 Item6;
+        public T7 Item7;
+        public TRest Rest;
+
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest)
+        {
+            if (!(rest is ITupleInternal))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleLastArgumentNotAValueTuple);
+            }
+
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+            Item6 = item6;
+            Item7 = item7;
+            Rest = rest;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> && Equals((ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)obj);
+        }
+
+        public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3)
+                && EqualityComparer<T4>.Default.Equals(Item4, other.Item4)
+                && EqualityComparer<T5>.Default.Equals(Item5, other.Item5)
+                && EqualityComparer<T6>.Default.Equals(Item6, other.Item6)
+                && EqualityComparer<T7>.Default.Equals(Item7, other.Item7)
+                && EqualityComparer<TRest>.Default.Equals(Rest, other.Rest);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3)
+                && comparer.Equals(Item4, objTuple.Item4)
+                && comparer.Equals(Item5, objTuple.Item5)
+                && comparer.Equals(Item6, objTuple.Item6)
+                && comparer.Equals(Item7, objTuple.Item7)
+                && comparer.Equals(Rest, objTuple.Rest);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other);
+        }
+
+        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            c = Comparer<T3>.Default.Compare(Item3, other.Item3);
+            if (c != 0) return c;
+
+            c = Comparer<T4>.Default.Compare(Item4, other.Item4);
+            if (c != 0) return c;
+
+            c = Comparer<T5>.Default.Compare(Item5, other.Item5);
+            if (c != 0) return c;
+
+            c = Comparer<T6>.Default.Compare(Item6, other.Item6);
+            if (c != 0) return c;
+
+            c = Comparer<T7>.Default.Compare(Item7, other.Item7);
+            if (c != 0) return c;
+
+            return Comparer<TRest>.Default.Compare(Rest, other.Rest);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item3, objTuple.Item3);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item4, objTuple.Item4);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item5, objTuple.Item5);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item6, objTuple.Item6);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item7, objTuple.Item7);
+            if (c != 0) return c;
+
+            return comparer.Compare(Rest, objTuple.Rest);
+        }
+
+        public override int GetHashCode()
+        {
+            // We want to have a limited hash in this case.  We'll use the last 8 elements of the tuple
+            ITupleInternal rest = Rest as ITupleInternal;
+            if (rest == null)
+            {
+                return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                                   EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                                   EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                   EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                   EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                   EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                   EqualityComparer<T7>.Default.GetHashCode(Item7));
+            }
+
+            int size = rest.Size;
+            if (size >= 8) { return rest.GetHashCode(); }
+
+            // In this case, the rest member has less than 8 elements so we need to combine some our elements with the elements in rest
+            int k = 8 - size;
+            switch (k)
+            {
+                case 1:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 2:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 3:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 4:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 5:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 6:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                                       EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 7:
+                case 8:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                                       EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                                       EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+            }
+
+            Debug.Assert(false, "Missed all cases for computing ValueTuple hash code");
+            return -1;
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            // We want to have a limited hash in this case.  We'll use the last 8 elements of the tuple
+            ITupleInternal rest = Rest as ITupleInternal;
+            if (rest == null)
+            {
+                return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1), comparer.GetHashCode(Item2), comparer.GetHashCode(Item3),
+                                                   comparer.GetHashCode(Item4), comparer.GetHashCode(Item5), comparer.GetHashCode(Item6),
+                                                   comparer.GetHashCode(Item7));
+            }
+
+            int size = rest.Size;
+            if (size >= 8) { return rest.GetHashCode(comparer); }
+
+            // In this case, the rest member has less than 8 elements so we need to combine some our elements with the elements in rest
+            int k = 8 - size;
+            switch (k)
+            {
+                case 1:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
+                case 2:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item6), comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
+                case 3:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item5), comparer.GetHashCode(Item6), comparer.GetHashCode(Item7),
+                                                       rest.GetHashCode(comparer));
+                case 4:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item4), comparer.GetHashCode(Item5), comparer.GetHashCode(Item6),
+                                                       comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
+                case 5:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item3), comparer.GetHashCode(Item4), comparer.GetHashCode(Item5),
+                                                       comparer.GetHashCode(Item6), comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
+                case 6:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item2), comparer.GetHashCode(Item3), comparer.GetHashCode(Item4),
+                                                       comparer.GetHashCode(Item5), comparer.GetHashCode(Item6), comparer.GetHashCode(Item7),
+                                                       rest.GetHashCode(comparer));
+                case 7:
+                case 8:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1), comparer.GetHashCode(Item2), comparer.GetHashCode(Item3),
+                                                       comparer.GetHashCode(Item4), comparer.GetHashCode(Item5), comparer.GetHashCode(Item6),
+                                                       comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
+            }
+
+            Debug.Assert(false, "Missed all cases for computing ValueTuple hash code");
+            return -1;
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        public override string ToString()
+        {
+            return "(" + Item1 + ", " + Item2 + ", " + Item3 + ", " + Item4 + ", " + Item5 + ", " + Item6 + ", " + Item7 + ", " + Rest + ")";
+        }
+
+        int ITupleInternal.Size
+        {
+            get
+            {
+                return 7 + ((ITupleInternal)Rest).Size;
+            }
+        }
+    }
+}

--- a/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
@@ -20,7 +20,7 @@ namespace System
     /// <summary>
     /// The ValueTuple types (from arity 0 to 8) comprise the runtime implementation that underlies tuples in C# and struct tuples in F#.
     /// Aside from created via language syntax, they are most easily created via the ValueTuple.Create factory methods.
-    /// The Value Tuple types differ from the System.Tuple types in that:
+    /// The System.ValueTuple types differ from the System.Tuple types in that:
     /// - they are structs rather than classes,
     /// - they are mutable rather than readonly, and
     /// - their members (such as Item1, Item2, etc) are fields rather than properties.

--- a/src/System.ValueTuple/src/project.json
+++ b/src/System.ValueTuple/src/project.json
@@ -1,0 +1,18 @@
+﻿{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.0.1-rc3-24015-00",
+    "System.Collections": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.0",
+    "System.Diagnostics.Tracing": "4.0.0",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Runtime": "4.0.0",
+    "System.Threading": "4.0.0"
+  },
+  "frameworks": {
+    "netstandard1.1": {
+      "imports": [
+        "dotnet5.2"
+      ]
+    }
+  }
+}

--- a/src/System.ValueTuple/tests/System.ValueTuple.Tests.builds
+++ b/src/System.ValueTuple/tests/System.ValueTuple.Tests.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.ValueTuple.Tests.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.ValueTuple/tests/System.ValueTuple.Tests.csproj
+++ b/src/System.ValueTuple/tests/System.ValueTuple.Tests.csproj
@@ -6,11 +6,10 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{CBD5AE8D-8595-48E2-848F-1A3492A28FDB}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <AssemblyName>System.Tuples.Tests</AssemblyName>
+    <AssemblyName>System.ValueTuple.Tests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ValueTuple\UnitTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.ValueTuple.csproj">

--- a/src/System.ValueTuple/tests/System.ValueTuple.Tests.csproj
+++ b/src/System.ValueTuple/tests/System.ValueTuple.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CBD5AE8D-8595-48E2-848F-1A3492A28FDB}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.Tuples.Tests</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ValueTuple\UnitTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.ValueTuple.csproj">
+      <Name>System.ValueTuple</Name>
+      <Project>{4C2655DB-BD9E-4C86-83A6-744ECDDBDF29}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.ValueTuple/tests/ValueTuple/UnitTests.cs
+++ b/src/System.ValueTuple/tests/ValueTuple/UnitTests.cs
@@ -1,0 +1,1054 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+public class ValueTupleTests
+{
+    private class ValueTupleTestDriver<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
+    {
+        private int _nItems;
+
+        private readonly object valueTuple;
+        private readonly ValueTuple valueTuple0;
+        private readonly ValueTuple<T1> valueTuple1;
+        private readonly ValueTuple<T1, T2> valueTuple2;
+        private readonly ValueTuple<T1, T2, T3> valueTuple3;
+        private readonly ValueTuple<T1, T2, T3, T4> valueTuple4;
+        private readonly ValueTuple<T1, T2, T3, T4, T5> valueTuple5;
+        private readonly ValueTuple<T1, T2, T3, T4, T5, T6> valueTuple6;
+        private readonly ValueTuple<T1, T2, T3, T4, T5, T6, T7> valueTuple7;
+        private readonly ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>> valueTuple8;
+        private readonly ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9>> valueTuple9;
+        private readonly ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10>> valueTuple10;
+
+        internal ValueTupleTestDriver(params object[] values)
+        {
+            if (values.Length > 10)
+                throw new ArgumentOutOfRangeException(nameof(values), "You must provide at most 10 values");
+
+            _nItems = values.Length;
+            switch (_nItems)
+            {
+                case 0:
+                    valueTuple0 = ValueTuple.Create();
+                    valueTuple = valueTuple0;
+                    break;
+                case 1:
+                    valueTuple1 = ValueTuple.Create((T1)values[0]);
+                    valueTuple = valueTuple1;
+                    break;
+                case 2:
+                    valueTuple2 = ValueTuple.Create((T1)values[0], (T2)values[1]);
+                    valueTuple = valueTuple2;
+                    break;
+                case 3:
+                    valueTuple3 = ValueTuple.Create((T1)values[0], (T2)values[1], (T3)values[2]);
+                    valueTuple = valueTuple3;
+                    break;
+                case 4:
+                    valueTuple4 = ValueTuple.Create((T1)values[0], (T2)values[1], (T3)values[2], (T4)values[3]);
+                    valueTuple = valueTuple4;
+                    break;
+                case 5:
+                    valueTuple5 = ValueTuple.Create((T1)values[0], (T2)values[1], (T3)values[2], (T4)values[3], (T5)values[4]);
+                    valueTuple = valueTuple5;
+                    break;
+                case 6:
+                    valueTuple6 = ValueTuple.Create((T1)values[0], (T2)values[1], (T3)values[2], (T4)values[3],
+                        (T5)values[4], (T6)values[5]);
+                    valueTuple = valueTuple6;
+                    break;
+                case 7:
+                    valueTuple7 = ValueTuple.Create((T1)values[0], (T2)values[1], (T3)values[2], (T4)values[3],
+                        (T5)values[4], (T6)values[5], (T7)values[6]);
+                    valueTuple = valueTuple7;
+                    break;
+                case 8:
+                    valueTuple8 = ValueTuple.Create((T1)values[0], (T2)values[1], (T3)values[2], (T4)values[3],
+                        (T5)values[4], (T6)values[5], (T7)values[6], ValueTuple.Create((T8)values[7]));
+                    valueTuple = valueTuple8;
+                    break;
+                case 9:
+                    valueTuple9 = ValueTuple.Create((T1)values[0], (T2)values[1], (T3)values[2], (T4)values[3],
+                        (T5)values[4], (T6)values[5], (T7)values[6], ValueTuple.Create((T8)values[7], (T9)values[8]));
+                    valueTuple = valueTuple9;
+                    break;
+                case 10:
+                    valueTuple10 = ValueTuple.Create((T1)values[0], (T2)values[1], (T3)values[2], (T4)values[3],
+                        (T5)values[4], (T6)values[5], (T7)values[6], ValueTuple.Create((T8)values[7], (T9)values[8], (T10)values[9]));
+                    valueTuple = valueTuple10;
+                    break;
+            }
+        }
+
+        private void VerifyItem(int itemPos, object Item1, object Item2)
+        {
+            Assert.True(object.Equals(Item1, Item2));
+        }
+
+        public void TestConstructor(params object[] expectedValue)
+        {
+            if (expectedValue.Length != _nItems)
+                throw new ArgumentOutOfRangeException("expectedValues", "You must provide " + _nItems + " expectedvalues");
+
+            switch (_nItems)
+            {
+                case 0:
+                    break;
+                case 1:
+                    VerifyItem(1, valueTuple1.Item1, expectedValue[0]);
+                    break;
+                case 2:
+                    VerifyItem(1, valueTuple2.Item1, expectedValue[0]);
+                    VerifyItem(2, valueTuple2.Item2, expectedValue[1]);
+                    break;
+                case 3:
+                    VerifyItem(1, valueTuple3.Item1, expectedValue[0]);
+                    VerifyItem(2, valueTuple3.Item2, expectedValue[1]);
+                    VerifyItem(3, valueTuple3.Item3, expectedValue[2]);
+                    break;
+                case 4:
+                    VerifyItem(1, valueTuple4.Item1, expectedValue[0]);
+                    VerifyItem(2, valueTuple4.Item2, expectedValue[1]);
+                    VerifyItem(3, valueTuple4.Item3, expectedValue[2]);
+                    VerifyItem(4, valueTuple4.Item4, expectedValue[3]);
+                    break;
+                case 5:
+                    VerifyItem(1, valueTuple5.Item1, expectedValue[0]);
+                    VerifyItem(2, valueTuple5.Item2, expectedValue[1]);
+                    VerifyItem(3, valueTuple5.Item3, expectedValue[2]);
+                    VerifyItem(4, valueTuple5.Item4, expectedValue[3]);
+                    VerifyItem(5, valueTuple5.Item5, expectedValue[4]);
+                    break;
+                case 6:
+                    VerifyItem(1, valueTuple6.Item1, expectedValue[0]);
+                    VerifyItem(2, valueTuple6.Item2, expectedValue[1]);
+                    VerifyItem(3, valueTuple6.Item3, expectedValue[2]);
+                    VerifyItem(4, valueTuple6.Item4, expectedValue[3]);
+                    VerifyItem(5, valueTuple6.Item5, expectedValue[4]);
+                    VerifyItem(6, valueTuple6.Item6, expectedValue[5]);
+                    break;
+                case 7:
+                    VerifyItem(1, valueTuple7.Item1, expectedValue[0]);
+                    VerifyItem(2, valueTuple7.Item2, expectedValue[1]);
+                    VerifyItem(3, valueTuple7.Item3, expectedValue[2]);
+                    VerifyItem(4, valueTuple7.Item4, expectedValue[3]);
+                    VerifyItem(5, valueTuple7.Item5, expectedValue[4]);
+                    VerifyItem(6, valueTuple7.Item6, expectedValue[5]);
+                    VerifyItem(7, valueTuple7.Item7, expectedValue[6]);
+                    break;
+                case 8: // Extended ValueTuple
+                    VerifyItem(1, valueTuple8.Item1, expectedValue[0]);
+                    VerifyItem(2, valueTuple8.Item2, expectedValue[1]);
+                    VerifyItem(3, valueTuple8.Item3, expectedValue[2]);
+                    VerifyItem(4, valueTuple8.Item4, expectedValue[3]);
+                    VerifyItem(5, valueTuple8.Item5, expectedValue[4]);
+                    VerifyItem(6, valueTuple8.Item6, expectedValue[5]);
+                    VerifyItem(7, valueTuple8.Item7, expectedValue[6]);
+                    VerifyItem(8, valueTuple8.Rest.Item1, expectedValue[7]);
+                    break;
+                case 9: // Extended ValueTuple
+                    VerifyItem(1, valueTuple9.Item1, expectedValue[0]);
+                    VerifyItem(2, valueTuple9.Item2, expectedValue[1]);
+                    VerifyItem(3, valueTuple9.Item3, expectedValue[2]);
+                    VerifyItem(4, valueTuple9.Item4, expectedValue[3]);
+                    VerifyItem(5, valueTuple9.Item5, expectedValue[4]);
+                    VerifyItem(6, valueTuple9.Item6, expectedValue[5]);
+                    VerifyItem(7, valueTuple9.Item7, expectedValue[6]);
+                    VerifyItem(8, valueTuple9.Rest.Item1, expectedValue[7]);
+                    VerifyItem(9, valueTuple9.Rest.Item2, expectedValue[8]);
+                    break;
+                case 10: // Extended ValueTuple
+                    VerifyItem(1, valueTuple10.Item1, expectedValue[0]);
+                    VerifyItem(2, valueTuple10.Item2, expectedValue[1]);
+                    VerifyItem(3, valueTuple10.Item3, expectedValue[2]);
+                    VerifyItem(4, valueTuple10.Item4, expectedValue[3]);
+                    VerifyItem(5, valueTuple10.Item5, expectedValue[4]);
+                    VerifyItem(6, valueTuple10.Item6, expectedValue[5]);
+                    VerifyItem(7, valueTuple10.Item7, expectedValue[6]);
+                    VerifyItem(8, valueTuple10.Rest.Item1, expectedValue[7]);
+                    VerifyItem(9, valueTuple10.Rest.Item2, expectedValue[8]);
+                    VerifyItem(10, valueTuple10.Rest.Item3, expectedValue[9]);
+                    break;
+                default:
+                    throw new ArgumentException("Must specify between 0 and 10 expected values (inclusive).");
+            }
+        }
+
+        public void TestToString(string expected)
+        {
+            Assert.Equal(expected, valueTuple.ToString());
+        }
+
+        public void TestEquals_GetHashCode(ValueTupleTestDriver<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> other, bool expectEqual, bool expectStructuallyEqual)
+        {
+            if (expectEqual)
+            {
+                Assert.True(valueTuple.Equals(other.valueTuple));
+                Assert.Equal(valueTuple.GetHashCode(), other.valueTuple.GetHashCode());
+            }
+            else
+            {
+                Assert.False(valueTuple.Equals(other.valueTuple));
+                Assert.NotEqual(valueTuple.GetHashCode(), other.valueTuple.GetHashCode());
+            }
+
+            if (expectStructuallyEqual)
+            {
+                var equatable = ((IStructuralEquatable)valueTuple);
+                var otherEquatable = ((IStructuralEquatable)other.valueTuple);
+                Assert.True(equatable.Equals(other.valueTuple, TestEqualityComparer.Instance));
+                Assert.Equal(equatable.GetHashCode(TestEqualityComparer.Instance), otherEquatable.GetHashCode(TestEqualityComparer.Instance));
+            }
+            else
+            {
+                var equatable = ((IStructuralEquatable)valueTuple);
+                var otherEquatable = ((IStructuralEquatable)other.valueTuple);
+                Assert.False(equatable.Equals(other.valueTuple, TestEqualityComparer.Instance));
+                Assert.NotEqual(equatable.GetHashCode(TestEqualityComparer.Instance), otherEquatable.GetHashCode(TestEqualityComparer.Instance));
+            }
+
+            Assert.False(valueTuple.Equals(null));
+            Assert.False(((IStructuralEquatable)valueTuple).Equals(null));
+        }
+
+        public void TestCompareTo(ValueTupleTestDriver<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> other, int expectedResult, int expectedStructuralResult)
+        {
+            Assert.Equal(expectedResult, ((IComparable)valueTuple).CompareTo(other.valueTuple));
+            Assert.Equal(expectedStructuralResult, ((IStructuralComparable)valueTuple).CompareTo(other.valueTuple, DummyTestComparer.Instance));
+            Assert.Equal(1, ((IComparable)valueTuple).CompareTo(null));
+        }
+
+        public void TestNotEqual()
+        {
+            ValueTuple<int> ValueTupleB = new ValueTuple<int>((int)10000);
+            Assert.NotEqual(valueTuple, ValueTupleB);
+        }
+
+        internal void TestCompareToThrows()
+        {
+            ValueTuple<int> ValueTupleB = new ValueTuple<int>((int)10000);
+            Assert.Throws<ArgumentException>(() => ((IComparable)valueTuple).CompareTo(ValueTupleB));
+        }
+    }
+
+    [Fact]
+    public static void TestConstructor()
+    {
+        ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan> ValueTupleDriverA;
+        //ValueTuple-0
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>();
+        ValueTupleDriverA.TestConstructor();
+
+        //ValueTuple-1
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MaxValue);
+        ValueTupleDriverA.TestConstructor(short.MaxValue);
+
+        //ValueTuple-2
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MinValue, int.MaxValue);
+        ValueTupleDriverA.TestConstructor(short.MinValue, int.MaxValue);
+
+        //ValueTuple-3
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)0, (int)0, long.MaxValue);
+        ValueTupleDriverA.TestConstructor((short)0, (int)0, long.MaxValue);
+
+        //ValueTuple-4
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "This");
+        ValueTupleDriverA.TestConstructor((short)1, (int)1, long.MinValue, "This");
+
+        //ValueTuple-5
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), (long)0, "is", 'A');
+        ValueTupleDriverA.TestConstructor((short)(-1), (int)(-1), (long)0, "is", 'A');
+
+        //ValueTuple-6
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MaxValue);
+        ValueTupleDriverA.TestConstructor((short)10, (int)100, (long)1, "testing", 'Z', Single.MaxValue);
+
+        //ValueTuple-7
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-100), (int)(-1000), (long)(-1), "ValueTuples", ' ', Single.MinValue, Double.MaxValue);
+        ValueTupleDriverA.TestConstructor((short)(-100), (int)(-1000), (long)(-1), "ValueTuples", ' ', Single.MinValue, Double.MaxValue);
+
+        object myObj = new object();
+        //ValueTuple-10
+        DateTime now = DateTime.Now;
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008?7?2?", '0', (Single)0.0001, (Double)0.0000001, now, ValueTuple.Create(false, myObj), TimeSpan.Zero);
+        ValueTupleDriverA.TestConstructor((short)10000, (int)1000000, (long)10000000, "2008?7?2?", '0', (Single)0.0001, (Double)0.0000001, now, ValueTuple.Create(false, myObj), TimeSpan.Zero);
+
+        Assert.Throws<ArgumentException>(() => ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, "not a tuple"));
+    }
+
+    [Fact]
+    public static void TestToString()
+    {
+        ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan> ValueTupleDriverA;
+        //ValueTuple-0
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>();
+        ValueTupleDriverA.TestToString("()");
+
+        //ValueTuple-1
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MaxValue);
+        ValueTupleDriverA.TestToString("(" + short.MaxValue + ")");
+
+        //ValueTuple-2
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MinValue, int.MaxValue);
+        ValueTupleDriverA.TestToString("(" + short.MinValue + ", " + int.MaxValue + ")");
+
+        //ValueTuple-3
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)0, (int)0, long.MaxValue);
+        ValueTupleDriverA.TestToString("(" + ((short)0) + ", " + ((int)0) + ", " + long.MaxValue + ")");
+
+        //ValueTuple-4
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "This");
+        ValueTupleDriverA.TestConstructor((short)1, (int)1, long.MinValue, "This");
+        ValueTupleDriverA.TestToString("(" + ((short)1) + ", " + ((int)1) + ", " + long.MinValue + ", This)");
+
+        //ValueTuple-5
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), (long)0, "is", 'A');
+        ValueTupleDriverA.TestToString("(" + ((short)(-1)) + ", " + ((int)(-1)) + ", " + ((long)0) + ", is, A)");
+
+        //ValueTuple-6
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MaxValue);
+        ValueTupleDriverA.TestToString("(" + ((short)10) + ", " + ((int)100) + ", " + ((long)1) + ", testing, Z, " + Single.MaxValue + ")");
+
+        //ValueTuple-7
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-100), (int)(-1000), (long)(-1), "ValueTuples", ' ', Single.MinValue, Double.MaxValue);
+        ValueTupleDriverA.TestToString("(" + ((short)(-100)) + ", " + ((int)(-1000)) + ", " + ((long)(-1)) + ", ValueTuples,  , " + Single.MinValue + ", " + Double.MaxValue + ")");
+
+        object myObj = new object();
+        //ValueTuple-10
+        DateTime now = DateTime.Now;
+
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008?7?2?", '0', (Single)0.0001, (Double)0.0000001, now, ValueTuple.Create(false, myObj), TimeSpan.Zero);
+        // .NET Native bug 438149 - object.ToString in incorrect
+        ValueTupleDriverA.TestToString("(" + ((short)10000) + ", " + ((int)1000000) + ", " + ((long)10000000) + ", 2008?7?2?, 0, " + ((Single)0.0001) + ", " + ((Double)0.0000001) + ", (" + now + ", (False, System.Object), " + TimeSpan.Zero + "))");
+    }
+
+    [Fact]
+    public static void TestEquals_GetHashCode()
+    {
+        ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan> ValueTupleDriverA, ValueTupleDriverB, ValueTupleDriverC, ValueTupleDriverD;
+        //ValueTuple-0
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>();
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>();
+        ValueTupleDriverD = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MaxValue, int.MaxValue);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverB, true, true);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverD, false, false);
+
+        //ValueTuple-1
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MaxValue);
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MaxValue);
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MinValue);
+        ValueTupleDriverD = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MaxValue, int.MaxValue);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverB, true, true);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverC, false, false);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverD, false, false);
+
+        //ValueTuple-2
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MinValue, int.MaxValue);
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MinValue, int.MaxValue);
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MinValue, int.MinValue);
+        ValueTupleDriverD = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), long.MinValue);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverB, true, true);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverC, false, false);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverD, false, false);
+
+        //ValueTuple-3
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)0, (int)0, long.MaxValue);
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)0, (int)0, long.MaxValue);
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), long.MinValue);
+        ValueTupleDriverD = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "this");
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverB, true, true);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverC, false, false);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverD, false, false);
+
+        //ValueTuple-4
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "This");
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "This");
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "this");
+        ValueTupleDriverD = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)0, (int)0, (long)1, "IS", 'a');
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverB, true, true);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverC, false, false);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverD, false, false);
+
+        //ValueTuple-5
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), (long)0, "is", 'A');
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), (long)0, "is", 'A');
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)0, (int)0, (long)1, "IS", 'a');
+        ValueTupleDriverD = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MinValue);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverB, true, true);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverC, false, false);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverD, false, false);
+
+        //ValueTuple-6
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MaxValue);
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MaxValue);
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MinValue);
+        ValueTupleDriverD = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-101), (int)(-1001), (long)(-2), "ValueTuples", ' ', Single.MinValue, (Double)0.0);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverB, true, true);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverC, false, false);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverD, false, false);
+
+        //ValueTuple-7
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-100), (int)(-1000), (long)(-1), "ValueTuples", ' ', Single.MinValue, Double.MaxValue);
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-100), (int)(-1000), (long)(-1), "ValueTuples", ' ', Single.MinValue, Double.MaxValue);
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-101), (int)(-1001), (long)(-2), "ValueTuples", ' ', Single.MinValue, (Double)0.0);
+        ValueTupleDriverD = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10001, (int)1000001, (long)10000001, "2008?7?3?", '1', (Single)0.0002, (Double)0.0000002, DateTime.Now.AddMilliseconds(1));
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverB, true, true);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverC, false, false);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverD, false, false);
+
+        //ValueTuple-8
+        DateTime now = DateTime.Now;
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-100), (int)(-1000), (long)(-1), "ValueTuples", ' ', Single.MinValue, Double.MaxValue, now);
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-100), (int)(-1000), (long)(-1), "ValueTuples", ' ', Single.MinValue, Double.MaxValue, now);
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-101), (int)(-1001), (long)(-2), "ValueTuples", ' ', Single.MinValue, (Double)0.0, now.AddMilliseconds(1));
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverB, true, true);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverC, false, false);
+
+        object myObj = new object();
+        //ValueTuple-10
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008?7?2?", '0', (Single)0.0001, (Double)0.0000001, now, ValueTuple.Create(false, myObj), TimeSpan.Zero);
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008?7?2?", '0', (Single)0.0001, (Double)0.0000001, now, ValueTuple.Create(false, myObj), TimeSpan.Zero);
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10001, (int)1000001, (long)10000001, "2008?7?3?", '1', (Single)0.0002, (Double)0.0000002, now.AddMilliseconds(1), ValueTuple.Create(true, myObj), TimeSpan.MaxValue);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverB, true, true);
+        ValueTupleDriverA.TestEquals_GetHashCode(ValueTupleDriverC, false, false);
+    }
+
+    [Fact]
+    public static void TestCompareTo()
+    {
+        ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan> ValueTupleDriverA, ValueTupleDriverB, ValueTupleDriverC;
+        //ValueTuple-0
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>();
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>();
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverB, 0, 0);
+
+        //ValueTuple-1
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MaxValue);
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MaxValue);
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MinValue);
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverB, 0, 5);
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverC, 65535, 5);
+        //ValueTuple-2
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MinValue, int.MaxValue);
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MinValue, int.MaxValue);
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>(short.MinValue, int.MinValue);
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverB, 0, 5);
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverC, 1, 5);
+        //ValueTuple-3
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)0, (int)0, long.MaxValue);
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)0, (int)0, long.MaxValue);
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), long.MinValue);
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverB, 0, 5);
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverC, 1, 5);
+        //ValueTuple-4
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "This");
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "This");
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "this");
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverB, 0, 5);
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverC, 1, 5);
+        //ValueTuple-5
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), (long)0, "is", 'A');
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), (long)0, "is", 'A');
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)0, (int)0, (long)1, "IS", 'a');
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverB, 0, 5);
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverC, -1, 5);
+        //ValueTuple-6
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MaxValue);
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MaxValue);
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MinValue);
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverB, 0, 5);
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverC, 1, 5);
+        //ValueTuple-7
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-100), (int)(-1000), (long)(-1), "ValueTuples", ' ', Single.MinValue, Double.MaxValue);
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-100), (int)(-1000), (long)(-1), "ValueTuples", ' ', Single.MinValue, Double.MaxValue);
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)(-101), (int)(-1001), (long)(-2), "ValueTuples", ' ', Single.MinValue, (Double)0.0);
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverB, 0, 5);
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverC, 1, 5);
+
+        object myObj = new object();
+        //ValueTuple-10
+        DateTime now = DateTime.Now;
+
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008?7?2?", '0', (Single)0.0001, (Double)0.0000001, now, ValueTuple.Create(false, myObj), TimeSpan.Zero);
+        ValueTupleDriverB = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008?7?2?", '0', (Single)0.0001, (Double)0.0000001, now, ValueTuple.Create(false, myObj), TimeSpan.Zero);
+        ValueTupleDriverC = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, ValueTuple<bool, object>, TimeSpan>((short)10001, (int)1000001, (long)10000001, "2008?7?3?", '1', (Single)0.0002, (Double)0.0000002, now.AddMilliseconds(1), ValueTuple.Create(true, myObj), TimeSpan.MaxValue);
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverB, 0, 5);
+        ValueTupleDriverA.TestCompareTo(ValueTupleDriverC, -1, 5);
+    }
+
+    [Fact]
+    public static void TestNotEqual()
+    {
+        ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan> ValueTupleDriverA;
+        //ValueTuple-0
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>();
+        ValueTupleDriverA.TestNotEqual();
+
+        //ValueTuple-1
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000);
+        ValueTupleDriverA.TestNotEqual();
+
+        // This is for code coverage purposes
+        //ValueTuple-2
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000);
+        ValueTupleDriverA.TestNotEqual();
+
+        //ValueTuple-3
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000);
+        ValueTupleDriverA.TestNotEqual();
+
+        //ValueTuple-4
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008?7?2?");
+        ValueTupleDriverA.TestNotEqual();
+
+        //ValueTuple-5
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008?7?2?", '0');
+        ValueTupleDriverA.TestNotEqual();
+
+        //ValueTuple-6
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008?7?2?", '0', Single.NaN);
+        ValueTupleDriverA.TestNotEqual();
+
+        //ValueTuple-7
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008?7?2?", '0', Single.NaN, Double.NegativeInfinity);
+        ValueTupleDriverA.TestNotEqual();
+
+        //ValueTuple-8, extended ValueTuple
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008?7?2?", '0', Single.NaN, Double.NegativeInfinity, DateTime.Now);
+        ValueTupleDriverA.TestNotEqual();
+
+        //ValueTuple-9 and ValueTuple-10 are not necessary because they use the same code path as ValueTuple-8
+    }
+
+    [Fact]
+    public static void IncomparableTypes()
+    {
+        ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan> ValueTupleDriverA;
+
+        //ValueTuple-0
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>();
+        ValueTupleDriverA.TestCompareToThrows();
+
+        //ValueTuple-1
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000);
+        ValueTupleDriverA.TestCompareToThrows();
+
+        // This is for code coverage purposes
+        //ValueTuple-2
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000);
+        ValueTupleDriverA.TestCompareToThrows();
+
+        //ValueTuple-3
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000);
+        ValueTupleDriverA.TestCompareToThrows();
+
+        //ValueTuple-4
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008?7?2?");
+        ValueTupleDriverA.TestCompareToThrows();
+
+        //ValueTuple-5
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008?7?2?", '0');
+        ValueTupleDriverA.TestCompareToThrows();
+
+        //ValueTuple-6
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008?7?2?", '0', Single.NaN);
+        ValueTupleDriverA.TestCompareToThrows();
+
+        //ValueTuple-7
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008?7?2?", '0', Single.NaN, Double.NegativeInfinity);
+        ValueTupleDriverA.TestCompareToThrows();
+
+        //ValueTuple-8, extended ValueTuple
+        ValueTupleDriverA = new ValueTupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008?7?2?", '0', Single.NaN, Double.NegativeInfinity, DateTime.Now);
+        ValueTupleDriverA.TestCompareToThrows();
+
+        //ValueTuple-9 and ValueTuple-10 are not necessary because they use the same code path as ValueTuple-8
+    }
+
+    [Fact]
+    public static void FloatingPointNaNCases()
+    {
+        var a = ValueTuple.Create(Double.MinValue, Double.NaN, Single.MinValue, Single.NaN);
+        var b = ValueTuple.Create(Double.MinValue, Double.NaN, Single.MinValue, Single.NaN);
+
+        Assert.True(a.Equals(b));
+        Assert.Equal(0, ((IComparable)a).CompareTo(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        Assert.True(((IStructuralEquatable)a).Equals(b, TestEqualityComparer.Instance));
+        Assert.Equal(5, ((IStructuralComparable)a).CompareTo(b, DummyTestComparer.Instance));
+        Assert.Equal(
+            ((IStructuralEquatable)a).GetHashCode(TestEqualityComparer.Instance),
+            ((IStructuralEquatable)b).GetHashCode(TestEqualityComparer.Instance));
+    }
+
+    [Fact]
+    public static void TestCustomTypeParameter1()
+    {
+        // Special case of ValueTuple<T1> where T1 is a custom type
+        var testClass = new TestClass();
+        var a = ValueTuple.Create(testClass);
+        var b = ValueTuple.Create(testClass);
+
+        Assert.True(a.Equals(b));
+        Assert.Equal(0, ((IComparable)a).CompareTo(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        Assert.True(((IStructuralEquatable)a).Equals(b, TestEqualityComparer.Instance));
+        Assert.Equal(5, ((IStructuralComparable)a).CompareTo(b, DummyTestComparer.Instance));
+        Assert.Equal(
+            ((IStructuralEquatable)a).GetHashCode(TestEqualityComparer.Instance),
+            ((IStructuralEquatable)b).GetHashCode(TestEqualityComparer.Instance));
+    }
+
+    [Fact]
+    public static void TestCustomTypeParameter2()
+    {
+        // Special case of ValueTuple<T1, T2> where T2 is a custom type
+        var testClass = new TestClass(1);
+        var a = ValueTuple.Create(1, testClass);
+        var b = ValueTuple.Create(1, testClass);
+
+        Assert.True(a.Equals(b));
+        Assert.Equal(0, ((IComparable)a).CompareTo(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        Assert.True(((IStructuralEquatable)a).Equals(b, TestEqualityComparer.Instance));
+        Assert.Equal(5, ((IStructuralComparable)a).CompareTo(b, DummyTestComparer.Instance));
+        Assert.Equal(
+            ((IStructuralEquatable)a).GetHashCode(TestEqualityComparer.Instance),
+            ((IStructuralEquatable)b).GetHashCode(TestEqualityComparer.Instance));
+    }
+
+    [Fact]
+    public static void TestCustomTypeParameter3()
+    {
+        // Special case of ValueTuple<T1, T2> where T1 and T2 are custom types
+        var testClassA = new TestClass(100);
+        var testClassB = new TestClass(101);
+        var a = ValueTuple.Create(testClassA, testClassB);
+        var b = ValueTuple.Create(testClassB, testClassA);
+
+        Assert.False(a.Equals(b));
+        Assert.Equal(-1, ((IComparable)a).CompareTo(b));
+        Assert.False(((IStructuralEquatable)a).Equals(b, TestEqualityComparer.Instance));
+        Assert.Equal(5, ((IStructuralComparable)a).CompareTo(b, DummyTestComparer.Instance));
+        // Equals(IEqualityComparer) is false, ignore hash code
+    }
+
+    [Fact]
+    public static void TestCustomTypeParameter4()
+    {
+        // Special case of ValueTuple<T1, T2> where T1 and T2 are custom types
+        var testClassA = new TestClass(100);
+        var testClassB = new TestClass(101);
+        var a = ValueTuple.Create(testClassA, testClassB);
+        var b = ValueTuple.Create(testClassA, testClassA);
+
+        Assert.False(a.Equals(b));
+        Assert.Equal(1, ((IComparable)a).CompareTo(b));
+        Assert.False(((IStructuralEquatable)a).Equals(b, TestEqualityComparer.Instance));
+        Assert.Equal(5, ((IStructuralComparable)a).CompareTo(b, DummyTestComparer.Instance));
+        // Equals(IEqualityComparer) is false, ignore hash code
+    }
+
+    [Fact]
+    public static void NestedValueTuples1()
+    {
+        var a = ValueTuple.Create(1, 2, ValueTuple.Create(31, 32), 4, 5, 6, 7, ValueTuple.Create(8, 9));
+        var b = ValueTuple.Create(1, 2, ValueTuple.Create(31, 32), 4, 5, 6, 7, ValueTuple.Create(8, 9));
+
+        Assert.True(a.Equals(b));
+        Assert.Equal(0, ((IComparable)a).CompareTo(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        Assert.True(((IStructuralEquatable)a).Equals(b, TestEqualityComparer.Instance));
+        Assert.Equal(5, ((IStructuralComparable)a).CompareTo(b, DummyTestComparer.Instance));
+        Assert.Equal(
+            ((IStructuralEquatable)a).GetHashCode(TestEqualityComparer.Instance),
+            ((IStructuralEquatable)b).GetHashCode(TestEqualityComparer.Instance));
+        Assert.Equal("(1, 2, (31, 32), 4, 5, 6, 7, (8, 9))", a.ToString());
+        Assert.Equal("(31, 32)", a.Item3.ToString());
+        Assert.Equal("(8, 9)", a.Rest.ToString());
+    }
+
+    [Fact]
+    public static void NestedValueTuples2()
+    {
+        var a = ValueTuple.Create(0, 1, 2, 3, 4, 5, 6, ValueTuple.Create(7, 8, 9, 10, 11, 12, 13, ValueTuple.Create(14, 15)));
+        var b = ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15, 16)));
+
+        Assert.False(a.Equals(b));
+        Assert.Equal(-1, ((IComparable)a).CompareTo(b));
+        Assert.False(((IStructuralEquatable)a).Equals(b, TestEqualityComparer.Instance));
+        Assert.Equal(5, ((IStructuralComparable)a).CompareTo(b, DummyTestComparer.Instance));
+        Assert.Equal("(0, 1, 2, 3, 4, 5, 6, (7, 8, 9, 10, 11, 12, 13, (14, 15)))", a.ToString());
+        Assert.Equal("(1, 2, 3, 4, 5, 6, 7, (8, 9, 10, 11, 12, 13, 14, (15, 16)))", b.ToString());
+        Assert.Equal("(7, 8, 9, 10, 11, 12, 13, (14, 15))", a.Rest.ToString());
+    }
+
+    [Fact]
+    public static void IncomparableTypesSpecialCase()
+    {
+        // Special case when T does not implement IComparable
+        var testClassA = new TestClass2(100);
+        var testClassB = new TestClass2(100);
+        var a = ValueTuple.Create(testClassA);
+        var b = ValueTuple.Create(testClassB);
+
+        Assert.True(a.Equals(b));
+        Assert.Throws<ArgumentException>(() => ((IComparable)a).CompareTo(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        Assert.True(((IStructuralEquatable)a).Equals(b, TestEqualityComparer.Instance));
+        Assert.Equal(5, ((IStructuralComparable)a).CompareTo(b, DummyTestComparer.Instance));
+        Assert.Equal(
+            ((IStructuralEquatable)a).GetHashCode(TestEqualityComparer.Instance),
+            ((IStructuralEquatable)b).GetHashCode(TestEqualityComparer.Instance));
+        Assert.Equal("([100])", a.ToString());
+    }
+
+    [Fact]
+    public static void ZeroTuples()
+    {
+        var a = ValueTuple.Create();
+        Assert.True(a.Equals(new ValueTuple()));
+
+        Assert.Equal(1, ((IStructuralComparable)a).CompareTo(null, DummyTestComparer.Instance));
+        Assert.Throws<ArgumentException>(() => ((IStructuralComparable)a).CompareTo("string", DummyTestComparer.Instance));
+    }
+
+    [Fact]
+    public static void OneTuples()
+    {
+        IComparable c = ValueTuple.Create(1);
+
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(3)));
+
+        IStructuralComparable sc = (IStructuralComparable)c;
+
+        Assert.Equal(1, sc.CompareTo(null, DummyTestComparer.Instance));
+        Assert.Throws<ArgumentException>(() => ((IStructuralComparable)sc).CompareTo("string", DummyTestComparer.Instance));
+
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(3), TestComparer.Instance));
+
+        Assert.False(((IStructuralEquatable)sc).Equals(sc, DummyTestEqualityComparer.Instance));
+    }
+
+    [Fact]
+    public static void TwoTuples()
+    {
+        IComparable c = ValueTuple.Create(1, 1);
+
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(3, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 3)));
+
+        IStructuralComparable sc = (IStructuralComparable)c;
+
+        Assert.Equal(1, sc.CompareTo(null, DummyTestComparer.Instance));
+        Assert.Throws<ArgumentException>(() => ((IStructuralComparable)sc).CompareTo("string", DummyTestComparer.Instance));
+
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 3), TestComparer.Instance));
+
+        Assert.False(((IStructuralEquatable)sc).Equals(sc, DummyTestEqualityComparer.Instance));
+    }
+
+    [Fact]
+    public static void ThreeTuples()
+    {
+        IComparable c = ValueTuple.Create(1, 1, 1);
+
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(3, 1, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 3, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 3)));
+
+        IStructuralComparable sc = (IStructuralComparable)c;
+
+        Assert.Equal(1, sc.CompareTo(null, DummyTestComparer.Instance));
+        Assert.Throws<ArgumentException>(() => ((IStructuralComparable)sc).CompareTo("string", DummyTestComparer.Instance));
+
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 3, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 3), TestComparer.Instance));
+
+        Assert.False(((IStructuralEquatable)sc).Equals(sc, DummyTestEqualityComparer.Instance));
+    }
+
+    [Fact]
+    public static void FourTuples()
+    {
+        IComparable c = ValueTuple.Create(1, 1, 1, 1);
+
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(3, 1, 1, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 3, 1, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 3, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 1, 3)));
+
+        IStructuralComparable sc = (IStructuralComparable)c;
+
+        Assert.Equal(1, sc.CompareTo(null, DummyTestComparer.Instance));
+        Assert.Throws<ArgumentException>(() => ((IStructuralComparable)sc).CompareTo("string", DummyTestComparer.Instance));
+
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(3, 1, 1, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 3, 1, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 3, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 1, 3), TestComparer.Instance));
+
+        Assert.False(((IStructuralEquatable)sc).Equals(sc, DummyTestEqualityComparer.Instance));
+    }
+
+    [Fact]
+    public static void FiveTuples()
+    {
+        IComparable c = ValueTuple.Create(1, 1, 1, 1, 1);
+
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(3, 1, 1, 1, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 3, 1, 1, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 3, 1, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 1, 3, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 1, 1, 3)));
+
+        IStructuralComparable sc = (IStructuralComparable)c;
+
+        Assert.Equal(1, sc.CompareTo(null, DummyTestComparer.Instance));
+        Assert.Throws<ArgumentException>(() => ((IStructuralComparable)sc).CompareTo("string", DummyTestComparer.Instance));
+
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(3, 1, 1, 1, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 3, 1, 1, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 3, 1, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 1, 3, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 1, 1, 3), TestComparer.Instance));
+
+        Assert.False(((IStructuralEquatable)sc).Equals(sc, DummyTestEqualityComparer.Instance));
+    }
+
+    [Fact]
+    public static void SixTuples()
+    {
+        IComparable c = ValueTuple.Create(1, 1, 1, 1, 1, 1);
+
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(3, 1, 1, 1, 1, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 3, 1, 1, 1, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 3, 1, 1, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 1, 3, 1, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 1, 1, 3, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 1, 1, 1, 3)));
+
+        IStructuralComparable sc = (IStructuralComparable)c;
+
+        Assert.Equal(1, sc.CompareTo(null, DummyTestComparer.Instance));
+        Assert.Throws<ArgumentException>(() => ((IStructuralComparable)sc).CompareTo("string", DummyTestComparer.Instance));
+
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(3, 1, 1, 1, 1, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 3, 1, 1, 1, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 3, 1, 1, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 1, 3, 1, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 1, 1, 3, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 1, 1, 1, 3), TestComparer.Instance));
+
+        Assert.False(((IStructuralEquatable)sc).Equals(sc, DummyTestEqualityComparer.Instance));
+    }
+
+    [Fact]
+    public static void SevenTuples()
+    {
+        IComparable c = ValueTuple.Create(1, 1, 1, 1, 1, 1, 1);
+
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(3, 1, 1, 1, 1, 1, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 3, 1, 1, 1, 1, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 3, 1, 1, 1, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 1, 3, 1, 1, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 1, 1, 3, 1, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 1, 1, 1, 3, 1)));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 1, 1, 1, 1, 3)));
+
+        IStructuralComparable sc = (IStructuralComparable)c;
+
+        Assert.Equal(1, sc.CompareTo(null, DummyTestComparer.Instance));
+        Assert.Throws<ArgumentException>(() => ((IStructuralComparable)sc).CompareTo("string", DummyTestComparer.Instance));
+
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(3, 1, 1, 1, 1, 1, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 3, 1, 1, 1, 1, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 3, 1, 1, 1, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 1, 3, 1, 1, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 1, 1, 3, 1, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 1, 1, 1, 3, 1), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 1, 1, 1, 1, 3), TestComparer.Instance));
+
+        Assert.False(((IStructuralEquatable)sc).Equals(sc, DummyTestEqualityComparer.Instance));
+    }
+
+    [Fact]
+    public static void EightTuples()
+    {
+        var t = ValueTuple.Create(1, 1, 1, 1, 1, 1, 1, ValueTuple.Create(1));
+
+        IStructuralEquatable se = t;
+        Assert.False(se.Equals(null, TestEqualityComparer.Instance));
+        Assert.False(se.Equals("string", TestEqualityComparer.Instance));
+        Assert.False(se.Equals(new ValueTuple(), TestEqualityComparer.Instance));
+
+        IComparable c = t;
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(3, 1, 1, 1, 1, 1, 1, ValueTuple.Create(1))));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 3, 1, 1, 1, 1, 1, ValueTuple.Create(1))));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 3, 1, 1, 1, 1, ValueTuple.Create(1))));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 1, 3, 1, 1, 1, ValueTuple.Create(1))));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 1, 1, 3, 1, 1, ValueTuple.Create(1))));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 1, 1, 1, 3, 1, ValueTuple.Create(1))));
+        Assert.Equal(-1, c.CompareTo(ValueTuple.Create(1, 1, 1, 1, 1, 1, 3, ValueTuple.Create(1))));
+
+        IStructuralComparable sc = t;
+        Assert.Equal(1, sc.CompareTo(null, DummyTestComparer.Instance));
+        Assert.Throws<ArgumentException>(() => sc.CompareTo("string", DummyTestComparer.Instance));
+
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(3, 1, 1, 1, 1, 1, 1, ValueTuple.Create(1)), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 3, 1, 1, 1, 1, 1, ValueTuple.Create(1)), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 3, 1, 1, 1, 1, ValueTuple.Create(1)), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 1, 3, 1, 1, 1, ValueTuple.Create(1)), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 1, 1, 3, 1, 1, ValueTuple.Create(1)), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 1, 1, 1, 3, 1, ValueTuple.Create(1)), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 1, 1, 1, 1, 3, ValueTuple.Create(1)), TestComparer.Instance));
+        Assert.Equal(1, sc.CompareTo(ValueTuple.Create(1, 1, 1, 1, 1, 1, 1, ValueTuple.Create(3)), TestComparer.Instance));
+
+        Assert.Equal(46208, ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create()).GetHashCode());
+        Assert.Equal(46216, ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8)).GetHashCode());
+        Assert.Equal(81152, ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9)).GetHashCode());
+        Assert.Equal(125864, ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10)).GetHashCode());
+        Assert.Equal(146432, ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11)).GetHashCode());
+        Assert.Equal(276872, ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12)).GetHashCode());
+        Assert.Equal(275712, ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13)).GetHashCode());
+        Assert.Equal(269608, ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13, 14)).GetHashCode());
+        Assert.Equal(269544, ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create())).GetHashCode());
+        Assert.Equal(269312, ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15))).GetHashCode());
+
+        Assert.Equal(46208, ((IStructuralEquatable)ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create())).GetHashCode(TestEqualityComparer.Instance));
+        Assert.Equal(46216, ((IStructuralEquatable)ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8))).GetHashCode(TestEqualityComparer.Instance));
+        Assert.Equal(81152, ((IStructuralEquatable)ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9))).GetHashCode(TestEqualityComparer.Instance));
+        Assert.Equal(125864, ((IStructuralEquatable)ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10))).GetHashCode(TestEqualityComparer.Instance));
+        Assert.Equal(146432, ((IStructuralEquatable)ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11))).GetHashCode(TestEqualityComparer.Instance));
+        Assert.Equal(276872, ((IStructuralEquatable)ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12))).GetHashCode(TestEqualityComparer.Instance));
+        Assert.Equal(275712, ((IStructuralEquatable)ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13))).GetHashCode(TestEqualityComparer.Instance));
+        Assert.Equal(269608, ((IStructuralEquatable)ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13, 14))).GetHashCode(TestEqualityComparer.Instance));
+        Assert.Equal(269544, ((IStructuralEquatable)ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create()))).GetHashCode(TestEqualityComparer.Instance));
+        Assert.Equal(269312, ((IStructuralEquatable)ValueTuple.Create(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15)))).GetHashCode(TestEqualityComparer.Instance));
+
+        var d = default(ValueTuple<int, int, int, int, int, int, int, int>);
+        d.Item1 = 1;
+        d.Rest = 42;
+        Assert.Equal(35937, d.GetHashCode());
+        Assert.Equal(35937, ((IStructuralEquatable)d).GetHashCode());
+
+        Assert.False(se.Equals(t, DummyTestEqualityComparer.Instance));
+    }
+
+    private class TestClass : IComparable
+    {
+        private readonly int _value;
+
+        internal TestClass()
+            : this(0)
+        { }
+
+        internal TestClass(int value)
+        {
+            this._value = value;
+        }
+
+        public override string ToString()
+        {
+            return "{" + _value.ToString() + "}";
+        }
+
+        public int CompareTo(object x)
+        {
+            TestClass tmp = x as TestClass;
+            if (tmp != null)
+                return this._value.CompareTo(tmp._value);
+            else
+                return 1;
+        }
+    }
+
+    private class TestClass2
+    {
+        private readonly int _value;
+
+        internal TestClass2()
+            : this(0)
+        { }
+
+        internal TestClass2(int value)
+        {
+            this._value = value;
+        }
+
+        public override string ToString()
+        {
+            return "[" + _value.ToString() + "]";
+        }
+
+        public override bool Equals(object x)
+        {
+            TestClass2 tmp = x as TestClass2;
+            if (tmp != null)
+                return _value.Equals(tmp._value);
+            else
+                return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
+    }
+
+    private class DummyTestComparer : IComparer
+    {
+        public static readonly DummyTestComparer Instance = new DummyTestComparer();
+
+        public int Compare(object x, object y)
+        {
+            return 5;
+        }
+    }
+
+    private class TestComparer : IComparer
+    {
+        public static readonly TestComparer Instance = new TestComparer();
+
+        public int Compare(object x, object y)
+        {
+            return x.Equals(y) ? 0 : 1;
+        }
+    }
+
+    private class DummyTestEqualityComparer : IEqualityComparer
+    {
+        public static readonly DummyTestEqualityComparer Instance = new DummyTestEqualityComparer();
+
+        public new bool Equals(object x, object y)
+        {
+            return false;
+        }
+
+        public int GetHashCode(object x)
+        {
+            return x.GetHashCode();
+        }
+    }
+
+    private class TestEqualityComparer : IEqualityComparer
+    {
+        public static readonly TestEqualityComparer Instance = new TestEqualityComparer();
+
+        public new bool Equals(object x, object y)
+        {
+            return x.Equals(y);
+        }
+
+        public int GetHashCode(object x)
+        {
+            return x.GetHashCode();
+        }
+    }
+}

--- a/src/System.ValueTuple/tests/project.json
+++ b/src/System.ValueTuple/tests/project.json
@@ -1,0 +1,33 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.0.1-rc3-24015-00",
+    "System.Diagnostics.Tracing": "4.1.0-rc3-24015-00",
+    "System.Linq.Expressions": "4.0.11-rc3-24015-00",
+    "System.ObjectModel": "4.0.12-rc3-24015-00",
+    "System.Resources.ResourceManager": "4.0.1-rc3-24015-00",
+    "System.Runtime": "4.1.0-rc3-24015-00",
+    "System.Runtime.Extensions": "4.1.0-rc3-24015-00",
+    "System.Text.RegularExpressions": "4.0.12-rc3-24015-00",
+    "System.Threading": "4.0.11-rc3-24015-00",
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00231-07",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    }
+  },
+  "frameworks": {
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
+  }
+}


### PR DESCRIPTION
Cherry-picks @jcouv's commit from https://github.com/dotnet/corefx/pull/7663, then adds two commits, one that should fix the build due to a wrongly-specified assembly name, and one that enables building the XML documentation file and fixes up a bunch of resulting failures.

cc: @jcouv
Replaces https://github.com/dotnet/corefx/pull/7663