### PR TITLE
Detect properly MIT-KRB5 headers on NetBSD with pkgsrc

### DIFF
--- a/src/Native/System.Net.Security.Native/CMakeLists.txt
+++ b/src/Native/System.Net.Security.Native/CMakeLists.txt
@@ -9,11 +9,14 @@ if (HAVE_GSSFW_HEADERS)
    if(LIBGSS STREQUAL LIBGSS-NOTFOUND)
       message(FATAL_ERROR "Cannot find GSS.Framework and System.Net.Security.Native cannot build without it. Try installing GSS.Framework (or the appropriate package for your platform)")
    endif()
+   find_path(LIBGSS_INCLUDE_DIR GSS/GSS.h)
 else()
    find_library(LIBGSS NAMES gssapi_krb5)
    if(LIBGSS STREQUAL LIBGSS-NOTFOUND)
       message(FATAL_ERROR "Cannot find libgssapi_krb5 and System.Net.Security.Native cannot build without it. Try installing libkrb5-dev (or the appropriate package for your platform)")
    endif()
+   # Look up for MIT-KRB5 specific header, not available in Heimdal
+   find_path(LIBGSS_INCLUDE_DIR gssapi/gssapi_ext.h)
 endif()
 
 set(NATIVEGSS_SOURCES
@@ -28,6 +31,10 @@ add_library(System.Net.Security.Native
 
 target_link_libraries(System.Net.Security.Native
     ${LIBGSS}
+)
+
+include_directories(SYSTEM
+    ${LIBGSS_INCLUDE_DIR}
 )
 
 install (TARGETS System.Net.Security.Native DESTINATION .)

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -447,10 +447,14 @@ if (HAVE_GSSFW_HEADERS)
         "GSS/GSS.h"
         HAVE_GSS_SPNEGO_MECHANISM)
 else ()
+    # Look up for MIT-KRB5 specific header, not available in Heimdal
+    find_path(LIBGSS_INCLUDE_DIR gssapi/gssapi_ext.h)
+    set(CMAKE_REQUIRED_INCLUDES ${LIBGSS_INCLUDE_DIR})
     check_symbol_exists(
         GSS_SPNEGO_MECHANISM
         "gssapi/gssapi.h"
         HAVE_GSS_SPNEGO_MECHANISM)
+    unset(CMAKE_REQUIRED_INCLUDES)
 endif ()
 
 set (CMAKE_REQUIRED_LIBRARIES)


### PR DESCRIPTION
NetBSD ships with Heimdal kerberos in base that has conflicting headers.
The CoreFX source assumes MIT-KRB5 headers so enforce this implementation.