### PR TITLE
Fix Process.StartTime on Unix on long-running systems

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -406,8 +406,9 @@ namespace System.Diagnostics
         /// <returns>The converted time.</returns>
         internal static DateTime BootTimeToDateTime(TimeSpan timespanAfterBoot)
         {
-            // Use the uptime and the current time to determine the absolute boot time
-            DateTime bootTime = DateTime.UtcNow - TimeSpan.FromMilliseconds(Environment.TickCount);
+            // Use the uptime and the current time to determine the absolute boot time. This implementation is relying on the 
+            // implementation detail that Stopwatch.GetTimestamp() uses a value based on time since boot.
+            DateTime bootTime = DateTime.UtcNow - TimeSpan.FromSeconds(Stopwatch.GetTimestamp() / (double)Stopwatch.Frequency);
 
             // And use that to determine the absolute time for timespan.
             DateTime dt = bootTime + timespanAfterBoot;


### PR DESCRIPTION
The current implementation of Process.StartTime on Unix uses Environment.TickCount to get a number of ticks since boot.  This value overflows after 24.8 days, resulting in incorrect StartTime values on systems that have run at least that long.  We have CI unix machines that have been running that long, and any test runs that get routed to those machines will fail due to Process tests.

As at least a temporary fix, this commit switches to using Stopwatch, which uses the same underlying APIs as Environment.TickCount, but which uses long instead of int and thus doesn't suffer from the same limitation.  (To make this more robust, we should consider putting a GetBootTime or similar method into the native shim.)

Fixes #7818 
cc: @Priya91