### PR TITLE
Ensure WinHttpHandler exceptions have good stack traces

### DIFF
--- a/src/Common/src/System/Diagnostics/ExceptionExtensions.cs
+++ b/src/Common/src/System/Diagnostics/ExceptionExtensions.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics
+{
+    /// <summary>Provides a set of static methods for working with Exceptions.</summary>
+    internal static class ExceptionHelpers
+    {
+        public static TException InitializeStackTrace<TException>(this TException e) where TException : Exception
+        {
+            Debug.Assert(e != null);
+            Debug.Assert(e.StackTrace == null);
+
+            try { throw e; }
+            catch { return e; }
+        }
+    }
+}

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
@@ -16,6 +16,7 @@
     <CompileItem Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs" />
     <CompileItem Include="$(CommonPath)\System\CharArrayHelpers.cs" />
     <CompileItem Include="$(CommonPath)\System\StringExtensions.cs" />
+    <CompileItem Include="$(CommonPath)\System\Diagnostics\ExceptionExtensions.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\HttpStatusDescription.cs" />

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -116,7 +116,7 @@ namespace System.Net.Http
                 if (value <= 0)
                 {
                     throw new ArgumentOutOfRangeException(
-nameof(value),
+                        nameof(value),
                         value,
                         SR.Format(SR.net_http_value_must_be_greater_than, 0));
                 }
@@ -348,7 +348,7 @@ nameof(value),
                     // In WinHTTP, setting this to 0 results in it being reset to 2.
                     // So, we'll only allow settings above 0.
                     throw new ArgumentOutOfRangeException(
-nameof(value),
+                        nameof(value),
                         value,
                         SR.Format(SR.net_http_value_must_be_greater_than, 0));
                 }
@@ -446,7 +446,7 @@ nameof(value),
                 if (value <= 0)
                 {
                     throw new ArgumentOutOfRangeException(
-nameof(value),
+                        nameof(value),
                         value,
                         SR.Format(SR.net_http_value_must_be_greater_than, 0));
                 }
@@ -468,7 +468,7 @@ nameof(value),
                 if (value <= 0)
                 {
                     throw new ArgumentOutOfRangeException(
-nameof(value),
+                        nameof(value),
                         value,
                         SR.Format(SR.net_http_value_must_be_greater_than, 0));
                 }

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -159,7 +159,7 @@ namespace System.Net.Http
                     new IOException(string.Format(
                         SR.net_http_io_read_incomplete,
                         state.ExpectedBytesToRead.Value,
-                        state.CurrentBytesRead)));
+                        state.CurrentBytesRead)).InitializeStackTrace());
             }
             else
             {
@@ -301,7 +301,7 @@ namespace System.Net.Http
             
             Debug.Assert(state != null, "OnRequestError: state is null");
 
-            var innerException = WinHttpException.CreateExceptionUsingError((int)asyncResult.dwError);
+            var innerException = WinHttpException.CreateExceptionUsingError((int)asyncResult.dwError).InitializeStackTrace();
 
             switch ((uint)asyncResult.dwResult.ToInt32())
             {

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
@@ -242,7 +242,7 @@ namespace System.Net.Http
                     IntPtr.Zero))
                 {
                     _state.TcsInternalWriteDataToRequestStream.TrySetException(
-                        new IOException(SR.net_http_io_write, WinHttpException.CreateExceptionUsingLastError()));
+                        new IOException(SR.net_http_io_write, WinHttpException.CreateExceptionUsingLastError().InitializeStackTrace()));
                 }
             }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -156,7 +157,7 @@ namespace System.Net.Http
                                 IntPtr.Zero))
                             {
                                 _state.TcsReadFromResponseStream.TrySetException(
-                                    new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError()));
+                                    new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError().InitializeStackTrace()));
                             }
                         }
                     }
@@ -170,7 +171,7 @@ namespace System.Net.Http
                 if (!Interop.WinHttp.WinHttpQueryDataAvailable(_requestHandle, IntPtr.Zero))
                 {
                     _state.TcsReadFromResponseStream.TrySetException(
-                        new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError()));
+                        new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError().InitializeStackTrace()));
                 }
             }
 

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -46,6 +46,9 @@
     <Compile Include="$(CommonPath)\System\StringExtensions.cs">
       <Link>Common\System\StringExtensions.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Diagnostics\ExceptionExtensions.cs">
+      <Link>Common\System\Diagnostics\ExceptionExtensions.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>


### PR DESCRIPTION
WinHttpHandler often creates an exception in response to some native error code and then stores that exception into a Task.  As the exception isn't actually thrown until it's propagated out at the eventual await site, the these exceptions often lack a good stack trace to help highlight where the error came from.

This commit ensures that such exceptions have a stack trace by throwing and catching them before storing them into either another exception as an inner exception or directly into a Task.  I've not touched cases where the exception was already being thrown or where an exception was wrapping another exception that has a stack trace.

cc: @davidsh 
Inspired by https://github.com/dotnet/corefx/issues/7812