### PR TITLE
Use IntPtr-based file descriptors exclusively, in native calls from Sockets code, part 3

### DIFF
--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -1357,11 +1357,6 @@ static bool GetMulticastOptionName(int32_t multicastOption, bool isIPv6, int& op
 
 extern "C" Error SystemNative_GetIPv4MulticastOption(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option)
 {
-    return SystemNative_GetIPv4MulticastOption_IntPtr(socket, multicastOption, option);
-}
-
-extern "C" Error SystemNative_GetIPv4MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option)
-{
     if (option == nullptr)
     {
         return PAL_EFAULT;
@@ -1400,11 +1395,6 @@ extern "C" Error SystemNative_GetIPv4MulticastOption_IntPtr(intptr_t socket, int
 
 extern "C" Error SystemNative_SetIPv4MulticastOption(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option)
 {
-    return SystemNative_SetIPv4MulticastOption_IntPtr(socket, multicastOption, option);
-}
-
-extern "C" Error SystemNative_SetIPv4MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option)
-{
     if (option == nullptr)
     {
         return PAL_EFAULT;
@@ -1436,11 +1426,6 @@ extern "C" Error SystemNative_SetIPv4MulticastOption_IntPtr(intptr_t socket, int
 
 extern "C" Error SystemNative_GetIPv6MulticastOption(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option)
 {
-    return SystemNative_GetIPv6MulticastOption_IntPtr(socket, multicastOption, option);
-}
-
-extern "C" Error SystemNative_GetIPv6MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option)
-{
     if (option == nullptr)
     {
         return PAL_EFAULT;
@@ -1468,11 +1453,6 @@ extern "C" Error SystemNative_GetIPv6MulticastOption_IntPtr(intptr_t socket, int
 }
 
 extern "C" Error SystemNative_SetIPv6MulticastOption(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option)
-{
-    return SystemNative_SetIPv6MulticastOption_IntPtr(socket, multicastOption, option);
-}
-
-extern "C" Error SystemNative_SetIPv6MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option)
 {
     if (option == nullptr)
     {
@@ -1533,11 +1513,6 @@ constexpr int32_t GetMaxLingerTime()
 
 extern "C" Error SystemNative_GetLingerOption(intptr_t socket, LingerOption* option)
 {
-    return SystemNative_GetLingerOption_IntPtr(socket, option);
-}
-
-extern "C" Error SystemNative_GetLingerOption_IntPtr(intptr_t socket, LingerOption* option)
-{
     if (option == nullptr)
     {
         return PAL_EFAULT;
@@ -1558,11 +1533,6 @@ extern "C" Error SystemNative_GetLingerOption_IntPtr(intptr_t socket, LingerOpti
 }
 
 extern "C" Error SystemNative_SetLingerOption(intptr_t socket, LingerOption* option)
-{
-    return SystemNative_SetLingerOption_IntPtr(socket, option);
-}
-
-extern "C" Error SystemNative_SetLingerOption_IntPtr(intptr_t socket, LingerOption* option)
 {
     if (option == nullptr)
     {
@@ -1611,20 +1581,10 @@ Error SetTimeoutOption(int32_t socket, int32_t millisecondsTimeout, int optionNa
 
 extern "C" Error SystemNative_SetReceiveTimeout(intptr_t socket, int32_t millisecondsTimeout)
 {
-    return SystemNative_SetReceiveTimeout_IntPtr(socket, millisecondsTimeout);
-}
-
-extern "C" Error SystemNative_SetReceiveTimeout_IntPtr(intptr_t socket, int32_t millisecondsTimeout)
-{
     return SetTimeoutOption(ToFileDescriptor(socket), millisecondsTimeout, SO_RCVTIMEO);
 }
 
 extern "C" Error SystemNative_SetSendTimeout(intptr_t socket, int32_t millisecondsTimeout)
-{
-    return SystemNative_SetSendTimeout_IntPtr(socket, millisecondsTimeout);
-}
-
-extern "C" Error SystemNative_SetSendTimeout_IntPtr(intptr_t socket, int32_t millisecondsTimeout)
 {
     return SetTimeoutOption(ToFileDescriptor(socket), millisecondsTimeout, SO_SNDTIMEO);
 }
@@ -1660,11 +1620,6 @@ static int32_t ConvertSocketFlagsPlatformToPal(int platformFlags)
 }
 
 extern "C" Error SystemNative_ReceiveMessage(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received)
-{
-    return SystemNative_ReceiveMessage_IntPtr(socket, messageHeader, flags, received);
-}
-
-extern "C" Error SystemNative_ReceiveMessage_IntPtr(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received)
 {
     if (messageHeader == nullptr || received == nullptr || messageHeader->SocketAddressLen < 0 ||
         messageHeader->ControlBufferLen < 0 || messageHeader->IOVectorCount < 0)
@@ -1708,11 +1663,6 @@ extern "C" Error SystemNative_ReceiveMessage_IntPtr(intptr_t socket, MessageHead
 
 extern "C" Error SystemNative_SendMessage(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent)
 {
-    return SystemNative_SendMessage_IntPtr(socket, messageHeader, flags, sent);
-}
-
-extern "C" Error SystemNative_SendMessage_IntPtr(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent)
-{
     if (messageHeader == nullptr || sent == nullptr || messageHeader->SocketAddressLen < 0 ||
         messageHeader->ControlBufferLen < 0 || messageHeader->IOVectorCount < 0)
     {
@@ -1744,11 +1694,6 @@ extern "C" Error SystemNative_SendMessage_IntPtr(intptr_t socket, MessageHeader*
 
 extern "C" Error SystemNative_Accept(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, intptr_t* acceptedSocket)
 {
-    return SystemNative_Accept_IntPtr(socket, socketAddress, socketAddressLen, acceptedSocket);
-}
-
-extern "C" Error SystemNative_Accept_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, intptr_t* acceptedSocket)
-{
     if (socketAddress == nullptr || socketAddressLen == nullptr || acceptedSocket == nullptr || *socketAddressLen < 0)
     {
         return PAL_EFAULT;
@@ -1773,11 +1718,6 @@ extern "C" Error SystemNative_Accept_IntPtr(intptr_t socket, uint8_t* socketAddr
 
 extern "C" Error SystemNative_Bind(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
 {
-    return SystemNative_Bind_IntPtr(socket, socketAddress, socketAddressLen);
-}
-
-extern "C" Error SystemNative_Bind_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
-{
     if (socketAddress == nullptr || socketAddressLen < 0)
     {
         return PAL_EFAULT;
@@ -1790,11 +1730,6 @@ extern "C" Error SystemNative_Bind_IntPtr(intptr_t socket, uint8_t* socketAddres
 }
 
 extern "C" Error SystemNative_Connect(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
-{
-    return SystemNative_Connect_IntPtr(socket, socketAddress, socketAddressLen);
-}
-
-extern "C" Error SystemNative_Connect_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
 {
     if (socketAddress == nullptr || socketAddressLen < 0)
     {
@@ -1809,11 +1744,6 @@ extern "C" Error SystemNative_Connect_IntPtr(intptr_t socket, uint8_t* socketAdd
 }
 
 extern "C" Error SystemNative_GetPeerName(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
-{
-    return SystemNative_GetPeerName_IntPtr(socket, socketAddress, socketAddressLen);
-}
-
-extern "C" Error SystemNative_GetPeerName_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
 {
     if (socketAddress == nullptr || socketAddressLen == nullptr || *socketAddressLen < 0)
     {
@@ -1836,11 +1766,6 @@ extern "C" Error SystemNative_GetPeerName_IntPtr(intptr_t socket, uint8_t* socke
 
 extern "C" Error SystemNative_GetSockName(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
 {
-    return SystemNative_GetSockName_IntPtr(socket, socketAddress, socketAddressLen);
-}
-
-extern "C" Error SystemNative_GetSockName_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
-{
     if (socketAddress == nullptr || socketAddressLen == nullptr || *socketAddressLen < 0)
     {
         return PAL_EFAULT;
@@ -1862,22 +1787,12 @@ extern "C" Error SystemNative_GetSockName_IntPtr(intptr_t socket, uint8_t* socke
 
 extern "C" Error SystemNative_Listen(intptr_t socket, int32_t backlog)
 {
-    return SystemNative_Listen_IntPtr(socket, backlog);
-}
-
-extern "C" Error SystemNative_Listen_IntPtr(intptr_t socket, int32_t backlog)
-{
     int fd = ToFileDescriptor(socket);
     int err = listen(fd, backlog);
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
 extern "C" Error SystemNative_Shutdown(intptr_t socket, int32_t socketShutdown)
-{
-    return SystemNative_Shutdown_IntPtr(socket, socketShutdown);
-}
-
-extern "C" Error SystemNative_Shutdown_IntPtr(intptr_t socket, int32_t socketShutdown)
 {
     int fd = ToFileDescriptor(socket);
 
@@ -1905,11 +1820,6 @@ extern "C" Error SystemNative_Shutdown_IntPtr(intptr_t socket, int32_t socketShu
 }
 
 extern "C" Error SystemNative_GetSocketErrorOption(intptr_t socket, Error* error)
-{
-    return SystemNative_GetSocketErrorOption_IntPtr(socket, error);
-}
-
-extern "C" Error SystemNative_GetSocketErrorOption_IntPtr(intptr_t socket, Error* error)
 {
     if (error == nullptr)
     {
@@ -2154,12 +2064,6 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionName, int32_t socketO
 extern "C" Error SystemNative_GetSockOpt(
     intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen)
 {
-    return SystemNative_GetSockOpt_IntPtr(socket, socketOptionLevel, socketOptionName, optionValue, optionLen);
-}
-
-extern "C" Error SystemNative_GetSockOpt_IntPtr(
-    intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen)
-{
     if (optionLen == nullptr || *optionLen < 0)
     {
         return PAL_EFAULT;
@@ -2187,12 +2091,6 @@ extern "C" Error SystemNative_GetSockOpt_IntPtr(
 
 extern "C" Error
 SystemNative_SetSockOpt(intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen)
-{
-    return SystemNative_SetSockOpt_IntPtr(socket, socketOptionLevel, socketOptionName, optionValue, optionLen);
-}
-
-extern "C" Error
-SystemNative_SetSockOpt_IntPtr(intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen)
 {
     if (optionLen < 0)
     {
@@ -2277,11 +2175,6 @@ static bool TryConvertProtocolTypePalToPlatform(int32_t palProtocolType, int* pl
 
 extern "C" Error SystemNative_Socket(int32_t addressFamily, int32_t socketType, int32_t protocolType, intptr_t* createdSocket)
 {
-    return SystemNative_Socket_IntPtr(addressFamily, socketType, protocolType, createdSocket);
-}
-
-extern "C" Error SystemNative_Socket_IntPtr(int32_t addressFamily, int32_t socketType, int32_t protocolType, intptr_t* createdSocket)
-{
     if (createdSocket == nullptr)
     {
         return PAL_EFAULT;
@@ -2313,11 +2206,6 @@ extern "C" Error SystemNative_Socket_IntPtr(int32_t addressFamily, int32_t socke
 }
 
 extern "C" Error SystemNative_GetBytesAvailable(intptr_t socket, int32_t* available)
-{
-    return SystemNative_GetBytesAvailable_IntPtr(socket, available);
-}
-
-extern "C" Error SystemNative_GetBytesAvailable_IntPtr(intptr_t socket, int32_t* available)
 {
     if (available == nullptr)
     {
@@ -2615,11 +2503,6 @@ static Error WaitForSocketEventsInner(int32_t port, SocketEvent* buffer, int32_t
 
 extern "C" Error SystemNative_CreateSocketEventPort(intptr_t* port)
 {
-    return SystemNative_CreateSocketEventPort_IntPtr(port);
-}
-
-extern "C" Error SystemNative_CreateSocketEventPort_IntPtr(intptr_t* port)
-{
     if (port == nullptr)
     {
         return PAL_EFAULT;
@@ -2632,11 +2515,6 @@ extern "C" Error SystemNative_CreateSocketEventPort_IntPtr(intptr_t* port)
 }
 
 extern "C" Error SystemNative_CloseSocketEventPort(intptr_t port)
-{
-    return SystemNative_CloseSocketEventPort_IntPtr(port);
-}
-
-extern "C" Error SystemNative_CloseSocketEventPort_IntPtr(intptr_t port)
 {
     return CloseSocketEventPortInner(ToFileDescriptor(port));
 }
@@ -2668,12 +2546,6 @@ extern "C" Error SystemNative_FreeSocketEventBuffer(SocketEvent* buffer)
 extern "C" Error
 SystemNative_TryChangeSocketEventRegistration(intptr_t port, intptr_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data)
 {
-    return SystemNative_TryChangeSocketEventRegistration_IntPtr(port, socket, currentEvents, newEvents, data);
-}
-
-extern "C" Error
-SystemNative_TryChangeSocketEventRegistration_IntPtr(intptr_t port, intptr_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data)
-{
     int portFd = ToFileDescriptor(port);
     int socketFd = ToFileDescriptor(socket);
 
@@ -2694,11 +2566,6 @@ SystemNative_TryChangeSocketEventRegistration_IntPtr(intptr_t port, intptr_t soc
 }
 
 extern "C" Error SystemNative_WaitForSocketEvents(intptr_t port, SocketEvent* buffer, int32_t* count)
-{
-    return SystemNative_WaitForSocketEvents_IntPtr(port, buffer, count);
-}
-
-extern "C" Error SystemNative_WaitForSocketEvents_IntPtr(intptr_t port, SocketEvent* buffer, int32_t* count)
 {
     if (buffer == nullptr || count == nullptr || *count < 0)
     {

--- a/src/Native/System.Native/pal_networking.h
+++ b/src/Native/System.Native/pal_networking.h
@@ -354,80 +354,54 @@ extern "C" int32_t
 SystemNative_TryGetIPPacketInformation(MessageHeader* messageHeader, int32_t isIPv4, IPPacketInformation* packetInfo);
 
 extern "C" Error SystemNative_GetIPv4MulticastOption(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option);
-extern "C" Error SystemNative_GetIPv4MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option);
 
 extern "C" Error SystemNative_SetIPv4MulticastOption(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option);
-extern "C" Error SystemNative_SetIPv4MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv4MulticastOption* option);
 
 extern "C" Error SystemNative_GetIPv6MulticastOption(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option);
-extern "C" Error SystemNative_GetIPv6MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option);
 
 extern "C" Error SystemNative_SetIPv6MulticastOption(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option);
-extern "C" Error SystemNative_SetIPv6MulticastOption_IntPtr(intptr_t socket, int32_t multicastOption, IPv6MulticastOption* option);
 
 extern "C" Error SystemNative_GetLingerOption(intptr_t socket, LingerOption* option);
-extern "C" Error SystemNative_GetLingerOption_IntPtr(intptr_t socket, LingerOption* option);
 
 extern "C" Error SystemNative_SetLingerOption(intptr_t socket, LingerOption* option);
-extern "C" Error SystemNative_SetLingerOption_IntPtr(intptr_t socket, LingerOption* option);
 
 extern "C" Error SystemNative_SetReceiveTimeout(intptr_t socket, int32_t millisecondsTimeout);
-extern "C" Error SystemNative_SetReceiveTimeout_IntPtr(intptr_t socket, int32_t millisecondsTimeout);
 
 extern "C" Error SystemNative_SetSendTimeout(intptr_t socket, int32_t millisecondsTimeout);
-extern "C" Error SystemNative_SetSendTimeout_IntPtr(intptr_t socket, int32_t millisecondsTimeout);
 
 extern "C" Error SystemNative_ReceiveMessage(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received);
-extern "C" Error SystemNative_ReceiveMessage_IntPtr(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received);
 
 extern "C" Error SystemNative_SendMessage(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent);
-extern "C" Error SystemNative_SendMessage_IntPtr(intptr_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent);
 
 extern "C" Error SystemNative_Accept(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, intptr_t* acceptedSocket);
-extern "C" Error SystemNative_Accept_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, intptr_t* acceptedSocket);
 
 extern "C" Error SystemNative_Bind(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
-extern "C" Error SystemNative_Bind_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
 
 extern "C" Error SystemNative_Connect(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
-extern "C" Error SystemNative_Connect_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
 
 extern "C" Error SystemNative_GetPeerName(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
-extern "C" Error SystemNative_GetPeerName_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
 
 extern "C" Error SystemNative_GetSockName(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
-extern "C" Error SystemNative_GetSockName_IntPtr(intptr_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
 
 extern "C" Error SystemNative_Listen(intptr_t socket, int32_t backlog);
-extern "C" Error SystemNative_Listen_IntPtr(intptr_t socket, int32_t backlog);
 
 extern "C" Error SystemNative_Shutdown(intptr_t socket, int32_t socketShutdown);
-extern "C" Error SystemNative_Shutdown_IntPtr(intptr_t socket, int32_t socketShutdown);
 
 extern "C" Error SystemNative_GetSocketErrorOption(intptr_t socket, Error* error);
-extern "C" Error SystemNative_GetSocketErrorOption_IntPtr(intptr_t socket, Error* error);
 
 extern "C" Error SystemNative_GetSockOpt(
-    intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen);
-extern "C" Error SystemNative_GetSockOpt_IntPtr(
     intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen);
 
 extern "C" Error SystemNative_SetSockOpt(
     intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen);
-extern "C" Error SystemNative_SetSockOpt_IntPtr(
-    intptr_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen);
 
 extern "C" Error SystemNative_Socket(int32_t addressFamily, int32_t socketType, int32_t protocolType, intptr_t* createdSocket);
-extern "C" Error SystemNative_Socket_IntPtr(int32_t addressFamily, int32_t socketType, int32_t protocolType, intptr_t* createdSocket);
 
 extern "C" Error SystemNative_GetBytesAvailable(intptr_t socket, int32_t* available);
-extern "C" Error SystemNative_GetBytesAvailable_IntPtr(intptr_t socket, int32_t* available);
 
 extern "C" Error SystemNative_CreateSocketEventPort(intptr_t* port);
-extern "C" Error SystemNative_CreateSocketEventPort_IntPtr(intptr_t* port);
 
 extern "C" Error SystemNative_CloseSocketEventPort(intptr_t port);
-extern "C" Error SystemNative_CloseSocketEventPort_IntPtr(intptr_t port);
 
 extern "C" Error SystemNative_CreateSocketEventBuffer(int32_t count, SocketEvent** buffer);
 
@@ -435,11 +409,8 @@ extern "C" Error SystemNative_FreeSocketEventBuffer(SocketEvent* buffer);
 
 extern "C" Error SystemNative_TryChangeSocketEventRegistration(
     intptr_t port, intptr_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data);
-extern "C" Error SystemNative_TryChangeSocketEventRegistration_IntPtr(
-    intptr_t port, intptr_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data);
 
 extern "C" Error SystemNative_WaitForSocketEvents(intptr_t port, SocketEvent* buffer, int32_t* count);
-extern "C" Error SystemNative_WaitForSocketEvents_IntPtr(intptr_t port, SocketEvent* buffer, int32_t* count);
 
 extern "C" int32_t SystemNative_PlatformSupportsDualModeIPv4PacketInfo();
 


### PR DESCRIPTION
Remove temporary native networking methods, now that the signatures of the permanent methods are fixed to take IntPtr arguments.

Fixes #6928 

@stephentoub