### PR TITLE
Change TODO comments to reference current issue on Sockets perf counters

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/SocketPerfCounters.cs
+++ b/src/System.Net.Sockets/src/System/Net/SocketPerfCounters.cs
@@ -42,19 +42,19 @@ namespace System.Net
         {
             get
             {
-                // TODO (Event logging for System.Net.* #2500): Implement socket perf counters.
+                // TODO (#7833): Implement socket perf counters.
                 return false;
             }
         }
 
         public void Increment(SocketPerfCounterName perfCounter)
         {
-            // TODO (Event logging for System.Net.* #2500): Implement socket perf counters.
+            // TODO (#7833): Implement socket perf counters.
         }
 
         public void Increment(SocketPerfCounterName perfCounter, long amount)
         {
-            // TODO (Event logging for System.Net.* #2500): Implement socket perf counters.
+            // TODO (#7833): Implement socket perf counters.
         }
     }
 }


### PR DESCRIPTION
Simply changes the TODO comments to reference #7833 instead of #2500.