### PR TITLE
Package appcontext as ref on net46

### DIFF
--- a/src/System.AppContext/src/redist/System.AppContext.depproj
+++ b/src/System.AppContext/src/redist/System.AppContext.depproj
@@ -8,6 +8,8 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <NuGetRuntimeIdentifier Condition="'$(TargetGroup)' == 'net46'">win7-x64</NuGetRuntimeIdentifier>
+    <!-- this is a facade on desktop and must forward to mscorlib -->
+    <PackageAsRefAndLib>true</PackageAsRefAndLib>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />


### PR DESCRIPTION
The NET46 facade wasn't being passed to the compiler so folks would see
duplicate types in mscorlib and System.AppContext when referencing this
package and targeting net46 or net461.

/cc @AlexGhiondea @weshaggard