### PR TITLE
Make ArrayPool rented/returned events Verbose

### DIFF
--- a/src/Common/tests/System/Diagnostics/Tracing/TestEventListener.cs
+++ b/src/Common/tests/System/Diagnostics/Tracing/TestEventListener.cs
@@ -16,10 +16,10 @@ namespace System.Diagnostics.Tracing
         private Action<EventWrittenEventArgs> _eventWritten;
         private List<EventSource> _tmpEventSourceList = new List<EventSource>();
 
-        public TestEventListener(string taretSourceName, EventLevel level)
+        public TestEventListener(string targetSourceName, EventLevel level)
         {
             // Store the arguments
-            _targetSourceName = taretSourceName;
+            _targetSourceName = targetSourceName;
             _level = level;
 
             LoadSourceList();

--- a/src/System.Buffers/src/Resources/Strings.resx
+++ b/src/System.Buffers/src/Resources/Strings.resx
@@ -117,18 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="event_BufferRented" xml:space="preserve">
-    <value>Rented Buffer {0} of size {1} from Pool {2} and Bucket {3}</value>
-  </data>
-  <data name="event_BufferAllocated" xml:space="preserve">
-    <value>Buffer {0} of size {1} created in Pool {2} and Bucket {3} with allocation reason {4}</value>
-  </data>
-  <data name="event_BufferReturned" xml:space="preserve">
-    <value>Returned Buffer {0} to Pool {1}</value>
-  </data>
-  <data name="event_BucketExhausted" xml:space="preserve">
-    <value>Bucket {0}, with {2} maximum buffers, exhausted of all Buffers of size {1} in Pool {3}</value>
-  </data>
   <data name="ArgumentException_BufferNotFromPool" xml:space="preserve">
     <value>The buffer is not associated with this pool and may not be returned to it.</value>
   </data>

--- a/src/System.Buffers/src/System/Buffers/ArrayPoolEventSource.cs
+++ b/src/System.Buffers/src/System/Buffers/ArrayPoolEventSource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics.Tracing;
 
 namespace System.Buffers
@@ -22,7 +21,7 @@ namespace System.Buffers
             PoolExhausted
         }
 
-        [Event(1, Level = EventLevel.Informational)]
+        [Event(1, Level = EventLevel.Verbose)]
         internal void BufferRented(int bufferId, int bufferSize, int poolId, int bucketId) { WriteEventHelper(1, bufferId, bufferSize, poolId, bucketId); }
 
         [Event(2, Level = EventLevel.Informational)]
@@ -45,7 +44,7 @@ namespace System.Buffers
              }
         }
 
-        [Event(3, Level = EventLevel.Informational)]
+        [Event(3, Level = EventLevel.Verbose)]
         internal void BufferReturned(int bufferId, int poolId) { WriteEvent(3, bufferId, poolId); }
 
         [Event(4, Level = EventLevel.Warning)]

--- a/src/System.Buffers/src/System/Buffers/ArrayPoolEventSource.cs
+++ b/src/System.Buffers/src/System/Buffers/ArrayPoolEventSource.cs
@@ -6,10 +6,7 @@ using System.Diagnostics.Tracing;
 
 namespace System.Buffers
 {
-    [EventSource(
-        Guid = "20b30044-b729-457e-8dda-8b41b5dd02e6", 
-        Name = "System.Buffers.BufferPoolEventSource",
-        LocalizationResources = "FxResources.System.Buffers.SR")]
+    [EventSource(Name = "System.Buffers.ArrayPoolEventSource")]
     internal sealed class ArrayPoolEventSource : EventSource
     {
         internal readonly static ArrayPoolEventSource Log = new ArrayPoolEventSource();
@@ -22,7 +19,8 @@ namespace System.Buffers
         }
 
         [Event(1, Level = EventLevel.Verbose)]
-        internal void BufferRented(int bufferId, int bufferSize, int poolId, int bucketId) { WriteEventHelper(1, bufferId, bufferSize, poolId, bucketId); }
+        internal void BufferRented(int bufferId, int bufferSize, int poolId, int bucketId) =>
+            WriteEventHelper(1, bufferId, bufferSize, poolId, bucketId);
 
         [Event(2, Level = EventLevel.Informational)]
         internal void BufferAllocated(int bufferId, int bufferSize, int poolId, int bucketId, BufferAllocationReason reason)
@@ -45,10 +43,12 @@ namespace System.Buffers
         }
 
         [Event(3, Level = EventLevel.Verbose)]
-        internal void BufferReturned(int bufferId, int poolId) { WriteEvent(3, bufferId, poolId); }
+        internal void BufferReturned(int bufferId, int poolId) =>
+            WriteEvent(3, bufferId, poolId);
 
         [Event(4, Level = EventLevel.Warning)]
-        internal void BucketExhausted(int bucketId, int bucketSize, int buffersInBucket, int poolId) { WriteEventHelper(4, bucketId, bucketSize, buffersInBucket, poolId); }
+        internal void BucketExhausted(int bucketId, int bucketSize, int buffersInBucket, int poolId) =>
+            WriteEventHelper(4, bucketId, bucketSize, buffersInBucket, poolId);
         
         [NonEvent]
         private unsafe void WriteEventHelper(int eventId, int arg0, int arg1, int arg2, int arg3)

--- a/src/System.Buffers/tests/ArrayPool/UnitTests.cs
+++ b/src/System.Buffers/tests/ArrayPool/UnitTests.cs
@@ -279,9 +279,9 @@ namespace System.Buffers.ArrayPool.Tests
             Assert.Equal(16, pool.Rent(15).Length);
         }
 
-        private static void ActionFiresSpecificEvent(Action body, int eventId, AutoResetEvent are)
+        private static void ActionFiresSpecificEvent(Action body, EventLevel level, int eventId, AutoResetEvent are)
         {
-            using (TestEventListener listener = new TestEventListener("System.Buffers.BufferPoolEventSource", EventLevel.Verbose))
+            using (TestEventListener listener = new TestEventListener("System.Buffers.ArrayPoolEventSource", level))
             {
                 listener.RunWithCallback((EventWrittenEventArgs e) =>
                 {
@@ -301,7 +301,7 @@ namespace System.Buffers.ArrayPool.Tests
             {
                 byte[] bt = pool.Rent(16);
                 Assert.True(are.WaitOne(MaxEventWaitTimeoutInMs));
-            }, 1, are);
+            }, EventLevel.Verbose, 1, are);
         }
 
         [Fact]
@@ -315,7 +315,7 @@ namespace System.Buffers.ArrayPool.Tests
                 byte[] bt = pool.Rent(16);
                 pool.Return(bt);
                 Assert.True(are.WaitOne(MaxEventWaitTimeoutInMs));
-            }, 3, are);
+            }, EventLevel.Verbose, 3, are);
         }
 
         [Fact]
@@ -328,7 +328,7 @@ namespace System.Buffers.ArrayPool.Tests
             {
                 byte[] bt = pool.Rent(16);
                 Assert.True(are.WaitOne(MaxEventWaitTimeoutInMs));
-            }, 2, are);
+            }, EventLevel.Informational, 2, are);
         }
 
         [Fact]
@@ -342,7 +342,7 @@ namespace System.Buffers.ArrayPool.Tests
                 byte[] bt = pool.Rent(16);
                 byte[] bt2 = pool.Rent(16);
                 Assert.True(are.WaitOne(MaxEventWaitTimeoutInMs));
-            }, 2, are);
+            }, EventLevel.Informational, 2, are);
         }
 
         [Fact]
@@ -355,7 +355,7 @@ namespace System.Buffers.ArrayPool.Tests
             {
                 byte[] bt = pool.Rent(64);
                 Assert.True(are.WaitOne(MaxEventWaitTimeoutInMs));
-            }, 2, are);
+            }, EventLevel.Informational, 2, are);
         }
         
         [Fact]
@@ -369,7 +369,7 @@ namespace System.Buffers.ArrayPool.Tests
                 byte[] bt = pool.Rent(16);
                 byte[] bt2 = pool.Rent(16);
                 Assert.True(are.WaitOne(MaxEventWaitTimeoutInMs));
-            }, 4, are);
+            }, EventLevel.Warning, 4, are);
         }
 
         [Fact]


### PR DESCRIPTION
The BufferRented and BufferReturned events are expected to be very common, firing in most usage of ArrayPool.Rent/Return.  This commit changes their event level to be Verbose.  This allows them to be easily separated from the informational and hopefully less frequent BufferAllocated, and hopefully even less frequent warning BucketExhausted.

cc: @sokket, @rynowak 