### PR TITLE
Only ignore tools dir in root.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ syntax: glob
 ### VisualStudio ###
 
 # Tool Runtime Dir
-[Tt]ools/
+/[Tt]ools/
 
 # User-specific files
 *.suo


### PR DESCRIPTION
* In wcf we have a tools dir deeper in the dir structure which we don't want ignored.
* Would prefer to make this simple change in the script than to rename the directory in our repo.
* I couldn't find any 'tools' directories deeper in the corefx directory structure so I don't believe it has any impact on corefx.