### PR TITLE
Re-enable disabled Immutable equality tests

### DIFF
--- a/src/System.Collections.Immutable/tests/ImmutableDictionaryTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableDictionaryTestBase.cs
@@ -190,7 +190,6 @@ namespace System.Collections.Immutable.Tests
             Assert.Throws<NotSupportedException>(() => map[3] = 5);
         }
 
-        [ActiveIssue(780)]
         [Fact]
         public void EqualsTest()
         {

--- a/src/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
@@ -78,7 +78,6 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
-        [ActiveIssue(780)]
         public void EmptyTest()
         {
             this.EmptyTestHelper(Empty<int>(), 5, null);


### PR DESCRIPTION
I believe these should be fixed by https://github.com/dotnet/coreclr/pull/4340 (if not, the problem is a different cause than previously suspected).

Fixes https://github.com/dotnet/corefx/issues/780
cc: @AArnott, @ellismg