### PR TITLE
Update System.Net TODO comments

### DIFF
--- a/src/Common/src/Interop/Windows/winhttp/Interop.SafeWinHttpHandle.cs
+++ b/src/Common/src/Interop/Windows/winhttp/Interop.SafeWinHttpHandle.cs
@@ -55,7 +55,7 @@ internal partial class Interop
                     _parentHandle = null;
                 }
                 
-                // TODO(Issue 2500): Add logging so we know when the handle gets closed.
+                // TODO (#7856): Add logging so we know when the handle gets closed.
                 return Interop.WinHttp.WinHttpCloseHandle(handle);
             }
         }

--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -1251,7 +1251,7 @@ static int32_t GetIPv4PacketInformation(cmsghdr* controlMessage, IPPacketInforma
 #if HAVE_IN_PKTINFO
     packetInfo->InterfaceIndex = static_cast<int32_t>(pktinfo->ipi_ifindex);
 #else
-    // TODO: Figure out how to get interface index with in_addr.
+    // TODO (#7855): Figure out how to get interface index with in_addr.
     // One option is http://www.unix.com/man-page/freebsd/3/if_nametoindex
     // which requires interface name to be known.
     // Meanwhile:

--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -1635,7 +1635,6 @@ static bool ConvertSocketFlagsPalToPlatform(int32_t palFlags, int& platformFlags
 
     if ((palFlags & ~SupportedFlagsMask) != 0)
     {
-        // TODO: we may want to simply mask off unsupported flags.
         return false;
     }
 

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -350,9 +350,9 @@ namespace System.Net.Sockets
         UpdateConnectContext = 28688,
         UseLoopback = 64,
     }
-    // TODO: Review note: RemoteEndPoint definition includes the Address and Port.
-    //       PacketInformation includes Address and Interface (physical interface number).
-    //       The redundancy could be removed by replacing RemoteEndPoint with Port.
+    // Review note: RemoteEndPoint definition includes the Address and Port.
+    // PacketInformation includes Address and Interface (physical interface number).
+    // The redundancy could be removed by replacing RemoteEndPoint with Port.
     
     // Alternative:
     //    public struct SocketReceiveFromResult

--- a/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Unix.cs
@@ -28,7 +28,7 @@ namespace System.Net.Sockets
 
         public void CompletionCallback(IntPtr acceptedFileDescriptor, byte[] socketAddress, int socketAddressLen, SocketError errorCode)
         {
-            // TODO: receive bytes on accepted socket if requested
+            // TODO #7836: receive bytes on accepted socket if requested
 
             _buffer = null;
             _localBytesTransferred = 0;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -5070,7 +5070,7 @@ namespace System.Net.Sockets
                 {
                     if (!s_initialized)
                     {
-                        // TODO: Note for PAL implementation: this call is not required for *NIX and should be avoided during PAL design.
+                        // TODO (#7849): this call is not required for *NIX and should be avoided during PAL design.
 
                         // Ensure that WSAStartup has been called once per process.  
                         // The System.Net.NameResolution contract is responsible with the initialization.

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -10,17 +10,6 @@ using System.Threading;
 
 namespace System.Net.Sockets
 {
-    // TODO:
-    // - Plumb status through async APIs to avoid callbacks on synchronous completion
-    //     - NOTE: this will require refactoring in the *Async APIs to accommodate the lack
-    //             of completion posting
-    // - Add support for unregistering + reregistering for events
-    //     - This will require a new state for each queue, unregistred, to track whether or
-    //       not the queue is currently registered to receive events
-    // - Audit Close()-related code for the possibility of file descriptor recycling issues
-    //     - It might make sense to change _closeLock to a ReaderWriterLockSlim that is
-    //       acquired for read by all public methods before attempting a completion and
-    //       acquired for write by Close() and HandlEvents()
     //
     // NOTE: the publicly-exposed asynchronous methods should match the behavior of
     //       Winsock overlapped sockets as closely as possible. Especially important are
@@ -41,6 +30,7 @@ namespace System.Net.Sockets
     //       case). The publicly-exposed synchronous methods may also encounter the second
     //       case. In this situation these methods should return SocketError.Interrupted
     //       (which again matches Winsock).
+    //
     internal sealed class SocketAsyncContext
     {
         private abstract class AsyncOperation

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -469,7 +469,7 @@ namespace System.Net.Sockets
                 Interop.Error errorCode;
                 if (!_asyncEngineToken.TryRegister(_socket, _registeredEvents, events, out errorCode))
                 {
-                    // TODO: throw an appropriate exception
+                    // TODO (#7850): throw an appropriate exception
                     throw new Exception(string.Format("SocketAsyncContext.Register: {0}", errorCode));
                 }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -52,7 +52,7 @@ namespace System.Net.Sockets
 
         private void AcceptCompletionCallback(IntPtr acceptedFileDescriptor, byte[] socketAddress, int socketAddressSize, SocketError socketError)
         {
-            // TODO: receive bytes on socket if requested
+            // TODO (#7836): receive bytes on socket if requested
 
             _acceptedFileDescriptor = acceptedFileDescriptor;
             Debug.Assert(socketAddress == null || socketAddress == _acceptBuffer, $"Unexpected socketAddress: {socketAddress}");

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -271,7 +271,6 @@ namespace System.Net.Sockets
 
         private void CompletionCallback(int bytesTransferred, SocketError socketError)
         {
-            // TODO: plumb SocketFlags through TransferOperation
             if (socketError == SocketError.Success)
             {
                 FinishOperationSuccess(socketError, bytesTransferred, _receivedFlags);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -231,7 +231,7 @@ namespace System.Net.Sockets
 
         internal void LogBuffer(int size)
         {
-            // TODO: implement?
+            // TODO (#7851): implement?
         }
 
         internal void LogSendPacketsBuffers(int size)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketReceiveMessageFromResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketReceiveMessageFromResult.cs
@@ -4,9 +4,9 @@
 
 namespace System.Net.Sockets
 {
-    // TODO: Review note: RemoteEndPoint definition includes the Address and Port.
-    //       PacketInformation includes Address and Interface (physical interface number).
-    //       The redundancy could be removed by replacing RemoteEndPoint with Port.
+    // Review note: RemoteEndPoint definition includes the Address and Port.
+    // PacketInformation includes Address and Interface (physical interface number).
+    // The redundancy could be removed by replacing RemoteEndPoint with Port.
 
     public struct SocketReceiveMessageFromResult
     {

--- a/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -12,7 +12,7 @@ using System.Threading;
 
 namespace System.Net.Sockets.Tests
 {
-    // TODO:
+    // TODO (#7852):
     //
     // - Connect(EndPoint):
     //   - disconnected socket

--- a/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -489,7 +489,6 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<ArgumentException>(() => GetSocket().SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.NoDelay, new object()));
         }
 
-        // TODO: Select
         [Fact]
         public void Select_NullOrEmptyLists_Throws_ArgumentNull()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
@@ -50,7 +50,7 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                // TODO: Behavior difference from .Net Desktop. This will actually throw InternalSocketException.
+                // TODO (#7853): Behavior difference from .Net Desktop. This will actually throw InternalSocketException.
                 SocketException ex = Assert.ThrowsAny<SocketException>(() =>
                 {
                     sock.Connect(new DnsEndPoint("notahostname.invalid.corp.microsoft.com", UnusedPort));
@@ -60,7 +60,7 @@ namespace System.Net.Sockets.Tests
                 Assert.True((errorCode == SocketError.HostNotFound) || (errorCode == SocketError.NoData),
                     "SocketErrorCode: {0}" + errorCode);
 
-                // TODO: Behavior difference from .Net Desktop. This will actually throw InternalSocketException.
+                // TODO (#7853): Behavior difference from .Net Desktop. This will actually throw InternalSocketException.
                 ex = Assert.ThrowsAny<SocketException>(() =>
                 {
                     sock.Connect(new DnsEndPoint("localhost", UnusedPort));
@@ -120,7 +120,7 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                // TODO: Behavior difference from .Net Desktop. This will actually throw InternalSocketException.
+                // TODO (#7853): Behavior difference from .Net Desktop. This will actually throw InternalSocketException.
                 SocketException ex = Assert.ThrowsAny<SocketException>(() =>
                 {
                     IAsyncResult result = sock.BeginConnect(new DnsEndPoint("notahostname.invalid.corp.microsoft.com", UnusedPort), null, null);
@@ -131,7 +131,7 @@ namespace System.Net.Sockets.Tests
                 Assert.True((errorCode == SocketError.HostNotFound) || (errorCode == SocketError.NoData),
                     "SocketErrorCode: {0}" + errorCode);
 
-                // TODO: Behavior difference from .Net Desktop. This will actually throw InternalSocketException.
+                // TODO (#7853): Behavior difference from .Net Desktop. This will actually throw InternalSocketException.
                 ex = Assert.ThrowsAny<SocketException>(() =>
                 {
                     IAsyncResult result = sock.BeginConnect(new DnsEndPoint("localhost", UnusedPort), null, null);

--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -2056,7 +2056,7 @@ namespace System.Net.Sockets.Tests
 
                 Assert.Equal(connectTo, ipPacketInformation.Address);
 
-                // TODO: Move to NetworkInformation tests.
+                // TODO (#7854): Move to NetworkInformation tests.
                 // Assert.Equal(NetworkInterface.IPv6LoopbackInterfaceIndex, ipPacketInformation.Interface);
             }
         }
@@ -2229,7 +2229,7 @@ namespace System.Net.Sockets.Tests
                 Assert.NotNull(ipPacketInformation);
                 Assert.Equal(connectTo, ipPacketInformation.Address);
 
-                // TODO: Move to NetworkInformation tests.
+                // TODO (#7854): Move to NetworkInformation tests.
                 //Assert.Equal(NetworkInterface.IPv6LoopbackInterfaceIndex, ipPacketInformation.Interface);
             }
         }
@@ -2402,7 +2402,7 @@ namespace System.Net.Sockets.Tests
                 Assert.NotNull(args.ReceiveMessageFromPacketInfo);
                 Assert.Equal(connectTo, args.ReceiveMessageFromPacketInfo.Address);
 
-                // TODO: Move to NetworkInformation tests.
+                // TODO (#7854): Move to NetworkInformation tests.
                 // Assert.Equal(NetworkInterface.IPv6LoopbackInterfaceIndex, args.ReceiveMessageFromPacketInfo.Interface);
             }
         }


### PR DESCRIPTION
Update some `TODO` comments with issue numbers.  Also, removed a few out-of-date or non-actionable `TODO` comments.  See individual commits for specifics on each change.

This PR covers all TODOs in `System.Net.Sockets`; I am working through the rest of `System.Net` now.