### PR TITLE
Remove EnterLoopInstruction class from Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -828,45 +828,4 @@ namespace System.Linq.Expressions.Interpreter
             return _cases.TryGetValue((string)value, out target) ? target : 1;
         }
     }
-
-    internal sealed class EnterLoopInstruction : Instruction
-    {
-        private readonly int _instructionIndex;
-        private Dictionary<ParameterExpression, LocalVariable> _variables;
-        private Dictionary<ParameterExpression, LocalVariable> _closureVariables;
-        private LoopExpression _loop;
-        private int _loopEnd;
-
-        public override string InstructionName
-        {
-            get { return "EnterLoop"; }
-        }
-
-        internal EnterLoopInstruction(LoopExpression loop, LocalVariables locals, int instructionIndex)
-        {
-            _loop = loop;
-            _variables = locals.CopyLocals();
-            _closureVariables = locals.ClosureVariables;
-            _instructionIndex = instructionIndex;
-        }
-
-        internal void FinishLoop(int loopEnd)
-        {
-            _loopEnd = loopEnd;
-        }
-
-        public override int Run(InterpretedFrame frame)
-        {
-            return 1;
-        }
-
-        private bool Compiled
-        {
-            get { return _loop == null; }
-        }
-
-        private void Compile(object frameObj)
-        {
-        }
-    }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -1497,7 +1497,6 @@ namespace System.Linq.Expressions.Interpreter
         private void CompileLoopExpression(Expression expr)
         {
             var node = (LoopExpression)expr;
-            var enterLoop = new EnterLoopInstruction(node, _locals, _instructions.Count);
 
             PushLabelBlock(LabelScopeKind.Statement);
             LabelInfo breakLabel = DefineLabel(node.BreakLabel);
@@ -1506,7 +1505,6 @@ namespace System.Linq.Expressions.Interpreter
             _instructions.MarkLabel(continueLabel.GetLabel(this));
 
             // emit loop body:
-            _instructions.Emit(enterLoop);
             CompileAsVoid(node.Body);
 
             // emit loop branch:
@@ -1515,8 +1513,6 @@ namespace System.Linq.Expressions.Interpreter
             _instructions.MarkLabel(breakLabel.GetLabel(this));
 
             PopLabelBlock(LabelScopeKind.Statement);
-
-            enterLoop.FinishLoop(_instructions.Count);
         }
 
         #endregion


### PR DESCRIPTION
It stores fields, but they are never actually used either in execution or in influencing the rest of the compilation.

Contributes to #3836