### PR TITLE
Port UriTypeConverter source and add tests.

### DIFF
--- a/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -203,3 +203,15 @@ namespace System.ComponentModel
         public UInt64Converter() { }
     }
 }
+
+namespace System
+{
+    public partial class UriTypeConverter : System.ComponentModel.TypeConverter
+    {
+        public UriTypeConverter() { }
+        public override bool CanConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Type sourceType) { return default(bool); }
+        public override bool CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType) { return default(bool); }
+        public override object ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) { return default(object); }
+        public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) { return default(object); }
+    }
+}

--- a/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
+++ b/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -15,7 +15,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45_Release|AnyCPU'" />
-  
   <ItemGroup Condition="'$(TargetGroup)'==''">
     <Compile Include="System\ComponentModel\ArrayConverter.cs" />
     <Compile Include="System\ComponentModel\BaseNumberConverter.cs" />
@@ -48,6 +47,7 @@
     <Compile Include="System\ComponentModel\UInt16Converter.cs" />
     <Compile Include="System\ComponentModel\UInt32Converter.cs" />
     <Compile Include="System\ComponentModel\UInt64Converter.cs" />
+    <Compile Include="System\ComponentModel\UriTypeConverter.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'==''">
     <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -83,6 +83,7 @@ namespace System.ComponentModel
                     temp[typeof(Array)] = typeof(ArrayConverter);
                     temp[typeof(ICollection)] = typeof(CollectionConverter);
                     temp[typeof(Enum)] = typeof(EnumConverter);
+                    temp[typeof(Uri)] = typeof(UriTypeConverter);
 
                     // Special cases for things that are not bound to a specific type
                     //

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UriTypeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UriTypeConverter.cs
@@ -1,0 +1,105 @@
+﻿// (c) Copyright Microsoft Corporation.
+// This source is subject to [###LICENSE_NAME###].
+// Please see [###LICENSE_LINK###] for details.
+// All other rights reserved.
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace System
+{
+    /// <summary>
+    /// Converts a String type to a Uri type.
+    /// </summary>
+    public sealed class UriTypeConverter : TypeConverter
+    {
+        /// <summary>
+        /// Initializes a new instance of the UriTypeConverter class. 
+        /// </summary>
+        public UriTypeConverter()
+        {
+        }
+
+        /// <summary>
+        /// Returns whether this converter can convert an object in the given source type to the type of the converter
+        /// using the context.
+        /// </summary>
+        /// <param name="sourceType">
+        /// A type that represents the type that you want to convert from.
+        /// </param>
+        /// <returns>
+        /// true if sourceType is a String type or a Uri type that can be
+        /// assigned from sourceType; otherwise, false.
+        /// </returns>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == null)
+                throw new ArgumentNullException("sourceType");
+
+            if (sourceType == typeof(string))
+                return true;
+
+            if (typeof(Uri).IsAssignableFrom(sourceType))
+                return true;
+
+            return false;
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(string))
+                return true;
+
+            if (destinationType == typeof(Uri))
+                return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// Converts the specified object to a Uri.
+        /// </summary>
+        /// <param name="value">Object to convert into a Uri.</param>
+        /// <returns>A Uri that represents the converted text.</returns>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            string uriString = value as string;
+            if (uriString != null)
+            {
+                if (String.IsNullOrEmpty(uriString))
+                    return null;
+
+                // Let the Uri constructor throw any informative exceptions
+                return new Uri(uriString, UriKind.RelativeOrAbsolute);
+            }
+
+            Uri valueAsUri = value as Uri;
+            if (valueAsUri != null)
+                return new Uri(valueAsUri.OriginalString); // return new instance like desktop fx
+
+            throw new NotSupportedException(String.Format(CultureInfo.CurrentCulture,
+                SR.GetString(SR.UriTypeConverter_ConvertFrom_CannotConvert), typeof(UriTypeConverter).Name,
+                value != null ? value.GetType().FullName : "null"));
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            Uri uri = value as Uri;
+
+            if (uri != null)
+            {
+                if (destinationType == typeof(string))
+                    return uri.OriginalString;
+
+                if (destinationType == typeof(Uri))
+                    return new Uri(uri.OriginalString, UriKind.RelativeOrAbsolute);
+            }
+
+            throw new NotSupportedException(String.Format(CultureInfo.CurrentCulture,
+                SR.GetString(SR.UriTypeConverter_ConvertTo_CannotConvert), typeof(UriTypeConverter).Name,
+                value != null ? value.GetType().FullName : "null",
+                destinationType != null ? destinationType.FullName : "null"));
+        }
+    }
+}

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UriTypeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UriTypeConverter.cs
@@ -1,92 +1,75 @@
-﻿// (c) Copyright Microsoft Corporation.
-// This source is subject to [###LICENSE_NAME###].
-// Please see [###LICENSE_LINK###] for details.
-// All other rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
-using System;
 using System.ComponentModel;
 using System.Globalization;
 
 namespace System
 {
-    /// <summary>
-    /// Converts a String type to a Uri type.
-    /// </summary>
-    public sealed class UriTypeConverter : TypeConverter
+    /// <devdoc>
+    ///    <para>Provides a type converter to convert Uri objects to and
+    ///       from various other representations.</para>
+    /// </devdoc>
+    public class UriTypeConverter : TypeConverter
     {
-        /// <summary>
-        /// Initializes a new instance of the UriTypeConverter class. 
-        /// </summary>
-        public UriTypeConverter()
-        {
-        }
-
-        /// <summary>
-        /// Returns whether this converter can convert an object in the given source type to the type of the converter
-        /// using the context.
-        /// </summary>
-        /// <param name="sourceType">
-        /// A type that represents the type that you want to convert from.
-        /// </param>
-        /// <returns>
-        /// true if sourceType is a String type or a Uri type that can be
-        /// assigned from sourceType; otherwise, false.
-        /// </returns>
+        /// <devdoc>
+        ///    <para>Gets a value indicating whether this converter can convert an object in the
+        ///       given source type to a Uri.</para>
+        /// </devdoc>
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
             if (sourceType == null)
-                throw new ArgumentNullException("sourceType");
+                throw new ArgumentNullException(nameof(sourceType));
 
-            if (sourceType == typeof(string))
-                return true;
-
-            if (typeof(Uri).IsAssignableFrom(sourceType))
-                return true;
-
-            return false;
+            return (sourceType == typeof(string) || sourceType == typeof(Uri));
         }
 
+        /// <devdoc>
+        ///    <para>Gets a value indicating whether this converter can
+        ///       convert an object to the given destination type using the context.</para>
+        /// </devdoc>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
-            if (destinationType == typeof(string))
-                return true;
-
-            if (destinationType == typeof(Uri))
-                return true;
-
-            return false;
+            return (destinationType == typeof(string) || destinationType == typeof(Uri));
         }
 
-        /// <summary>
-        /// Converts the specified object to a Uri.
-        /// </summary>
-        /// <param name="value">Object to convert into a Uri.</param>
-        /// <returns>A Uri that represents the converted text.</returns>
+        /// <devdoc>
+        ///    <para>Converts the given object to the a Uri.</para>
+        /// </devdoc>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
             string uriString = value as string;
             if (uriString != null)
             {
-                if (String.IsNullOrEmpty(uriString))
+                if (string.IsNullOrEmpty(uriString))
                     return null;
 
                 // Let the Uri constructor throw any informative exceptions
                 return new Uri(uriString, UriKind.RelativeOrAbsolute);
             }
 
-            Uri valueAsUri = value as Uri;
-            if (valueAsUri != null)
-                return new Uri(valueAsUri.OriginalString); // return new instance like desktop fx
+            Uri uri = value as Uri;
+            if (uri != null)
+            {
+                return new Uri(uri.OriginalString); // return new instance
+            }
 
-            throw new NotSupportedException(String.Format(CultureInfo.CurrentCulture,
-                SR.GetString(SR.UriTypeConverter_ConvertFrom_CannotConvert), typeof(UriTypeConverter).Name,
-                value != null ? value.GetType().FullName : "null"));
+            throw GetConvertFromException(value);
         }
 
+        /// <devdoc>
+        ///    <para>Converts the given value object to
+        ///       the specified destination type using the specified context and arguments.</para>
+        /// </devdoc>
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
-            Uri uri = value as Uri;
+            if (destinationType == null)
+            {
+                throw new ArgumentNullException(nameof(destinationType));
+            }
 
+            Uri uri = value as Uri;
             if (uri != null)
             {
                 if (destinationType == typeof(string))
@@ -96,10 +79,7 @@ namespace System
                     return new Uri(uri.OriginalString, UriKind.RelativeOrAbsolute);
             }
 
-            throw new NotSupportedException(String.Format(CultureInfo.CurrentCulture,
-                SR.GetString(SR.UriTypeConverter_ConvertTo_CannotConvert), typeof(UriTypeConverter).Name,
-                value != null ? value.GetType().FullName : "null",
-                destinationType != null ? destinationType.FullName : "null"));
+            throw GetConvertToException(value, destinationType);
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/Performance/Perf.TypeDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Performance/Perf.TypeDescriptorTests.cs
@@ -44,6 +44,7 @@ namespace System.ComponentModel.Tests
         [InlineData(typeof(IDerived), typeof(IBaseConverter))]
         [InlineData(typeof(ClassIBase), typeof(IBaseConverter))]
         [InlineData(typeof(ClassIDerived), typeof(IBaseConverter))]
+        [InlineData(typeof(Uri), typeof(UriTypeConverter))]
         public static void GetConverter(Type typeToConvert, Type expectedConverter)
         {
             const int innerIterations = 100;

--- a/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="UInt16ConverterTests.cs" />
     <Compile Include="UInt32ConverterTests.cs" />
     <Compile Include="UInt64ConverterTests.cs" />
+    <Compile Include="UriTypeConverterTests.cs" />
     <!-- Performance Tests -->
     <Compile Include="Performance\Perf.TypeDescriptorTests.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">

--- a/src/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.cs
@@ -69,7 +69,8 @@ namespace System.ComponentModel.Tests
             new Tuple<Type, Type> (typeof(IBase), typeof(IBaseConverter)),
             new Tuple<Type, Type> (typeof(IDerived), typeof(IBaseConverter)),
             new Tuple<Type, Type> (typeof(ClassIBase), typeof(IBaseConverter)),
-            new Tuple<Type, Type> (typeof(ClassIDerived), typeof(IBaseConverter))
+            new Tuple<Type, Type> (typeof(ClassIDerived), typeof(IBaseConverter)),
+            new Tuple<Type, Type> (typeof(Uri), typeof(UriTypeConverter))
         };
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/UriTypeConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/UriTypeConverterTests.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using Xunit;
+
+namespace System.ComponentModel.Tests
+{
+    public class UriTypeConverterTests : ConverterTestBase
+    {
+        private static UriTypeConverter s_converter = new UriTypeConverter();
+
+        [Fact]
+        public static void CanConvertFrom_WithContext()
+        {
+            CanConvertFrom_WithContext(new object[2, 2]
+                {
+                    { typeof(string), true },
+                    { typeof(Uri), true }
+                },
+                UriTypeConverterTests.s_converter);
+        }
+
+        [Fact]
+        public static void ConvertFrom_WithContext()
+        {
+            ConvertFrom_WithContext(new object[2, 3]
+                {
+                    {"http://www.Microsoft.com/", new Uri("http://www.Microsoft.com/"),  CultureInfo.InvariantCulture},
+                    {"mailto:?to=User2@Host2.com;cc=User3@Host3com", new Uri("mailto:?to=User2@Host2.com;cc=User3@Host3com"),  null}
+                },
+                UriTypeConverterTests.s_converter);
+        }
+
+        [Fact]
+        public static void ConvertFrom_WithContext_Negative()
+        {
+            Assert.Throws<NotSupportedException>(
+                () => UriTypeConverterTests.s_converter.ConvertFrom(TypeConverterTests.s_context, null, null));
+            Assert.Throws<UriFormatException>(
+                () => UriTypeConverterTests.s_converter.ConvertFrom(TypeConverterTests.s_context, null, "mailto:User@"));
+        }
+    }
+}


### PR DESCRIPTION
The first commit ports the sources from TFS by dotnet-bot.

The second commit clean ups and changes the sources to work in CoreFX. It also adds some tests. I couldn't find the existing tests so I just wrote some new ones in the style of the other tests in the project. The unusual comment style of the sources (devdoc) is to match the other sources in the TypeConverter namespace for consistency.

resolves #7501

@Tanya-Solyanik @stephentoub