### PR TITLE
Fix a rare overflow issue in Environment.TickCount tests.

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Environment.TickCount.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.TickCount.cs
@@ -13,7 +13,7 @@ namespace System.Tests
         public void TickCountTest()
         {
             int start = Environment.TickCount;
-            Assert.True(SpinWait.SpinUntil(() => Environment.TickCount > start, TimeSpan.FromSeconds(1)));
+            Assert.True(SpinWait.SpinUntil(() => Environment.TickCount - start > 0, TimeSpan.FromSeconds(1)));
         }
     }
 }


### PR DESCRIPTION
Environment.TickCount can overflow after 25 days as the value is stored in a signed 32-bit integer. We have some machines which have been online for a very long time running our CI jobs, and a couple of failures in this test case look like the values have overflown (despite how incredibly unlikely that seems).

The test now attempts to take overflow into consideration. If the "starting" TickCount value is positive, then receiving a negative value later means that TickCount has overflown, and therefore we are still "later" than the first value.

@stephentoub Does this look like a reasonable fix? I'm just trying to detect the case where we go from reading a positive `TickCount` value to a negative one. Any other cases, like starting with a negative value, seem to already work fine with existing logic.