### PR TITLE
Re-Enable Unicode Compression tests

### DIFF
--- a/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.NetCore.Extensions;
 
 namespace System.IO.Compression.Tests
 {
@@ -15,10 +16,13 @@ namespace System.IO.Compression.Tests
         public async Task CreateFromDirectoryNormal()
         {
             await TestCreateDirectory(zfolder("normal"), true);
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // [ActiveIssue(5459, PlatformID.AnyUnix)]
-            {
-                await TestCreateDirectory(zfolder("unicode"), true);
-            }
+        }
+
+        [Fact]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]
+        public async Task CreateFromDirectoryUnicodel()
+        {
+            await TestCreateDirectory(zfolder("unicode"), true);
         }
 
         private async Task TestCreateDirectory(string folderName, Boolean testWithBaseDir)
@@ -67,16 +71,19 @@ namespace System.IO.Compression.Tests
         public void ExtractToDirectoryNormal()
         {
             TestExtract(zfile("normal.zip"), zfolder("normal"));
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // [ActiveIssue(5459, PlatformID.AnyUnix)]
-            {
-                TestExtract(zfile("unicode.zip"), zfolder("unicode"));
-            }
             TestExtract(zfile("empty.zip"), zfolder("empty"));
             TestExtract(zfile("explicitdir1.zip"), zfolder("explicitdir"));
             TestExtract(zfile("explicitdir2.zip"), zfolder("explicitdir"));
             TestExtract(zfile("appended.zip"), zfolder("small"));
             TestExtract(zfile("prepended.zip"), zfolder("small"));
             TestExtract(zfile("noexplicitdir.zip"), zfolder("explicitdir"));
+        }
+
+        [Fact]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]
+        public void ExtractToDirectoryUnicode()
+        {
+            TestExtract(zfile("unicode.zip"), zfolder("unicode"));
         }
 
         private void TestExtract(string zipFileName, string folderName)
@@ -162,16 +169,18 @@ namespace System.IO.Compression.Tests
 
                 DirsEqual(tempFolder, zfolder("normal"));
             }
+        }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // [ActiveIssue(5459, PlatformID.AnyUnix)]
+        [Fact]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]
+        public void ExtractToDirectoryTest_Unicode()
+        {
+            using (ZipArchive archive = ZipFile.OpenRead(zfile("unicode.zip")))
             {
-                using (ZipArchive archive = ZipFile.OpenRead(zfile("unicode.zip")))
-                {
-                    string tempFolder = GetTmpDirPath(false);
-                    archive.ExtractToDirectory(tempFolder);
+                string tempFolder = GetTmpDirPath(false);
+                archive.ExtractToDirectory(tempFolder);
 
-                    DirsEqual(tempFolder, zfolder("unicode"));
-                }
+                DirsEqual(tempFolder, zfolder("unicode"));
             }
         }
 

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
@@ -19,7 +19,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
-        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Jenkins fails with unicode characters [JENKINS-12610]
         public async Task CreateFromDirectoryUnicodel()
         {
             await TestCreateDirectory(zfolder("unicode"), true);
@@ -80,7 +80,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
-        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Jenkins fails with unicode characters [JENKINS-12610]
         public void ExtractToDirectoryUnicode()
         {
             TestExtract(zfile("unicode.zip"), zfolder("unicode"));
@@ -172,7 +172,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
-        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Jenkins fails with unicode characters [JENKINS-12610]
         public void ExtractToDirectoryTest_Unicode()
         {
             using (ZipArchive archive = ZipFile.OpenRead(zfile("unicode.zip")))

--- a/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -76,7 +76,7 @@ namespace System.IO.Compression.Tests
         [Theory]
         [InlineData("unicode", true)]
         [InlineData("unicode", false)]
-        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Jenkins fails with unicode characters [JENKINS-12610]
         public static async Task CreateNormal_Unicode(string folder, bool seekable)
         {
             using (var s = new MemoryStream())

--- a/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -5,6 +5,7 @@
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.NetCore.Extensions;
 
 namespace System.IO.Compression.Tests
 {
@@ -75,7 +76,7 @@ namespace System.IO.Compression.Tests
         [Theory]
         [InlineData("unicode", true)]
         [InlineData("unicode", false)]
-        [ActiveIssue(5096, PlatformID.AnyUnix)]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)]
         public static async Task CreateNormal_Unicode(string folder, bool seekable)
         {
             using (var s = new MemoryStream())


### PR DESCRIPTION
Some Compression tests were using unicode files that were failing specifically in CI runs. I've modified those tests to use the IgnoreForCI tag so we can avoid those failures.

resolves #5459, #5096