### PR TITLE
Prepare for Unix current culture changes

### DIFF
--- a/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -106,7 +106,6 @@ namespace System.Globalization.Tests
         [InlineData("en_GB", "en-GB")]
         [InlineData("fr-FR", "fr-FR")]
         [InlineData("ru", "ru")]
-        [InlineData("", "en-US-POSIX")]
         public void CurrentCulture_BasedOnLangEnvVar(string langEnvVar, string expectedCultureName)
         {
             var psi = new ProcessStartInfo();

--- a/src/System.Globalization/tests/RegionInfo/RegionInfoTests.Properties.cs
+++ b/src/System.Globalization/tests/RegionInfo/RegionInfoTests.Properties.cs
@@ -12,9 +12,20 @@ namespace System.Globalization.Tests
         [Fact]
         public void CurrentRegion()
         {
-            RegionInfo ri = new RegionInfo(new RegionInfo(CultureInfo.CurrentCulture.Name).TwoLetterISORegionName);
-            Assert.True(RegionInfo.CurrentRegion.Equals(ri) || RegionInfo.CurrentRegion.Equals(new RegionInfo(CultureInfo.CurrentCulture.Name)));
-            Assert.Same(RegionInfo.CurrentRegion, RegionInfo.CurrentRegion);
+            CultureInfo oldThreadCulture = CultureInfo.CurrentCulture;
+
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("en-US");
+
+                RegionInfo ri = new RegionInfo(new RegionInfo(CultureInfo.CurrentCulture.Name).TwoLetterISORegionName);
+                Assert.True(RegionInfo.CurrentRegion.Equals(ri) || RegionInfo.CurrentRegion.Equals(new RegionInfo(CultureInfo.CurrentCulture.Name)));
+                Assert.Same(RegionInfo.CurrentRegion, RegionInfo.CurrentRegion);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = oldThreadCulture;
+            }
         }
 
         [Theory]


### PR DESCRIPTION
We are going to change the default locale we use on Unix when we can't
figure out one based on LANG and friends to be Invariant instead of
en-US-POSIX, since that provides a better default (the collation rules
in en-US-POSIX are very strange).

Two tests depend on the current behavior, one that explicitly tests the
default (which I will update after the coresponding CoreCLR changes have
landed) and one which does not work currently if the current culture is
Invariant (I found this via directed testing where I ran all the tests
with empty LANG vars).

Fix one to run out of process and just set the CurrentCulture to
en-US (it should not impact what the tests wants to cover) and remove
the other test.