### PR TITLE
Move DbEnumerator to System.Data.Common

### DIFF
--- a/src/Common/src/System/Data/Common/BasicFieldNameLookup.cs
+++ b/src/Common/src/System/Data/Common/BasicFieldNameLookup.cs
@@ -1,0 +1,143 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Globalization;
+
+namespace System.Data.ProviderBase
+{
+    internal class BasicFieldNameLookup
+    {
+        // Dictionary stores the index into the _fieldNames, match via case-sensitive
+        private Dictionary<string, int> _fieldNameLookup;
+
+        // original names for linear searches when exact matches fail
+        private readonly string[] _fieldNames;
+
+        // By default _compareInfo is set to InvariantCulture CompareInfo 
+        private CompareInfo _compareInfo;
+
+        public BasicFieldNameLookup(string[] fieldNames)
+        {
+            if (null == fieldNames)
+            {
+                throw ADP.ArgumentNull(nameof(fieldNames));
+            }
+            _fieldNames = fieldNames;
+        }
+
+        public BasicFieldNameLookup(System.Collections.ObjectModel.ReadOnlyCollection<string> columnNames)
+        {
+            int length = columnNames.Count;
+            string[] fieldNames = new string[length];
+            for (int i = 0; i < length; ++i)
+            {
+                fieldNames[i] = columnNames[i];
+            }
+            _fieldNames = fieldNames;
+            GenerateLookup();
+        }
+
+        public BasicFieldNameLookup(DbDataReader reader)
+        {
+            int length = reader.FieldCount;
+            string[] fieldNames = new string[length];
+            for (int i = 0; i < length; ++i)
+            {
+                fieldNames[i] = reader.GetName(i);
+            }
+            _fieldNames = fieldNames;
+        }
+
+        public int GetOrdinal(string fieldName)
+        {
+            if (null == fieldName)
+            {
+                throw ADP.ArgumentNull(nameof(fieldName));
+            }
+            int index = IndexOf(fieldName);
+            if (-1 == index)
+            {
+                throw ADP.IndexOutOfRange(fieldName);
+            }
+            return index;
+        }
+
+        public int IndexOfName(string fieldName)
+        {
+            if (null == _fieldNameLookup)
+            {
+                GenerateLookup();
+            }
+
+            int value;
+            // via case sensitive search, first match with lowest ordinal matches
+            return _fieldNameLookup.TryGetValue(fieldName, out value) ? value : -1;
+        }
+
+        public int IndexOf(string fieldName)
+        {
+            if (null == _fieldNameLookup)
+            {
+                GenerateLookup();
+            }
+            int index;
+            // via case sensitive search, first match with lowest ordinal matches
+            if (!_fieldNameLookup.TryGetValue(fieldName, out index))
+            {
+                // via case insensitive search, first match with lowest ordinal matches
+                index = LinearIndexOf(fieldName, CompareOptions.IgnoreCase);
+                if (-1 == index)
+                {
+                    // do the slow search now (kana, width insensitive comparison)
+                    index = LinearIndexOf(fieldName, ADP.compareOptions);
+                }
+            }
+
+            return index;
+        }
+
+        protected virtual CompareInfo GetCompareInfo()
+        {
+            return CultureInfo.InvariantCulture.CompareInfo;
+        }
+
+        private int LinearIndexOf(string fieldName, CompareOptions compareOptions)
+        {
+            CompareInfo compareInfo = _compareInfo;
+            if (null == compareInfo)
+            {
+                _compareInfo = GetCompareInfo();
+            }
+
+            int length = _fieldNames.Length;
+            for (int i = 0; i < length; ++i)
+            {
+                if (0 == compareInfo.Compare(fieldName, _fieldNames[i], compareOptions))
+                {
+                    _fieldNameLookup[fieldName] = i; // add an exact match for the future
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        // RTM common code for generating Dictionary from array of column names
+        private void GenerateLookup()
+        {
+            int length = _fieldNames.Length;
+            Dictionary<string, int> hash = new Dictionary<string, int>(length);
+
+            // via case sensitive search, first match with lowest ordinal matches
+            for (int i = length - 1; 0 <= i; --i)
+            {
+                string fieldName = _fieldNames[i];
+                hash[fieldName] = i;
+            }
+            _fieldNameLookup = hash;
+        }
+    }
+}

--- a/src/System.Data.Common/src/Resources/Strings.resx
+++ b/src/System.Data.Common/src/Resources/Strings.resx
@@ -138,4 +138,17 @@
   <data name="SqlConvert_ConvertFailed" xml:space="preserve">
     <value> Cannot convert object of type '{0}' to object of type '{1}'.</value>
   </data>
+  <data name="ADP_InvalidSourceBufferIndex" xml:space="preserve">
+    <value>Invalid source buffer (size of {0}) offset: {1}</value>
+  </data>
+  <data name="SQL_InvalidDataLength" xml:space="preserve">
+    <value>Data length '{0}' is less than 0.</value>
+  </data>
+  <data name="SQL_InvalidBufferSizeOrIndex" xml:space="preserve">
+    <value>Buffer offset '{1}' plus the bytes available '{0}' is greater than the length of the passed in buffer.</value>
+  </data>
+  <data name="ADP_InvalidDestinationBufferIndex" xml:space="preserve">
+    <value>Invalid destination buffer (size of {0}) offset: {1}</value>
+  </data>
+
 </root>

--- a/src/System.Data.Common/src/System.Data.Common.csproj
+++ b/src/System.Data.Common/src/System.Data.Common.csproj
@@ -57,6 +57,11 @@
     <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskHelpers.cs">
       <Link>Common\System\Threading\Tasks\TaskHelpers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Data\Common\BasicFieldNameLookup.cs">
+      <Link>System\Data\Common\BasicFieldNameLookup.cs</Link>
+    </Compile>
+    <Compile Include="System\Data\Common\DbEnumerator.cs" />
+    <Compile Include="System\Data\Common\DataRecordInternal.cs" />
     <Compile Include="System\Data\Common\DbDataRecord.cs" />
     <Compile Include="System\Data\DataRowVersion.cs" />
     <Compile Include="System\Data\DataTable.cs" />

--- a/src/System.Data.Common/src/System/Data/Common/AdapterUtil.cs
+++ b/src/System.Data.Common/src/System/Data/Common/AdapterUtil.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 
 
@@ -158,9 +160,106 @@ namespace System.Data.Common
         }
         internal const int DefaultConnectionTimeout = DbConnectionStringDefaults.ConnectTimeout;
 
+        internal const CompareOptions compareOptions = CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase;
+
         static internal bool IsEmpty(string str)
         {
             return string.IsNullOrEmpty(str);
+        }
+        static internal IndexOutOfRangeException IndexOutOfRange(string error)
+        {
+            IndexOutOfRangeException e = new IndexOutOfRangeException(error);
+            return e;
+        }
+        static internal ArgumentOutOfRangeException InvalidSourceBufferIndex(int maxLen, long srcOffset, string parameterName)
+        {
+            return ArgumentOutOfRange(SR.Format(SR.ADP_InvalidSourceBufferIndex, maxLen.ToString(CultureInfo.InvariantCulture), srcOffset.ToString(CultureInfo.InvariantCulture)), parameterName);
+        }
+        static internal ArgumentOutOfRangeException ArgumentOutOfRange(string message, string parameterName)
+        {
+            ArgumentOutOfRangeException e = new ArgumentOutOfRangeException(parameterName, message);
+            return e;
+        }
+        static internal Exception InvalidDataLength(long length)
+        {
+            return IndexOutOfRange(SR.Format(SR.SQL_InvalidDataLength, length.ToString(CultureInfo.InvariantCulture)));
+        }
+        static internal IndexOutOfRangeException InvalidBufferSizeOrIndex(int numBytes, int bufferIndex)
+        {
+            return IndexOutOfRange(SR.Format(SR.SQL_InvalidBufferSizeOrIndex, numBytes.ToString(CultureInfo.InvariantCulture), bufferIndex.ToString(CultureInfo.InvariantCulture)));
+        }
+        static internal ArgumentOutOfRangeException InvalidDestinationBufferIndex(int maxLen, int dstOffset, string parameterName)
+        {
+            return ArgumentOutOfRange(SR.Format(SR.ADP_InvalidDestinationBufferIndex, maxLen.ToString(CultureInfo.InvariantCulture), dstOffset.ToString(CultureInfo.InvariantCulture)), parameterName);
+        }
+
+        // { "a", "a", "a" } -> { "a", "a1", "a2" }
+        // { "a", "a", "a1" } -> { "a", "a2", "a1" }
+        // { "a", "A", "a" } -> { "a", "A1", "a2" }
+        // { "a", "A", "a1" } -> { "a", "A2", "a1" }
+        static internal void BuildSchemaTableInfoTableNames(string[] columnNameArray)
+        {
+            Dictionary<string, int> hash = new Dictionary<string, int>(columnNameArray.Length);
+
+            int startIndex = columnNameArray.Length; // lowest non-unique index
+            for (int i = columnNameArray.Length - 1; 0 <= i; --i)
+            {
+                string columnName = columnNameArray[i];
+                if ((null != columnName) && (0 < columnName.Length))
+                {
+                    columnName = columnName.ToLowerInvariant();
+                    int index;
+                    if (hash.TryGetValue(columnName, out index))
+                    {
+                        startIndex = Math.Min(startIndex, index);
+                    }
+                    hash[columnName] = i;
+                }
+                else
+                {
+                    columnNameArray[i] = string.Empty;
+                    startIndex = i;
+                }
+            }
+            int uniqueIndex = 1;
+            for (int i = startIndex; i < columnNameArray.Length; ++i)
+            {
+                string columnName = columnNameArray[i];
+                if (0 == columnName.Length)
+                { // generate a unique name
+                    columnNameArray[i] = "Column";
+                    uniqueIndex = GenerateUniqueName(hash, ref columnNameArray[i], i, uniqueIndex);
+                }
+                else
+                {
+                    columnName = columnName.ToLowerInvariant();
+                    if (i != hash[columnName])
+                    {
+                        GenerateUniqueName(hash, ref columnNameArray[i], i, 1);
+                    }
+                }
+            }
+        }
+
+        static private int GenerateUniqueName(Dictionary<string, int> hash, ref string columnName, int index, int uniqueIndex)
+        {
+            for (; ; ++uniqueIndex)
+            {
+                string uniqueName = columnName + uniqueIndex.ToString(CultureInfo.InvariantCulture);
+                string lowerName = uniqueName.ToLowerInvariant();
+                if (!hash.ContainsKey(lowerName))
+                {
+                    columnName = uniqueName;
+                    hash.Add(lowerName, index);
+                    break;
+                }
+            }
+            return uniqueIndex;
+        }
+
+        static internal bool IsCatchableExceptionType(Exception e)
+        {
+            return !(e is NullReferenceException);
         }
     }
 }

--- a/src/System.Data.Common/src/System/Data/Common/DataRecordInternal.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DataRecordInternal.cs
@@ -1,0 +1,302 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System.Data.ProviderBase;
+using System.Diagnostics;
+
+namespace System.Data.Common
+{
+    internal sealed class DataRecordInternal : DbDataRecord
+    {
+        private SchemaInfo[] _schemaInfo;
+        private object[] _values;
+        private BasicFieldNameLookup _fieldNameLookup;
+
+        // copy all runtime data information
+        internal DataRecordInternal(SchemaInfo[] schemaInfo, object[] values, BasicFieldNameLookup fieldNameLookup)
+        {
+            Debug.Assert(null != schemaInfo, "invalid attempt to instantiate DataRecordInternal with null schema information");
+            Debug.Assert(null != values, "invalid attempt to instantiate DataRecordInternal with null value[]");
+            _schemaInfo = schemaInfo;
+            _values = values;
+            _fieldNameLookup = fieldNameLookup;
+        }
+
+        internal void SetSchemaInfo(SchemaInfo[] schemaInfo)
+        {
+            Debug.Assert(null == _schemaInfo, "invalid attempt to override DataRecordInternal schema information");
+            _schemaInfo = schemaInfo;
+        }
+
+        public override int FieldCount
+        {
+            get
+            {
+                return _schemaInfo.Length;
+            }
+        }
+
+        public override int GetValues(object[] values)
+        {
+            if (null == values)
+            {
+                throw ADP.ArgumentNull(nameof(values));
+            }
+
+            int copyLen = (values.Length < _schemaInfo.Length) ? values.Length : _schemaInfo.Length;
+            for (int i = 0; i < copyLen; i++)
+            {
+                values[i] = _values[i];
+            }
+            return copyLen;
+        }
+
+        public override string GetName(int i)
+        {
+            return _schemaInfo[i].name;
+        }
+
+
+        public override object GetValue(int i)
+        {
+            return _values[i];
+        }
+
+        public override string GetDataTypeName(int i)
+        {
+            return _schemaInfo[i].typeName;
+        }
+
+        public override Type GetFieldType(int i)
+        {
+            return _schemaInfo[i].type;
+        }
+
+        public override int GetOrdinal(string name)
+        {
+            return _fieldNameLookup.GetOrdinal(name);
+        }
+
+        public override object this[int i]
+        {
+            get
+            {
+                return GetValue(i);
+            }
+        }
+
+        public override object this[string name]
+        {
+            get
+            {
+                return GetValue(GetOrdinal(name));
+            }
+        }
+
+        public override bool GetBoolean(int i)
+        {
+            return ((bool)_values[i]);
+        }
+
+        public override byte GetByte(int i)
+        {
+            return ((byte)_values[i]);
+        }
+
+        public override long GetBytes(int i, long dataIndex, byte[] buffer, int bufferIndex, int length)
+        {
+            int cbytes = 0;
+            int ndataIndex;
+
+            byte[] data = (byte[])_values[i];
+
+            cbytes = data.Length;
+
+            // since arrays can't handle 64 bit values and this interface doesn't
+            // allow chunked access to data, a dataIndex outside the rang of Int32
+            // is invalid
+            if (dataIndex > Int32.MaxValue)
+            {
+                throw ADP.InvalidSourceBufferIndex(cbytes, dataIndex, nameof(dataIndex));
+            }
+
+            ndataIndex = (int)dataIndex;
+
+            // if no buffer is passed in, return the number of characters we have
+            if (null == buffer)
+                return cbytes;
+
+            try
+            {
+                if (ndataIndex < cbytes)
+                {
+                    // help the user out in the case where there's less data than requested
+                    if ((ndataIndex + length) > cbytes)
+                        cbytes = cbytes - ndataIndex;
+                    else
+                        cbytes = length;
+                }
+
+                // until arrays are 64 bit, we have to do these casts
+                Buffer.BlockCopy(data, ndataIndex, buffer, bufferIndex, (int)cbytes);
+            }
+            catch (Exception e)
+            {
+                if (ADP.IsCatchableExceptionType(e))
+                {
+                    cbytes = data.Length;
+
+                    if (length < 0)
+                        throw ADP.InvalidDataLength(length);
+
+                    // if bad buffer index, throw
+                    if (bufferIndex < 0 || bufferIndex >= buffer.Length)
+                        throw ADP.InvalidDestinationBufferIndex(length, bufferIndex, nameof(bufferIndex));
+
+                    // if bad data index, throw
+                    if (dataIndex < 0 || dataIndex >= cbytes)
+                        throw ADP.InvalidSourceBufferIndex(length, dataIndex, nameof(dataIndex));
+
+                    // if there is not enough room in the buffer for data
+                    if (cbytes + bufferIndex > buffer.Length)
+                        throw ADP.InvalidBufferSizeOrIndex(cbytes, bufferIndex);
+                }
+
+                throw;
+            }
+
+            return cbytes;
+        }
+
+        public override char GetChar(int i)
+        {
+            return ((string)_values[i])[0];
+        }
+
+        public override long GetChars(int i, long dataIndex, char[] buffer, int bufferIndex, int length)
+        {
+            var s = (string)_values[i];
+            int cchars = s.Length;
+
+            // since arrays can't handle 64 bit values and this interface doesn't
+            // allow chunked access to data, a dataIndex outside the rang of Int32
+            // is invalid
+            if (dataIndex > Int32.MaxValue)
+            {
+                throw ADP.InvalidSourceBufferIndex(cchars, dataIndex, nameof(dataIndex));
+            }
+
+            int ndataIndex = (int)dataIndex;
+
+            // if no buffer is passed in, return the number of characters we have
+            if (null == buffer)
+                return cchars;
+
+            try
+            {
+                if (ndataIndex < cchars)
+                {
+                    // help the user out in the case where there's less data than requested
+                    if ((ndataIndex + length) > cchars)
+                        cchars = cchars - ndataIndex;
+                    else
+                        cchars = length;
+                }
+
+                s.CopyTo(ndataIndex, buffer, bufferIndex, cchars);
+            }
+            catch (Exception e)
+            {
+                if (ADP.IsCatchableExceptionType(e))
+                {
+                    cchars = s.Length;
+
+                    if (length < 0)
+                        throw ADP.InvalidDataLength(length);
+
+                    // if bad buffer index, throw
+                    if (bufferIndex < 0 || bufferIndex >= buffer.Length)
+                        throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
+
+                    // if bad data index, throw
+                    if (ndataIndex < 0 || ndataIndex >= cchars)
+                        throw ADP.InvalidSourceBufferIndex(cchars, dataIndex, nameof(dataIndex));
+
+                    // if there is not enough room in the buffer for data
+                    if (cchars + bufferIndex > buffer.Length)
+                        throw ADP.InvalidBufferSizeOrIndex(cchars, bufferIndex);
+                }
+
+                throw;
+            }
+
+            return cchars;
+        }
+
+        public override Guid GetGuid(int i)
+        {
+            return ((Guid)_values[i]);
+        }
+
+
+        public override Int16 GetInt16(int i)
+        {
+            return ((Int16)_values[i]);
+        }
+
+        public override Int32 GetInt32(int i)
+        {
+            return ((Int32)_values[i]);
+        }
+
+        public override Int64 GetInt64(int i)
+        {
+            return ((Int64)_values[i]);
+        }
+
+        public override float GetFloat(int i)
+        {
+            return ((float)_values[i]);
+        }
+
+        public override double GetDouble(int i)
+        {
+            return ((double)_values[i]);
+        }
+
+        public override string GetString(int i)
+        {
+            return ((string)_values[i]);
+        }
+
+        public override Decimal GetDecimal(int i)
+        {
+            return ((Decimal)_values[i]);
+        }
+
+        public override DateTime GetDateTime(int i)
+        {
+            return ((DateTime)_values[i]);
+        }
+
+        public override bool IsDBNull(int i)
+        {
+            object o = _values[i];
+            return (null == o || o is DBNull);
+        }
+
+        //
+        // ICustomTypeDescriptor
+        //
+    }
+
+    // this doesn't change per record, only alloc once
+    internal struct SchemaInfo
+    {
+        public string name;
+        public string typeName;
+        public Type type;
+    }
+}

--- a/src/System.Data.Common/src/System/Data/Common/DbEnumerator.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbEnumerator.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+
+//------------------------------------------------------------------------------
+
+using System.Collections;
+using System.Data.ProviderBase;
+using System.Diagnostics;
+using System.ComponentModel;
+
+namespace System.Data.Common
+{
+    public class DbEnumerator : IEnumerator
+    {
+        internal DbDataReader _reader;
+        internal DbDataRecord _current;
+        internal SchemaInfo[] _schemaInfo; // shared schema info among all the data records
+        private BasicFieldNameLookup _fieldNameLookup;
+
+        private bool _closeReader;
+
+        public DbEnumerator(DbDataReader reader, bool closeReader)
+        {
+            if (null == reader)
+            {
+                throw ADP.ArgumentNull(nameof(reader));
+            }
+            _reader = reader;
+            _closeReader = closeReader;
+        }
+
+
+        public object Current
+        {
+            get
+            {
+                return _current;
+            }
+        }
+
+        public bool MoveNext()
+        {
+            if (null == _schemaInfo)
+            {
+                BuildSchemaInfo();
+            }
+
+            Debug.Assert(null != _schemaInfo, "unable to build schema information!");
+            _current = null;
+
+            if (_reader.Read())
+            {
+                // setup our current record
+                object[] values = new object[_schemaInfo.Length];
+                _reader.GetValues(values); // this.GetValues()
+                _current = new DataRecordInternal(_schemaInfo, values, _fieldNameLookup); // this.NewRecord()
+                return true;
+            }
+            if (_closeReader)
+            {
+                _reader.Dispose();
+            }
+            return false;
+        }
+
+        [EditorBrowsableAttribute(EditorBrowsableState.Never)]
+        public void Reset()
+        {
+            throw ADP.NotSupported();
+        }
+
+        private void BuildSchemaInfo()
+        {
+            int count = _reader.FieldCount;
+            string[] fieldnames = new string[count];
+            for (int i = 0; i < count; ++i)
+            {
+                fieldnames[i] = _reader.GetName(i);
+            }
+            ADP.BuildSchemaTableInfoTableNames(fieldnames);
+
+            SchemaInfo[] si = new SchemaInfo[count];
+            for (int i = 0; i < si.Length; i++)
+            {
+                SchemaInfo s = new SchemaInfo();
+                s.name = _reader.GetName(i);
+                s.type = _reader.GetFieldType(i);
+                s.typeName = _reader.GetDataTypeName(i);
+                si[i] = s;
+            }
+
+            _schemaInfo = si;
+            _fieldNameLookup = new BasicFieldNameLookup(_reader);
+        }
+    }
+}

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -60,7 +60,10 @@
     <Compile Include="System\Data\Common\DbConnectionStringCommon.cs" />
     <Compile Include="System\Data\Common\DbEnumerator.cs" />
     <Compile Include="$(CommonPath)\System\Data\Common\FieldNameLookup.cs">
-        <Link>System\Data\Common\FieldNameLookup.cs</Link>
+      <Link>System\Data\Common\FieldNameLookup.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Data\Common\BasicFieldNameLookup.cs">
+      <Link>System\Data\Common\BasicFieldNameLookup.cs</Link>
     </Compile>
     <Compile Include="System\Data\Common\MultipartIdentifier.cs" />
     <Compile Include="System\Data\Common\NameValuePair.cs" />
@@ -151,12 +154,12 @@
     <Compile Include="System\Data\SqlTypes\SqlXml.cs" />
     <Compile Include="$(CommonPath)\System\NotImplemented.cs" />
     <Compile Include="$(CommonPath)\System\Data\Locale\Locale.cs">
-        <Link>System\Data\Locale\Locale.cs</Link>
+      <Link>System\Data\Locale\Locale.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(IsPartialFacadeAssembly)' != 'true' ">
     <Compile Include="$(CommonPath)\System\Data\Locale\LocaleMapper.Windows.cs">
-        <Link>System\Data\Locale\LocaleMapper.Windows.cs</Link>
+      <Link>System\Data\Locale\LocaleMapper.Windows.cs</Link>
     </Compile>
     <Compile Include="System\Data\ProviderBase\DbConnectionPoolIdentity.Windows.cs" />
     <Compile Include="Interop\SNINativeMethodWrapper.Windows.cs" />
@@ -164,7 +167,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' != 'true' And '$(IsPartialFacadeAssembly)' != 'true' ">
     <Compile Include="$(CommonPath)\System\Data\Locale\LocaleMapper.Unix.cs">
-        <Link>System\Data\Locale\LocaleMapper.Unix.cs</Link>
+      <Link>System\Data\Locale\LocaleMapper.Unix.cs</Link>
     </Compile>
     <Compile Include="System\Data\ProviderBase\DbConnectionPoolIdentity.Unix.cs" />
     <Compile Include="Interop\SNINativeMethodWrapper.Unix.cs" />


### PR DESCRIPTION
The commit contains the following changes.

1.  DbEnumerator and the other related classes have been moved to System.Data.Common
2. Refactored FieldNameLookup to extract a base class which doesn't need to do a Locale based comparison to avoid making System.Data.Common dependent on Locale functionality.