### PR TITLE
Added KeepProjectReference flag to the tests that are not compiling.

### DIFF
--- a/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
+++ b/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
@@ -33,6 +33,7 @@
     <ProjectReference Include="..\..\src\System.Net.Primitives.csproj">
       <Project>{8772BC91-7B55-49B9-94FA-4B1BE5BEAB55}</Project>
       <Name>System.Net.Primitives</Name>
+      <KeepProjectReference>true</KeepProjectReference>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\src\System.Security.Cryptography.Cng.csproj">
       <Project>{4C1BD451-6A99-45E7-9339-79C77C42EE9E}</Project>
       <Name>System.Security.Cryptography.Cng</Name>
+      <KeepProjectReference>true</KeepProjectReference>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Xml.XDocument/tests/TreeManipulation/System.Xml.XDocument.TreeManipulation.Tests.csproj
+++ b/src/System.Xml.XDocument/tests/TreeManipulation/System.Xml.XDocument.TreeManipulation.Tests.csproj
@@ -8,6 +8,8 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Xml.XDocument.TreeManipulation.Tests</AssemblyName>
     <RootNamespace>XLinqTests</RootNamespace>
+    <!-- Don't allow project reference to package dependency conversion -->
+    <KeepAllProjectReferences>true</KeepAllProjectReferences>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Xml.XmlSerializer/tests/System.Xml.XmlSerializer.Tests.csproj
+++ b/src/System.Xml.XmlSerializer/tests/System.Xml.XmlSerializer.Tests.csproj
@@ -31,11 +31,12 @@
     </ProjectReference>
       <ProjectReference Include="..\..\System.Runtime.Serialization.Primitives\src\System.Runtime.Serialization.Primitives.csproj">
       <Project>{CDF0ACB5-1361-4E48-8ECB-22E8022F5F01}</Project>
-    <Name>System.Runtime.Serialization.Primitives</Name>
+      <Name>System.Runtime.Serialization.Primitives</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Xml.XmlSerializer\src\System.Xml.XmlSerializer.csproj">
       <Project>{D62A6082-5229-4845-8BE9-75753E08C65A}</Project>
       <Name>System.Xml.XmlSerializer</Name>
+      <KeepProjectReference>true</KeepProjectReference>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
These are the tests that are not compiling as of today. I added these flags to get the build to not have errors.
@weshaggard , @ericstj  : Please have a look. 
Should we file an issue to track this?