### PR TITLE
Associate issues with more TODO comments in System.Net

### DIFF
--- a/src/Common/src/System/Net/Http/WinHttpException.cs
+++ b/src/Common/src/System/Net/Http/WinHttpException.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices;
 
 namespace System.Net.Http
 {
-    // TODO(Issue 2542): Unify this code (and other common code) with WinHttpHandler.
     internal class WinHttpException : Win32Exception
     {
         public WinHttpException(int error, string message) : base(error, message)

--- a/src/Common/src/System/Net/Internals/SocketExceptionFactory.cs
+++ b/src/Common/src/System/Net/Internals/SocketExceptionFactory.cs
@@ -10,7 +10,7 @@ namespace System.Net.Internals
     {
         public static SocketException CreateSocketException(int socketError, EndPoint endPoint)
         {
-            // TODO: expose SocketException(int, EndPoint) to maintain exception Message compatibility.
+            // TODO (#7873): expose SocketException(int, EndPoint) to maintain exception Message compatibility.
             return new SocketException(socketError);
         }
     }

--- a/src/Common/src/System/Net/Logging/NetEventSource.cs
+++ b/src/Common/src/System/Net/Logging/NetEventSource.cs
@@ -7,7 +7,7 @@ using System.Globalization;
 
 namespace System.Net
 {
-    // TODO: Issue #5101: This class should not change or it can introduce incompatibility issues.
+    // TODO: Issue #5144: This class should not change or it can introduce incompatibility issues.
     [EventSource(Name = "Microsoft-System-Net",
         Guid = "501a994a-eb63-5415-9af1-1b031260f16c")]
     internal sealed class NetEventSource : EventSource

--- a/src/Common/src/System/Net/NetworkInformation/HostInformationPal.NetNative.cs
+++ b/src/Common/src/System/Net/NetworkInformation/HostInformationPal.NetNative.cs
@@ -29,8 +29,6 @@ namespace System.Net.NetworkInformation
             return s_fixedInfo.domainName;
         }
 
-        // TODO: #2485: Temporarily made GetFixedInfo() public to make things build.
-        // This function needs to be switched back to private since it has no correspondent in the Unix world.
         public static Interop.IpHlpApi.FIXED_INFO GetFixedInfo()
         {
             Interop.IpHlpApi.FIXED_INFO fixedInfo = new Interop.IpHlpApi.FIXED_INFO();

--- a/src/Common/src/System/Net/NetworkInformation/HostInformationPal.Windows.cs
+++ b/src/Common/src/System/Net/NetworkInformation/HostInformationPal.Windows.cs
@@ -30,8 +30,6 @@ namespace System.Net.NetworkInformation
             return s_fixedInfo.domainName;
         }
 
-        // TODO: #2485: Temporarily made GetFixedInfo() public to make things build.
-        // This function needs to be switched back to private since it has no correspondent in the Unix world.
         public static Interop.IpHlpApi.FIXED_INFO GetFixedInfo()
         {
             uint size = 0;

--- a/src/Common/tests/System/Net/Sockets/SocketTestServerAPM.cs
+++ b/src/Common/tests/System/Net/Sockets/SocketTestServerAPM.cs
@@ -154,7 +154,6 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        // TODO: Cache and reuse ServerSocketState objects.
         private class ServerSocketState
         {
             private Socket __socket;

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -624,7 +624,7 @@ namespace System.Net.Http
             // Serialize entity-body (content) headers.
             if (requestMessage.Content != null)
             {
-                // TODO: Content-Length header isn't getting correctly placed using ToString()
+                // TODO (#5523): Content-Length header isn't getting correctly placed using ToString()
                 // This is a bug in HttpContentHeaders that needs to be fixed.
                 if (requestMessage.Content.Headers.ContentLength.HasValue)
                 {

--- a/src/System.Net.Http/src/Shims/Uri.cs
+++ b/src/System.Net.Http/src/Shims/Uri.cs
@@ -4,7 +4,7 @@
 
 namespace System
 {
-    // TODO: Move this class to System.Net.Common.
+    // TODO (#5715): Move this class to System.Net.Common.
     internal class UriShim
     {
         private const char c_DummyChar = (char)0xFFFF;

--- a/src/System.Net.Http/src/System/Net/Http/Headers/UriHeaderParser.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/UriHeaderParser.cs
@@ -56,7 +56,7 @@ namespace System.Net.Http.Headers
             return true;
         }
 
-        // TODO: This is a helper method copied from WebHeaderCollection.HeaderEncoding.DecodeUtf8FromString.
+        // TODO (#5525): This is a helper method copied from WebHeaderCollection.HeaderEncoding.DecodeUtf8FromString.
         // Merge this code and move to System.Net.Common.
         //
         // The normal client header parser just casts bytes to chars (see GetString).

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -136,7 +136,7 @@ namespace System.Net.Http
             // 'Transfer-Encoding: chunked'. The handler will never automatically buffer in the request content.
             get { return 0; }
             
-            // TODO: Add message/link to exception explaining the deprecation. 
+            // TODO (#7879): Add message/link to exception explaining the deprecation. 
             // Update corresponding exception in HttpClientHandler.Unix.cs if/when this is updated.
             set { throw new PlatformNotSupportedException(); }
         }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -645,7 +645,7 @@ namespace System.Net.Http
 
             internal sealed class SendTransferState
             {
-                internal readonly byte[] _buffer = new byte[RequestBufferSize]; // PERF TODO: Determine if this should be optimized to start smaller and grow
+                internal readonly byte[] _buffer = new byte[RequestBufferSize]; // PERF TODO (#7884): Determine if this should be optimized to start smaller and grow
                 internal int _offset;
                 internal int _count;
                 internal Task<int> _task;

--- a/src/System.Net.Http/src/netcore50/System/Net/CookieHelper.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/CookieHelper.cs
@@ -27,7 +27,7 @@ namespace System.Net
             }
             catch (InternalCookieException)
             {
-                // TODO: We should log this.  But there isn't much we can do about it other
+                // TODO (#7856): We should log this.  But there isn't much we can do about it other
                 // than to drop the rest of the cookies.
             }
             

--- a/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
@@ -350,7 +350,7 @@ namespace System.Net.Http
             
             // The .NET Desktop System.Net Http APIs (based on HttpWebRequest/HttpClient) uses no caching by default.
             // To preserve app-compat, we turn off caching (as much as possible) in the WinRT HttpClient APIs.
-            // TODO: use RTHttpCacheReadBehavior.NoCache when available in the next version of WinRT HttpClient API.
+            // TODO (#7877): use RTHttpCacheReadBehavior.NoCache when available in the next version of WinRT HttpClient API.
             this.rtFilter.CacheControl.ReadBehavior = RTHttpCacheReadBehavior.MostRecent; 
             this.rtFilter.CacheControl.WriteBehavior = RTHttpCacheWriteBehavior.NoCache;
         }

--- a/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
@@ -307,7 +307,7 @@ namespace System.Net.Http
 
         public bool CheckCertificateRevocationList
         {
-            // TODO: We can't get this property to actually work yet since the current WinRT Windows.Web.Http APIs don't have a setting for this.
+            // We can't get this property to actually work yet since the current WinRT Windows.Web.Http APIs don't have a setting for this.
             // FYI: The WinRT API always checks for certificate revocation. If the revocation status can't be determined completely, i.e.
             // the revocation server is offline, then the request is still allowed.
             get { return true; }

--- a/src/System.Net.Http/src/netcore50/System/Net/HttpHandlerToFilter.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpHandlerToFilter.cs
@@ -90,7 +90,7 @@ namespace System.Net.Http
                 }
                 else
                 {
-                    // TODO: We need to throw an exception here similar to .NET Desktop
+                    // TODO (#7878): We need to throw an exception here similar to .NET Desktop
                     // throw new ArgumentException(SR.GetString(SR.net_wrongversion), "value");
                     //
                     // But we need to do that checking in the HttpClientHandler object itself.

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -380,7 +380,7 @@ namespace System.Net.Http.Functional.Tests
         [OuterLoop]
         public void Timeout_SetTo60AndGetResponseFromServerWhichTakes40_Success()
         {
-            // TODO: This server path will change once the final test infrastructure is in place (Issue #1477).
+            // TODO: This is a placeholder until GitHub Issue #2383 gets resolved.
             const string SlowServer = "http://httpbin.org/drip?numbytes=1&duration=1&delay=40&code=200";
             
             using (var client = new HttpClient())

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -472,8 +472,6 @@ namespace System.Net.Http.Functional.Tests
                 }
 
                 Assert.False(requestLogged, "Request was logged while logging disabled.");
-                // TODO: Waiting for one second is not ideal, but how else be reasonably sure that
-                // some logging message hasn't slipped through?
                 WaitForFalse(() => responseLogged, TimeSpan.FromSeconds(1), "Response was logged while logging disabled.");
             }
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpMethodTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpMethodTest.cs
@@ -54,17 +54,23 @@ namespace System.Net.Http.Functional.Tests
             Assert.Throws<ArgumentException>(() => { new HttpMethod(null); } );
         }
 
-        // TODO: This should be a [Theory]
-        [Fact]
-        public void Ctor_SeparatorInMethod_Exception()
+        [Theory]
+        [InlineData('(')]
+        [InlineData(')')]
+        [InlineData('<')]
+        [InlineData('>')]
+        [InlineData('@')]
+        [InlineData(',')]
+        [InlineData(';')]
+        [InlineData(':')]
+        [InlineData('\\')]
+        [InlineData('"')]
+        [InlineData('/')]
+        [InlineData('[')]
+        [InlineData(']')]
+        public void Ctor_SeparatorInMethod_Exception(char separator)
         {
-            char[] separators = new char[] { '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', 
-                '?', '=', '{', '}', ' ', '\t' };
-
-            for (int i = 0; i < separators.Length; i++)
-            {
-                Assert.Throws<FormatException>(() => { new HttpMethod("Get" + separators[i]); } );
-            }
+            Assert.Throws<FormatException>(() => { new HttpMethod("Get" + separator); } );
         }
 
         [Fact]

--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -141,7 +141,7 @@ namespace System.Net.Http.Functional.Tests
         // These methods help to validate the response body since the endpoint will echo
         // all request headers.
         //
-        // TODO: This validation will be improved in the future once the test server endpoint
+        // TODO (#7885): This validation will be improved in the future once the test server endpoint
         // is able to provide a custom response header with a SHA1 hash of the expected response body.
         private readonly string[] CustomHeaderValues = new string[] {"abcdefg", "12345678", "A1B2C3D4"};
         private HttpClient GetHttpClient()

--- a/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
@@ -10,12 +10,12 @@ using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
-    // TODO: This class will eventually be moved to Common once the HttpTestServers are finalized.
+    // TODO (#5525): This class will eventually be moved to Common once the HttpTestServers are finalized.
     public static class TestHelper
     {
         public static bool JsonMessageContainsKeyValue(string message, string key, string value)
         {
-            // TODO: Align with the rest of tests w.r.t response parsing once the test server is finalized.
+            // TODO (#5525): Align with the rest of tests w.r.t response parsing once the test server is finalized.
             // Currently not adding any new dependencies
             string pattern = string.Format(@"""{0}"": ""{1}""", key, value);
             return message.Contains(pattern);
@@ -23,7 +23,7 @@ namespace System.Net.Http.Functional.Tests
 
         public static bool JsonMessageContainsKey(string message, string key)
         {
-            // TODO: Align with the rest of tests w.r.t response parsing once the test server is finalized.
+            // TODO (#5525): Align with the rest of tests w.r.t response parsing once the test server is finalized.
             // Currently not adding any new dependencies
             string pattern = string.Format(@"""{0}"": """, key);
             return message.Contains(pattern);

--- a/src/System.Net.Http/tests/UnitTests/HttpRuleParserTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpRuleParserTest.cs
@@ -15,28 +15,44 @@ namespace System.Net.Http.Tests
     {
         private const string ValidTokenChars = "!#$%&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz^_`|~";
 
-        [Fact]
-        public void IsTokenChar_IterateArrayWithAllValidTokenChars_AllCharsConsideredValid()
+        public static IEnumerable<object[]> ValidTokenCharsArguments
         {
-            for (int i = 0; i < ValidTokenChars.Length; i++)
+            get
             {
-                // TODO: This test should be a [Theory]
-                Assert.True(HttpRuleParser.IsTokenChar(ValidTokenChars[i]));
+                foreach (var c in ValidTokenChars)
+                {
+                    yield return new object[] { c };
+                }
             }
         }
 
-        [Fact]
-        public void IsTokenChar_IterateArrayWithAllInvalidTokenChars_AllCharsConsideredInvalid()
+        public static IEnumerable<object[]> InvalidTokenCharsArguments
         {
-            // All octets not in 'validTokenChars' must be considered invalid characters.
-            for (int i = 0; i < 256; i++)
+            get
             {
-                if (ValidTokenChars.IndexOf((char)i) == -1)
+                // All octets not in 'ValidTokenChars' must be considered invalid characters.
+                for (int i = 0; i < 256; i++)
                 {
-                    // TODO: This test should be a [Theory]
-                    Assert.False(HttpRuleParser.IsTokenChar((char)i));
+                    if (ValidTokenChars.IndexOf((char)i) == -1)
+                    {
+                        yield return new object[] { (char)i };
+                    }
                 }
             }
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidTokenCharsArguments))]
+        public void IsTokenChar_ValidTokenChars_ConsideredValid(char token)
+        {
+            Assert.True(HttpRuleParser.IsTokenChar(token));
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTokenCharsArguments))]
+        public void IsTokenChar_InvalidTokenChars_ConsideredInvalid(char token)
+        {
+            Assert.False(HttpRuleParser.IsTokenChar(token));
         }
 
         [Fact]

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
@@ -136,7 +136,7 @@ namespace System.Net.NetworkInformation
         // Maps values from /sys/class/net/<interface>/operstate to OperationStatus values.
         private static OperationalStatus MapState(string state)
         {
-            // TODO: Figure out the possible values that Linux might return.
+            // TODO (#7889): Figure out the possible values that Linux might return.
             switch (state)
             {
                 case "up":

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxNetworkInterface.cs
@@ -83,7 +83,7 @@ namespace System.Net.NetworkInformation
         {
             get
             {
-                // TODO: This is a crude approximation, but does allow us to determine
+                // This is a crude approximation, but does allow us to determine
                 // whether an interface is operational or not. The OS exposes more information
                 // (see ifconfig and the "Status" label), but it's unclear how closely
                 // that information maps to the OperationalStatus enum we expose here.

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemIPGlobalProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemIPGlobalProperties.cs
@@ -22,7 +22,6 @@ namespace System.Net.NetworkInformation
         {
             get
             {
-                // TODO: #2485: This will need to be moved to PAL.
                 return HostInformationPal.GetFixedInfo();
             }
         }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
@@ -89,7 +89,6 @@ namespace System.Net.NetworkInformation
             uint bufferSize = 0;
             SafeLocalAllocHandle buffer = null;
 
-            // TODO: #2485: This will probably require changes in the PAL for HostInformation.
             Interop.IpHlpApi.FIXED_INFO fixedInfo = HostInformationPal.GetFixedInfo();
             List<SystemNetworkInterface> interfaceList = new List<SystemNetworkInterface>();
 

--- a/src/System.Net.Requests/src/System/Net/RequestStream.cs
+++ b/src/System.Net.Requests/src/System/Net/RequestStream.cs
@@ -114,7 +114,7 @@ namespace System.Net
 
             if (!success)
             {
-                // TODO: Need to figure out how to log this and throw a good exception.
+                // TODO (#7890): Need to figure out how to log this and throw a good exception.
                 throw new Exception();
             }
 

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocket.cs
@@ -16,7 +16,7 @@ namespace System.Net.WebSockets
     internal class WinHttpWebSocket : WebSocket
     {
         #region Constants
-        // TODO: This code needs to be shared with WinHttpClientHandler
+        // TODO (#7893): This code needs to be shared with WinHttpClientHandler
         private const string HeaderNameCookie = "Cookie";
         private const string HeaderNameWebSocketProtocol = "Sec-WebSocket-Protocol";
         #endregion

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocketCallback.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocketCallback.cs
@@ -183,10 +183,10 @@ namespace System.Net.WebSockets
                 SR.net_webstatus_ConnectFailure,
                 innerException);
 
-            // TODO: handle SSL related exceptions.
+            // TODO (#2509): handle SSL related exceptions.
             state.UpdateState(WebSocketState.Closed);
 
-            // TODO: Create exception from WINHTTP_CALLBACK_STATUS_SECURE_FAILURE flags.
+            // TODO (#2509): Create exception from WINHTTP_CALLBACK_STATUS_SECURE_FAILURE flags.
             state.TcsUpgrade.TrySetException(exception);
         }
         #endregion

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -380,7 +380,7 @@ namespace System.Net.WebSockets
         }
 
         #region State // Code related to state management
-        // TODO: Refactor state into encapsulated class
+        // TODO (#7896): Refactor state into encapsulated class
         public void InterlockedCheckValidStates(WebSocketState[] validStates)
         {
             lock (_stateLock)


### PR DESCRIPTION
This covers all TODO comments I found in the System.Net code.  We should now have an open issue for every TODO, and every TODO should reference each issue by ID. 

There were a couple of comments suggesting that we change some iterative `[Fact]` cases into `[Theory]` cases; rather than file issues on these, I just went ahead and did it.

@stephentoub, @CIPop, @davidsh