### PR TITLE
Move GCHandle from System.Runtime to System.Runtime.InteropServices.PInvoke

### DIFF
--- a/src/System.Runtime.InteropServices.PInvoke/ref/System.Runtime.InteropServices.PInvoke.cs
+++ b/src/System.Runtime.InteropServices.PInvoke/ref/System.Runtime.InteropServices.PInvoke.cs
@@ -24,6 +24,37 @@ namespace System
 namespace System.Runtime.InteropServices
 {
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct GCHandle
+    {
+        public bool IsAllocated { get { return default(bool); } }
+        public object Target { [System.Security.SecurityCriticalAttribute]get { return default(object); } [System.Security.SecurityCriticalAttribute]set { } }
+        [System.Security.SecurityCriticalAttribute]
+        public System.IntPtr AddrOfPinnedObject() { return default(System.IntPtr); }
+        [System.Security.SecurityCriticalAttribute]
+        public static System.Runtime.InteropServices.GCHandle Alloc(object value) { return default(System.Runtime.InteropServices.GCHandle); }
+        [System.Security.SecurityCriticalAttribute]
+        public static System.Runtime.InteropServices.GCHandle Alloc(object value, System.Runtime.InteropServices.GCHandleType type) { return default(System.Runtime.InteropServices.GCHandle); }
+        public override bool Equals(object o) { return default(bool); }
+        [System.Security.SecurityCriticalAttribute]
+        public void Free() { }
+        [System.Security.SecurityCriticalAttribute]
+        public static System.Runtime.InteropServices.GCHandle FromIntPtr(System.IntPtr value) { return default(System.Runtime.InteropServices.GCHandle); }
+        public override int GetHashCode() { return default(int); }
+        public static bool operator ==(System.Runtime.InteropServices.GCHandle a, System.Runtime.InteropServices.GCHandle b) { return default(bool); }
+        [System.Security.SecurityCriticalAttribute]
+        public static explicit operator System.Runtime.InteropServices.GCHandle(System.IntPtr value) { return default(System.Runtime.InteropServices.GCHandle); }
+        public static explicit operator System.IntPtr(System.Runtime.InteropServices.GCHandle value) { return default(System.IntPtr); }
+        public static bool operator !=(System.Runtime.InteropServices.GCHandle a, System.Runtime.InteropServices.GCHandle b) { return default(bool); }
+        public static System.IntPtr ToIntPtr(System.Runtime.InteropServices.GCHandle value) { return default(System.IntPtr); }
+    }
+    public enum GCHandleType
+    {
+        Normal = 2,
+        Pinned = 3,
+        Weak = 0,
+        WeakTrackResurrection = 1,
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ArrayWithOffset
     {
         public ArrayWithOffset(object array, int offset) { throw new System.NotImplementedException(); }

--- a/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -9,13 +9,11 @@
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.CriticalHandle))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.SafeHandle))]
 
-// Types moved to System.Runtime
-[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.GCHandle))]
-[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.GCHandleType))]
-
 // Types moved to System.Runtime.InteropServices.PInvoke
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.DataMisalignedException))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.DllNotFoundException))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.GCHandle))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.GCHandleType))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.ArrayWithOffset))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.BestFitMappingAttribute))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.CallingConvention))]

--- a/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.csproj
+++ b/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.csproj
@@ -18,5 +18,13 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../System.Runtime.InteropServices.PInvoke/ref/System.Runtime.InteropServices.PInvoke.csproj">
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="../../System.Runtime/ref/System.Runtime.csproj">
+      <Private>false</Private>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime/ref/System.Runtime.Manual.cs
+++ b/src/System.Runtime/ref/System.Runtime.Manual.cs
@@ -44,38 +44,3 @@ namespace System
         public abstract string Name { get; }
     }
 }
-
-namespace System.Runtime.InteropServices
-{
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct GCHandle
-    {
-        public bool IsAllocated { get { return default(bool); } }
-        public object Target { [System.Security.SecurityCriticalAttribute]get { return default(object); } [System.Security.SecurityCriticalAttribute]set { } }
-        [System.Security.SecurityCriticalAttribute]
-        public System.IntPtr AddrOfPinnedObject() { return default(System.IntPtr); }
-        [System.Security.SecurityCriticalAttribute]
-        public static System.Runtime.InteropServices.GCHandle Alloc(object value) { return default(System.Runtime.InteropServices.GCHandle); }
-        [System.Security.SecurityCriticalAttribute]
-        public static System.Runtime.InteropServices.GCHandle Alloc(object value, System.Runtime.InteropServices.GCHandleType type) { return default(System.Runtime.InteropServices.GCHandle); }
-        public override bool Equals(object o) { return default(bool); }
-        [System.Security.SecurityCriticalAttribute]
-        public void Free() { }
-        [System.Security.SecurityCriticalAttribute]
-        public static System.Runtime.InteropServices.GCHandle FromIntPtr(System.IntPtr value) { return default(System.Runtime.InteropServices.GCHandle); }
-        public override int GetHashCode() { return default(int); }
-        public static bool operator ==(System.Runtime.InteropServices.GCHandle a, System.Runtime.InteropServices.GCHandle b) { return default(bool); }
-        [System.Security.SecurityCriticalAttribute]
-        public static explicit operator System.Runtime.InteropServices.GCHandle(System.IntPtr value) { return default(System.Runtime.InteropServices.GCHandle); }
-        public static explicit operator System.IntPtr(System.Runtime.InteropServices.GCHandle value) { return default(System.IntPtr); }
-        public static bool operator !=(System.Runtime.InteropServices.GCHandle a, System.Runtime.InteropServices.GCHandle b) { return default(bool); }
-        public static System.IntPtr ToIntPtr(System.Runtime.InteropServices.GCHandle value) { return default(System.IntPtr); }
-    }
-    public enum GCHandleType
-    {
-        Normal = 2,
-        Pinned = 3,
-        Weak = 0,
-        WeakTrackResurrection = 1,
-    }
-}

--- a/src/System.Runtime/src/System.Runtime.Forwards.cs
+++ b/src/System.Runtime/src/System.Runtime.Forwards.cs
@@ -1,0 +1,6 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. 
+// The .NET Foundation licenses this file to you under the MIT license. 
+// See the LICENSE file in the project root for more information. 
+
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.GCHandle))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.InteropServices.GCHandleType))]

--- a/src/System.Runtime/src/System.Runtime.csproj
+++ b/src/System.Runtime/src/System.Runtime.csproj
@@ -16,6 +16,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462_Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="System.Runtime.Forwards.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net462'">
     <Compile Include="System\Action.cs" />
     <Compile Include="System\Function.cs" />


### PR DESCRIPTION
I had an earlier change that moved GCHandle from System.Runtime.InteropServices to System.Runtime: https://github.com/dotnet-bot/corefx/commit/4af3f030a158af663dfc42533adab290b294114b

It turns out that changing the System.Runtime contract in this way will make it more difficult for us to do some future work involving
- enabling the the use of System.Runtime.InteropServices.PInvoke on all releases, and
- allowing the use of the System.Runtime.InteropServices legacy contract on all releases that support it.

This future work will involve creating new type forwarders and facades for the types that have been moved out of System.Runtime.InteropServices, and the involvement of the System.Runtime contract would greatly complicate the work needed to be done. Thus, this PR moves the GCHandle and GCHandleType types from System.Runtime into System.Runtime.InteropServices.PInvoke. The new PInvoke contract is a good place for it, since it is meant to be part of our cross platform offerings.