### PR TITLE
Fix shell assignment to IgnoreForCI

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -254,7 +254,7 @@ coreclr_code_coverage()
 
 ((serverGC = 0))
 OuterLoop="-notrait category=outerloop"
-IgnoreForCI =""
+IgnoreForCI=""
 
 while [[ $# > 0 ]]
 do


### PR DESCRIPTION
This form: "A =bcd" has no effect.

There mustn't be whitespace between a variable and =.