### PR TITLE
Multiple fixes and cleanups for ArrayPool

### DIFF
--- a/src/System.Buffers/src/System/Buffers/ArrayPool.cs
+++ b/src/System.Buffers/src/System/Buffers/ArrayPool.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace System.Buffers
@@ -37,17 +38,15 @@ namespace System.Buffers
         /// </remarks>
         public static ArrayPool<T> Shared
         {
-            get
-            {
-                ArrayPool<T> instance = Volatile.Read(ref s_sharedInstance);
-                if (instance == null)
-                {
-                    Interlocked.CompareExchange(ref s_sharedInstance, Create(), null);
-                    instance = s_sharedInstance;
-                }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return Volatile.Read(ref s_sharedInstance) ?? EnsureSharedCreated(); }
+        }
 
-                return instance;
-            }
+        /// <summary>Ensures that <see cref="s_sharedInstance"/> has been initialized to a pool and returns it.</summary>
+        private static ArrayPool<T> EnsureSharedCreated()
+        {
+            Interlocked.CompareExchange(ref s_sharedInstance, Create(), null);
+            return s_sharedInstance;
         }
 
         /// <summary>
@@ -97,12 +96,12 @@ namespace System.Buffers
         /// Returns to the pool an array that was previously obtained via <see cref="Rent"/> on the same 
         /// <see cref="ArrayPool{T}"/> instance.
         /// </summary>
-        /// <param name="buffer">
+        /// <param name="array">
         /// The buffer previously obtained from <see cref="Rent"/> to return to the pool.
         /// </param>
         /// <param name="clearArray">
         /// If <c>true</c> and if the pool will store the buffer to enable subsequent reuse, <see cref="Return"/>
-        /// will clear <paramref name="buffer"/> of its contents so that a subsequent consumer via <see cref="Rent"/> 
+        /// will clear <paramref name="array"/> of its contents so that a subsequent consumer via <see cref="Rent"/> 
         /// will not see the previous consumer's content.  If <c>false</c> or if the pool will release the buffer,
         /// the array's contents are left unchanged.
         /// </param>
@@ -113,6 +112,6 @@ namespace System.Buffers
         /// may hold onto the returned buffer in order to rent it again, or it may release the returned buffer
         /// if it's determined that the pool already has enough buffers stored.
         /// </remarks>
-        public abstract void Return(T[] buffer, bool clearArray = false);
+        public abstract void Return(T[] array, bool clearArray = false);
     }
 }

--- a/src/System.Buffers/src/System/Buffers/ArrayPool.cs
+++ b/src/System.Buffers/src/System/Buffers/ArrayPool.cs
@@ -43,6 +43,7 @@ namespace System.Buffers
         }
 
         /// <summary>Ensures that <see cref="s_sharedInstance"/> has been initialized to a pool and returns it.</summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static ArrayPool<T> EnsureSharedCreated()
         {
             Interlocked.CompareExchange(ref s_sharedInstance, Create(), null);

--- a/src/System.Buffers/src/System/Buffers/ArrayPoolEventSource.cs
+++ b/src/System.Buffers/src/System/Buffers/ArrayPoolEventSource.cs
@@ -11,64 +11,68 @@ namespace System.Buffers
     {
         internal readonly static ArrayPoolEventSource Log = new ArrayPoolEventSource();
 
-        internal enum BufferAllocationReason : int
+        /// <summary>The reason for a BufferAllocated event.</summary>
+        internal enum BufferAllocatedReason : int
         {
+            /// <summary>The pool is allocating a buffer to be pooled in a bucket.</summary>
             Pooled,
+            /// <summary>The requested buffer size was too large to be pooled.</summary>
             OverMaximumSize,
+            /// <summary>The pool has already allocated for pooling as many buffers of a particular size as it's allowed.</summary>
             PoolExhausted
         }
 
+        /// <summary>
+        /// Event for when a buffer is rented.  This is invoked once for every successful call to Rent,
+        /// regardless of whether a buffer is allocated or a buffer is taken from the pool.  In a
+        /// perfect situation where all rented buffers are returned, we expect to see the number
+        /// of BufferRented events exactly match the number of BuferReturned events, with the number
+        /// of BufferAllocated events being less than or equal to those numbers (ideally significantly
+        /// less than).
+        /// </summary>
         [Event(1, Level = EventLevel.Verbose)]
-        internal void BufferRented(int bufferId, int bufferSize, int poolId, int bucketId) =>
-            WriteEventHelper(1, bufferId, bufferSize, poolId, bucketId);
+        internal unsafe void BufferRented(int bufferId, int bufferSize, int poolId, int bucketId)
+        {
+            EventData* payload = stackalloc EventData[4];
+            payload[0].Size = sizeof(int);
+            payload[0].DataPointer = ((IntPtr)(&bufferId));
+            payload[1].Size = sizeof(int);
+            payload[1].DataPointer = ((IntPtr)(&bufferSize));
+            payload[2].Size = sizeof(int);
+            payload[2].DataPointer = ((IntPtr)(&poolId));
+            payload[3].Size = sizeof(int);
+            payload[3].DataPointer = ((IntPtr)(&bucketId));
+            WriteEventCore(1, 4, payload);
+        }
 
+        /// <summary>
+        /// Event for when a buffer is allocated by the pool.  In an ideal situation, the number
+        /// of BufferAllocated events is significantly smaller than the number of BufferRented and
+        /// BufferReturned events.
+        /// </summary>
         [Event(2, Level = EventLevel.Informational)]
-        internal void BufferAllocated(int bufferId, int bufferSize, int poolId, int bucketId, BufferAllocationReason reason)
+        internal unsafe void BufferAllocated(int bufferId, int bufferSize, int poolId, int bucketId, BufferAllocatedReason reason)
         {
-            unsafe
-            {
-                 EventData* payload = stackalloc EventData[5];
-                 payload[0].Size = sizeof(int);
-                 payload[0].DataPointer = ((IntPtr) (&bufferId));
-                 payload[1].Size = sizeof(int);
-                 payload[1].DataPointer = ((IntPtr) (&bufferSize));
-                 payload[2].Size = sizeof(int);
-                 payload[2].DataPointer = ((IntPtr) (&poolId));
-                 payload[3].Size = sizeof(int);
-                 payload[3].DataPointer = ((IntPtr) (&bucketId));
-                 payload[4].Size = sizeof(BufferAllocationReason);
-                 payload[4].DataPointer = ((IntPtr) (&reason));
-                 WriteEventCore(2, 5, payload);
-             }
+            EventData* payload = stackalloc EventData[5];
+            payload[0].Size = sizeof(int);
+            payload[0].DataPointer = ((IntPtr)(&bufferId));
+            payload[1].Size = sizeof(int);
+            payload[1].DataPointer = ((IntPtr)(&bufferSize));
+            payload[2].Size = sizeof(int);
+            payload[2].DataPointer = ((IntPtr)(&poolId));
+            payload[3].Size = sizeof(int);
+            payload[3].DataPointer = ((IntPtr)(&bucketId));
+            payload[4].Size = sizeof(BufferAllocatedReason);
+            payload[4].DataPointer = ((IntPtr)(&reason));
+            WriteEventCore(2, 5, payload);
         }
 
+        /// <summary>
+        /// Event raised when a buffer is returned to the pool.  This event is raised regardless of whether
+        /// the returned buffer is stored or dropped.  In an ideal situation, the number of BufferReturned
+        /// events exactly matches the number of BufferRented events.
+        /// </summary>
         [Event(3, Level = EventLevel.Verbose)]
-        internal void BufferReturned(int bufferId, int poolId) =>
-            WriteEvent(3, bufferId, poolId);
-
-        [Event(4, Level = EventLevel.Warning)]
-        internal void BucketExhausted(int bucketId, int bucketSize, int buffersInBucket, int poolId) =>
-            WriteEventHelper(4, bucketId, bucketSize, buffersInBucket, poolId);
-        
-        [NonEvent]
-        private unsafe void WriteEventHelper(int eventId, int arg0, int arg1, int arg2, int arg3)
-        {
-            if (IsEnabled())
-            {
-                unsafe
-                {
-                    EventData* payload = stackalloc EventData[4];
-                    payload[0].Size = sizeof(int);
-                    payload[0].DataPointer = ((IntPtr) (&arg0));
-                    payload[1].Size = sizeof(int);
-                    payload[1].DataPointer = ((IntPtr) (&arg1));
-                    payload[2].Size = sizeof(int);
-                    payload[2].DataPointer = ((IntPtr) (&arg2));
-                    payload[3].Size = sizeof(int);
-                    payload[3].DataPointer = ((IntPtr) (&arg3));
-                    WriteEventCore(eventId, 4, payload);
-                }
-            }
-        }
+        internal void BufferReturned(int bufferId, int bufferSize, int poolId) => WriteEvent(3, bufferId, bufferSize, poolId);
     }
 }

--- a/src/System.Buffers/src/System/Buffers/DefaultArrayPool.cs
+++ b/src/System.Buffers/src/System/Buffers/DefaultArrayPool.cs
@@ -4,77 +4,93 @@
 
 namespace System.Buffers
 {
-    internal sealed class DefaultArrayPool<T> : ArrayPool<T>
+    internal sealed partial class DefaultArrayPool<T> : ArrayPool<T>
     {
-        /// <summary>The default maximum number of arrays per bucket that are available for rent.</summary>
-        private const int DefaultMaxNumberOfArraysPerBucket = 50;
         /// <summary>The default maximum length of each array in the pool (2^20).</summary>
         private const int DefaultMaxArrayLength = 1024 * 1024;
-        /// <summary>The minimum length of an array in the pool.</summary>
-        private const int MinimumArrayLength = 16;
+        /// <summary>The default maximum number of arrays per bucket that are available for rent.</summary>
+        private const int DefaultMaxNumberOfArraysPerBucket = 50;
 
-        private readonly DefaultArrayPoolBucket<T>[] _buckets;
+        private readonly Bucket[] _buckets;
 
         internal DefaultArrayPool() : this(DefaultMaxArrayLength, DefaultMaxNumberOfArraysPerBucket)
         {
         }
 
-        internal DefaultArrayPool(int maxLength, int arraysPerBucket)
+        internal DefaultArrayPool(int maxArrayLength, int maxArraysPerBucket)
         {
-            if (maxLength <= 0)
-                throw new ArgumentOutOfRangeException(nameof(maxLength));
-            if (arraysPerBucket <= 0)
-                throw new ArgumentOutOfRangeException(nameof(arraysPerBucket));
+            if (maxArrayLength <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxArrayLength));
+            }
+            if (maxArraysPerBucket <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxArraysPerBucket));
+            }
 
-            // Our bucketing algorithm has a minimum length of 16
-            if (maxLength < MinimumArrayLength)
-                maxLength = MinimumArrayLength;
+            // Our bucketing algorithm has a min length of 2^4 and a max length of 2^30.
+            // Constrain the actual max used to those values.
+            const int MinimumArrayLength = 0x10, MaximumArrayLength = 0x40000000;
+            if (maxArrayLength > MaximumArrayLength)
+            {
+                maxArrayLength = MaximumArrayLength;
+            }
+            else if (maxArrayLength < MinimumArrayLength)
+            {
+                maxArrayLength = MinimumArrayLength;
+            }
 
-            int maxBuckets = Utilities.SelectBucketIndex(maxLength);
-            _buckets = new DefaultArrayPoolBucket<T>[maxBuckets + 1];
-            for (int i = 0; i < _buckets.Length; i++)
-                _buckets[i] = new DefaultArrayPoolBucket<T>(Utilities.GetMaxSizeForBucket(i), arraysPerBucket, Utilities.GetPoolId(this));
+            // Create the buckets.
+            int poolId = Id;
+            int maxBuckets = Utilities.SelectBucketIndex(maxArrayLength);
+            var buckets = new Bucket[maxBuckets + 1];
+            for (int i = 0; i < buckets.Length; i++)
+            {
+                buckets[i] = new Bucket(Utilities.GetMaxSizeForBucket(i), maxArraysPerBucket, poolId);
+            }
+            _buckets = buckets;
         }
+
+        /// <summary>Gets an ID for the pool to use with events.</summary>
+        private int Id => GetHashCode();
 
         public override T[] Rent(int minimumLength)
         {
-            if (minimumLength <= 0)
+            // Arrays can't be smaller than zero.  We allow requesting zero-length arrays (even though
+            // pooling such an array isn't valuable) as it's a valid length array, and we want the pool
+            // to be usable in general instead of using `new`, even for computed lengths.
+            if (minimumLength < 0)
+            {
                 throw new ArgumentOutOfRangeException(nameof(minimumLength));
-                
-            var log = ArrayPoolEventSource.Log;
+            }
 
+            var log = ArrayPoolEventSource.Log;
             T[] buffer = null;
+
             int index = Utilities.SelectBucketIndex(minimumLength);
             if (index < _buckets.Length)
             {
                 // Search for an array starting at the 'index' bucket. If the bucket is empty, bump up to the
-                // next higher bucket and try that one. Only try a max number of buckets, e.g. a max of 2 will
-                // guarantee that for a request that maps to a bucket of size N, we'll not return a buffer larger
-                // than N*2, and for a max of 3, we'll not return a buffer larger than N*4, etc.
-
+                // next higher bucket and try that one, but only try at most a few buckets.
                 const int MaxBucketsToTry = 2;
-                int maxIndex = index + MaxBucketsToTry;
-                if (maxIndex >= _buckets.Length)
+                int i = index;
+                do
                 {
-                    maxIndex = _buckets.Length;
-                }
-
-                for (int i = index; i < maxIndex; i++)
-                {
+                    // Attempt to rent from the bucket.  If we get a buffer from it, return it.
                     buffer = _buckets[i].Rent();
-
-                    // If the bucket has an array left and returned it, give it to the caller
                     if (buffer != null)
                     {
                         if (log.IsEnabled())
                         {
-                            log.BufferRented(Utilities.GetBufferId(buffer), buffer.Length, Utilities.GetBucketId(_buckets[i]), Utilities.GetPoolId(this));
+                            log.BufferRented(buffer.GetHashCode(), buffer.Length, Id, _buckets[i].Id);
                         }
                         return buffer;
                     }
                 }
+                while (++i < _buckets.Length && i != index + MaxBucketsToTry);
 
-                // The pool was exhausted.  Allocate a new buffer with a size corresponding to the appropriate bucket.
+                // The pool was exhausted for this buffer size.  Allocate a new buffer with a size corresponding
+                // to the appropriate bucket.
                 buffer = new T[_buckets[index]._bufferLength];
             }
             else
@@ -84,40 +100,48 @@ namespace System.Buffers
                 buffer = new T[minimumLength];
             }
 
-            // We had to allocate a buffer, so log that fact.
             if (log.IsEnabled())
             {
-                log.BufferAllocated(
-                    Utilities.GetBufferId(buffer),
-                    buffer.Length,
-                    Utilities.GetPoolId(this),
-                    -1, // no bucket for an on-demand allocated buffer,
-                    index >= _buckets.Length ? 
-                        ArrayPoolEventSource.BufferAllocationReason.OverMaximumSize :
-                        ArrayPoolEventSource.BufferAllocationReason.PoolExhausted);
+                int bufferId = buffer.GetHashCode(), bucketId = -1; // no bucket for an on-demand allocated buffer
+                log.BufferRented(bufferId, buffer.Length, Id, bucketId);
+                log.BufferAllocated(bufferId, buffer.Length, Id, bucketId, index >= _buckets.Length ?
+                    ArrayPoolEventSource.BufferAllocatedReason.OverMaximumSize : ArrayPoolEventSource.BufferAllocatedReason.PoolExhausted);
             }
 
             return buffer;
         }
 
-        public override void Return(T[] buffer, bool clearArray = false)
+        public override void Return(T[] array, bool clearArray = false)
         {
-            if (buffer == null)
-                throw new ArgumentNullException(nameof(buffer));
+            if (array == null)
+            {
+                throw new ArgumentNullException(nameof(array));
+            }
+
+            // Determine with what bucket this array length is associated
+            int bucket = Utilities.SelectBucketIndex(array.Length);
 
             // If we can tell that the buffer was allocated, drop it. Otherwise, check if we have space in the pool
-            int bucket = Utilities.SelectBucketIndex(buffer.Length);
             if (bucket < _buckets.Length)
             {
                 // Clear the array if the user requests
-                if (clearArray) Array.Clear(buffer, 0, buffer.Length);
+                if (clearArray)
+                {
+                    Array.Clear(array, 0, array.Length);
+                }
 
-                _buckets[bucket].Return(buffer);
+                // Return the buffer to its bucket.  In the future, we might consider having Return return false
+                // instead of dropping a bucket, in which case we could try to return to a lower-sized bucket,
+                // just as how in Rent we allow renting from a higher-sized bucket.
+                _buckets[bucket].Return(array);
             }
 
+            // Log that the buffer was returned
             var log = ArrayPoolEventSource.Log;
             if (log.IsEnabled())
-                log.BufferReturned(Utilities.GetBufferId(buffer), Utilities.GetPoolId(this));
+            {
+                log.BufferReturned(array.GetHashCode(), array.Length, Id);
+            }
         }
     }
 }

--- a/src/System.Buffers/src/System/Buffers/DefaultArrayPool.cs
+++ b/src/System.Buffers/src/System/Buffers/DefaultArrayPool.cs
@@ -68,7 +68,7 @@ namespace System.Buffers
             else if (minimumLength == 0)
             {
                 // No need for events with the empty array.  Our pool is effectively infinite
-                // and we'll never allocate fo rents and never store for returns.
+                // and we'll never allocate for rents and never store for returns.
                 return s_emptyArray ?? (s_emptyArray = new T[0]);
             }
 
@@ -127,7 +127,8 @@ namespace System.Buffers
             }
             else if (array.Length == 0)
             {
-                // Throw away empty arrays.
+                // Ignore empty arrays.  When a zero-length array is rented, we return a singleton
+                // rather than actually taking a buffer out of the lowest bucket.
                 return;
             }
 

--- a/src/System.Buffers/src/System/Buffers/DefaultArrayPoolBucket.cs
+++ b/src/System.Buffers/src/System/Buffers/DefaultArrayPoolBucket.cs
@@ -7,114 +7,108 @@ using System.Threading;
 
 namespace System.Buffers
 {
-    /// <summary>
-    /// Provides a thread-safe bucket containing buffers that can be Rented and Returned as part 
-    /// of a buffer pool; it should not be used independent of the pool.
-    /// </summary>
-    internal sealed class DefaultArrayPoolBucket<T>
+    internal sealed partial class DefaultArrayPool<T> : ArrayPool<T>
     {
-        private int _index;
-        private readonly T[][] _data;
-        internal readonly int _bufferLength;
-        private SpinLock _lock;
-        private bool _exhaustedEventSent;
-        private readonly int _poolId;
-
-        /// <summary>
-        /// Creates the pool with numberOfBuffers arrays where each buffer is of bufferLength length.
-        /// </summary>
-        internal DefaultArrayPoolBucket(int bufferLength, int numberOfBuffers, int poolId)
+        /// <summary>Provides a thread-safe bucket containing buffers that can be Rent'd and Return'd.</summary>
+        private sealed class Bucket
         {
-            _lock = new SpinLock(Debugger.IsAttached); // only enable thread tracking if debugger is attached; it adds non-trivial overheads to Enter/Exit
-            _data = new T[numberOfBuffers][];
-            _bufferLength = bufferLength;
-            _exhaustedEventSent = false;
-            _poolId = poolId;
-        }
+            internal readonly int _bufferLength;
+            private readonly T[][] _buffers;
+            private readonly int _poolId;
 
-        /// <summary>
-        /// Returns an array from the Bucket sized according to the Bucket size.
-        /// If the Bucket is empty, null is returned.
-        /// </summary>
-        /// <returns>Returns a valid buffer when the bucket has free buffers; otherwise, returns null</returns>
-        internal T[] Rent()
-        {
-            T[] buffer = null;
+            private SpinLock _lock; // do not make this readonly; it's a mutable struct
+            private int _index;
 
-            // Use a SpinLock since it is super lightweight
-            // and our lock is very short lived. Wrap in try-finally
-            // to protect against thread-aborts
-            bool taken = false;
-            bool alloc = false;
-            try
+            /// <summary>
+            /// Creates the pool with numberOfBuffers arrays where each buffer is of bufferLength length.
+            /// </summary>
+            internal Bucket(int bufferLength, int numberOfBuffers, int poolId)
             {
-                _lock.Enter(ref taken);
+                _lock = new SpinLock(Debugger.IsAttached); // only enable thread tracking if debugger is attached; it adds non-trivial overheads to Enter/Exit
+                _buffers = new T[numberOfBuffers][];
+                _bufferLength = bufferLength;
+                _poolId = poolId;
+            }
 
-                // Check if all of our buffers have been rented
-                if (_index < _data.Length)
+            /// <summary>Gets an ID for the bucket to use with events.</summary>
+            internal int Id => GetHashCode();
+
+            /// <summary>Takes an array from the bucket.  If the bucket is empty, returns null.</summary>
+            internal T[] Rent()
+            {
+                T[][] buffers = _buffers;
+                T[] buffer = null;
+
+                // While holding the lock, grab whatever is at the next available index and
+                // update the index.  We do as little work as possible while holding the spin
+                // lock to minimize contention with other threads.  The try/finally is
+                // necessary to properly handle thread aborts on platforms which have them.
+                bool lockTaken = false, allocateBuffer = false;
+                try
                 {
-                    buffer = _data[_index];
-                    alloc = buffer == null;
-                    _data[_index++] = null;
+                    _lock.Enter(ref lockTaken);
+
+                    if (_index < buffers.Length)
+                    {
+                        buffer = buffers[_index];
+                        buffers[_index++] = null;
+                        allocateBuffer = buffer == null;
+                    }
                 }
-                else if (_exhaustedEventSent == false)
+                finally
                 {
-                    if (ArrayPoolEventSource.Log.IsEnabled())
-                        ArrayPoolEventSource.Log.BucketExhausted(Utilities.GetBucketId(this), _bufferLength, _data.Length, _poolId);
-                    _exhaustedEventSent = true;
+                    if (lockTaken) _lock.Exit(false);
                 }
-            }
-            finally
-            {
-                if (taken) _lock.Exit(false);
-            }
 
-            if (alloc)
-            {
-                buffer = new T[_bufferLength];
-                if (ArrayPoolEventSource.Log.IsEnabled())
-                    ArrayPoolEventSource.Log.BufferAllocated(
-                        Utilities.GetBufferId(buffer),
-                        _bufferLength,
-                        _poolId,
-                        Utilities.GetBucketId(this),
-                        ArrayPoolEventSource.BufferAllocationReason.Pooled);
-            }
-
-            return buffer;
-        }
-
-        /// <summary>
-        /// Attempts to return a Buffer to the bucket. This can fail
-        /// if the buffer being returned was allocated and we don't have
-        /// room for it in the bucket.
-        /// </summary>
-        internal void Return(T[] buffer)
-        {
-            // Check to see if the buffer is the correct size for this bucket
-            if (buffer.Length != _bufferLength)
-                throw new ArgumentException(SR.ArgumentException_BufferNotFromPool, nameof(buffer));
-
-            // Use a SpinLock since it is super lightweight
-            // and our lock is very short lived. Wrap in try-finally
-            // to protect against thread-aborts
-            bool taken = false;
-            try
-            {
-                _lock.Enter(ref taken);
-
-                // If we have space to put the buffer back, do it. If we don't
-                // then there was a buffer alloc'd that was returned instead so
-                // we can just drop this buffer
-                if (_index != 0)
+                // While we were holding the lock, we grabbed whatever was at the next available index, if
+                // there was one.  If we tried and if we got back null, that means we hadn't yet allocated
+                // for that slot, in which case we should do so now.
+                if (allocateBuffer)
                 {
-                    _data[--_index] = buffer;
-                    _exhaustedEventSent = false; // always setting this should be cheaper than a branch
+                    buffer = new T[_bufferLength];
+
+                    var log = ArrayPoolEventSource.Log;
+                    if (log.IsEnabled())
+                    {
+                        log.BufferAllocated(buffer.GetHashCode(), _bufferLength, _poolId, Id,
+                            ArrayPoolEventSource.BufferAllocatedReason.Pooled);
+                    }
                 }
+
+                return buffer;
             }
-            finally
+
+            /// <summary>
+            /// Attempts to return the buffer to the bucket.  If successful, the buffer will be stored
+            /// in the bucket and true will be returned; otherwise, the buffer won't be stored, and false
+            /// will be returned.
+            /// </summary>
+            internal void Return(T[] array)
             {
-                if (taken) _lock.Exit(false);
+                // Check to see if the buffer is the correct size for this bucket
+                if (array.Length != _bufferLength)
+                {
+                    throw new ArgumentException(SR.ArgumentException_BufferNotFromPool, nameof(array));
+                }
+
+                // While holding the spin lock, if there's room available in the bucket,
+                // put the buffer into the next available slot.  Otherwise, we just drop it.
+                // The try/finally is necessary to properly handle thread aborts on platforms
+                // which have them.
+                bool lockTaken = false;
+                try
+                {
+                    _lock.Enter(ref lockTaken);
+
+                    if (_index != 0)
+                    {
+                        _buffers[--_index] = array;
+                    }
+                }
+                finally
+                {
+                    if (lockTaken) _lock.Exit(false);
+                }
             }
         }
     }

--- a/src/System.Buffers/src/System/Buffers/Utilities.cs
+++ b/src/System.Buffers/src/System/Buffers/Utilities.cs
@@ -12,7 +12,7 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int SelectBucketIndex(int bufferSize)
         {
-            if (bufferSize == 0) return 0; // map 0-length arrays to the lowest bucket
+            Debug.Assert(bufferSize > 0);
 
             uint bitsRemaining = ((uint)bufferSize - 1) >> 4;
 

--- a/src/System.Buffers/src/System/Buffers/Utilities.cs
+++ b/src/System.Buffers/src/System/Buffers/Utilities.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace System.Buffers
@@ -11,6 +12,8 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int SelectBucketIndex(int bufferSize)
         {
+            if (bufferSize == 0) return 0; // map 0-length arrays to the lowest bucket
+
             uint bitsRemaining = ((uint)bufferSize - 1) >> 4;
 
             int poolIndex = 0;
@@ -26,28 +29,9 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetMaxSizeForBucket(int binIndex)
         {
-            checked
-            {
-                int result = 2;
-                int shifts = binIndex + 3;
-                result <<= shifts;
-                return result;
-            }
-        }
-
-        internal static int GetPoolId<T>(ArrayPool<T> pool)
-        {
-            return pool.GetHashCode();
-        }
-
-        internal static int GetBufferId<T>(T[] buffer)
-        {
-            return buffer.GetHashCode();
-        }
-
-        internal static int GetBucketId<T>(DefaultArrayPoolBucket<T> bucket)
-        {
-            return bucket.GetHashCode();
+            int maxSize = 16 << binIndex;
+            Debug.Assert(maxSize >= 0);
+            return maxSize;
         }
     }
 }

--- a/src/System.Buffers/tests/ArrayPool/UnitTests.cs
+++ b/src/System.Buffers/tests/ArrayPool/UnitTests.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Buffers;
+using System.Collections.Generic;
 using System.Diagnostics.Tracing;
+using System.Linq;
 using System.Threading;
 using Xunit;
 
@@ -46,7 +46,7 @@ namespace System.Buffers.ArrayPool.Tests
         [InlineData(-1)]
         public static void CreatingAPoolWithInvalidArrayCountThrows(int length)
         {
-            Assert.Throws<ArgumentOutOfRangeException>("arraysPerBucket", () => ArrayPool<byte>.Create(maxArraysPerBucket: length, maxArrayLength: 16));
+            Assert.Throws<ArgumentOutOfRangeException>("maxArraysPerBucket", () => ArrayPool<byte>.Create(maxArraysPerBucket: length, maxArrayLength: 16));
         }
 
         [Theory]
@@ -54,11 +54,22 @@ namespace System.Buffers.ArrayPool.Tests
         [InlineData(-1)]
         public static void CreatingAPoolWithInvalidMaximumArraySizeThrows(int length)
         {
-            Assert.Throws<ArgumentOutOfRangeException>("maxLength", () => ArrayPool<byte>.Create(maxArrayLength: length, maxArraysPerBucket: 1));
+            Assert.Throws<ArgumentOutOfRangeException>("maxArrayLength", () => ArrayPool<byte>.Create(maxArrayLength: length, maxArraysPerBucket: 1));
         }
 
         [Theory]
-        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(16)]
+        [InlineData(0x40000000)]
+        [InlineData(0x7FFFFFFF)]
+        public static void CreatingAPoolWithValidMaximumArraySizeSucceeds(int length)
+        {
+            var pool = ArrayPool<byte>.Create(maxArrayLength: length, maxArraysPerBucket: 1);
+            Assert.NotNull(pool);
+            Assert.NotNull(pool.Rent(1));
+        }
+
+        [Theory]
         [InlineData(-1)]
         public static void RentingWithInvalidLengthThrows(int length)
         {
@@ -66,10 +77,29 @@ namespace System.Buffers.ArrayPool.Tests
             Assert.Throws<ArgumentOutOfRangeException>("minimumLength", () => pool.Rent(length));
         }
 
-        [Fact]
-        public static void RentingAValidSizeArraySucceeds()
+        [Theory]
+        [InlineData(0, 16)]
+        [InlineData(100, 128)]
+        public static void RentingAValidSizeArraySucceeds(int minimumLength, int expectedLength)
         {
-            Assert.NotNull(ArrayPool<byte>.Create().Rent(100));
+            var pool = ArrayPool<byte>.Create();
+            byte[] arr = pool.Rent(minimumLength);
+            Assert.Equal(expectedLength, arr.Length);
+            pool.Return(arr);
+            Assert.Same(arr, pool.Rent(minimumLength));
+        }
+
+        [Fact]
+        public static void RentingGiganticArraySucceedsOrOOMs()
+        {
+            try
+            {
+                int len = 0x70000000;
+                byte[] buffer = ArrayPool<byte>.Shared.Rent(len);
+                Assert.NotNull(buffer);
+                Assert.True(buffer.Length >= len);
+            }
+            catch (OutOfMemoryException) { }
         }
 
         [Fact]
@@ -106,7 +136,7 @@ namespace System.Buffers.ArrayPool.Tests
         public static void CallingReturnBufferWithNullBufferThrows()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create();
-            Assert.Throws<ArgumentNullException>("buffer", () => pool.Return(null));
+            Assert.Throws<ArgumentNullException>("array", () => pool.Return(null));
         }
 
         private static void FillArray(byte[] buffer)
@@ -308,15 +338,17 @@ namespace System.Buffers.ArrayPool.Tests
             Assert.Equal(64, pool.Rent(63).Length); // still get original size
         }
 
-        private static void ActionFiresSpecificEvent(Action body, EventLevel level, int eventId, AutoResetEvent are)
+        private static int RunWithListener(Action body, EventLevel level, Action<EventWrittenEventArgs> callback)
         {
             using (TestEventListener listener = new TestEventListener("System.Buffers.ArrayPoolEventSource", level))
             {
-                listener.RunWithCallback((EventWrittenEventArgs e) =>
+                int count = 0;
+                listener.RunWithCallback(e =>
                 {
-                    if (e.EventId == eventId)
-                        are.Set();
+                    Interlocked.Increment(ref count);
+                    callback(e);
                 }, body);
+                return count;
             }
         }
 
@@ -324,89 +356,72 @@ namespace System.Buffers.ArrayPool.Tests
         public static void RentBufferFiresRentedDiagnosticEvent()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
-            AutoResetEvent are = new AutoResetEvent(false);
 
-            ActionFiresSpecificEvent(() =>
+            byte[] buffer = pool.Rent(16);
+            pool.Return(buffer);
+
+            Assert.Equal(1, RunWithListener(() => pool.Rent(16), EventLevel.Verbose, e =>
             {
-                byte[] bt = pool.Rent(16);
-                Assert.True(are.WaitOne(MaxEventWaitTimeoutInMs));
-            }, EventLevel.Verbose, 1, are);
+                Assert.Equal(1, e.EventId);
+                Assert.Equal(buffer.GetHashCode(), e.Payload[0]);
+                Assert.Equal(buffer.Length, e.Payload[1]);
+                Assert.Equal(pool.GetHashCode(), e.Payload[2]);
+            }));
         }
 
         [Fact]
         public static void ReturnBufferFiresDiagnosticEvent()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
-            AutoResetEvent are = new AutoResetEvent(false);
-
-            ActionFiresSpecificEvent(() => 
+            byte[] buffer = pool.Rent(16);
+            Assert.Equal(1, RunWithListener(() => pool.Return(buffer), EventLevel.Verbose, e =>
             {
-                byte[] bt = pool.Rent(16);
-                pool.Return(bt);
-                Assert.True(are.WaitOne(MaxEventWaitTimeoutInMs));
-            }, EventLevel.Verbose, 3, are);
+                Assert.Equal(3, e.EventId);
+                Assert.Equal(buffer.GetHashCode(), e.Payload[0]);
+                Assert.Equal(buffer.Length, e.Payload[1]);
+                Assert.Equal(pool.GetHashCode(), e.Payload[2]);
+            }));
         }
 
         [Fact]
-        public static void FirstCallToRentBufferFiresCreatedDiagnosticEvent()
+        public static void RentingNonExistentBufferFiresAllocatedDiagnosticEvent()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
-            AutoResetEvent are = new AutoResetEvent(false);
-
-            ActionFiresSpecificEvent(() => 
-            {
-                byte[] bt = pool.Rent(16);
-                Assert.True(are.WaitOne(MaxEventWaitTimeoutInMs));
-            }, EventLevel.Informational, 2, are);
-        }
-
-        [Fact]
-        public static void AllocatingABufferDueToBucketExhaustionFiresDiagnosticEvent()
-        {
-            ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
-            AutoResetEvent are = new AutoResetEvent(false);
-
-            ActionFiresSpecificEvent(() => 
-            {
-                byte[] bt = pool.Rent(16);
-                byte[] bt2 = pool.Rent(16);
-                Assert.True(are.WaitOne(MaxEventWaitTimeoutInMs));
-            }, EventLevel.Informational, 2, are);
+            Assert.Equal(1, RunWithListener(() => pool.Rent(16), EventLevel.Informational, e => Assert.Equal(2, e.EventId)));
         }
 
         [Fact]
         public static void RentingBufferOverConfiguredMaximumSizeFiresDiagnosticEvent()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
-            AutoResetEvent are = new AutoResetEvent(false);
-
-            ActionFiresSpecificEvent(() => 
-            {
-                byte[] bt = pool.Rent(64);
-                Assert.True(are.WaitOne(MaxEventWaitTimeoutInMs));
-            }, EventLevel.Informational, 2, are);
+            Assert.Equal(1, RunWithListener(() => pool.Rent(64), EventLevel.Informational, e => Assert.Equal(2, e.EventId)));
         }
-        
+
         [Fact]
-        public static void ExhaustingBufferBucketFiresDiagnosticEvent()
+        public static void RentingManyBuffersFiresExpectedDiagnosticEvents()
         {
-            ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
-            AutoResetEvent are = new AutoResetEvent(false);
+            ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 10);
+            var list = new List<EventWrittenEventArgs>();
 
-            ActionFiresSpecificEvent(() => 
+            Assert.Equal(60, RunWithListener(() =>
             {
-                byte[] bt = pool.Rent(16);
-                byte[] bt2 = pool.Rent(16);
-                Assert.True(are.WaitOne(MaxEventWaitTimeoutInMs));
-            }, EventLevel.Warning, 4, are);
+                for (int i = 0; i < 10; i++) pool.Return(pool.Rent(16)); // 10 rents + 10 allocations, 10 returns
+                for (int i = 0; i < 10; i++) pool.Rent(16); // 10 rents
+                for (int i = 0; i < 10; i++) pool.Rent(16); // 10 rents + 10 allocations
+            }, EventLevel.Verbose, list.Add));
+
+            Assert.Equal(30, list.Where(e => e.EventId == 1).Count()); // rents
+            Assert.Equal(20, list.Where(e => e.EventId == 2).Count()); // allocations
+            Assert.Equal(10, list.Where(e => e.EventId == 3).Count()); // returns
         }
+
 
         [Fact]
         public static void ReturningANonPooledBufferOfDifferentSizeToThePoolThrows()
         {
             ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
             byte[] buffer = pool.Rent(15);
-            Assert.Throws<ArgumentException>("buffer", () => pool.Return(new byte[1]));
+            Assert.Throws<ArgumentException>("array", () => pool.Return(new byte[1]));
             buffer = pool.Rent(15);
             Assert.Equal(buffer.Length, 16);
         }


### PR DESCRIPTION
(I intended to do this as multiple commits, but inadvertently ended up squashing them all into one. Sorry for the more complicated review.)

Changes:
- Removed the BucketExhausted event.  Over the last few days I experimented with various alternative bucket implementations, and none of them could easily support the BucketExhaused event in a cheap way.  Since the event has limited value, since it could limit our ability in the future to change implementations and optimize further, and since it's already somewhat inconsistent due to sending it only when we trip over the threshold, I've removed it.  This also ends up helping to remove further additional checks from within the spin lock in Rent.
- Made bucket a nested type.  The DefaultArrayPoolBucket<T> type is an implementation detail of DefaultArrayPool<T>, but it was defined as its own separate type.  I've made it a nested Bucket type and fixed up visibility accordingly.
- Optimized ArrayPool<T>.Shared.  This wasn't getting inlined and ends up contributing a non-trivial percentage of overhead to code that does ```ArrayPool<T>.Shared.Return(ArrayPool<T>.Shared.Rent(n))```.  Streamlining the property and enabling it to be inlined resulted in microbenchmarks showing around a 10% increase in throughput.
- Fixed BufferRented firing consistency.  Previously it wasn't firing for all Rent calls, only some of them.  initially I thought it was designed such that you'd get either a BufferRented or a BufferAllocated, but in some situations you'd get both.  I made it such that Rent always generates a BufferRented event, and if Rent allocates, you also get a BufferAllocated event.  This matches nicely with Return, which always generates a BufferReturned event, even if the buffer is dropped.
- Added bufferSize to BufferReturned event.  If a buffer is returned to the pool that didn't previously come from the pool, there's no way to know from the event previously how large the buffer is.  Now there is.
- Fixed handling of a maxArrayLength when too large.  In situations where it was larger than the bucketing scheme could handle, we'd end up getting IndexOutOfRangeExceptions.  We now constraint it to a limit that will work with our scheme.
- Renamed arguments to be consistent.  In one place we used "buffer" rather than "array" in the public surface area, making it inconsistent with the rest.  In other places we used different names internally and then used those names in argument exceptions corresponding to differently named public arguments.
- Allow Rent'ing 0-length arrays.  Previously we threw an exception if you tried to Rent a 0-length array.  But we should allow this, as 0 is valid for using new with arrays.
- Fixed args to BufferRented.  In one call site we had arguments in the wrong order, such that the bucket and pool IDs were reversed.
- Minor perf tweaks.  Found a few places things could be streamlined a bit to add a few percentage points to throughput.
- Added a bunch of comments, and cleaned up some formatting, naming, etc.
- Added and augmented unit tests, in particular around events.

Fixes #7250, #7727 
cc: @ianhays, @rynowak, @benaadams