### PR TITLE
Re-enable disabled Uri tests on Unix

### DIFF
--- a/src/System.Runtime/tests/System/Uri.CreateString.cs
+++ b/src/System.Runtime/tests/System/Uri.CreateString.cs
@@ -72,7 +72,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(OriginalString_AbsoluteUri_ToString_TestData))]
-        [ActiveIssue(7791, PlatformID.AnyUnix)]
         public void OriginalString_AbsoluteUri_ToString(string uriString, string absoluteUri, string toString)
         {
             PerformAction(uriString, UriKind.Absolute, uri =>
@@ -392,7 +391,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Scheme_Authority_TestData))]
-        [ActiveIssue(7791, PlatformID.AnyUnix)]
         public void Scheme_Authority_Basic(string uriString, string scheme, string userInfo, string host, UriHostNameType hostNameType, int port, bool isDefaultPort, bool isLoopback)
         {
             string idnHost = host;
@@ -419,7 +417,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Scheme_Authority_IdnHost_TestData))]
-        [ActiveIssue(7791, PlatformID.AnyUnix)]
         public void Scheme_Authority_IdnHost(string uriString, string scheme, string userInfo, string host, string idnHost, string dnsSafeHost, UriHostNameType hostNameType, int port, bool isDefaultPort, bool isLoopback)
         {
             string authority = host;
@@ -717,7 +714,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Path_Query_Fragment_TestData))]
-        [ActiveIssue(7791, PlatformID.AnyUnix)]
         public void Path_Query_Fragment(string uriString, string path, string query, string fragment)
         {
             IEnumerable<string> segments = null;
@@ -1149,7 +1145,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue(7791, PlatformID.AnyUnix)]
         public void Create_String_InvalidUnicode()
         {
             Create_String_Invalid("http://\uD800", UriKind.Absolute);

--- a/src/System.Runtime/tests/System/Uri.Methods.cs
+++ b/src/System.Runtime/tests/System/Uri.Methods.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Tests
@@ -479,7 +480,10 @@ namespace System.Tests
 
             Uri invalidPunicodeUri = new Uri("http://xn--\u1234pck.com");
             yield return new object[] { invalidPunicodeUri, UriComponents.Host, "xn--\u1234pck.com" };
-            yield return new object[] { invalidPunicodeUri, UriComponents.NormalizedHost, "xn--\u1234pck.com" };
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // TODO: [ActiveIssue(7921, PlatformID.AnyUnix)]
+            {
+                yield return new object[] { invalidPunicodeUri, UriComponents.NormalizedHost, "xn--\u1234pck.com" };
+            }
 
             // Custom port
             Uri customPortUri = new Uri("http://www.domain.com:50");

--- a/src/System.Runtime/tests/System/Uri.Methods.cs
+++ b/src/System.Runtime/tests/System/Uri.Methods.cs
@@ -537,7 +537,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(GetComponents_Basic_TestData))]
-        [ActiveIssue(7791, PlatformID.AnyUnix)]
         public void GetComponents(Uri uri, UriComponents components, string expected)
         {
             GetComponents(uri, components, UriFormat.SafeUnescaped, expected);
@@ -608,7 +607,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(GetComponents_Advanced_TestData))]
-        [ActiveIssue(7791, PlatformID.AnyUnix)]
         public void GetComponents(Uri uri, UriComponents components, UriFormat format, string expected)
         {
             Assert.Equal(expected, uri.GetComponents(components, format));


### PR DESCRIPTION
cc: @hughbe 
Closes https://github.com/dotnet/corefx/issues/7791 after https://github.com/dotnet/corefx/pull/7829 hopefully fixed it.