### PR TITLE
Delete ConnectTimeout TODO from CurlHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -85,7 +85,7 @@ namespace System.Net.Http
         private CredentialCache _credentialCache = null; // protected by LockObject
         private CookieContainer _cookieContainer = new CookieContainer();
         private bool _useCookie = HttpHandlerDefaults.DefaultUseCookies;
-        private TimeSpan _connectTimeout = Timeout.InfiniteTimeSpan; // TODO: Use the WinHttp default once we determine how to expose this. HttpHandlerDefaults.DefaultConnectTimeout;
+        private TimeSpan _connectTimeout = Timeout.InfiniteTimeSpan;
         private bool _automaticRedirection = HttpHandlerDefaults.DefaultAutomaticRedirection;
         private int _maxAutomaticRedirections = HttpHandlerDefaults.DefaultMaxAutomaticRedirections;
         private int _maxConnectionsPerServer = HttpHandlerDefaults.DefaultMaxConnectionsPerServer;


### PR DESCRIPTION
Either this property will be exposed and the value will remain infinite, or the property won't be exposed and this won't matter (hopefully the former).  Regardless, the TODO is now stale.  Removing.

Fixes https://github.com/dotnet/corefx/issues/7883