### PR TITLE
Reduce ConcurrentBag Node allocations

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -846,7 +846,7 @@ namespace System.Collections.Concurrent
             {
                 _value = value;
             }
-            public readonly T _value;
+            public T _value;
             public Node _next;
             public Node _prev;
         }
@@ -856,6 +856,10 @@ namespace System.Collections.Concurrent
         /// </summary>
         internal class ThreadLocalList
         {
+            private const int _maxPooledNodesPerThread = 32;
+
+            private Queue<Node> _nodePool;
+
             // Head node in the list, null means the list is empty
             internal volatile Node _head;
 
@@ -890,6 +894,7 @@ namespace System.Collections.Concurrent
             internal ThreadLocalList(int ownerThreadId)
             {
                 _ownerThreadId = ownerThreadId;
+                _nodePool = new Queue<Node>(_maxPooledNodesPerThread);
             }
             /// <summary>
             /// Add new item to head of the list
@@ -902,7 +907,7 @@ namespace System.Collections.Concurrent
                 {
                     _count++;
                 }
-                Node node = new Node(item);
+                Node node = RentNodeForItem(item); // Get pooled Node
                 if (_head == null)
                 {
                     Debug.Assert(_tail == null);
@@ -942,6 +947,8 @@ namespace System.Collections.Concurrent
                 }
                 _count--;
                 result = head._value;
+
+                ReturnNode(head); // Pool the Node
             }
 
             /// <summary>
@@ -970,6 +977,8 @@ namespace System.Collections.Concurrent
             {
                 Node tail = _tail;
                 Debug.Assert(tail != null);
+                result = tail._value;
+
                 if (remove) // Take operation
                 {
                     _tail = _tail._prev;
@@ -983,10 +992,10 @@ namespace System.Collections.Concurrent
                     }
                     // Increment the steal count
                     _stealCount++;
-                }
-                result = tail._value;
-            }
 
+                    ReturnNode(tail); // Pool the Node
+                }
+            }
 
             /// <summary>
             /// Gets the total list count, it's not thread safe, may provide incorrect count if it is called concurrently
@@ -996,6 +1005,30 @@ namespace System.Collections.Concurrent
                 get
                 {
                     return _count - _stealCount;
+                }
+            }
+
+            private Node RentNodeForItem(T item)
+            {
+                if (_nodePool.Count > 0)
+                {
+                    var node = _nodePool.Dequeue();
+                    node._value = item;
+                    return node;
+                }
+                return new Node(item);
+            }
+
+            private void ReturnNode(Node node)
+            {
+                if (_nodePool.Count < _maxPooledNodesPerThread)
+                {
+                    // Clear node before pooling
+                    node._value = default(T);
+                    node._next = null;
+                    node._prev = null;
+
+                    _nodePool.Enqueue(node);
                 }
             }
         }


### PR DESCRIPTION
Should allow higher throughput object pooling use with lower allocations

* Up to 32 "at rest" Nodes are pooled per thread in ThreadLocalList in a `Queue<Node>`
* Node references are cleared when pooled

The following code
```csharp
var o = new object();
var bag = new ConcurrentBag<object>();
for (var ii = 0; ii < 1000000; ii++)
{
    for (var i = 0; i < 32; i++)
    {
        bag.Add(o);
    }
    for (var i = 0; i < 32; i++)
    {
        bag.TryTake(out o);
    }
}
```

Before allocations  31,974,596 Nodes for 1,278,983,840 bytes

![Node allocations](http://aoa.blob.core.windows.net/aspnet/concurrentbag1.png)

After allocations  32 Nodes for 1,280 bytes

![Node allocations](http://aoa.blob.core.windows.net/aspnet/concurrentbag2.png)

Fixes  #7917 

/cc @stephentoub 