### PR TITLE
Size CurlHandler's SendTransferState based on content length

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -652,7 +652,7 @@ namespace System.Net.Http
 
                 internal SendTransferState(int bufferLength)
                 {
-                    Debug.Assert(bufferLength > 0 && bufferLength <= RequestBufferSize, $"Expected 0 < bufferLength <= {RequestBufferSize}, got {bufferLength}");
+                    Debug.Assert(bufferLength > 0 && bufferLength <= MaxRequestBufferSize, $"Expected 0 < bufferLength <= {MaxRequestBufferSize}, got {bufferLength}");
                     _buffer = new byte[bufferLength];
                 }
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -645,10 +645,16 @@ namespace System.Net.Http
 
             internal sealed class SendTransferState
             {
-                internal readonly byte[] _buffer = new byte[RequestBufferSize]; // PERF TODO (#7884): Determine if this should be optimized to start smaller and grow
+                internal readonly byte[] _buffer;
                 internal int _offset;
                 internal int _count;
                 internal Task<int> _task;
+
+                internal SendTransferState(int bufferLength)
+                {
+                    Debug.Assert(bufferLength > 0 && bufferLength <= RequestBufferSize, $"Expected 0 < bufferLength <= {RequestBufferSize}, got {bufferLength}");
+                    _buffer = new byte[bufferLength];
+                }
 
                 internal void SetTaskOffsetCount(Task<int> task, int offset, int count)
                 {

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -804,7 +804,7 @@ namespace System.Net.Http
             private static ulong CurlSendCallback(IntPtr buffer, ulong size, ulong nitems, IntPtr context)
             {
                 int length = checked((int)(size * nitems));
-                Debug.Assert(length <= RequestBufferSize, $"length {length} should not be larger than RequestBufferSize {RequestBufferSize}");
+                Debug.Assert(length <= MaxRequestBufferSize, $"length {length} should not be larger than RequestBufferSize {MaxRequestBufferSize}");
                 if (length == 0)
                 {
                     return 0;
@@ -920,9 +920,9 @@ namespace System.Net.Http
                     // Allocate a transfer state object to use for the remainder of this request.
                     Debug.Assert(easy._requestMessage.Content != null, "Content shouldn't be null, since we already got a content request stream");
                     long bufferSize = easy._requestMessage.Content.Headers.ContentLength.GetValueOrDefault();
-                    if (bufferSize <= 0 || bufferSize > RequestBufferSize)
+                    if (bufferSize <= 0 || bufferSize > MaxRequestBufferSize)
                     {
-                        bufferSize = RequestBufferSize;
+                        bufferSize = MaxRequestBufferSize;
                     }
                     easy._sendTransferState = sts = new EasyRequest.SendTransferState((int)bufferSize);
                 }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -918,7 +918,13 @@ namespace System.Net.Http
                 else // sts == null
                 {
                     // Allocate a transfer state object to use for the remainder of this request.
-                    easy._sendTransferState = sts = new EasyRequest.SendTransferState();
+                    Debug.Assert(easy._requestMessage.Content != null, "Content shouldn't be null, since we already got a content request stream");
+                    long bufferSize = easy._requestMessage.Content.Headers.ContentLength.GetValueOrDefault();
+                    if (bufferSize <= 0 || bufferSize > RequestBufferSize)
+                    {
+                        bufferSize = RequestBufferSize;
+                    }
+                    easy._sendTransferState = sts = new EasyRequest.SendTransferState((int)bufferSize);
                 }
 
                 Debug.Assert(sts != null, "By this point we should have a transfer object");

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -30,8 +30,8 @@ namespace System.Net.Http
         private const string UriSchemeHttps = "https";
         private const string EncodingNameGzip = "gzip";
         private const string EncodingNameDeflate = "deflate";
-
-        private const int RequestBufferSize = 16384; // Default used by libcurl
+        
+        private const int MaxRequestBufferSize = 16384; // Default used by libcurl
         private const string NoTransferEncoding = HttpKnownHeaderNames.TransferEncoding + ":";
         private const string NoContentType = HttpKnownHeaderNames.ContentType + ":";
         private const int CurlAge = 5;

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -107,6 +107,23 @@ namespace System.Net.Http.Functional.Tests
                 useContentLengthUpload: false, useChunkedEncodingUpload: false);
         }
 
+        [Theory]
+        [InlineData(5 * 1024)]
+        [InlineData(63 * 1024)]
+        public async Task PostLongerContentLengths_UsesChunkedSemantics(int contentLength)
+        {
+            var rand = new Random(42);
+            var sb = new StringBuilder(contentLength);
+            for (int i = 0; i < contentLength; i++)
+            {
+                sb.Append((char)(rand.Next(0, 26) + 'a'));
+            }
+            string content = sb.ToString();
+
+            await PostHelper(HttpTestServers.RemoteEchoServer, content, new StringContent(content),
+                useContentLengthUpload: true, useChunkedEncodingUpload: false);
+        }
+
         [Theory, MemberData(nameof(BasicAuthEchoServers))]
         public async Task PostRewindableContentUsingAuth_NoPreAuthenticate_Success(Uri serverUri)
         {


### PR DESCRIPTION
libcurl will never request more than 16K at a time from a request content stream, so our transfer state object allocates a 16K buffer to use the first time data needs to be transferred.  This size can be efficient in limiting the number of operations required in passing data around, but for small posts, it's an unnecessarily large size.  This commit changes the code to inspect the request content length, and if it's known to be less than 16K, that size is used instead.

cc: @ericeil, @davidsh 
Fixes #7884