### PR TITLE
Throw ArgumentNullException on public members of ExpressionVisitor

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs
@@ -51,6 +51,7 @@ namespace System.Linq.Expressions
         /// otherwise, returns the original expression list.</returns>
         public ReadOnlyCollection<Expression> Visit(ReadOnlyCollection<Expression> nodes)
         {
+            ContractUtils.RequiresNotNull(nodes, nameof(nodes));
             Expression[] newNodes = null;
             for (int i = 0, n = nodes.Count; i < n; i++)
             {
@@ -93,6 +94,8 @@ namespace System.Linq.Expressions
         /// otherwise, returns the original node list.</returns>
         public static ReadOnlyCollection<T> Visit<T>(ReadOnlyCollection<T> nodes, Func<T, T> elementVisitor)
         {
+            ContractUtils.RequiresNotNull(nodes, nameof(nodes));
+            ContractUtils.RequiresNotNull(elementVisitor, nameof(elementVisitor));
             T[] newNodes = null;
             for (int i = 0, n = nodes.Count; i < n; i++)
             {
@@ -152,6 +155,7 @@ namespace System.Linq.Expressions
         /// <exception cref="InvalidOperationException">The visit method for this node returned a different type.</exception>
         public ReadOnlyCollection<T> VisitAndConvert<T>(ReadOnlyCollection<T> nodes, string callerName) where T : Expression
         {
+            ContractUtils.RequiresNotNull(nodes, nameof(nodes));
             T[] newNodes = null;
             for (int i = 0, n = nodes.Count; i < n; i++)
             {

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -232,6 +232,7 @@
     <Compile Include="Variables\RuntimeVariablesTests.cs" />
     <Compile Include="Variables\VariableTests.cs" />
     <Compile Include="Visitor\ExpressionVisitorTests.cs" />
+    <Compile Include="Visitor\VisitorTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Linq.Expressions.csproj">

--- a/src/System.Linq.Expressions/tests/Visitor/VisitorTests.cs
+++ b/src/System.Linq.Expressions/tests/Visitor/VisitorTests.cs
@@ -1,0 +1,343 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class VisitorTests
+    {
+        private class UsingExpression : Expression
+        {
+            public UsingExpression(Expression disposable, Expression body)
+            {
+                if (!typeof(IDisposable).IsAssignableFrom(disposable.Type))
+                {
+                    throw new ArgumentException();
+                }
+                // Omit other exception handling as this is just an example for testing purposes.
+
+                Disposable = disposable;
+                Body = body;
+            }
+
+            private Expression Disposable { get; }
+
+            private Expression Body { get; }
+
+            public override bool CanReduce => true;
+
+            public override Expression Reduce()
+            {
+                if (Disposable.Type.GetTypeInfo().IsValueType)
+                {
+                    return TryFinally(
+                        Body,
+                        Call(
+                            Disposable,
+                            typeof(IDisposable).GetMethod(nameof(IDisposable.Dispose))
+                            )
+                        );
+                }
+
+                return TryFinally(
+                    Body,
+                    IfThen(
+                        ReferenceNotEqual(Disposable, Constant(null)),
+                        Call(
+                            Disposable,
+                            typeof(IDisposable).GetMethod(nameof(IDisposable.Dispose))
+                            )
+                        )
+                    );
+            }
+
+            public override Type Type => Body.Type;
+
+            public override ExpressionType NodeType => ExpressionType.Extension;
+        }
+
+        private class ForEachExpression : Expression
+        {
+            public ForEachExpression(ParameterExpression item, Expression enumerable, Expression body)
+            {
+                ItemVariable = item;
+                Enumerable = enumerable;
+                Body = body;
+            }
+
+            public ParameterExpression ItemVariable { get; }
+
+            public Expression Enumerable { get; }
+
+            public Expression Body { get; }
+
+            public override bool CanReduce => true;
+
+            public override Type Type => typeof(void);
+
+            public override ExpressionType NodeType => ExpressionType.Extension;
+
+            public override Expression Reduce()
+            {
+                var enType = typeof(IEnumerator<>).MakeGenericType(ItemVariable.Type);
+                var enumerator = Variable(enType);
+                var breakLabel = Label();
+                return Block(
+                    new[] {ItemVariable, enumerator},
+                    Assign(enumerator, Call(Enumerable, typeof(IEnumerable<>).MakeGenericType(ItemVariable.Type).GetMethod(nameof(IEnumerable.GetEnumerator)))),
+                    new UsingExpression(
+                        enumerator,
+                        Loop(
+                            Block(
+                                IfThen(
+                                    IsFalse(
+                                        Call(enumerator, typeof(IEnumerator).GetMethod(nameof(IEnumerator.MoveNext)))
+                                        ),
+                                    Break(breakLabel)
+                                    ),
+                                Assign(ItemVariable, Property(enumerator, enType.GetProperty(nameof(IEnumerator.Current)))),
+                                Body
+                                ),
+                            breakLabel
+                            )
+                        )
+                    );
+            }
+        }
+
+        private class DefaultVisitor : ExpressionVisitor
+        {
+        }
+
+        private class ConstantRefreshingVisitor : ExpressionVisitor
+        {
+            protected override Expression VisitConstant(ConstantExpression node)
+                => Expression.Constant(node.Value, node.Type);
+        }
+
+        private class ResultExpression : Expression
+        {
+        }
+
+        private class SourceExpression : Expression
+        {
+            protected override Expression Accept(ExpressionVisitor visitor) => new ResultExpression();
+        }
+
+        private class NullBecomingExpression : Expression
+        {
+            protected override Expression Accept(ExpressionVisitor visitor) => null;
+        }
+
+        private static string UpperCaseIfNotAlready(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            string upper = value.ToUpperInvariant();
+            return upper == value ? value : upper;
+        }
+
+        [Fact]
+        public void IsAbstract()
+        {
+            Assert.True(typeof(ExpressionVisitor).GetTypeInfo().IsAbstract);
+        }
+
+        [Fact]
+        public void VisitNullDefaultsToReturnNull()
+        {
+            Assert.Null(new DefaultVisitor().Visit(default(Expression)));
+        }
+
+        [Fact]
+        public void VisitExpressionDefaultsCallAccept()
+        {
+            Assert.IsType<ResultExpression>(new DefaultVisitor().Visit(new SourceExpression()));
+        }
+
+        [Fact, ActiveIssue(7820)]
+        public void VisitNullCollection()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DefaultVisitor().Visit(default(ReadOnlyCollection<Expression>)));
+        }
+
+        [Fact, ActiveIssue(7820)]
+        public void VisitNullCollectionWithVisitorFunction()
+        {
+            Assert.Throws<ArgumentNullException>(() => ExpressionVisitor.Visit(null, (Expression i) => i));
+        }
+
+        [Fact, ActiveIssue(7820)]
+        public void VisitCollectionVisitorWithNullFunction()
+        {
+            Assert.Throws<ArgumentNullException>(() => ExpressionVisitor.Visit(new List<Expression> { Expression.Empty() }.AsReadOnly(), null));
+        }
+
+        [Fact]
+        public void VisitAndConvertNullNode()
+        {
+            Assert.Null(new DefaultVisitor().VisitAndConvert(default(Expression), ""));
+        }
+
+        [Fact, ActiveIssue(7820)]
+        public void VisitAndConvertNullCollection()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DefaultVisitor().VisitAndConvert(default(ReadOnlyCollection<Expression>), ""));
+        }
+
+        [Fact]
+        public void VisitCollectionReturnSameIfChildrenUnchanged()
+        {
+            var collection = new List<Expression> { Expression.Constant(0), Expression.Constant(2) }.AsReadOnly();
+            Assert.Same(collection, new DefaultVisitor().Visit(collection));
+        }
+
+        [Fact]
+        public void VisitCollectionDifferOnFirst()
+        {
+            string value = new string(new[] { 'a', 'b', 'c' });
+            var collection = new List<Expression> { Expression.Constant(value) }.AsReadOnly();
+            var visited = new ConstantRefreshingVisitor().Visit(collection);
+            Assert.NotSame(collection, visited);
+            Assert.NotSame(collection[0], visited[0]);
+            Assert.Same(value, ((ConstantExpression)visited[0]).Value);
+        }
+
+        [Fact]
+        public void VisitCollectionDifferOnLater()
+        {
+            string value = new string(new[] { 'a', 'b', 'c' });
+            var collection = new List<Expression> { Expression.Empty(), Expression.Constant(value) }.AsReadOnly();
+            var visited = new ConstantRefreshingVisitor().Visit(collection);
+            Assert.NotSame(collection, visited);
+            Assert.Same(collection[0], visited[0]);
+            Assert.NotSame(collection[1], visited[1]);
+            Assert.Same(value, ((ConstantExpression)visited[1]).Value);
+        }
+
+        [Fact]
+        public void VisitCollectionNullNodes()
+        {
+            var collection = new List<Expression> { null, null, null }.AsReadOnly();
+            Assert.Same(collection, new DefaultVisitor().Visit(collection));
+        }
+
+        [Fact]
+        public void VisitCollectionWithElementVisitorReturnSameIfChildrenUnchanged()
+        {
+            var collection = new List<string> { "ABC", "DEF" }.AsReadOnly();
+            Assert.Same(collection, ExpressionVisitor.Visit(collection, UpperCaseIfNotAlready));
+        }
+
+        [Fact]
+        public void VisitCollectionWithElementVisitorDifferOnFirst()
+        {
+            var collection = new List<string> { "abc" }.AsReadOnly();
+            var visited = ExpressionVisitor.Visit(collection, UpperCaseIfNotAlready);
+            Assert.NotSame(collection, visited);
+            Assert.NotSame(collection[0], visited[0]);
+        }
+
+        [Fact]
+        public void VisitCollectionWithElementVisitorDifferOnLater()
+        {
+            var collection = new List<string> { "ABC", "def", "GHI", "jkl" }.AsReadOnly();
+            var visited = ExpressionVisitor.Visit(collection, UpperCaseIfNotAlready);
+            Assert.NotSame(collection, visited);
+            Assert.Same(collection[0], visited[0]);
+            Assert.NotSame(collection[1], visited[1]);
+            Assert.Same(collection[2], visited[2]);
+            Assert.NotSame(collection[3], visited[3]);
+        }
+
+        [Fact]
+        public void VisitCollectionWithElementVisitorNullNodes()
+        {
+            var collection = new List<string> { null, null, null }.AsReadOnly();
+            Assert.Same(collection, ExpressionVisitor.Visit(collection, UpperCaseIfNotAlready));
+        }
+
+        [Fact]
+        public void VisitAndConvertReturnsSameIfVisitDoes()
+        {
+            var constant = Expression.Constant(0);
+            Assert.Same(constant, new DefaultVisitor().Visit(constant));
+            Assert.Same(constant, new DefaultVisitor().VisitAndConvert(constant, "foo"));
+        }
+
+        [Fact]
+        public void VisitAndConvertThrowsIfVisitReturnsNull()
+        {
+            string slug = "Won't be found by chance 3f8d0006-32f9-4622-9ff4-c88e95c9babc";
+            string errMsg = Assert.Throws<InvalidOperationException>(() => new DefaultVisitor().VisitAndConvert(new NullBecomingExpression(), slug)).Message;
+            Assert.Contains(slug, errMsg);
+        }
+
+        [Fact]
+        public void VisitAndConvertThrowsIfVisitChangesType()
+        {
+            string slug = "Won't be found by chance 5154E15C-A475-49B0-B596-8F822D7ACFC4";
+            string errMsg = Assert.Throws<InvalidOperationException>(() => new DefaultVisitor().VisitAndConvert(new SourceExpression(), slug)).Message;
+            Assert.Contains(slug, errMsg);
+        }
+
+        [Fact]
+        public void VisitAndConvertNullName()
+        {
+            new DefaultVisitor().VisitAndConvert(Expression.Constant(0), null);
+            Assert.Throws<InvalidOperationException>(() => new DefaultVisitor().VisitAndConvert(new SourceExpression(), null));
+        }
+
+        [Fact]
+        public void VisitAndConvertReturnsIfForcedToCommonBase()
+        {
+            Assert.IsNotType<SourceExpression>(new DefaultVisitor().VisitAndConvert<Expression>(new SourceExpression(), ""));
+        }
+
+        [Fact]
+        public void VisitAndConvertSameResultAsVisit()
+        {
+            var constant = Expression.Constant(0);
+            var visited = new ConstantRefreshingVisitor().VisitAndConvert(constant, "");
+            Assert.NotSame(constant, visited);
+            Assert.Equal(0, visited.Value);
+        }
+
+        [Fact]
+        public void ReduceChildrenCascades()
+        {
+            var intVar = Expression.Variable(typeof(int));
+            List<int> list = new List<int>();
+            var foreachExp = new ForEachExpression(
+                intVar,
+                Expression.Constant(Enumerable.Range(5, 4)),
+                Expression.Call(
+                    Expression.Constant(list),
+                    typeof(List<int>).GetMethod(nameof(List<int>.Insert)),
+                    Expression.Constant(0),
+                    intVar
+                    )
+                );
+
+            // Check that not only has the visitor reduced the foreach into a block
+            // but the using within that block into a try…finally.
+            var reduced = new DefaultVisitor().Visit(foreachExp);
+            var block = (BlockExpression)reduced;
+            var tryExp = (TryExpression)block.Expressions[1];
+            var loop = (LoopExpression)tryExp.Body;
+            var innerBlock = (BlockExpression)loop.Body;
+            var call = (MethodCallExpression)innerBlock.Expressions.Last();
+            var instance = (ConstantExpression)call.Object;
+            Assert.Same(list, instance.Value);
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Visitor/VisitorTests.cs
+++ b/src/System.Linq.Expressions/tests/Visitor/VisitorTests.cs
@@ -164,19 +164,19 @@ namespace System.Linq.Expressions.Tests
             Assert.IsType<ResultExpression>(new DefaultVisitor().Visit(new SourceExpression()));
         }
 
-        [Fact, ActiveIssue(7820)]
+        [Fact]
         public void VisitNullCollection()
         {
             Assert.Throws<ArgumentNullException>(() => new DefaultVisitor().Visit(default(ReadOnlyCollection<Expression>)));
         }
 
-        [Fact, ActiveIssue(7820)]
+        [Fact]
         public void VisitNullCollectionWithVisitorFunction()
         {
             Assert.Throws<ArgumentNullException>(() => ExpressionVisitor.Visit(null, (Expression i) => i));
         }
 
-        [Fact, ActiveIssue(7820)]
+        [Fact]
         public void VisitCollectionVisitorWithNullFunction()
         {
             Assert.Throws<ArgumentNullException>(() => ExpressionVisitor.Visit(new List<Expression> { Expression.Empty() }.AsReadOnly(), null));
@@ -188,7 +188,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Null(new DefaultVisitor().VisitAndConvert(default(Expression), ""));
         }
 
-        [Fact, ActiveIssue(7820)]
+        [Fact]
         public void VisitAndConvertNullCollection()
         {
             Assert.Throws<ArgumentNullException>(() => new DefaultVisitor().VisitAndConvert(default(ReadOnlyCollection<Expression>), ""));


### PR DESCRIPTION
Fixes #7820

Also some further tests.

This does have a case where it introduces a throw rather than merely changes what is thrown, in that if a call to the overload of `Visit` takes a collection and a converter `Func` had an empty collection passed along with a null function, then it will now throw when before it would not. It seems unlikely that there would be code that would only ever pass a null function along with an empty collection, but the null check could be moved if it was deemed necessary for backwards compatibility.