### PR TITLE
System.Net.Security test stabilization

### DIFF
--- a/src/Common/tests/Scripts/ParallelTestExecution.ps1
+++ b/src/Common/tests/Scripts/ParallelTestExecution.ps1
@@ -1,0 +1,249 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+# See the LICENSE file in the project root for more information.
+
+# Usage:
+#
+#   . ParallelTestExecution.ps1
+#   cd <testFolder> (e.g. testFolder = src\System.Net.Security\tests\FunctionalTests)
+#   RunMultiple <n> <delayVarianceMilliseconds> [-UntilFailed]
+#
+#   The above sequence will open up <n> windows running the test project present in the current folder.
+#   If -UntilFailed is used, the tests will continuously loop until a failure is detected. 
+#   Between loops, the execution will pause for <delayVarianceMilliseconds>. 
+
+function BuildAndTestBinary
+{
+    $output = (msbuild /t:rebuild,test)
+    if ($lastexitcode -ne 0)
+    {
+        throw "Build/test failed."
+    }
+
+    return $output
+}
+
+function TileWindows
+{
+    $shell = New-Object -ComObject Shell.Application
+    $shell.TileHorizontally()
+}
+
+function CurrentPath
+{
+    return (Get-Item -Path ".\" -Verbose).FullName
+}
+
+function ParseCurrentPath
+{
+    $p = CurrentPath
+    
+    $test_found = $false
+    $contract_found = $false
+    $root_found = $false
+    
+    while ((-not $root_found) -and ($p -ne ""))
+    {
+      $leaf = Split-Path $p -Leaf
+      
+      if (Test-Path (Join-Path $p 'build.cmd'))
+      {
+          $Global:RootPath = $p
+          $root_found = $true
+      }
+      
+      if ($test_found -and (-not $contract_found))
+      {
+          $Global:ContractName = $leaf
+          $contract_found = $true
+      }
+      
+      if ($leaf -eq "tests")
+      {
+          $test_found = $true
+      }
+      
+      $p = Split-Path $p
+    }
+    
+    if (-not $test_found)
+    {
+       throw "This folder doesn't appear to be part of a test (looking for ...\contract\tests\...)." 
+    }
+}
+
+function ParseTestExecutionCommand($msBuildOutput)
+{
+    $foundTestExecution = $false
+    $cmdLine = ""
+
+    foreach ($line in $msBuildOutput)
+    {
+        if ($foundTestExecution -eq $true)
+        {
+            $cmdLine = $line
+            break
+        }
+        
+        if ($line.Contains("RunTestsForProject:"))
+        {
+            $foundTestExecution = $true
+        }
+    }
+
+    if (-not $foundTestExecution)
+    {
+        throw "Cannot parse MSBuild output: please ensure that the current folder contains a test."
+    }
+
+    $Global:TestCommand = $cmdLine.Trim()
+}
+
+function ParseTestFolder($testExecutionCmdLine)
+{
+    $coreRunPath = $testExecutionCmdLine.Split()[0]
+    return Split-Path $coreRunPath
+}
+
+function Initialize
+{
+    ParseCurrentPath
+
+    Write-Host -NoNewline "Initializing tests for $($Global:ContractName) . . . "
+
+    try
+    {
+        $output = BuildAndTestBinary
+        ParseTestExecutionCommand($output)
+
+        Write-Host -ForegroundColor Green "OK"
+    }
+    catch
+    {
+        Write-Host -ForegroundColor Red "Failed"
+        throw
+    }
+}
+
+function RunOne($testCommand)
+{
+    if ($testCommand -ne "")
+    {
+        $Global:TestCommand = $testCommand
+    }
+
+    if ($Global:TestCommand -eq $null)
+    {
+        throw "Run Initialize first or pass the test command line as a parameter."
+    }
+
+    Write-Host $Global:TestCommand
+    $path = ParseTestFolder($Global:TestCommand)
+    Write-Host "$path"
+
+    Push-Location
+    cd $path
+    Invoke-Expression $Global:TestCommand
+    if ($lastexitcode -ne 0)
+    {
+        throw "Test execution failed."
+    }
+
+    Pop-Location
+}
+
+function RunUntilFailed($testCommand, $delayVarianceMilliseconds = 0)
+{
+
+    try
+    {
+        while($true)
+        {
+            RunOne $testCommand
+
+            if ($delayVarianceMilliseconds -ne 0)
+            {
+                $sleepMilliseconds = Get-Random -Minimum 0 -Maximum $delayVarianceMilliseconds
+                Write-Host -ForegroundColor Cyan "Sleeping $sleepMilliseconds"
+                Start-Sleep -Milliseconds $sleepMilliseconds
+            }
+        }
+    }
+    catch
+    {
+        Write-Host -ForegroundColor Red "Test execution failed!"
+        Read-Host "Press ENTER to continue..."
+    }
+}
+
+function RunMultiple(
+    [int]$n = 2, 
+    [int]$RandomDelayVarianceMilliseconds = 0,
+    [switch]$UntilFailed = $false)
+{  
+    if ($Global:TestCommand -eq $null)
+    {
+        Initialize
+    }
+
+    $script = $PSCommandPath
+    $testCommand = $Global:TestCommand
+    
+    if ($untilFailed)
+    {
+        $executionMethod = "RunUntilFailed"
+    }
+    else
+    {
+        $executionMethod = "RunOne"
+    }
+
+    $cmdArguments = "-Command `"&{. $script; $executionMethod '$testCommand' $RandomDelayVarianceMilliseconds}`""
+
+    $processes = @()
+
+    for ($i=0; $i -lt $n; $i++)
+    {
+        $thisCmdArguments = $cmdArguments -replace ("testResults.xml", "testResults$i.xml")
+        $process = Start-Process -PassThru powershell -ArgumentList $thisCmdArguments
+        $processes += $process
+    }
+
+    $processesExited = $false
+    while (-not ([console]::KeyAvailable -or $processesExited))
+    {
+        Clear-Host
+
+        Write-Host -ForegroundColor Cyan "Active test processes:"
+        Write-Host
+        Write-Host "[Press any key to close.]"
+        Write-Host
+        $processes | Format-Table -Property Id, CPU, Handles, WS, ExitCode
+
+        $processesExited = $true
+        foreach($p in $processes)
+        {
+            if (-not $p.HasExited)
+            {
+                $processesExited = $false
+            }
+        }
+
+        Start-Sleep -Milliseconds 1000
+        TileWindows
+    }
+
+    if (-not $processesExited)
+    {
+        Write-Host -ForegroundColor Cyan "Terminating all processes."
+        foreach ($p in $processes)
+        {
+            if (-not $p.HasExited)
+            {
+                $p.Kill()
+            }
+        }
+    }
+
+    Write-Host "Done."
+}

--- a/src/Common/tests/System/Net/VirtualNetwork/VirtualNetworkStream.cs
+++ b/src/Common/tests/System/Net/VirtualNetwork/VirtualNetworkStream.cs
@@ -114,16 +114,9 @@ namespace System.Net.Test.Common
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            try
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                Write(buffer, offset, count);
-                return Task.CompletedTask;
-            }
-            catch (Exception e)
-            {
-                return Task.FromException(e);
-            }
+            return cancellationToken.IsCancellationRequested ?
+                Task.FromCanceled<int>(cancellationToken) :
+                Task.Run(() => Write(buffer, offset, count));
         }
     }
 }

--- a/src/Common/tests/project.json
+++ b/src/Common/tests/project.json
@@ -18,6 +18,7 @@
     "System.Runtime.Handles": "4.0.1-rc3-24022-00",
     "System.Runtime.InteropServices": "4.1.0-rc3-24022-00",
     "System.Text.RegularExpressions": "4.1.0-rc3-24022-00",
+    "System.Threading.Thread": "4.0.0-rc3-24022-00",
     "System.Threading.Tasks": "4.0.11-rc3-24022-00",
     "System.Threading.Tasks.Parallel": "4.0.1-rc3-24022-00",
     "xunit": "2.1.0",

--- a/src/System.Net.Security/System.Net.Security.sln
+++ b/src/System.Net.Security/System.Net.Security.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{1B8F56A7-863B-4E11-A882-D83EEA79C997}"
 EndProject
@@ -24,57 +24,57 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 		Unix_Debug|Any CPU = Unix_Debug|Any CPU
 		Unix_Release|Any CPU = Unix_Release|Any CPU
-		Release|Any CPU = Release|Any CPU
 		Windows_Debug|Any CPU = Windows_Debug|Any CPU
 		Windows_Release|Any CPU = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0F78E13E-74EE-40F0-8E0B-A026C7794CCB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0F78E13E-74EE-40F0-8E0B-A026C7794CCB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F78E13E-74EE-40F0-8E0B-A026C7794CCB}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F78E13E-74EE-40F0-8E0B-A026C7794CCB}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{0F78E13E-74EE-40F0-8E0B-A026C7794CCB}.Unix_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0F78E13E-74EE-40F0-8E0B-A026C7794CCB}.Unix_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F78E13E-74EE-40F0-8E0B-A026C7794CCB}.Unix_Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{0F78E13E-74EE-40F0-8E0B-A026C7794CCB}.Unix_Release|Any CPU.Build.0 = Debug|Any CPU
-		{0F78E13E-74EE-40F0-8E0B-A026C7794CCB}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{0F78E13E-74EE-40F0-8E0B-A026C7794CCB}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{0F78E13E-74EE-40F0-8E0B-A026C7794CCB}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0F78E13E-74EE-40F0-8E0B-A026C7794CCB}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F78E13E-74EE-40F0-8E0B-A026C7794CCB}.Windows_Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{0F78E13E-74EE-40F0-8E0B-A026C7794CCB}.Windows_Release|Any CPU.Build.0 = Debug|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Unix_Debug|Any CPU.ActiveCfg = Unix_Debug|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Unix_Debug|Any CPU.Build.0 = Unix_Debug|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Unix_Release|Any CPU.ActiveCfg = Unix_Release|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Unix_Release|Any CPU.Build.0 = Unix_Release|Any CPU
-		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
-		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
 		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
 		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
-		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Unix_Debug|Any CPU.ActiveCfg = Unix_Debug|Any CPU
-		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Unix_Debug|Any CPU.Build.0 = Unix_Debug|Any CPU
-		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Unix_Release|Any CPU.ActiveCfg = Unix_Release|Any CPU
-		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Unix_Release|Any CPU.Build.0 = Unix_Release|Any CPU
 		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Unix_Debug|Any CPU.ActiveCfg = OSX_Release|Any CPU
+		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Unix_Debug|Any CPU.Build.0 = OSX_Release|Any CPU
+		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Unix_Release|Any CPU.ActiveCfg = OSX_Release|Any CPU
+		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Unix_Release|Any CPU.Build.0 = OSX_Release|Any CPU
 		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
 		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
 		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Unix_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Unix_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Unix_Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Unix_Release|Any CPU.Build.0 = Release|Any CPU
-		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0D174EA9-9E61-4519-8D31-7BD2331A1982}.Windows_Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
@@ -30,7 +30,6 @@ namespace System.Net.Security.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        [ActiveIssue(4467, PlatformID.Windows)]
         public async Task CertificateValidationClientServer_EndToEnd_Ok(bool useClientSelectionCallback)
         {
             IPEndPoint endPoint = new IPEndPoint(IPAddress.IPv6Loopback, 0);

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
@@ -17,7 +17,6 @@ namespace System.Net.Security.Tests
     {
         private readonly byte[] _sampleMsg = Encoding.UTF8.GetBytes("Sample Test Message");
 
-        [ActiveIssue(5284)]
         [Fact]
         public void NegotiateStream_StreamToStream_Authentication_Success()
         {
@@ -69,7 +68,6 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [ActiveIssue(5284)]
         [Fact]
         public void NegotiateStream_StreamToStream_Authentication_TargetName_Success()
         {
@@ -124,7 +122,6 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [ActiveIssue(5284)]
         [Fact]
         public void NegotiateStream_StreamToStream_Authentication_EmptyCredentials_Fails()
         {
@@ -188,7 +185,6 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [ActiveIssue(5283)]
         [Fact]
         public void NegotiateStream_StreamToStream_Successive_ClientWrite_Sync_Success()
         {
@@ -222,7 +218,6 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [ActiveIssue(5284)]
         [Fact]
         public void NegotiateStream_StreamToStream_Successive_ClientWrite_Async_Success()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -17,7 +17,6 @@ namespace System.Net.Security.Tests
     {
         private readonly byte[] _sampleMsg = Encoding.UTF8.GetBytes("Sample Test Message");
 
-        [ActiveIssue(4467)]
         [Fact]
         public void SslStream_StreamToStream_Authentication_Success()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -14,7 +14,7 @@ namespace System.Net.Security.Tests
 {
     internal static class TestConfiguration
     {
-        public const int PassingTestTimeoutMilliseconds = 15 * 1000;
+        public const int PassingTestTimeoutMilliseconds = 1 * 60 * 1000;
         public const int FailingTestTimeoutMiliseconds = 250;
 
         private const string CertificatePassword = "testcertificate";

--- a/src/System.Net.Security/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/unix/project.json
@@ -16,6 +16,7 @@
     "System.Security.Cryptography.X509Certificates": "4.1.0-rc3-24022-00",
     "System.Security.Principal": "4.0.1-rc3-24022-00",
     "System.Text.RegularExpressions": "4.1.0-rc3-24022-00",
+    "System.Threading.Thread": "4.0.0-rc3-24022-00",
     "System.Resources.ResourceManager": "4.0.1-rc3-24022-00",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",

--- a/src/System.Net.Security/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/win/project.json
@@ -13,6 +13,7 @@
     "System.Security.Principal": "4.0.1-rc3-24022-00",
     "System.Security.Principal.Windows": "4.0.0-rc3-24022-00",
     "System.Text.RegularExpressions": "4.1.0-rc3-24022-00",
+    "System.Threading.Thread": "4.0.0-rc3-24022-00",
     "System.Resources.ResourceManager": "4.0.1-rc3-24022-00",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",


### PR DESCRIPTION
* Adding generic parallel test execution script.
* Address several System.Net.Security test issues found using the script.

The following tests have been used:
* 100 parallel test processes on a 12CPU/16GB machine for 1hr
* 20 parallel test processes on a 8CPU/3GB machine (leaving this to run overnight)
* 20 parallel test processes on a 2CPU/2GB machine (leaving this to run overnight)

Most of below bugs were potentially fixed by #7800 at least in part. Other test-code fixes to issues discovered during stress tests have been added to this PR.

Fixes #4467 #5283 #5284 #5991.

@davidsh @stephentoub @ericeil PTAL
/cc @himadrisarkar