### PR TITLE
Fail more gracefully if the user specifies a receive buffer for AcceptAsync

### DIFF
--- a/src/System.Net.Sockets/src/Resources/Strings.resx
+++ b/src/System.Net.Sockets/src/Resources/Strings.resx
@@ -282,4 +282,7 @@
   <data name="net_sockets_dualmode_receivefrom_notsupported" xml:space="preserve">
     <value>This platform does not support packet information for dual-mode sockets.  If packet information is not required, use Socket.Receive.  If packet information is required set Socket.DualMode to false.</value>
   </data>
+  <data name="net_sockets_accept_receive_notsupported" xml:space="preserve">
+    <value>This platform does not support receiving data with Socket.AcceptAsync.  Instead, make a separate call to Socket.ReceiveAsync.</value>
+  </data>
 </root>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Unix.cs
@@ -28,8 +28,6 @@ namespace System.Net.Sockets
 
         public void CompletionCallback(IntPtr acceptedFileDescriptor, byte[] socketAddress, int socketAddressLen, SocketError errorCode)
         {
-            // TODO #7836: receive bytes on accepted socket if requested
-
             _buffer = null;
             _localBytesTransferred = 0;
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -1287,6 +1287,7 @@ namespace System.Net.Sockets
         public static SocketError AcceptAsync(Socket socket, SafeCloseSocket handle, SafeCloseSocket acceptHandle, int receiveSize, int socketAddressSize, AcceptOverlappedAsyncResult asyncResult)
         {
             Debug.Assert(acceptHandle == null, $"Unexpected acceptHandle: {acceptHandle}");
+            Debug.Assert(receiveSize == 0, $"Unexpected receiveSize: {receiveSize}");
 
             byte[] socketAddressBuffer = new byte[socketAddressSize];
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/AcceptAsync.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/AcceptAsync.cs
@@ -114,6 +114,82 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void AcceptAsync_WithReceiveBuffer_Success()
+        {
+            Assert.True(Capability.IPv4Support());
+
+            AutoResetEvent accepted = new AutoResetEvent(false);
+
+            using (Socket server = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                int port = server.BindToAnonymousPort(IPAddress.Loopback);
+                server.Listen(1);
+
+                const int acceptBufferOverheadSize = 288; // see https://msdn.microsoft.com/en-us/library/system.net.sockets.socket.acceptasync(v=vs.110).aspx
+                const int acceptBufferDataSize = 256;
+                const int acceptBufferSize = acceptBufferOverheadSize + acceptBufferDataSize;
+
+                byte[] sendBuffer = new byte[acceptBufferDataSize];
+                new Random().NextBytes(sendBuffer);
+
+                SocketAsyncEventArgs acceptArgs = new SocketAsyncEventArgs();
+                acceptArgs.Completed += OnAcceptCompleted;
+                acceptArgs.UserToken = accepted;
+                acceptArgs.SetBuffer(new byte[acceptBufferSize], 0, acceptBufferSize);
+
+                Assert.True(server.AcceptAsync(acceptArgs));
+                _log.WriteLine("IPv4 Server: Waiting for clients.");
+
+                using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    client.Connect(IPAddress.Loopback, port);
+                    client.Send(sendBuffer);
+                    client.Shutdown(SocketShutdown.Both);
+                }
+
+                Assert.True(
+                    accepted.WaitOne(Configuration.PassingTestTimeout), "Test completed in alotted time");
+
+                Assert.Equal(
+                    SocketError.Success, acceptArgs.SocketError);
+
+                Assert.Equal(
+                    acceptBufferDataSize, acceptArgs.BytesTransferred);
+
+                Assert.Equal(
+                    new ArraySegment<byte>(sendBuffer), 
+                    new ArraySegment<byte>(acceptArgs.Buffer, 0, acceptArgs.BytesTransferred));
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void AcceptAsync_WithReceiveBuffer_Failure()
+        {
+            //
+            // Unix platforms don't yet support receiving data with AcceptAsync.
+            //
+
+            Assert.True(Capability.IPv4Support());
+
+            using (Socket server = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                int port = server.BindToAnonymousPort(IPAddress.Loopback);
+                server.Listen(1);
+
+                SocketAsyncEventArgs acceptArgs = new SocketAsyncEventArgs();
+                acceptArgs.Completed += OnAcceptCompleted;
+                acceptArgs.UserToken = new ManualResetEvent(false);
+
+                byte[] buffer = new byte[1024];
+                acceptArgs.SetBuffer(buffer, 0, buffer.Length);
+
+                Assert.Throws<PlatformNotSupportedException>(() => server.AcceptAsync(acceptArgs));
+            }
+        }
+
         #region GC Finalizer test
         // This test assumes sequential execution of tests and that it is going to be executed after other tests
         // that used Sockets. 


### PR DESCRIPTION
On Windows, `AcceptAsync` can optionally receive an initial buffer-full of data from the newly connected socket, via the magic of [`AcceptEx`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms737524(v=vs.85).aspx).  We currently have no emulation of this feature on Unix.  Instead, we fail an assert in Debug builds, or report erroneous results in Release builds.

This change causes `AcceptAsync` to throw `PlatformNotSupportedException` if the user has supplied a buffer to receive data.  In the future, we can consider implementing this feature, but for now it's better to fail correctly rather than succeed erroneously.

I've also added a couple of new test cases (to check that this works on Windows, and does *not* work on Unix), and some new asserts to make sure this doesn't come up elsewhere.

Addresses #7836

@stephentoub, @CIPop 