### PR TITLE
Fixed a Test Bug

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
@@ -107,7 +107,8 @@ public static class XmlDictionaryWriterTest
             var t2 = Assert.ThrowsAsync<InvalidOperationException>(() => writer.WriteBase64Async(bytes, 0, byteSize));
 
             InvalidOperationException e = t2.Result;
-            Assert.StrictEqual(e.Message, "An asynchronous operation is already in progress.");
+            bool isAsyncIsRunningException = e.Message.Contains("XmlAsyncIsRunningException") || e.Message.Contains("in progress");
+            Assert.True(isAsyncIsRunningException, "The exception is not XmlAsyncIsRunningException.");
 
             // let the first task complete
             ms.blockAsync(false);


### PR DESCRIPTION
The test asserts the exception message. But in Net Native the exception contains the resource name only instead of the error message, thus the test fails in Net Native.

Fix #7942.

/cc: @khdang @SGuyGe