### PR TITLE
Force CurlHandler active operations to shutdown when handler disposed

### DIFF
--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -351,6 +351,9 @@
   <data name="net_http_unix_invalid_response" xml:space="preserve">
     <value>The server returned an invalid or unrecognized response.</value>
   </data>
+  <data name="net_http_unix_handler_disposed" xml:space="preserve">
+    <value>The handler was disposed of while active operations were in progress.</value>
+  </data>
   <data name="net_http_buffer_insufficient_length" xml:space="preserve">
     <value>The buffer was not long enough.</value>
   </data>


### PR DESCRIPTION
If the CurlHandler is disposed of while active operations are in progress, fail them.  This was generally already happening, but not reliably, and not with the right exception type (a cancellation exception).

cc: @ericeil, @kapilash, @davidsh