### PR TITLE
[rfc] monoandroid403 and monoandroid

### DIFF
--- a/Documentation/architecture/net-platform-standard.md
+++ b/Documentation/architecture/net-platform-standard.md
@@ -125,7 +125,7 @@ Existing PCL projects in VS2013 and VS2015 (excluding UWP targets), can only tar
 | Windows Phone 8.1 | wpa8.1 |
 | Universal Windows Platform 10 | uap10, netcore50 |
 | Silverlight 4, 5 | sl4, sl5 |
-| MonoAndroid | monoandroid |
+| MonoAndroid | monoandroid, monoandroid403 |
 | MonoTouch | monotouch |
 | MonoMac | monomac |
 | Xamarin iOS | xamarinios |


### PR DESCRIPTION
With Xamarin.Android there are actually two identifiers commonly in use, this is omitted from the document - was this deliberate or an omission?

> monoandroid = supports pretty much all Android API levels since the beginging of time. Great target for framework libraries.
> monoandroir403 = supports Android API 15 (4.0.3 - Ice Cream Sandwich) and up. Great target for user interface libraries.

I suspect `monoandroid403` supersedes `monoandroid` but do not have official confirmation. For v7 of ReactiveUI and onwards we moved to using `monoandroid403` across the board for all our packages as matches what other library maintainers are doing (some of which are Xamarin employees). The project consists of nine different nuspec packages and can be viewed at https://github.com/reactiveui/ReactiveUI/tree/myget/src

Thanks for the fantastic document.