### PR TITLE
Mark SafeX509ChainHandle.InvalidHandle as internal.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Microsoft/Win32/SafeHandles/SafeX509ChainHandle.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Microsoft/Win32/SafeHandles/SafeX509ChainHandle.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Win32.SafeHandles
             get { return handle == IntPtr.Zero; }
         }
 
-        public static SafeX509ChainHandle InvalidHandle
+        internal static SafeX509ChainHandle InvalidHandle
         {
             get { return SafeHandleCache<SafeX509ChainHandle>.GetInvalidHandle(() => new SafeX509ChainHandle()); }
         }

--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -251,21 +251,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        public static void SafeX509ChainHandle_InvalidHandle_IsInvalid()
-        {
-            Assert.True(SafeX509ChainHandle.InvalidHandle.IsInvalid);
-        }
-
-        [Fact]
-        public static void SafeX509ChainHandle_InvalidHandle_StaticObject()
-        {
-            SafeX509ChainHandle firstCall = SafeX509ChainHandle.InvalidHandle;
-            SafeX509ChainHandle secondCall = SafeX509ChainHandle.InvalidHandle;
-
-            Assert.Same(firstCall, secondCall);
-        }
-
-        [Fact]
         [OuterLoop( /* May require using the network, to download CRLs and intermediates */)]
         public static void VerifyWithRevocation()
         {


### PR DESCRIPTION
SafeX509ChainHandle.InvalidHandle isn't in the contract, but it was declared
as public in the implementation type; and then it got tested because it was
public.

Since it's not in the contract, mark it as internal, and remove the tests.

Fixes #7910.