### PR TITLE
Adding a hook to do setup and cleanup steps.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -134,4 +134,7 @@
     <RemoveDir Directories="$(BinDir)" />
   </Target>
 
+  <!-- Hook that can be used to insert custom build tasks to the build process such as setup and/or cleanup tasks -->
+  <Import Project="build.override.targets" Condition="Exists('build.override.targets')" />
+
 </Project>


### PR DESCRIPTION
* Initially wanted to add the hook to src\tests.builds but tests.builds is included as just one more item in the 'Project' collection and in testing the hook I couldn't get the import of the targets file to work and invoke the custom Targets in it. Moving it out of the 'Project' ItemGroup worked.