### PR TITLE
Port to RC2: Fix CurlResponseStream.Dispose to cancel the request

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
@@ -345,7 +345,7 @@ namespace System.Net.Http
             }
 
             /// <summary>Notifies the stream that no more data will be written.</summary>
-            internal void SignalComplete(Exception error = null)
+            internal void SignalComplete(Exception error = null, bool forceCancel = false)
             {
                 lock (_lockObject)
                 {
@@ -361,6 +361,17 @@ namespace System.Net.Http
                     _completed = error != null ?
                         error :
                         s_completionSentinel;
+
+                    // If the request wasn't already completed, and if requested, send a cancellation
+                    // request to ensure that the connection gets cleaned up.  This is only necessary
+                    // to do if this method is being called for a reason other than the request/response
+                    // completing naturally, e.g. if the response stream is being disposed of before
+                    // all of the response has been downloaded.
+                    if (forceCancel)
+                    {
+                        EventSourceTrace("Completing the response stream prematurely.");
+                        _easy._associatedMultiAgent.RequestCancel(_easy);
+                    }
 
                     // If there's a pending read request, complete it, either with 0 bytes for success
                     // or with the exception/CancellationToken for failure.
@@ -409,7 +420,7 @@ namespace System.Net.Http
                 if (disposing && !_disposed)
                 {
                     _disposed = true;
-                    SignalComplete();
+                    SignalComplete(forceCancel: true);
                 }
 
                 base.Dispose(disposing);


### PR DESCRIPTION
We weren't canceling the request when prematurely Dispose'ing the response stream.  Because of how asynchronous transfers work, where we need to pause the connection until a reader has requested data, if no reader ever requested data (e.g. the stream was disposed without reading anything) then the connection could remain paused indefinitely, and it would sit around until the HttpClient timeout kicked in and canceled it.  This could lead to unbounded growth of the number of sockets being used, as sockets couldn't be pooled or cleaned up due to still being associated with an active download.  The fix is simply to cancel the request in Dispose if the request isn't already completed.

Port of #7946