### PR TITLE
Add OSGroupPath for Windows platform so that we can build Windows nat…

### DIFF
--- a/src/Native/pkg/dir.props
+++ b/src/Native/pkg/dir.props
@@ -2,6 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.props))\dir.props" />
   <!-- coalesce RIDs into the correct build output directory -->
   <PropertyGroup>
+    <OSGroupPath Condition="$(OSGroup.StartsWith('windows', StringComparison.OrdinalIgnoreCase))">Windows_NT</OSGroupPath>
     <OSGroupPath Condition="$(OSGroup.StartsWith('debian'))">Linux</OSGroupPath>
     <OSGroupPath Condition="$(OSGroup.StartsWith('osx'))">OSX</OSGroupPath>
     <OSGroupPath Condition="$(OSGroup.StartsWith('rhel'))">Linux</OSGroupPath>


### PR DESCRIPTION
…ive packages in corefx.

Windows native packages won't currently build out of corefx because the OSGroupPath for Windows is not getting set.

/cc @weshaggard , @AlfredoMS , @jhendrixMSFT , @ericstj