### PR TITLE
Make EmptyReadOnlyCollection.Instance readonly.

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/EmptyReadOnlyCollection.cs
+++ b/src/Common/src/System/Dynamic/Utils/EmptyReadOnlyCollection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.Contracts;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
 
@@ -11,6 +9,6 @@ namespace System.Dynamic.Utils
 {
     internal static class EmptyReadOnlyCollection<T>
     {
-        public static ReadOnlyCollection<T> Instance = new TrueReadOnlyCollection<T>(Array.Empty<T>());
+        public readonly static ReadOnlyCollection<T> Instance = new TrueReadOnlyCollection<T>(Array.Empty<T>());
     }
 }


### PR DESCRIPTION
As an internally-visible member it could potentially be over-written in error.