### PR TITLE
Throw Argument‎Exception on light-compiling extension expressions.

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -375,9 +375,6 @@
   <data name="FaultBlockNotSupported" xml:space="preserve">
     <value>Fault blocks are not supported</value>
   </data>
-  <data name="NonReducibleExpressionExtensionsNotSupported" xml:space="preserve">
-    <value>Non-reducible expression extensions are not supported</value>
-  </data>
   <data name="ParameterExpressionNotValidAsDelegate" xml:space="preserve">
     <value>ParameterExpression of type '{0}' cannot be used for delegate parameter of type '{1}'</value>
   </data>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Generated.cs
@@ -239,7 +239,14 @@ namespace System.Linq.Expressions.Compiler
                     return new Result(RewriteAction.None, node);
 
                 default:
-                    throw ContractUtils.Unreachable;
+                    result = RewriteExpression(node.ReduceAndCheck(), stack);
+                    if (result.Action == RewriteAction.None)
+                    {
+                        // it's at least Copy because we reduced the node
+                        result = new Result(result.Action | RewriteAction.Copy, result.Node);
+                    }
+
+                    break;
             }
 
             VerifyRewrite(result, node);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
@@ -11,11 +11,6 @@ using System.Runtime.CompilerServices;
 
 namespace System.Linq.Expressions.Interpreter
 {
-    internal interface IInstructionProvider
-    {
-        void AddInstructions(LightCompiler compiler);
-    }
-
     internal abstract partial class Instruction
     {
         public const int UnknownInstrIndex = int.MaxValue;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2555,12 +2555,6 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private void CompileExtensionExpression(Expression expr)
-        {
-            Compile(expr.ReduceAndCheck());
-        }
-
-
         private void CompileDebugInfoExpression(Expression expr)
         {
             var node = (DebugInfoExpression)expr;
@@ -3038,7 +3032,6 @@ namespace System.Linq.Expressions.Interpreter
                 case ExpressionType.DebugInfo: CompileDebugInfoExpression(expr); break;
                 case ExpressionType.Decrement: CompileUnaryExpression(expr); break;
                 case ExpressionType.Default: CompileDefaultExpression(expr); break;
-                case ExpressionType.Extension: CompileExtensionExpression(expr); break;
                 case ExpressionType.Goto: CompileGotoExpression(expr); break;
                 case ExpressionType.Increment: CompileUnaryExpression(expr); break;
                 case ExpressionType.Index: CompileIndexExpression(expr); break;
@@ -3053,32 +3046,10 @@ namespace System.Linq.Expressions.Interpreter
                 case ExpressionType.OnesComplement: CompileUnaryExpression(expr); break;
                 case ExpressionType.IsTrue: CompileUnaryExpression(expr); break;
                 case ExpressionType.IsFalse: CompileUnaryExpression(expr); break;
-                case ExpressionType.AddAssign:
-                case ExpressionType.AndAssign:
-                case ExpressionType.DivideAssign:
-                case ExpressionType.ExclusiveOrAssign:
-                case ExpressionType.LeftShiftAssign:
-                case ExpressionType.ModuloAssign:
-                case ExpressionType.MultiplyAssign:
-                case ExpressionType.OrAssign:
-                case ExpressionType.PowerAssign:
-                case ExpressionType.RightShiftAssign:
-                case ExpressionType.SubtractAssign:
-                case ExpressionType.AddAssignChecked:
-                case ExpressionType.MultiplyAssignChecked:
-                case ExpressionType.SubtractAssignChecked:
-                case ExpressionType.PreIncrementAssign:
-                case ExpressionType.PreDecrementAssign:
-                case ExpressionType.PostIncrementAssign:
-                case ExpressionType.PostDecrementAssign:
                 default:
-                    if (expr.CanReduce)
-                    {
-                        Compile(expr.Reduce());
-                        break;
-                    }
-                    throw new PlatformNotSupportedException(SR.Format(SR.UnsupportedExpressionType, expr.NodeType));
-            };
+                    Compile(expr.ReduceAndCheck());
+                    break;
+            }
             Debug.Assert(_instructions.CurrentStackDepth == startingStackDepth + (expr.Type == typeof(void) ? 0 : 1),
                 String.Format("{0} vs {1} for {2}", _instructions.CurrentStackDepth, startingStackDepth + (expr.Type == typeof(void) ? 0 : 1), expr.NodeType));
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2557,13 +2557,6 @@ namespace System.Linq.Expressions.Interpreter
 
         private void CompileExtensionExpression(Expression expr)
         {
-            var instructionProvider = expr as IInstructionProvider;
-            if (instructionProvider != null)
-            {
-                instructionProvider.AddInstructions(this);
-                return;
-            }
-
             Compile(expr.ReduceAndCheck());
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2564,14 +2564,7 @@ namespace System.Linq.Expressions.Interpreter
                 return;
             }
 
-            if (expr.CanReduce)
-            {
-                Compile(expr.Reduce());
-            }
-            else
-            {
-                throw new PlatformNotSupportedException(SR.NonReducibleExpressionExtensionsNotSupported);
-            }
+            Compile(expr.ReduceAndCheck());
         }
 
 

--- a/src/System.Linq.Expressions/tests/ExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ExpressionTests.cs
@@ -111,6 +111,13 @@ namespace System.Linq.Expressions.Tests
 #pragma warning restore 0618
         }
 
+        private class IrreducibleWithTypeAndNodeType : Expression
+        {
+            public override Type Type => typeof(void);
+
+            public override ExpressionType NodeType => ExpressionType.Extension;
+        }
+
         public static IEnumerable<object[]> AllNodeTypesPlusSomeInvalid
         {
             get
@@ -389,6 +396,13 @@ namespace System.Linq.Expressions.Tests
         public void ConfirmCanWrite(Expression writableExpression)
         {
             Expression.Assign(writableExpression, Expression.Default(writableExpression.Type));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void CompileIrreduciebleExtension(bool useInterpreter)
+        {
+            var exp = Expression.Lambda<Action>(new IrreducibleWithTypeAndNodeType());
+            Assert.Throws<ArgumentException>(() => exp.Compile(useInterpreter));
         }
     }
 }


### PR DESCRIPTION
To be more in line with compiler.

Fixes #7980.

Also 	remove `IInstructionProvider` interface; internal-visible interface tested for in this path, but which has no implementations.