### PR TITLE
Remove some redundances from expression interpreter

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -190,6 +190,7 @@ namespace System.Linq.Expressions.Interpreter
         }
 #endif
 
+#if FEATURE_FAST_CREATE
         /// <summary>
         /// Gets the next type or null if no more types are available.
         /// </summary>
@@ -224,6 +225,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             return pi.Length != index || (pi.Length == index && !target.IsStatic);
         }
+#endif
 
 #if FEATURE_DLG_INVOKE
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -765,21 +765,6 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private bool EmitLiftedNullCheck(Expression node, BranchLabel makeCall)
-        {
-            Compile(node);
-            if (TypeUtils.IsNullableType(node.Type) || !node.Type.GetTypeInfo().IsValueType)
-            {
-                _instructions.EmitDup();
-                _instructions.EmitLoad(null, typeof(object));
-                _instructions.EmitNotEqual(typeof(object));
-                _instructions.EmitBranch(makeCall);
-                _instructions.EmitPop();
-                return true;
-            }
-            return false;
-        }
-
         private static bool IsNullableOrReferenceType(Type t)
         {
             return !t.GetTypeInfo().IsValueType || TypeUtils.IsNullableType(t);
@@ -827,7 +812,6 @@ namespace System.Linq.Expressions.Interpreter
                                 goto default;
                             }
 
-                            Type resultType = TypeUtils.GetNullableType(node.Type);
                             BranchLabel testRight = _instructions.MakeLabel();
                             BranchLabel callMethod = _instructions.MakeLabel();
 
@@ -878,7 +862,7 @@ namespace System.Linq.Expressions.Interpreter
                         default:
                             BranchLabel loadDefault = _instructions.MakeLabel();
 
-                            if (!node.Left.Type.GetTypeInfo().IsValueType || TypeUtils.IsNullableType(node.Left.Type))
+                            if (IsNullableOrReferenceType(node.Left.Type))
                             {
                                 _instructions.EmitLoadLocal(leftTemp.Index);
                                 _instructions.EmitLoad(null, typeof(object));
@@ -886,7 +870,7 @@ namespace System.Linq.Expressions.Interpreter
                                 _instructions.EmitBranchTrue(loadDefault);
                             }
 
-                            if (!node.Right.Type.GetTypeInfo().IsValueType || TypeUtils.IsNullableType(node.Right.Type))
+                            if (IsNullableOrReferenceType(node.Right.Type))
                             {
                                 _instructions.EmitLoadLocal(rightTemp.Index);
                                 _instructions.EmitLoad(null, typeof(object));

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightDelegateCreator.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightDelegateCreator.cs
@@ -32,11 +32,6 @@ namespace System.Linq.Expressions.Interpreter
             get { return _interpreter; }
         }
 
-        private bool HasClosure
-        {
-            get { return _interpreter.ClosureSize > 0; }
-        }
-
         public Delegate CreateDelegate()
         {
             return CreateDelegate(null);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -219,7 +219,9 @@ namespace System.Linq.Expressions.Interpreter
 
     internal static class ExceptionHelpers
     {
+#if FEATURE_STACK_TRACES
         private const string prevStackTraces = "PreviousStackTraces";
+#endif
 
         /// <summary>
         /// Updates an exception before it's getting re-thrown so


### PR DESCRIPTION
Contributes to #3836

`TryGetParameterOrReturnType` and `IndexIsNotReturnType` are only called from code for the `FEATURE_FAST_CREATE` switch. Have them only compile for that switch.

`LightCompiler.EmitLiftedNullCheck` and `LightDelegateCreator.HasClosure` are never used. Remove.

Result of call to `TypeUtils.GetNullableType(node.Type)` in `CompileBinaryExpression` is never used and it has no side-effects. Remove.

`IsNullableOrReferenceType` is never used, but there are two places where doing so would be a slight improvement. Use it.

`ExceptionHelpers.prevStackTraces` is only used if `FEATURE_STACK_TRACES` is set. Have it only compile in that case.