### PR TITLE
Simplify Parameter instruction in Expressions interpreter

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -623,14 +623,14 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        internal void EmitInitializeParameter(int index, Type parameterType)
+        internal void EmitInitializeParameter(int index)
         {
-            Emit(Parameter(index, parameterType));
+            Emit(Parameter(index));
         }
 
-        internal static Instruction Parameter(int index, Type parameterType)
+        internal static Instruction Parameter(int index)
         {
-            return new InitializeLocalInstruction.Parameter(index, parameterType);
+            return new InitializeLocalInstruction.Parameter(index);
         }
 
         internal static Instruction ParameterBox(int index)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -342,7 +342,7 @@ namespace System.Linq.Expressions.Interpreter
             foreach (var p in node.Parameters)
             {
                 var local = _locals.DefineLocal(p, 0);
-                _instructions.EmitInitializeParameter(local.Index, p.Type);
+                _instructions.EmitInitializeParameter(local.Index);
             }
 
             Compile(node.Body);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
@@ -406,7 +406,7 @@ namespace System.Linq.Expressions.Interpreter
 
         internal sealed class Parameter : InitializeLocalInstruction, IBoxableInstruction
         {
-            internal Parameter(int index, Type parameterType)
+            internal Parameter(int index)
                 : base(index)
             {
             }


### PR DESCRIPTION
Remove unused parameter in constructor, and pass the deletion up the call stack.