### PR TITLE
Fix System.ComponentModel.TypeConverter package generation

### DIFF
--- a/src/System.ComponentModel.TypeConverter/pkg/System.ComponentModel.TypeConverter.pkgproj
+++ b/src/System.ComponentModel.TypeConverter/pkg/System.ComponentModel.TypeConverter.pkgproj
@@ -2,11 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <ProjectReference Include="..\ref\4.0\System.ComponentModel.TypeConverter.depproj">
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\ref\System.ComponentModel.TypeConverter.csproj">
-      <SupportedFramework>net45;netcore45;netstandardapp1.5;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net462;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ComponentModel.TypeConverter.builds" />
-  </ItemGroup>
+  </ItemGroup>  
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />

--- a/src/System.ComponentModel.TypeConverter/ref/4.0/System.ComponentModel.TypeConverter.depproj
+++ b/src/System.ComponentModel.TypeConverter/ref/4.0/System.ComponentModel.TypeConverter.depproj
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.5</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.0</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.0</NuGetTargetMoniker>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="System.ComponentModel.TypeConverter.cs" />
-  </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.ComponentModel.TypeConverter/ref/4.0/project.json
+++ b/src/System.ComponentModel.TypeConverter/ref/4.0/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.ComponentModel.TypeConverter": "4.0.0"
+  },
+  "frameworks": {
+    "netstandard1.0": {
+      "imports": [
+        "dotnet5.1"
+      ]
+    }
+  }
+}

--- a/src/System.ComponentModel.TypeConverter/ref/project.json
+++ b/src/System.ComponentModel.TypeConverter/ref/project.json
@@ -8,7 +8,7 @@
     "System.Runtime": "4.0.0"
   },
   "frameworks": {
-    "netstandard1.0": {
+    "netstandard1.5": {
       "imports": [
         "dotnet5.1"
       ]

--- a/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.builds
+++ b/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.builds
@@ -6,6 +6,12 @@
     <Project Include="System.ComponentModel.TypeConverter.csproj">
       <TargetGroup>net45</TargetGroup>
     </Project>
+    <Project Include="System.ComponentModel.TypeConverter.csproj">
+      <TargetGroup>net462</TargetGroup>
+    </Project>
+    <Project Include="System.ComponentModel.TypeConverter.csproj">
+      <TargetGroup>netstandard1.0</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
+++ b/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
@@ -17,56 +17,80 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)'==''">
+  
+  <PropertyGroup Condition="'$(TargetGroup)'=='netstandard1.0'">
+      <DefineConstants>NETSTANDARD10</DefineConstants>
+  </PropertyGroup>
+  
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.0'">
+      <Compile Include="System\ComponentModel\ReflectTypeDescriptionProvider.NetStandard10.cs" />
+      <Compile Include="System\ComponentModel\TypeDescriptor.NetStandard10.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetGroup)'=='' OR '$(TargetGroup)'=='netstandard1.0'">
     <Compile Include="System\ComponentModel\ArrayConverter.cs" />
-    <Compile Include="System\ComponentModel\AttributeCollection.cs" />
-    <Compile Include="System\ComponentModel\AttributeProviderAttribute.cs" />
     <Compile Include="System\ComponentModel\BaseNumberConverter.cs" />
     <Compile Include="System\ComponentModel\BooleanConverter.cs" />
     <Compile Include="System\ComponentModel\ByteConverter.cs" />
-    <Compile Include="System\ComponentModel\CancelEventHandler.cs" />
     <Compile Include="System\ComponentModel\CharConverter.cs" />
+    <Compile Include="System\ComponentModel\CollectionConverter.cs" />
+    <Compile Include="System\ComponentModel\DateTimeConverter.cs" />
+    <Compile Include="System\ComponentModel\DateTimeOffsetConverter.cs" />
+    <Compile Include="System\ComponentModel\DecimalConverter.cs" />
+    <Compile Include="System\ComponentModel\DoubleConverter.cs" />
+    <Compile Include="System\ComponentModel\EnumConverter.cs" />
+    <Compile Include="System\ComponentModel\GuidConverter.cs" />
+    <Compile Include="System\ComponentModel\Int16Converter.cs" />
+    <Compile Include="System\ComponentModel\Int32Converter.cs" />
+    <Compile Include="System\ComponentModel\Int64Converter.cs" />
+    <Compile Include="System\ComponentModel\ITypeDescriptorContext.cs" />
+    <Compile Include="System\ComponentModel\MultilineStringConverter.cs" />
+    <Compile Include="System\ComponentModel\NullableConverter.cs" />
+    <Compile Include="System\ComponentModel\PropertyDescriptor.cs" />
+    <Compile Include="System\ComponentModel\SByteConverter.cs" />
+    <Compile Include="System\ComponentModel\SingleConverter.cs" />
+    <Compile Include="System\ComponentModel\StringConverter.cs" />
+    <Compile Include="System\ComponentModel\TimeSpanConverter.cs" />
+    <Compile Include="System\ComponentModel\TypeConverter.cs" />
+    <Compile Include="System\ComponentModel\TypeConverterAttribute.cs" />
+    <Compile Include="System\ComponentModel\TypeListConverter.cs" />
+    <Compile Include="System\ComponentModel\UInt16Converter.cs" />
+    <Compile Include="System\ComponentModel\UInt32Converter.cs" />
+    <Compile Include="System\ComponentModel\UInt64Converter.cs" />
+    <Compile Include="System\ComponentModel\UriTypeConverter.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetGroup)'==''">
+    <Compile Include="System\ComponentModel\AttributeCollection.cs" />
+    <Compile Include="System\ComponentModel\AttributeProviderAttribute.cs" />
+    <Compile Include="System\ComponentModel\CancelEventHandler.cs" />
     <Compile Include="System\ComponentModel\CollectionChangeAction.cs" />
     <Compile Include="System\ComponentModel\CollectionChangeEventArgs.cs" />
     <Compile Include="System\ComponentModel\CollectionChangeEventHandler.cs" />
-    <Compile Include="System\ComponentModel\CollectionConverter.cs" />
     <!-- CultureInfoConverter is excluded because it relies on enumerating the execution
          environment's supported cultures, which is impossible on some platforms -->
     <!--<Compile Include="System\ComponentModel\CultureInfoConverter.cs" />-->
     <Compile Include="System\ComponentModel\CustomTypeDescriptor.cs" />
-    <Compile Include="System\ComponentModel\DateTimeConverter.cs" />
-    <Compile Include="System\ComponentModel\DateTimeOffsetConverter.cs" />
-    <Compile Include="System\ComponentModel\DecimalConverter.cs" />
     <Compile Include="System\ComponentModel\DefaultEventAttribute.cs" />
     <Compile Include="System\ComponentModel\DefaultPropertyAttribute.cs" />
     <Compile Include="System\ComponentModel\DelegatingTypeDescriptionProvider.cs" />
     <Compile Include="System\ComponentModel\DesignerSerializationVisibility.cs" />
     <Compile Include="System\ComponentModel\DesignerSerializationVisibilityAttribute.cs" />
-    <Compile Include="System\ComponentModel\DoubleConverter.cs" />
-    <Compile Include="System\ComponentModel\EnumConverter.cs" />
     <Compile Include="System\ComponentModel\EventDescriptor.cs" />
     <Compile Include="System\ComponentModel\EventDescriptorCollection.cs" />
     <Compile Include="System\ComponentModel\EventHandlerList.cs" />
     <Compile Include="System\ComponentModel\ExtendedPropertyDescriptor.cs" />
     <Compile Include="System\ComponentModel\ExtenderProvidedPropertyAttribute.cs" />
-    <Compile Include="System\ComponentModel\GuidConverter.cs" />
     <Compile Include="System\ComponentModel\HandledEventArgs.cs" />
     <Compile Include="System\ComponentModel\HandledEventHandler.cs" />
     <!--<Compile Include="System\ComponentModel\Design\IDesignerHost.cs" />-->
-    <Compile Include="System\ComponentModel\Int16Converter.cs" />
-    <Compile Include="System\ComponentModel\Int32Converter.cs" />
-    <Compile Include="System\ComponentModel\Int64Converter.cs" />
     <Compile Include="System\ComponentModel\ICustomTypeDescriptor.cs" />
     <Compile Include="System\ComponentModel\IExtenderProvider.cs" />
     <Compile Include="System\ComponentModel\IListSource.cs" />
     <Compile Include="System\ComponentModel\InvalidAsynchronousStateException.cs" />
     <Compile Include="System\InvariantComparer.cs" />
-    <Compile Include="System\ComponentModel\ITypeDescriptorContext.cs" />
     <Compile Include="System\ComponentModel\ITypedList.cs" />
     <Compile Include="System\ComponentModel\MemberDescriptor.cs" />
-    <Compile Include="System\ComponentModel\MultilineStringConverter.cs" />
-    <Compile Include="System\ComponentModel\NullableConverter.cs" />
-    <Compile Include="System\ComponentModel\PropertyDescriptor.cs" />
     <Compile Include="System\ComponentModel\PropertyDescriptorCollection.cs" />
     <Compile Include="System\ComponentModel\ProvidePropertyAttribute.cs" />
     <!-- ReferenceConverter is excluded because its purpose is to enable displaying the properties of an
@@ -78,20 +102,9 @@
     <Compile Include="System\ComponentModel\ReflectTypeDescriptionProvider.ReflectedTypeData.cs" />
     <Compile Include="System\ComponentModel\RefreshEventArgs.cs" />
     <Compile Include="System\ComponentModel\RefreshEventHandler.cs" />
-    <Compile Include="System\ComponentModel\SByteConverter.cs" />
-    <Compile Include="System\ComponentModel\SingleConverter.cs" />
-    <Compile Include="System\ComponentModel\StringConverter.cs" />
-    <Compile Include="System\ComponentModel\TimeSpanConverter.cs" />
-    <Compile Include="System\ComponentModel\TypeConverter.cs" />
-    <Compile Include="System\ComponentModel\TypeConverterAttribute.cs" />
     <Compile Include="System\ComponentModel\TypeDescriptor.cs" />
     <Compile Include="System\ComponentModel\TypeDescriptionProvider.cs" />
     <Compile Include="System\ComponentModel\TypeDescriptionProviderAttribute.cs" />
-    <Compile Include="System\ComponentModel\TypeListConverter.cs" />
-    <Compile Include="System\ComponentModel\UInt16Converter.cs" />
-    <Compile Include="System\ComponentModel\UInt32Converter.cs" />
-    <Compile Include="System\ComponentModel\UInt64Converter.cs" />
-    <Compile Include="System\ComponentModel\UriTypeConverter.cs" />
     <Compile Include="System\ComponentModel\WeakHashtable.cs" />
     <Compile Include="System\ComponentModel\Design\IDictionaryService.cs" />
     <Compile Include="System\ComponentModel\Design\IExtenderListService.cs" />

--- a/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
+++ b/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
@@ -5,9 +5,11 @@
     <ProjectGuid>{AF3EBF3B-526A-4B51-9F3D-62B0113CD01F}</ProjectGuid>
     <RootNamespace>System.ComponentModel.TypeConverter</RootNamespace>
     <AssemblyName>System.ComponentModel.TypeConverter</AssemblyName>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)' == '' OR '$(TargetGroup)'=='net462'">4.1.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetGroup)' == 'netstandard1.0' OR '$(TargetGroup)'=='net45'">4.0.0.0</AssemblyVersion>
+    <ContractProject Condition="'$(TargetGroup)'=='net45'">..\ref\4.0\$(AssemblyName).depproj</ContractProject>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.5</PackageTargetFramework>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net45'">true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net45' OR '$(TargetGroup)'=='net462'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.5</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
@@ -95,7 +97,7 @@
     <Compile Include="System\ComponentModel\Design\IExtenderListService.cs" />
     <Compile Include="System\ComponentModel\Design\ITypeDescriptorFilterService.cs" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'==''">
     <ProjectReference Include="..\..\System.ComponentModel.Primitives\src\System.ComponentModel.Primitives.csproj">
       <Name>System.ComponentModel.TypeConverter.Primitives</Name>
     </ProjectReference>
@@ -103,7 +105,7 @@
   <ItemGroup Condition="'$(TargetGroup)'==''">
     <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='net45'">
+  <ItemGroup Condition="'$(TargetGroup)'=='net45' OR '$(TargetGroup)'=='net462'">
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System" />
   </ItemGroup>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ArrayConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ArrayConverter.cs
@@ -33,6 +33,7 @@ namespace System.ComponentModel
             return base.ConvertTo(context, culture, value, destinationType);
         }
 
+#if !NETSTANDARD10
         /// <devdoc>
         ///    <para>Gets a collection of properties for the type of array specified by the value parameter.</para>
         /// </devdoc>
@@ -57,6 +58,7 @@ namespace System.ComponentModel
 
             return new PropertyDescriptorCollection(props);
         }
+#endif // !NETSTANDARD10
 
         /// <devdoc>
         ///    <para>Gets a value indicating whether this object supports properties.</para>
@@ -66,6 +68,7 @@ namespace System.ComponentModel
             return true;
         }
 
+#if !NETSTANDARD10
         private class ArrayPropertyDescriptor : SimplePropertyDescriptor
         {
             private readonly int _index;
@@ -104,5 +107,6 @@ namespace System.ComponentModel
                 }
             }
         }
+#endif // !NETSTANDARD10
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CollectionConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CollectionConverter.cs
@@ -36,6 +36,7 @@ namespace System.ComponentModel
             return base.ConvertTo(context, culture, value, destinationType);
         }
 
+#if !NETSTANDARD10
         /// <devdoc>
         ///    <para>
         ///        Gets a collection of properties for the type of array specified by the value parameter using
@@ -46,6 +47,7 @@ namespace System.ComponentModel
         {
             return new PropertyDescriptorCollection(null);
         }
+#endif // !NETSTANDARD10
 
         /// <devdoc>
         ///    <para>Gets a value indicating whether this object supports properties.</para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
@@ -99,6 +99,7 @@ namespace System.ComponentModel
             return base.CanConvertTo(context, destinationType);
         }
 
+#if !NETSTANDARD10
         /// <devdoc>
         ///     <para>
         ///         Gets an <see cref='System.Collections.IComparer'/> interface that can
@@ -112,6 +113,7 @@ namespace System.ComponentModel
                 return InvariantComparer.Default;
             }
         }
+#endif // !NETSTANDARD10
 
         /// <internalonly/>
         /// <devdoc>
@@ -233,6 +235,7 @@ namespace System.ComponentModel
             return base.ConvertTo(context, culture, value, destinationType);
         }
 
+#if !NETSTANDARD10
         /// <internalonly/>
         /// <devdoc>
         ///    <para>Gets a collection of standard values for the data type this validator is
@@ -337,5 +340,6 @@ namespace System.ComponentModel
         {
             return Enum.IsDefined(_type, value);
         }
+#endif // !NETSTANDARD10
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MultilineStringConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MultilineStringConverter.cs
@@ -33,6 +33,7 @@ namespace System.ComponentModel
             return base.ConvertTo(context, culture, value, destinationType);
         }
 
+#if !NETSTANDARD10
         /// <devdoc>
         /// Gets a collection of properties for the type of array specified by the value
         /// parameter using the specified context and attributes.
@@ -41,6 +42,7 @@ namespace System.ComponentModel
         {
             return null;
         }
+#endif // !NETSTANDARD10
 
         /// <devdoc>
         /// Gets a value indicating whether this object supports properties.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/NullableConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/NullableConverter.cs
@@ -156,6 +156,7 @@ namespace System.ComponentModel
             return base.GetCreateInstanceSupported(context);
         }
 
+#if !NETSTANDARD10
         /// <devdoc>
         ///    <para>
         ///        Gets a collection of properties for the type of array specified by the value
@@ -172,6 +173,7 @@ namespace System.ComponentModel
 
             return base.GetProperties(context, value, attributes);
         }
+#endif // !NETSTANDARD10
 
         /// <devdoc>
         ///    <para>Gets a value indicating whether this object supports properties using the specified context.</para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
@@ -10,8 +10,13 @@ namespace System.ComponentModel
     /// <devdoc>
     ///    <para>Provides a description of a property.</para>
     /// </devdoc>
+#if NETSTANDARD10
+    public abstract class PropertyDescriptor
+#else
     public abstract class PropertyDescriptor : MemberDescriptor
+#endif
     {
+#if !NETSTANDARD10
         private TypeConverter _converter = null;
         private Hashtable _valueChangedHandlers;
         private object[] _editors;
@@ -527,5 +532,6 @@ namespace System.ComponentModel
                 return false;
             }
         }
+#endif // NETSTANDARD10
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.NetStandard10.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.NetStandard10.cs
@@ -1,0 +1,401 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+
+namespace System.ComponentModel
+{
+    /// <devdoc>
+    ///     This type description provider provides type information through 
+    ///     reflection.  Unless someone has provided a custom type description
+    ///     provider for a type or instance, or unless an instance implements
+    ///     ICustomTypeDescriptor, any query for type information will go through
+    ///     this class.  There should be a single instance of this class associated
+    ///     with "object", as it can provide all type information for any type.
+    /// </devdoc>
+    internal sealed class ReflectTypeDescriptionProvider
+    {
+        // This is where we store the various converters for the intrinsic types.
+        //
+        private static volatile Dictionary<object, object> s_intrinsicConverters;
+
+        // For converters, etc that are bound to class attribute data, rather than a class
+        // type, we have special key sentinel values that we put into the hash table.
+        //
+        private static object s_intrinsicNullableKey = new object();
+
+        private static object s_syncObject = new object();
+
+        /// <devdoc>
+        ///     Creates a new ReflectTypeDescriptionProvider.  The type is the
+        ///     type we will obtain type information for.
+        /// </devdoc>
+        internal ReflectTypeDescriptionProvider()
+        {
+        }
+
+        /// <devdoc> 
+        ///      This is a table we create for intrinsic types. 
+        ///      There should be entries here ONLY for intrinsic 
+        ///      types, as all other types we should be able to 
+        ///      add attributes directly as metadata. 
+        /// </devdoc> 
+        private static Dictionary<object, object> IntrinsicTypeConverters
+        {
+            get
+            {
+                Debug.Assert(Monitor.IsEntered(s_syncObject));
+
+                // It is not worth taking a lock for this -- worst case of a collision
+                // would build two tables, one that garbage collects very quickly.
+                //
+                if (ReflectTypeDescriptionProvider.s_intrinsicConverters == null)
+                {
+                    Dictionary<object, object> temp = new Dictionary<object, object>();
+
+                    // Add the intrinsics
+                    //
+                    temp[typeof(bool)] = typeof(BooleanConverter);
+                    temp[typeof(byte)] = typeof(ByteConverter);
+                    temp[typeof(SByte)] = typeof(SByteConverter);
+                    temp[typeof(char)] = typeof(CharConverter);
+                    temp[typeof(double)] = typeof(DoubleConverter);
+                    temp[typeof(string)] = typeof(StringConverter);
+                    temp[typeof(int)] = typeof(Int32Converter);
+                    temp[typeof(short)] = typeof(Int16Converter);
+                    temp[typeof(long)] = typeof(Int64Converter);
+                    temp[typeof(float)] = typeof(SingleConverter);
+                    temp[typeof(UInt16)] = typeof(UInt16Converter);
+                    temp[typeof(UInt32)] = typeof(UInt32Converter);
+                    temp[typeof(UInt64)] = typeof(UInt64Converter);
+                    temp[typeof(object)] = typeof(TypeConverter);
+                    temp[typeof(void)] = typeof(TypeConverter);
+                    temp[typeof(DateTime)] = typeof(DateTimeConverter);
+                    temp[typeof(DateTimeOffset)] = typeof(DateTimeOffsetConverter);
+                    temp[typeof(Decimal)] = typeof(DecimalConverter);
+                    temp[typeof(TimeSpan)] = typeof(TimeSpanConverter);
+                    temp[typeof(Guid)] = typeof(GuidConverter);
+                    temp[typeof(Array)] = typeof(ArrayConverter);
+                    temp[typeof(ICollection)] = typeof(CollectionConverter);
+                    temp[typeof(Enum)] = typeof(EnumConverter);
+
+                    // Special cases for things that are not bound to a specific type
+                    //
+                    temp[ReflectTypeDescriptionProvider.s_intrinsicNullableKey] = typeof(NullableConverter);
+
+                    ReflectTypeDescriptionProvider.s_intrinsicConverters = temp;
+                }
+                return ReflectTypeDescriptionProvider.s_intrinsicConverters;
+            }
+        }
+
+        /// <devdoc> 
+        ///     Helper method to create type converters. This checks to see if the
+        ///     type implements a Type constructor, and if it does it invokes that ctor. 
+        ///     Otherwise, it just tries to create the type.
+        /// </devdoc> 
+        private static object CreateInstance(Type objectType, Type parameterType, ref bool noTypeConstructor)
+        {
+            ConstructorInfo typeConstructor = null;
+            noTypeConstructor = true;
+
+            foreach (ConstructorInfo constructor in objectType.GetTypeInfo().DeclaredConstructors)
+            {
+                if (!constructor.IsPublic)
+                {
+                    continue;
+                }
+
+                // This is the signature we look for when creating types that are generic, but
+                // want to know what type they are dealing with.  Enums are a good example of this;
+                // there is one enum converter that can work with all enums, but it needs to know
+                // the type of enum it is dealing with.
+                //
+                ParameterInfo[] parameters = constructor.GetParameters();
+                if (parameters.Length != 1 || !parameters[0].ParameterType.Equals(typeof(Type)))
+                {
+                    continue;
+                }
+                typeConstructor = constructor;
+                break;
+            }
+
+            if (typeConstructor != null)
+            {
+                noTypeConstructor = false;
+                return typeConstructor.Invoke(new object[] { parameterType });
+            }
+
+            return Activator.CreateInstance(objectType);
+        }
+
+        private static TypeConverterAttribute GetTypeConverterAttributeIfAny(Type type)
+        {
+            foreach (TypeConverterAttribute attribute in type.GetTypeInfo().GetCustomAttributes<TypeConverterAttribute>(false))
+            {
+                return attribute;
+            }
+            return null;
+        }
+
+        /// <devdoc>
+        ///    Gets a type converter for the specified type.
+        /// </devdoc>
+        internal static TypeConverter GetConverter(Type type)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            // Check the cached TypeConverter dictionary for an exact match of the given type.
+            object ans = SearchIntrinsicTable_ExactTypeMatch(type);
+            if (ans != null)
+                return (TypeConverter)ans;
+
+            // Obtaining attributes follows a very critical order: we must take care that
+            // we merge attributes the right way.  Consider this:
+            //
+            // [A4]
+            // interface IBase;
+            //
+            // [A3]
+            // interface IDerived;
+            //
+            // [A2]
+            // class Base : IBase;
+            //
+            // [A1]
+            // class Derived : Base, IDerived
+            //
+            // We are retrieving attributes in the following order:  A1 - A4.
+            // Interfaces always lose to types, and interfaces and types
+            // must be looked up in the same order.
+            TypeConverterAttribute converterAttribute = ReflectTypeDescriptionProvider.GetTypeConverterAttributeIfAny(type);
+            if (converterAttribute == null)
+            {
+                Type baseType = type.GetTypeInfo().BaseType;
+
+                while (baseType != null && baseType != typeof(object))
+                {
+                    converterAttribute = ReflectTypeDescriptionProvider.GetTypeConverterAttributeIfAny(baseType);
+                    if (converterAttribute != null)
+                    {
+                        break;
+                    }
+                    baseType = baseType.GetTypeInfo().BaseType;
+                }
+            }
+
+            if (converterAttribute == null)
+            {
+                IEnumerable<Type> interfaces = type.GetTypeInfo().ImplementedInterfaces;
+                foreach (Type iface in interfaces)
+                {
+                    // only do this for public interfaces.
+                    //
+                    if ((iface.GetTypeInfo().Attributes & (TypeAttributes.Public | TypeAttributes.NestedPublic)) != 0)
+                    {
+                        converterAttribute = GetTypeConverterAttributeIfAny(iface);
+                        if (converterAttribute != null)
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (converterAttribute != null)
+            {
+                Type converterType = ReflectTypeDescriptionProvider.GetTypeFromName(converterAttribute.ConverterTypeName, type);
+                if (converterType != null && typeof(TypeConverter).GetTypeInfo().IsAssignableFrom(converterType.GetTypeInfo()))
+                {
+                    bool noTypeConstructor = true;
+                    object instance = (TypeConverter)ReflectTypeDescriptionProvider.CreateInstance(converterType, type, ref noTypeConstructor);
+                    if (noTypeConstructor)
+                    {
+                        lock (s_syncObject)
+                        {
+                            ReflectTypeDescriptionProvider.IntrinsicTypeConverters[type] = instance;
+                        }
+                    }
+                    return (TypeConverter)instance;
+                }
+            }
+
+            // We did not get a converter. Traverse up the base class chain until
+            // we find one in the stock hashtable.
+            //
+            return (TypeConverter)ReflectTypeDescriptionProvider.SearchIntrinsicTable(type);
+        }
+
+        /// <devdoc>
+        ///     Retrieve a type from a name, if the name is not a fully qualified assembly name, then 
+        ///     look for this type name in the same assembly as the "type" parameter is defined in.
+        /// </devdoc>
+        private static Type GetTypeFromName(string typeName, Type type)
+        {
+            if (string.IsNullOrEmpty(typeName))
+            {
+                return null;
+            }
+
+            int commaIndex = typeName.IndexOf(',');
+            Type t = null;
+
+            if (commaIndex == -1)
+            {
+                t = type.GetTypeInfo().Assembly.GetType(typeName);
+            }
+
+            if (t == null)
+            {
+                t = Type.GetType(typeName);
+            }
+
+            return t;
+        }
+
+        /// <devdoc> 
+        ///      Searches the provided intrinsic hashtable for a match with the object type. 
+        ///      At the beginning, the hashtable contains types for the various converters. 
+        ///      As this table is searched, the types for these objects 
+        ///      are replaced with instances, so we only create as needed.  This method 
+        ///      does the search up the base class hierarchy and will create instances 
+        ///      for types as needed.  These instances are stored back into the table 
+        ///      for the base type, and for the original component type, for fast access. 
+        /// </devdoc> 
+        private static object SearchIntrinsicTable(Type callingType)
+        {
+            object hashEntry = null;
+
+            // We take a lock on this table.  Nothing in this code calls out to
+            // other methods that lock, so it should be fairly safe to grab this
+            // lock.  Also, this allows multiple intrinsic tables to be searched
+            // at once.
+            //
+            lock (ReflectTypeDescriptionProvider.s_syncObject)
+            {
+                Type baseType = callingType;
+                while (baseType != null && baseType != typeof(object))
+                {
+                    if (ReflectTypeDescriptionProvider.IntrinsicTypeConverters.TryGetValue(baseType, out hashEntry) && hashEntry != null)
+                    {
+                        break;
+                    }
+
+                    baseType = baseType.GetTypeInfo().BaseType;
+                }
+
+                TypeInfo callingTypeInfo = callingType.GetTypeInfo();
+
+                // Now make a scan through each value in the table, looking for interfaces.
+                // If we find one, see if the object implements the interface.
+                //
+                if (hashEntry == null)
+                {
+                    foreach (object key in ReflectTypeDescriptionProvider.IntrinsicTypeConverters.Keys)
+                    {
+                        Type keyType = key as Type;
+
+                        if (keyType != null)
+                        {
+                            TypeInfo keyTypeInfo = keyType.GetTypeInfo();
+                            if (keyTypeInfo.IsInterface && keyTypeInfo.IsAssignableFrom(callingTypeInfo))
+                            {
+                                ReflectTypeDescriptionProvider.IntrinsicTypeConverters.TryGetValue(key, out hashEntry);
+                                string converterTypeString = hashEntry as string;
+
+                                if (converterTypeString != null)
+                                {
+                                    hashEntry = Type.GetType(converterTypeString);
+                                    if (hashEntry != null)
+                                    {
+                                        ReflectTypeDescriptionProvider.IntrinsicTypeConverters[callingType] = hashEntry;
+                                    }
+                                }
+
+                                if (hashEntry != null)
+                                {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Special case converter
+                //
+                if (hashEntry == null)
+                {
+                    if (callingTypeInfo.IsGenericType && callingTypeInfo.GetGenericTypeDefinition() == typeof(Nullable<>))
+                    {
+                        // Check if it is a nullable value
+                        ReflectTypeDescriptionProvider.IntrinsicTypeConverters.TryGetValue(ReflectTypeDescriptionProvider.s_intrinsicNullableKey, out hashEntry);
+                    }
+                }
+
+                // Interfaces do not derive from object, so we
+                // must handle the case of no hash entry here.
+                //
+                if (hashEntry == null)
+                {
+                    ReflectTypeDescriptionProvider.IntrinsicTypeConverters.TryGetValue(typeof(object), out hashEntry);
+                }
+
+                // If the entry is a type, create an instance of it and then
+                // replace the entry.  This way we only need to create once.
+                // We can only do this if the object doesn't want a type
+                // in its constructor.
+                //
+                Type type = hashEntry as Type;
+
+                if (type != null)
+                {
+                    bool noTypeConstructor = true;
+                    hashEntry = ReflectTypeDescriptionProvider.CreateInstance(type, callingType, ref noTypeConstructor);
+                    if (noTypeConstructor)
+                    {
+                        ReflectTypeDescriptionProvider.IntrinsicTypeConverters[callingType] = hashEntry;
+                    }
+                }
+            }
+            return hashEntry;
+        }
+
+        private static object SearchIntrinsicTable_ExactTypeMatch(Type callingType)
+        {
+            object hashEntry = null;
+
+            // We take a lock on this table.  Nothing in this code calls out to
+            // other methods that lock, so it should be fairly safe to grab this
+            // lock.  Also, this allows multiple intrinsic tables to be searched
+            // at once.
+            //
+            lock (s_syncObject)
+            {
+                if (callingType != null && !IntrinsicTypeConverters.TryGetValue(callingType, out hashEntry))
+                    return null;
+
+                // If the entry is a type, create an instance of it and then
+                // replace the entry.  This way we only need to create once.
+                // We can only do this if the object doesn't want a type
+                // in its constructor.
+                Type type = hashEntry as Type;
+                if (type != null)
+                {
+                    bool noTypeConstructor = true;
+                    hashEntry = CreateInstance(type, callingType, ref noTypeConstructor);
+                    if (noTypeConstructor)
+                        IntrinsicTypeConverters[callingType] = hashEntry;
+                }
+            }
+            return hashEntry;
+        }
+    }
+}

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverter.cs
@@ -266,6 +266,7 @@ namespace System.ComponentModel
             return false;
         }
 
+#if !NETSTANDARD10
         /// <devdoc>
         ///    <para>Gets a collection of properties for the type of array specified by the value parameter.</para>
         /// </devdoc>
@@ -295,6 +296,7 @@ namespace System.ComponentModel
         {
             return null;
         }
+#endif // !NETSTANDARD10
 
         /// <devdoc>
         ///    <para>Gets a value indicating whether this object supports properties.</para>
@@ -409,6 +411,7 @@ namespace System.ComponentModel
             return isValid;
         }
 
+#if !NETSTANDARD10
         /// <devdoc>
         ///    <para>Sorts a collection of properties.</para>
         /// </devdoc>
@@ -516,6 +519,7 @@ namespace System.ComponentModel
                 return false;
             }
         }
+#endif // !NETSTANDARD10
 
         /// <devdoc>
         ///    <para>Represents a collection of values.</para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.NetStandard10.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.NetStandard10.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ComponentModel
+{
+    /// <devdoc>
+    ///    Provides information about the properties and events
+    ///    for a component. This class cannot be inherited.
+    ///
+    ///    This is only a stub to support the TypeConverter scenario.
+    /// </devdoc>
+    public sealed class TypeDescriptor
+    {
+        private TypeDescriptor()
+        {
+        }
+
+        /// <devdoc>
+        ///    Gets a type converter for the specified type.
+        /// </devdoc>
+        public static TypeConverter GetConverter(Type type)
+        {
+            return ReflectTypeDescriptionProvider.GetConverter(type);
+        }
+    }
+}

--- a/src/System.ComponentModel.TypeConverter/src/project.json
+++ b/src/System.ComponentModel.TypeConverter/src/project.json
@@ -20,8 +20,34 @@
         "System.Threading": "4.0.10"
       },
       "imports": [
+        "dotnet5.6"
+      ]
+    },    
+    "netstandard1.0": {
+      "dependencies": {
+        "System.Collections": "4.0.0",
+        "System.ComponentModel": "4.0.0",
+        "System.ComponentModel.Primitives": "4.0.0",
+        "System.Diagnostics.Contracts": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.0",
+        "System.Diagnostics.Tools": "4.0.0",
+        "System.Globalization": "4.0.0",
+        "System.Reflection": "4.0.0",
+        "System.Reflection.Extensions": "4.0.0",
+        "System.Reflection.Primitives": "4.0.0",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.0",
+        "System.Runtime.Extensions": "4.0.0",
+        "System.Threading": "4.0.0"
+      },
+      "imports": [
         "dotnet5.1"
       ]
+    },
+    "net462": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6.2": "1.0.1"
+      }
     },
     "net45": {
       "dependencies": {


### PR DESCRIPTION
Due to implementation requirements for TypeDescriptors, the .NET Standard generation needs to be bumped to 1.5. The packages then broke, and this gives the NET Standard 1.0 surface area to wp8/win8 for S.CM.TypeDescriptor 4.1.0.

The generation bump is due to new Reflection surface area (such as UnderlyingType and BindingFlags among others). There are also a many places where non-generic and specialized collections are used (which require 1.3) and in an attempt to get the implementation functional, those have not been replaced with generic versions.

@chlowell @ericstj @weshaggard