### PR TITLE
Improve performance of encoding only safe chars and spaces in WebUtility

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -396,8 +396,14 @@ namespace System.Net
                 }
             }
 
-            if (cSafe == value.Length)
+            if (cSafe + cSpaces == value.Length)
             {
+                if (cSpaces != 0)
+                {
+                    // Only spaces to encode
+                    return value.Replace(' ', '+');
+                }
+
                 // Nothing to expand
                 return value;
             }


### PR DESCRIPTION
- x4 performance boost
- halved number of allocations

This is quite common, so worth the extra code
Existing tests cover these branches
I didn't try to remove all allocations as this would negatively affect performance of encoding other strings

## Benchmark
![benchmark encoding](https://cloud.githubusercontent.com/assets/1275900/14745778/c5549138-08a4-11e6-8d1f-257127fefd7d.png)

## Benchmark Code
<details>
<summary> Click here </summary>
```
public static void PerformanceTests()
{
    TimeAction("Old: ", () => Old.UrlEncode("abc def"));
    TimeAction("New: ", () => New.UrlEncode("abc def"));
}

public static void TimeAction(string prefix, Action action)
{
    var sw = new Stopwatch();
    for (int iter = 0; iter < 5; iter++)
    {
        int gen0 = GC.CollectionCount(0);
        sw.Restart();
        for (int i = 0; i < 10000000; i++)
        {
            action();
        }
        sw.Stop();
        Console.WriteLine($"{prefix}Time: {sw.Elapsed.TotalSeconds}\tGC0: {GC.CollectionCount(0) - gen0}");
    }
}
```

</details>

/cc @davidsh @jamesqo @stephentoub