### PR TITLE
Redirect error messages to error stream.

### DIFF
--- a/build-packages.cmd
+++ b/build-packages.cmd
@@ -19,7 +19,7 @@ call %~dp0init-tools.cmd
 echo msbuild.exe %~dp0src\packages.builds !options! !allargs! >> %packagesLog%
 call msbuild.exe %~dp0src\packages.builds !options! !allargs!
 if NOT [%ERRORLEVEL%]==[0] (
-  echo ERROR: An error occurred while building packages, see %packagesLog% for more details.
+  echo ERROR: An error occurred while building packages, see %packagesLog% for more details.>&2
   exit /b
 )
 

--- a/build-tests.cmd
+++ b/build-tests.cmd
@@ -19,7 +19,7 @@ call %~dp0init-tools.cmd
 echo msbuild.exe %~dp0src\tests.builds !options! !allargs! >> %buildTests%
 call msbuild.exe %~dp0src\tests.builds !options! !allargs!
 if NOT [%ERRORLEVEL%]==[0] (
-  echo ERROR: An error occurred while building the tests, see %buildTests% for more details.
+  echo ERROR: An error occurred while building the tests, see %buildTests% for more details.>&2
   exit /b
 )
 

--- a/clean.cmd
+++ b/clean.cmd
@@ -126,7 +126,7 @@ if /I [%clean_successful%] == [true] (
   echo. >> %cleanlog% && echo Clean completed successfully. >> %cleanlog%
   exit /b 0
 ) else (
-  echo An error occured while cleaning; see %cleanlog% for more details.
+  echo An error occured while cleaning; see %cleanlog% for more details.>&2
   echo. >> %cleanlog% && echo Clean completed with errors. >> %cleanlog%
   exit /b 1
 )

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -43,7 +43,7 @@ set DOTNET_LOCAL_PATH=%DOTNET_PATH%%DOTNET_ZIP_NAME%
 echo Installing '%DOTNET_REMOTE_PATH%' to '%DOTNET_LOCAL_PATH%' >> %INIT_TOOLS_LOG%
 powershell -NoProfile -ExecutionPolicy unrestricted -Command "(New-Object Net.WebClient).DownloadFile('%DOTNET_REMOTE_PATH%', '%DOTNET_LOCAL_PATH%'); Add-Type -Assembly 'System.IO.Compression.FileSystem' -ErrorVariable AddTypeErrors; if ($AddTypeErrors.Count -eq 0) { [System.IO.Compression.ZipFile]::ExtractToDirectory('%DOTNET_LOCAL_PATH%', '%DOTNET_PATH%') } else { (New-Object -com shell.application).namespace('%DOTNET_PATH%').CopyHere((new-object -com shell.application).namespace('%DOTNET_LOCAL_PATH%').Items(),16) }" >> %INIT_TOOLS_LOG%
 if NOT exist "%DOTNET_LOCAL_PATH%" (
-  echo ERROR: Could not install dotnet cli correctly. See '%INIT_TOOLS_LOG%' for more details.
+  echo ERROR: Could not install dotnet cli correctly. See '%INIT_TOOLS_LOG%' for more details.>&2
   goto :EOF
 )
 
@@ -54,7 +54,7 @@ echo Restoring BuildTools version %BUILDTOOLS_VERSION%...
 echo Running: "%DOTNET_CMD%" restore "%PROJECT_JSON_FILE%" --packages %PACKAGES_DIR% --source "%BUILDTOOLS_SOURCE%" >> %INIT_TOOLS_LOG%
 call "%DOTNET_CMD%" restore "%PROJECT_JSON_FILE%" --packages %PACKAGES_DIR% --source "%BUILDTOOLS_SOURCE%" >> %INIT_TOOLS_LOG%
 if NOT exist "%BUILD_TOOLS_PATH%init-tools.cmd" (
-  echo ERROR: Could not restore build tools correctly. See '%INIT_TOOLS_LOG%' for more details.
+  echo ERROR: Could not restore build tools correctly. See '%INIT_TOOLS_LOG%' for more details.>&2
   goto :EOF
 )
 

--- a/publish-packages.cmd
+++ b/publish-packages.cmd
@@ -17,7 +17,7 @@ call %~dp0init-tools.cmd
 echo msbuild.exe %~dp0src\publish.proj !options! !allargs! >> %packagesLog%
 call msbuild.exe %~dp0src\publish.proj !options! !allargs!
 if NOT [%ERRORLEVEL%]==[0] (
-  echo ERROR: An error occurred while publishing packages, see %packagesLog% for more details.
+  echo ERROR: An error occurred while publishing packages, see %packagesLog% for more details.>&2
   exit /b
 )
 

--- a/sync.cmd
+++ b/sync.cmd
@@ -64,7 +64,7 @@ if [%src%] == [true] (
   echo Fetching git database from remote repos ...
   call git fetch --all -p -v >> %synclog% 2>&1
   if NOT [!ERRORLEVEL!]==[0] (
-    echo ERROR: An error occurred while fetching remote source code, see %synclog% for more details.
+    echo ERROR: An error occurred while fetching remote source code, see %synclog% for more details.>&2
     exit /b
   )
 )
@@ -74,7 +74,7 @@ if [%azureBlobs%] == [true] (
   echo msbuild.exe %~dp0src\syncAzure.proj !options! !unprocessedBuildArgs! >> %synclog%
   call msbuild.exe %~dp0src\syncAzure.proj !options! !unprocessedBuildArgs!
   if NOT [!ERRORLEVEL!]==[0] (
-    echo ERROR: An error occurred while downloading packages from Azure BLOB, see %synclog% for more details. There may have been networking problems so please try again in a few minutes.
+    echo ERROR: An error occurred while downloading packages from Azure BLOB, see %synclog% for more details. There may have been networking problems so please try again in a few minutes.>&2
     exit /b
   )
 )
@@ -90,7 +90,7 @@ if [%packages%] == [true] (
   echo msbuild.exe %~dp0build.proj !options! !unprocessedBuildArgs! >> %synclog%
   call msbuild.exe %~dp0build.proj !options! !unprocessedBuildArgs!
   if NOT [!ERRORLEVEL!]==[0] (
-    echo ERROR: An error occurred while syncing packages, see %synclog% for more details. There may have been networking problems so please try again in a few minutes.
+    echo ERROR: An error occurred while syncing packages, see %synclog% for more details. There may have been networking problems so please try again in a few minutes.>&2
     exit /b
   )
 )


### PR DESCRIPTION
VSO detects errors during builds by reading the error stream.  This change redirects error messages from our wrapper scripts to the error stream so that errors are not ignored if you are running a script via VSO.

/cc @maririos , @weshaggard , @jhendrixMSFT