### PR TITLE
Disable system.linq.Expressions test from project reference conversion

### DIFF
--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -13,6 +13,7 @@
     <AssemblyName>System.Linq.Expressions.Tests</AssemblyName>
     <RootNamespace>System.Linq.Expressions.Tests</RootNamespace>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
+    <KeepAllProjectReferences>true</KeepAllProjectReferences>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
System.Linq.Expressions does not build when project references are converted to package dependencies due to 

> Catalog\ExpressionCatalog.RuntimeVariables.cs(34,39): error CS0246: The type or namespace name 'IRuntimeVariables' could not be found (are you missing a using directive or an assembly reference?) [D:\A\_work\8\s\src\System.Linq.Expressions\tests\System.Linq.Expressions.Tests.csproj]

I still need to provide public documentation on this issue, in the meantime I am working towards having a clean test build.

/cc @weshaggard