### PR TITLE
Add support for all OperationStatus values on Linux

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
@@ -136,13 +136,25 @@ namespace System.Net.NetworkInformation
         // Maps values from /sys/class/net/<interface>/operstate to OperationStatus values.
         private static OperationalStatus MapState(string state)
         {
-            // TODO (#7889): Figure out the possible values that Linux might return.
+            //
+            // http://users.sosdg.org/~qiyong/lxr/source/Documentation/networking/operstates.txt?a=um#L41
+            //
             switch (state)
             {
-                case "up":
-                    return OperationalStatus.Up;
+                case "unknown":
+                    return OperationalStatus.Unknown;
+                case "notpresent":
+                    return OperationalStatus.NotPresent;
                 case "down":
                     return OperationalStatus.Down;
+                case "lowerlayerdown":
+                    return OperationalStatus.LowerLayerDown;
+                case "testing":
+                    return OperationalStatus.Testing;
+                case "dormant":
+                    return OperationalStatus.Dormant;
+                case "up":
+                    return OperationalStatus.Up;
                 default:
                     return OperationalStatus.Unknown;
             }


### PR DESCRIPTION
I found some documentation on this (now linked from the source).  Also, this appears to be how Mono does it.

Fixes #7889.

@stephentoub @CIPop