### PR TITLE
CoreCLR port: Don't allocate in NullStream.CopyToAsync

### DIFF
--- a/src/System.IO/src/System/IO/Stream.cs
+++ b/src/System.IO/src/System/IO/Stream.cs
@@ -28,6 +28,36 @@ namespace System.IO
             // WaitHandle, we don't need to worry about Disposing it.
             return LazyInitializer.EnsureInitialized(ref _asyncActiveSemaphore, () => new SemaphoreSlim(1, 1));
         }
+        
+        // This method is used by CopyTo, CopyToAsync,
+        // and NullStream's override of the latter.
+        internal void ValidateCopyToArguments(Stream destination, int bufferSize)
+        {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+            if (bufferSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedPosNum);
+            }
+            if (!CanRead && !CanWrite)
+            {
+                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
+            }
+            if (!destination.CanRead && !destination.CanWrite)
+            {
+                throw new ObjectDisposedException(nameof(destination), SR.ObjectDisposed_StreamClosed);
+            }
+            if (!CanRead)
+            {
+                throw new NotSupportedException(SR.NotSupported_UnreadableStream);
+            }
+            if (!destination.CanWrite)
+            {
+                throw new NotSupportedException(SR.NotSupported_UnwritableStream);
+            }
+        }
 
         public abstract bool CanRead
         {
@@ -104,30 +134,7 @@ namespace System.IO
 
         public virtual Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
-            if (destination == null)
-            {
-                throw new ArgumentNullException(nameof(destination));
-            }
-            if (bufferSize <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedPosNum);
-            }
-            if (!CanRead && !CanWrite)
-            {
-                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
-            }
-            if (!destination.CanRead && !destination.CanWrite)
-            {
-                throw new ObjectDisposedException(nameof(destination), SR.ObjectDisposed_StreamClosed);
-            }
-            if (!CanRead)
-            {
-                throw new NotSupportedException(SR.NotSupported_UnreadableStream);
-            }
-            if (!destination.CanWrite)
-            {
-                throw new NotSupportedException(SR.NotSupported_UnwritableStream);
-            }
+            ValidateCopyToArguments(destination, bufferSize);
 
             return CopyToAsyncInternal(destination, bufferSize, cancellationToken);
         }
@@ -178,40 +185,7 @@ namespace System.IO
 
         public void CopyTo(Stream destination, int bufferSize)
         {
-            if (destination == null)
-            {
-                throw new ArgumentNullException(nameof(destination));
-            }
-            if (bufferSize <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedPosNum);
-            }
-            if (!CanRead && !CanWrite)
-            {
-                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
-            }
-            if (!destination.CanRead && !destination.CanWrite)
-            {
-                throw new ObjectDisposedException(nameof(destination), SR.ObjectDisposed_StreamClosed);
-            }
-            if (!CanRead)
-            {
-                throw new NotSupportedException(SR.NotSupported_UnreadableStream);
-            }
-            if (!destination.CanWrite)
-            {
-                throw new NotSupportedException(SR.NotSupported_UnwritableStream);
-            }
-
-            InternalCopyTo(destination, bufferSize);
-        }
-
-        private void InternalCopyTo(Stream destination, int bufferSize)
-        {
-            Debug.Assert(destination != null);
-            Debug.Assert(CanRead);
-            Debug.Assert(destination.CanWrite);
-            Debug.Assert(bufferSize > 0);
+            ValidateCopyToArguments(destination, bufferSize);
 
             byte[] buffer = new byte[bufferSize];
             int read;
@@ -221,13 +195,11 @@ namespace System.IO
             }
         }
 
-
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
-
 
         protected virtual void Dispose(bool disposing)
         {
@@ -397,6 +369,17 @@ namespace System.IO
             {
                 get { return 0; }
                 set { }
+            }
+            
+            public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+            {
+                // Validate arguments for compat, since previously this
+                // method was inherited from Stream, which did check its arguments.
+                ValidateCopyToArguments(destination, bufferSize);
+                
+                return cancellationToken.IsCancellationRequested ?
+                    Task.FromCanceled(cancellationToken) :
+                    Task.CompletedTask;
             }
 
             protected override void Dispose(bool disposing)

--- a/src/System.IO/src/System/IO/Stream.cs
+++ b/src/System.IO/src/System/IO/Stream.cs
@@ -28,36 +28,6 @@ namespace System.IO
             // WaitHandle, we don't need to worry about Disposing it.
             return LazyInitializer.EnsureInitialized(ref _asyncActiveSemaphore, () => new SemaphoreSlim(1, 1));
         }
-        
-        // This method is used by CopyTo, CopyToAsync,
-        // and NullStream's override of the latter.
-        internal void ValidateCopyToArguments(Stream destination, int bufferSize)
-        {
-            if (destination == null)
-            {
-                throw new ArgumentNullException(nameof(destination));
-            }
-            if (bufferSize <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedPosNum);
-            }
-            if (!CanRead && !CanWrite)
-            {
-                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
-            }
-            if (!destination.CanRead && !destination.CanWrite)
-            {
-                throw new ObjectDisposedException(nameof(destination), SR.ObjectDisposed_StreamClosed);
-            }
-            if (!CanRead)
-            {
-                throw new NotSupportedException(SR.NotSupported_UnreadableStream);
-            }
-            if (!destination.CanWrite)
-            {
-                throw new NotSupportedException(SR.NotSupported_UnwritableStream);
-            }
-        }
 
         public abstract bool CanRead
         {
@@ -312,6 +282,34 @@ namespace System.IO
             byte[] oneByteArray = new byte[1];
             oneByteArray[0] = value;
             Write(oneByteArray, 0, 1);
+        }
+        
+        internal void ValidateCopyToArguments(Stream destination, int bufferSize)
+        {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+            if (bufferSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedPosNum);
+            }
+            if (!CanRead && !CanWrite)
+            {
+                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
+            }
+            if (!destination.CanRead && !destination.CanWrite)
+            {
+                throw new ObjectDisposedException(nameof(destination), SR.ObjectDisposed_StreamClosed);
+            }
+            if (!CanRead)
+            {
+                throw new NotSupportedException(SR.NotSupported_UnreadableStream);
+            }
+            if (!destination.CanWrite)
+            {
+                throw new NotSupportedException(SR.NotSupported_UnwritableStream);
+            }
         }
 
         private sealed class NullStream : Stream

--- a/src/System.IO/src/System/IO/Stream.cs
+++ b/src/System.IO/src/System/IO/Stream.cs
@@ -159,28 +159,7 @@ namespace System.IO
         // the current position.
         public void CopyTo(Stream destination)
         {
-            if (destination == null)
-            {
-                throw new ArgumentNullException(nameof(destination));
-            }
-            if (!CanRead && !CanWrite)
-            {
-                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
-            }
-            if (!destination.CanRead && !destination.CanWrite)
-            {
-                throw new ObjectDisposedException(nameof(destination), SR.ObjectDisposed_StreamClosed);
-            }
-            if (!CanRead)
-            {
-                throw new NotSupportedException(SR.NotSupported_UnreadableStream);
-            }
-            if (!destination.CanWrite)
-            {
-                throw new NotSupportedException(SR.NotSupported_UnwritableStream);
-            }
-
-            InternalCopyTo(destination, DefaultCopyBufferSize);
+            CopyTo(destination, DefaultCopyBufferSize);
         }
 
         public void CopyTo(Stream destination, int bufferSize)

--- a/src/System.IO/tests/Stream/Stream.NullTests.cs
+++ b/src/System.IO/tests/Stream/Stream.NullTests.cs
@@ -5,31 +5,130 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace System.IO.Tests
 {
-    public class NullCtorTests
+    public class NullTests
     {
         [Fact]
-        public static async Task TestNullStream()
+        public async static Task TestNullStream_Flush()
         {
-            Stream s = Stream.Null;
-
-            s.Flush();
-
-            Assert.Equal(-1, s.ReadByte());
-
-            s.WriteByte(5);
-            int n = s.Read(new byte[2], 0, 2);
-            Assert.Equal(0, n);
-            s.Write(new byte[2], 0, 2);
-
-            Assert.Equal(0, await s.ReadAsync(new byte[2], 0, 2));
-
-            s.Flush();
-            s.Dispose();
+            // Neither of these methods should have
+            // side effects, so call them twice to
+            // make sure they don't throw something
+            // the second time around
+            
+            Stream.Null.Flush();
+            await Stream.Null.FlushAsync();
+            
+            Stream.Null.Flush();
+            await Stream.Null.FlushAsync();
+        }
+        
+        [Fact]
+        public static void TestNullStream_Dispose()
+        {
+            Stream.Null.Dispose();
+            Stream.Null.Dispose(); // Dispose shouldn't have any side effects
+        }
+        
+        [Fact]
+        public async static Task TestNullStream_CopyTo()
+        {
+            Stream source = Stream.Null;
+            
+            int originalCapacity = 0;
+            var destination = new MemoryStream(originalCapacity);
+            
+            source.CopyTo(destination, 12345);
+            await source.CopyToAsync(destination, 67890, CancellationToken.None);
+            
+            Assert.Equal(0, source.Position);
+            Assert.Equal(0, destination.Position);
+            
+            Assert.Equal(0, source.Length);
+            Assert.Equal(0, destination.Length);
+            
+            Assert.Equal(originalCapacity, destination.Capacity);
+        }
+        
+        [Fact]
+        public async static Task TestNullStream_CopyToAsyncValidation()
+        {
+            // Since Stream.Null previously inherited its CopyToAsync
+            // implementation from the base class, which did check its
+            // arguments, we have to make sure it validates them as
+            // well for compat.
+            
+            var disposedStream = new MemoryStream();
+            disposedStream.Dispose();
+            
+            var readOnlyStream = new MemoryStream(new byte[1], writable: false);
+            
+            await Assert.ThrowsAsync<ArgumentNullException>("destination", () => Stream.Null.CopyToAsync(null));
+            await Assert.ThrowsAsync<ArgumentNullException>("destination", () => Stream.Null.CopyToAsync(null, -123)); // Should check if destination == null first
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>("bufferSize", () => Stream.Null.CopyToAsync(Stream.Null, 0)); // 0 shouldn't be a valid buffer size
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>("bufferSize", () => Stream.Null.CopyToAsync(Stream.Null, -123));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => Stream.Null.CopyToAsync(disposedStream));
+            await Assert.ThrowsAsync<NotSupportedException>(() => Stream.Null.CopyToAsync(readOnlyStream));
+        }
+        
+        [Theory]
+        [MemberData(nameof(NullStream_ReadWriteData))]
+        public async static Task TestNullStream_Read(byte[] buffer, int offset, int count)
+        {
+            byte[] copy = buffer?.ToArray();
+            Stream source = Stream.Null;
+            
+            int read = source.Read(buffer, offset, count);
+            Assert.Equal(0, read);
+            Assert.Equal(copy, buffer); // Make sure Read doesn't modify the buffer
+            Assert.Equal(0, source.Position);            
+            
+            read = await source.ReadAsync(buffer, offset, count);
+            Assert.Equal(0, read);
+            Assert.Equal(copy, buffer);
+            Assert.Equal(0, source.Position);
+        }
+        
+        [Fact]
+        public static void TestNullStream_ReadByte()
+        {
+            Stream source = Stream.Null;
+            
+            int data = source.ReadByte();
+            Assert.Equal(-1, data);
+            Assert.Equal(0, source.Position);
+        }
+        
+        [Theory]
+        [MemberData(nameof(NullStream_ReadWriteData))]
+        public async static Task TestNullStream_Write(byte[] buffer, int offset, int count)
+        {
+            byte[] copy = buffer?.ToArray();
+            Stream source = Stream.Null;
+            
+            source.Write(buffer, offset, count);
+            Assert.Equal(copy, buffer); // Make sure Write doesn't modify the buffer
+            Assert.Equal(0, source.Position);            
+            
+            await source.WriteAsync(buffer, offset, count);
+            Assert.Equal(copy, buffer);
+            Assert.Equal(0, source.Position);
+        }
+        
+        [Theory]
+        [InlineData(3)]
+        public static void TestNullStream_WriteByte(byte data)
+        {
+            Stream source = Stream.Null;
+            
+            source.WriteByte(data);
+            Assert.Equal(0, source.Position);
         }
 
         [Theory]
@@ -87,5 +186,13 @@ namespace System.IO.Tests
             }
         }
 
+        public static IEnumerable<object[]> NullStream_ReadWriteData
+        {
+            get
+            {
+                yield return new object[] { new byte[10], 0, 10 };
+                yield return new object[] { null, -123, 456 }; // Stream.Null.Read/Write should not perform argument validation
+            }
+        }
     }
 }

--- a/src/System.IO/tests/Stream/Stream.NullTests.cs
+++ b/src/System.IO/tests/Stream/Stream.NullTests.cs
@@ -121,13 +121,12 @@ namespace System.IO.Tests
             Assert.Equal(0, source.Position);
         }
         
-        [Theory]
-        [InlineData(3)]
-        public static void TestNullStream_WriteByte(byte data)
+        [Fact]
+        public static void TestNullStream_WriteByte()
         {
             Stream source = Stream.Null;
             
-            source.WriteByte(data);
+            source.WriteByte(3);
             Assert.Equal(0, source.Position);
         }
 


### PR DESCRIPTION
Port of dotnet/coreclr#4383 to the CoreRT version of `Stream`. Also added a couple of tests improving the coverage for `NullStream`.

List of test changes:

- Moved `NopStream` into a new file
- Added `ReadOnlyStream`, which acts like `Stream.Null` but throws when trying to write
- Added a bunch more `NullStream` tests (which are also more clean)
  - Refactored this from the previous testing scheme, which only used one method

cc @JonHanna @justinvp @stephentoub (also @jkotas since he originally requested the port)