### PR TITLE
Move legacy ASCIIEncoding tests to the modern files

### DIFF
--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingEncode.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingEncode.cs
@@ -14,6 +14,8 @@ namespace System.Text.Tests
             string testString = "Hello World123#?!";
             yield return new object[] { testString, 0, testString.Length };
             yield return new object[] { testString, 4, 5 };
+
+            yield return new object[] { "ABCDEFGH", 0, 8 };
                         
             yield return new object[] { "\u1234\u2345", 0, 2 };
             yield return new object[] { "a\u1234\u2345b", 0, 4 };

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingEquals.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingEquals.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Text.Tests
+{
+    public class ASCIIEncodingEquals
+    {
+        public static IEnumerable<object[]> Equals_TestData()
+        {
+            yield return new object[] { new ASCIIEncoding(), new ASCIIEncoding(), true };
+            yield return new object[] { Encoding.ASCII, Encoding.ASCII, true };
+            yield return new object[] { Encoding.ASCII, new ASCIIEncoding(), true };
+            yield return new object[] { Encoding.ASCII, Encoding.GetEncoding("ascii"), true };
+            yield return new object[] { Encoding.ASCII, Encoding.GetEncoding("us-ascii"), true };
+
+            yield return new object[] { new ASCIIEncoding(), new object(), false };
+            yield return new object[] { new ASCIIEncoding(), null, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(Equals_TestData))]
+        public void Equals(ASCIIEncoding encoding, object value, bool expected)
+        {
+            Assert.Equal(expected, encoding.Equals(value));
+            if (value is ASCIIEncoding)
+            {
+                Assert.Equal(expected, encoding.GetHashCode().Equals(value.GetHashCode()));
+            }
+        }
+    }
+}

--- a/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingProperties.cs
+++ b/src/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingProperties.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Text.Tests
+{
+    public class ASCIIEncodingProperties
+    {
+        public static IEnumerable<object[]> Encodings_TestData()
+        {
+            yield return new object[] { new ASCIIEncoding() };
+            yield return new object[] { Encoding.ASCII };
+            yield return new object[] { Encoding.GetEncoding("ascii") };
+            yield return new object[] { Encoding.GetEncoding("us-ascii") };
+        }
+
+        [Theory]
+        [MemberData(nameof(Encodings_TestData))]
+        public void WebName(ASCIIEncoding encoding)
+        {
+            Assert.Equal("us-ascii", encoding.WebName);
+        }
+    }
+}

--- a/src/System.Text.Encoding/tests/Encoding/ConvertUnicodeEncodings.cs
+++ b/src/System.Text.Encoding/tests/Encoding/ConvertUnicodeEncodings.cs
@@ -8,40 +8,10 @@ namespace System.Text.Tests
 {
     public class ConvertUnicodeEncodings
     {
-        // The characters to encode:
-        //    Latin Small Letter Z (U+007A)
-        //    Latin Small Letter A (U+0061)
-        //    Combining Breve (U+0306)
-        //    Latin Small Letter AE With Acute (U+01FD)
-        //    Greek Small Letter Beta (U+03B2)
-        //    a high-surrogate value (U+D8FF)
-        //    a low-surrogate value (U+DCFF)
-        private static char[] s_myChars = new char[] { 'z', 'a', '\u0306', '\u01FD', '\u03B2', '\uD8FF', '\uDCFF' };
-        private static string s_myString = new String(s_myChars);
         private static byte[] s_leBytes = new byte[] { 0x7A, 0x00, 0x61, 0x00, 0x06, 0x03, 0xFD, 0x01, 0xB2, 0x03, 0xFF, 0xD8, 0xFF, 0xDC };
         private static byte[] s_beBytes = new byte[] { 0x00, 0x7A, 0x00, 0x61, 0x03, 0x06, 0x01, 0xFD, 0x03, 0xB2, 0xD8, 0xFF, 0xDC, 0xFF };
         private static byte[] s_utf8Bytes = new byte[] { 0x7A, 0x61, 0xCC, 0x86, 0xC7, 0xBD, 0xCE, 0xB2, 0xF1, 0x8F, 0xB3, 0xBF };
-
-        [Fact]
-        public void TestGetEncoding()
-        {
-            Encoding unicodeEnc = Encoding.Unicode;
-            Encoding bigEndianEnc = Encoding.BigEndianUnicode;
-            Encoding utf8Enc = Encoding.UTF8;
-
-            TestEncoding(Encoding.BigEndianUnicode, 14, 16, s_beBytes);
-            TestEncoding(Encoding.Unicode, 14, 16, s_leBytes);
-            TestEncoding(Encoding.UTF8, 12, 24, s_utf8Bytes);
-
-            unicodeEnc = Encoding.GetEncoding("utf-16");
-            bigEndianEnc = Encoding.GetEncoding("utf-16BE");
-            utf8Enc = Encoding.GetEncoding("utf-8");
-
-            TestEncoding(Encoding.BigEndianUnicode, 14, 16, s_beBytes);
-            TestEncoding(Encoding.Unicode, 14, 16, s_leBytes);
-            TestEncoding(Encoding.UTF8, 12, 24, s_utf8Bytes);
-        }
-
+        
         [Fact]
         public void TestConversion()
         {
@@ -53,17 +23,6 @@ namespace System.Text.Tests
 
             Assert.Equal(Encoding.Convert(Encoding.BigEndianUnicode, Encoding.Unicode, s_beBytes), s_leBytes);
             Assert.Equal(Encoding.Convert(Encoding.Unicode, Encoding.BigEndianUnicode, s_leBytes), s_beBytes);
-        }
-
-        private void TestEncoding(Encoding enc, int byteCount, int maxByteCount, byte[] bytes)
-        {
-            Assert.Equal(byteCount, enc.GetByteCount(s_myChars));
-            Assert.Equal(maxByteCount, enc.GetMaxByteCount(s_myChars.Length));
-            Assert.Equal(enc.GetBytes(s_myChars), bytes);
-            Assert.Equal(enc.GetCharCount(bytes), s_myChars.Length);
-            Assert.Equal(enc.GetChars(bytes), s_myChars);
-            Assert.Equal(enc.GetString(bytes, 0, bytes.Length), s_myString);
-            Assert.NotEqual(0, enc.GetHashCode());
         }
     }
 }

--- a/src/System.Text.Encoding/tests/Encoding/Encoding.cs
+++ b/src/System.Text.Encoding/tests/Encoding/Encoding.cs
@@ -31,26 +31,10 @@ namespace System.Text.Tests
         [Fact]
         public static void TestEncodingDecoding()
         {
-            Encoding encoding = Encoding.ASCII;
+            Encoding encoding = Encoding.GetEncoding("latin1");
             byte[] bytes = encoding.GetBytes(s_asciiString);
             Assert.Equal<byte>(bytes, s_asciiBytes);
             string s = encoding.GetString(bytes, 0, bytes.Length);
-            Assert.True(s.Equals(s_asciiString));
-            s = encoding.GetString(bytes);
-            Assert.True(s.Equals(s_asciiString));
-
-            encoding = Encoding.GetEncoding("us-ascii");
-            bytes = encoding.GetBytes(s_asciiString);
-            Assert.Equal<byte>(bytes, s_asciiBytes);
-            s = encoding.GetString(bytes, 0, bytes.Length);
-            Assert.True(s.Equals(s_asciiString));
-            s = encoding.GetString(bytes);
-            Assert.True(s.Equals(s_asciiString));
-
-            encoding = Encoding.GetEncoding("latin1");
-            bytes = encoding.GetBytes(s_asciiString);
-            Assert.Equal<byte>(bytes, s_asciiBytes);
-            s = encoding.GetString(bytes, 0, bytes.Length);
             Assert.True(s.Equals(s_asciiString));
             s = encoding.GetString(bytes);
             Assert.True(s.Equals(s_asciiString));

--- a/src/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
+++ b/src/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
@@ -17,6 +17,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ASCIIEncoding\ASCIIEncodingProperties.cs" />
+    <Compile Include="ASCIIEncoding\ASCIIEncodingEquals.cs" />
     <Compile Include="ASCIIEncoding\ASCIIEncodingEncode.cs" />
     <Compile Include="ASCIIEncoding\ASCIIEncodingDecode.cs" />
     <Compile Include="ASCIIEncoding\ASCIIEncodingGetDecoder.cs" />


### PR DESCRIPTION
- Also removes some old tests that are now duplicates and were undeleted
in the recent cleanup
- Also adds some tests for Equals and getting cached copies of ASCIIEncoding

/cc @tarekgh (sorry for spamming you with so many PRs recently - I just want it to be easy to review as there is a lot of code movement)