### PR TITLE
Set exit codes for wrapper scripts if there is an error.

### DIFF
--- a/build-packages.cmd
+++ b/build-packages.cmd
@@ -20,7 +20,7 @@ echo msbuild.exe %~dp0src\packages.builds !options! !allargs! >> %packagesLog%
 call msbuild.exe %~dp0src\packages.builds !options! !allargs!
 if NOT [%ERRORLEVEL%]==[0] (
   echo ERROR: An error occurred while building packages, see %packagesLog% for more details.
-  exit /b
+  exit /b 1
 )
 
 echo Done Building Packages.

--- a/build-tests.cmd
+++ b/build-tests.cmd
@@ -20,7 +20,7 @@ echo msbuild.exe %~dp0src\tests.builds !options! !allargs! >> %buildTests%
 call msbuild.exe %~dp0src\tests.builds !options! !allargs!
 if NOT [%ERRORLEVEL%]==[0] (
   echo ERROR: An error occurred while building the tests, see %buildTests% for more details.
-  exit /b
+  exit /b 1
 )
 
 echo Done Building tests.

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -44,7 +44,7 @@ echo Installing '%DOTNET_REMOTE_PATH%' to '%DOTNET_LOCAL_PATH%' >> %INIT_TOOLS_L
 powershell -NoProfile -ExecutionPolicy unrestricted -Command "(New-Object Net.WebClient).DownloadFile('%DOTNET_REMOTE_PATH%', '%DOTNET_LOCAL_PATH%'); Add-Type -Assembly 'System.IO.Compression.FileSystem' -ErrorVariable AddTypeErrors; if ($AddTypeErrors.Count -eq 0) { [System.IO.Compression.ZipFile]::ExtractToDirectory('%DOTNET_LOCAL_PATH%', '%DOTNET_PATH%') } else { (New-Object -com shell.application).namespace('%DOTNET_PATH%').CopyHere((new-object -com shell.application).namespace('%DOTNET_LOCAL_PATH%').Items(),16) }" >> %INIT_TOOLS_LOG%
 if NOT exist "%DOTNET_LOCAL_PATH%" (
   echo ERROR: Could not install dotnet cli correctly. See '%INIT_TOOLS_LOG%' for more details.
-  goto :EOF
+  exit /b 1
 )
 
 :afterdotnetrestore
@@ -55,7 +55,7 @@ echo Running: "%DOTNET_CMD%" restore "%PROJECT_JSON_FILE%" --packages %PACKAGES_
 call "%DOTNET_CMD%" restore "%PROJECT_JSON_FILE%" --packages %PACKAGES_DIR% --source "%BUILDTOOLS_SOURCE%" >> %INIT_TOOLS_LOG%
 if NOT exist "%BUILD_TOOLS_PATH%init-tools.cmd" (
   echo ERROR: Could not restore build tools correctly. See '%INIT_TOOLS_LOG%' for more details.
-  goto :EOF
+  exit /b 1
 )
 
 :afterbuildtoolsrestore

--- a/publish-packages.cmd
+++ b/publish-packages.cmd
@@ -18,7 +18,7 @@ echo msbuild.exe %~dp0src\publish.proj !options! !allargs! >> %packagesLog%
 call msbuild.exe %~dp0src\publish.proj !options! !allargs!
 if NOT [%ERRORLEVEL%]==[0] (
   echo ERROR: An error occurred while publishing packages, see %packagesLog% for more details.
-  exit /b
+  exit /b 1
 )
 
 echo Done publishing packages.

--- a/sync.cmd
+++ b/sync.cmd
@@ -65,7 +65,7 @@ if [%src%] == [true] (
   call git fetch --all -p -v >> %synclog% 2>&1
   if NOT [!ERRORLEVEL!]==[0] (
     echo ERROR: An error occurred while fetching remote source code, see %synclog% for more details.
-    exit /b
+    exit /b 1
   )
 )
 
@@ -75,7 +75,7 @@ if [%azureBlobs%] == [true] (
   call msbuild.exe %~dp0src\syncAzure.proj !options! !unprocessedBuildArgs!
   if NOT [!ERRORLEVEL!]==[0] (
     echo ERROR: An error occurred while downloading packages from Azure BLOB, see %synclog% for more details. There may have been networking problems so please try again in a few minutes.
-    exit /b
+    exit /b 1
   )
 )
 
@@ -91,7 +91,7 @@ if [%packages%] == [true] (
   call msbuild.exe %~dp0build.proj !options! !unprocessedBuildArgs!
   if NOT [!ERRORLEVEL!]==[0] (
     echo ERROR: An error occurred while syncing packages, see %synclog% for more details. There may have been networking problems so please try again in a few minutes.
-    exit /b
+    exit /b 1
   )
 )
 


### PR DESCRIPTION
VSO will not report errors unless either the exit code is set or the "Fail on standard error" option is set and text is redirected to the error stream.  This change sets exit codes for scripts which were not explicitly setting them.

/cc @weshaggard , @maririos 

@weshaggard , is there a reason not to both set the exit codes AND redirect the error text to the error stream?  Setting the exit codes should unblock my needs though.