### PR TITLE
Re-enable the CNG MachineKey tests

### DIFF
--- a/src/System.Security.Cryptography.Cng/tests/AesCngTests.cs
+++ b/src/System.Security.Cryptography.Cng/tests/AesCngTests.cs
@@ -74,9 +74,8 @@ namespace System.Security.Cryptography.Cng.Tests
             }
         }
 
-        [ActiveIssue(7465)]
         [OuterLoop(/* Creates/Deletes a persisted key, limit exposure to key leaking */)]
-        [ConditionalFact(nameof(SupportsPersistedSymmetricKeys))]
+        [ConditionalFact(nameof(SupportsPersistedSymmetricKeys), nameof(IsAdministrator))]
         public static void VerifyMachineKey()
         {
             SymmetricCngTestHelpers.VerifyMachineKey(
@@ -89,6 +88,11 @@ namespace System.Security.Cryptography.Cng.Tests
         public static bool SupportsPersistedSymmetricKeys
         {
             get { return SymmetricCngTestHelpers.SupportsPersistedSymmetricKeys; }
+        }
+
+        public static bool IsAdministrator
+        {
+            get { return SymmetricCngTestHelpers.IsAdministrator; }
         }
     }
 }

--- a/src/System.Security.Cryptography.Cng/tests/SymmetricCngTestHelpers.cs
+++ b/src/System.Security.Cryptography.Cng/tests/SymmetricCngTestHelpers.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
+using System.Security.Principal;
 using Xunit;
 
 namespace System.Security.Cryptography.Cng.Tests
@@ -255,6 +256,7 @@ namespace System.Security.Cryptography.Cng.Tests
                 cngKey.Delete();
             }
         }
+
         private static bool? s_supportsPersistedSymmetricKeys;
         internal static bool SupportsPersistedSymmetricKeys
         {
@@ -270,6 +272,18 @@ namespace System.Security.Cryptography.Cng.Tests
                 return s_supportsPersistedSymmetricKeys.Value;
             }
         }
+
+        private static readonly Lazy<bool> s_isAdministrator = new Lazy<bool>(
+            () =>
+            {
+                using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
+                {
+                    WindowsPrincipal principal = new WindowsPrincipal(identity);
+                    return principal.IsInRole(WindowsBuiltInRole.Administrator);
+                }
+            });
+
+        internal static bool IsAdministrator => s_isAdministrator.Value;
 
         internal static byte[] GenerateRandom(int count)
         {

--- a/src/System.Security.Cryptography.Cng/tests/TripleDESCngTests.cs
+++ b/src/System.Security.Cryptography.Cng/tests/TripleDESCngTests.cs
@@ -72,9 +72,8 @@ namespace System.Security.Cryptography.Cng.Tests
             }
         }
 
-        [ActiveIssue(7465)]
         [OuterLoop(/* Creates/Deletes a persisted key, limit exposure to key leaking */)]
-        [ConditionalFact(nameof(SupportsPersistedSymmetricKeys))]
+        [ConditionalFact(nameof(SupportsPersistedSymmetricKeys), nameof(IsAdministrator))]
         public static void VerifyMachineKey()
         {
             SymmetricCngTestHelpers.VerifyMachineKey(
@@ -87,6 +86,11 @@ namespace System.Security.Cryptography.Cng.Tests
         public static bool SupportsPersistedSymmetricKeys
         {
             get { return SymmetricCngTestHelpers.SupportsPersistedSymmetricKeys; }
+        }
+
+        public static bool IsAdministrator
+        {
+            get { return SymmetricCngTestHelpers.IsAdministrator; }
         }
     }
 }

--- a/src/System.Security.Cryptography.Cng/tests/project.json
+++ b/src/System.Security.Cryptography.Cng/tests/project.json
@@ -10,6 +10,7 @@
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc3-24022-00",
     "System.Runtime.Numerics": "4.0.1-rc3-24022-00",
     "System.Security.Cryptography.Algorithms": "4.1.0-rc3-24022-00",
+    "System.Security.Principal.Windows": "4.0.0-rc3-24022-00",
     "System.Text.Encoding.Extensions": "4.0.11-rc3-24022-00",
     "System.Text.RegularExpressions": "4.1.0-rc3-24022-00",
     "xunit": "2.1.0",


### PR DESCRIPTION
These tests require administrator rights, but didn't test for those rights before executing.

No negative test is being written because the permissions can be changed,
Administrator accounts are sufficient, but not necessary.

Fixes #7465.