### PR TITLE
[no merge] Port System.IO async changes from CoreCLR

### DIFF
--- a/src/System.IO/src/System/IO/Stream.cs
+++ b/src/System.IO/src/System/IO/Stream.cs
@@ -408,25 +408,24 @@ namespace System.IO
             {
             }
 
-#pragma warning disable 1998 // async method with no await
-            public override async Task FlushAsync(CancellationToken cancellationToken)
+            public override Task FlushAsync(CancellationToken cancellationToken)
             {
-                cancellationToken.ThrowIfCancellationRequested();
+                return cancellationToken.IsCancellationRequested ?
+                    Task.FromCanceled(cancellationToken) :
+                    Task.CompletedTask;
             }
-#pragma warning restore 1998
 
             public override int Read(byte[] buffer, int offset, int count)
             {
                 return 0;
             }
 
-#pragma warning disable 1998 // async method with no await
-            public override async Task<int> ReadAsync(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            public override Task<int> ReadAsync(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                return 0;
+                return cancellationToken.IsCancellationRequested ?
+                    Task.FromCanceled<int>(cancellationToken) :
+                    Task.FromResult(0); // TODO: Get this Task from a cache for better perf
             }
-#pragma warning restore 1998
 
             public override int ReadByte()
             {
@@ -437,12 +436,12 @@ namespace System.IO
             {
             }
 
-#pragma warning disable 1998 // async method with no await
-            public override async Task WriteAsync(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            public override Task WriteAsync(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
-                cancellationToken.ThrowIfCancellationRequested();
+                return cancellationToken.IsCancellationRequested ?
+                    Task.FromCanceled(cancellationToken) :
+                    Task.CompletedTask;
             }
-#pragma warning restore 1998
 
             public override void WriteByte(byte value)
             {


### PR DESCRIPTION
Addresses #8012; also somewhat of a subset of the changes in #7782.

List of changes:

- Removed a bunch of unnecessary `async`
  - Converted `ThrowIfCancellationRequested` -> `IsCancellationRequested` + `FromCanceled` in those call sites
  - Removed a bunch of `#pragma` along with that
- `MemoryStream.CopyToAsync` doesn't need to be async
  - This is already how it is implemented in CoreCLR-- see [here](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/IO/MemoryStream.cs#L406)
- Converted a bunch of `*Impl` methods to `*Core`

Note: I haven't added tests or anything yet (and the methods here still differ significantly from their mscorlib counterparts), so this probably shouldn't be merged right now.

cc @justinvp @jkotas @stephentoub