### PR TITLE
Add more negative tests to System.Text.Encoding

### DIFF
--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingEncode.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingEncode.cs
@@ -93,5 +93,16 @@ namespace System.Text.Tests
             Encode("\uFFFE", 0, 1, new byte[] { 254, 255 });
             Encode("\uFFFF", 0, 1, new byte[] { 255, 255 });
         }
+
+        [Fact]
+        public unsafe void GetByteCount_OverlyLargeCount_ThrowsArgumentOutOfRangeException()
+        {
+            UnicodeEncoding encoding = new UnicodeEncoding();
+            fixed (char* pChars = "abc")
+            {
+                char* pCharsLocal = pChars;
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => encoding.GetByteCount(pCharsLocal, int.MaxValue / 2 + 1));
+            }
+        }
     }
 }


### PR DESCRIPTION
- Null byte[] in GetBytes()
- Make sure GetMaxByteCount and GetMaxCharCount respect the MaxCharCount
property of EncoderFallback and DecoderFallback

/cc @tarekgh