### PR TITLE
Make interpreter act like compiler on member bindings

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -1073,5 +1073,10 @@ namespace System.Linq.Expressions
         {
             return new InvalidOperationException(Strings.NonAbstractConstructorRequired);
         }
+
+        internal static Exception InvalidProgram()
+        {
+            return new InvalidProgramException();
+        }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -209,6 +209,21 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
+        // "Un-emit" the previous instruction.
+        // Useful if the instruction was emitted in the calling method, and covers the more usual case.
+        // In particular, calling this after an EmitPush() or EmitDup() costs about the same as adding
+        // an EmitPop() to undo it at compile time, and leaves a slightly leaner instruction list.
+        public void UnEmit()
+        {
+            Instruction instruction = _instructions[_instructions.Count - 1];
+            _instructions.RemoveAt(_instructions.Count - 1);
+
+            _currentContinuationsDepth -= instruction.ProducedContinuations;
+            _currentContinuationsDepth += instruction.ConsumedContinuations;
+            _currentStackDepth -= instruction.ProducedStack;
+            _currentStackDepth += instruction.ConsumedStack;
+        }
+
         /// <summary>
         /// Attaches a cookie to the last emitted instruction.
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -661,15 +661,20 @@ namespace System.Linq.Expressions.Interpreter
                 EmitThisForMethodCall(expr);
             }
 
-            CompileMemberAssignment(asVoid, member.Member, node.Right);
+            CompileMemberAssignment(asVoid, member.Member, node.Right, false);
         }
 
-        private void CompileMemberAssignment(bool asVoid, MemberInfo refMember, Expression value)
+        private void CompileMemberAssignment(bool asVoid, MemberInfo refMember, Expression value, bool forBinding)
         {
             PropertyInfo pi = refMember as PropertyInfo;
             if (pi != null)
             {
                 var method = pi.GetSetMethod(true);
+                if (forBinding && method.IsStatic)
+                {
+                    throw Error.InvalidProgram();
+                }
+
                 EmitThisForMethodCall(value);
 
                 int start = _instructions.Count;
@@ -2650,7 +2655,8 @@ namespace System.Linq.Expressions.Interpreter
                         CompileMemberAssignment(
                             true,
                             ((MemberAssignment)binding).Member,
-                            ((MemberAssignment)binding).Expression
+                            ((MemberAssignment)binding).Expression,
+                            true
                         );
                         break;
                     case MemberBindingType.ListBinding:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -685,29 +685,31 @@ namespace System.Linq.Expressions.Interpreter
                 {
                     _instructions.EmitCall(method);
                 }
-                return;
             }
             else
             {
                 // other types inherited from MemberInfo (EventInfo\MethodBase\Type) cannot be used in MemberAssignment
                 FieldInfo fi = (FieldInfo)refMember;
-                if (fi != null)
+                Debug.Assert(fi != null);
+                if (fi.IsLiteral)
                 {
-                    EmitThisForMethodCall(value);
+                    throw Error.NotSupported();
+                }
 
-                    int start = _instructions.Count;
-                    if (!asVoid)
-                    {
-                        LocalDefinition local = _locals.DefineLocal(Expression.Parameter(value.Type), start);
-                        _instructions.EmitAssignLocal(local.Index);
-                        _instructions.EmitStoreField(fi);
-                        _instructions.EmitLoadLocal(local.Index);
-                        _locals.UndefineLocal(local, _instructions.Count);
-                    }
-                    else
-                    {
-                        _instructions.EmitStoreField(fi);
-                    }
+                EmitThisForMethodCall(value);
+
+                int start = _instructions.Count;
+                if (!asVoid)
+                {
+                    LocalDefinition local = _locals.DefineLocal(Expression.Parameter(value.Type), start);
+                    _instructions.EmitAssignLocal(local.Index);
+                    _instructions.EmitStoreField(fi);
+                    _instructions.EmitLoadLocal(local.Index);
+                    _locals.UndefineLocal(local, _instructions.Count);
+                }
+                else
+                {
+                    _instructions.EmitStoreField(fi);
                 }
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -701,6 +701,11 @@ namespace System.Linq.Expressions.Interpreter
                     throw Error.NotSupported();
                 }
 
+                if (forBinding && fi.IsStatic)
+                {
+                    _instructions.UnEmit(); // Undo having pushed the instance to the stack.
+                }
+
                 EmitThisForMethodCall(value);
 
                 int start = _instructions.Count;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2428,10 +2428,16 @@ namespace System.Linq.Expressions.Interpreter
             {
                 if (fi.IsLiteral)
                 {
+                    Debug.Assert(!forBinding);
                     _instructions.EmitLoad(fi.GetValue(null), fi.FieldType);
                 }
                 else if (fi.IsStatic)
                 {
+                    if (forBinding)
+                    {
+                        throw Error.InvalidProgram();
+                    }
+
                     if (fi.IsInitOnly)
                     {
                         _instructions.EmitLoad(fi.GetValue(null), fi.FieldType);
@@ -2447,6 +2453,7 @@ namespace System.Linq.Expressions.Interpreter
                     {
                         EmitThisForMethodCall(from);
                     }
+
                     _instructions.EmitLoadField(fi);
                 }
             }

--- a/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
@@ -191,7 +191,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentException>("member", () => Expression.Bind(property, Expression.Constant("")));
         }
 
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void StaticField(bool useInterpreter)
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember(nameof(PropertyAndFields.StaticStringField))[0];
@@ -207,14 +207,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("ABC", PropertyAndFields.StaticStringField);
         }
 
-        [Fact, ActiveIssue(5963)]
-        public void StaticFieldInterpreted()
-        {
-            // Mis-balances stack.
-            StaticField(true);
-        }
-
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void StaticReadonlyField(bool useInterpreter)
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember(nameof(PropertyAndFields.StaticReadonlyStringField))[0];
@@ -227,12 +220,6 @@ namespace System.Linq.Expressions.Tests
             var func = assignToReadonly.Compile(useInterpreter);
             func();
             Assert.Equal("ABC" + useInterpreter, PropertyAndFields.StaticReadonlyStringField);
-        }
-
-        [Fact, ActiveIssue(5963)]
-        public void StaticReadonlyFieldInterpreted()
-        {
-            StaticReadonlyField(true);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]

--- a/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
@@ -145,7 +145,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("Hello Property", result.StringProperty);
         }
 
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void ConstantField(bool useInterpreter)
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember(nameof(PropertyAndFields.ConstantString))[0];
@@ -157,13 +157,6 @@ namespace System.Linq.Expressions.Tests
                 );
 
             Assert.Throws<NotSupportedException>(() => attemptAssignToConstant.Compile(useInterpreter));
-        }
-
-        [Fact, ActiveIssue(5963)]
-        public void ConstantFieldInterpreted()
-        {
-            // Mis-balaces stack.
-            ConstantField(true);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]

--- a/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
@@ -235,7 +235,7 @@ namespace System.Linq.Expressions.Tests
             StaticReadonlyField(true);
         }
 
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void StaticProperty(bool useInterpreter)
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember(nameof(PropertyAndFields.StaticStringProperty))[0];
@@ -246,13 +246,6 @@ namespace System.Linq.Expressions.Tests
                     )
                 );
             Assert.Throws<InvalidProgramException>(() => assignToStaticProperty.Compile(useInterpreter));
-        }
-
-        [Fact, ActiveIssue(5963)]
-        public void StaticPropertyInterpreted()
-        {
-            // Mis-balances stack.
-            StaticProperty(true);
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
@@ -171,7 +171,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentException>("member", () => Expression.ListBind(member, Enumerable.Empty<ElementInit>()));
         }
 
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void StaticListProperty(bool useInterpreter)
         {
             PropertyInfo property = typeof(ListWrapper<int>).GetProperty(nameof(ListWrapper<int>.StaticListProperty));
@@ -189,13 +189,6 @@ namespace System.Linq.Expressions.Tests
                 );
 
             Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
-        }
-
-        [Fact, ActiveIssue(5693)]
-        public void StaticListPropertyInterpreted()
-        {
-            // Misbalances stack.
-            StaticListProperty(true);
         }
 
         [Theory, InlineData(false)]

--- a/src/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
@@ -191,7 +191,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
         }
 
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void StaticListField(bool useInterpreter)
         {
             FieldInfo field = typeof(ListWrapper<int>).GetField(nameof(ListWrapper<int>.StaticListField));
@@ -209,13 +209,6 @@ namespace System.Linq.Expressions.Tests
                 );
 
             Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
-        }
-
-        [Fact, ActiveIssue(5963)]
-        public void StaticListFieldInterpreted()
-        {
-            // Misbalances stack.
-            StaticListField(true);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
@@ -23,6 +23,25 @@ namespace System.Linq.Expressions.Tests
 #pragma warning restore 649
         }
 
+        public class Inner
+        {
+            public int Value { get; set; }
+        }
+
+        public class Outer
+        {
+            public Inner InnerProperty { get; set; } = new Inner();
+            public Inner InnerField = new Inner();
+            public Inner ReadonlyInnerProperty { get; } = new Inner();
+            public Inner WriteonlyInnerProperty { set { } }
+            public readonly Inner ReadonlyInnerField = new Inner();
+            public static Inner StaticInnerProperty { get; set; } = new Inner();
+            public static Inner StaticInnerField = new Inner();
+            public static Inner StaticReadonlyInnerProperty { get; } = new Inner();
+            public static readonly Inner StaticReadonlyInnerField = new Inner();
+            public static Inner StaticWriteonlyInnerProperty { set { } }
+        }
+
         [Fact]
         public void NullMethodOrMemberInfo()
         {
@@ -68,7 +87,176 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void MemberBindingMustBeMemberOfType()
         {
-            
+            var bind = Expression.MemberBind(
+                typeof(Outer).GetProperty(nameof(Outer.InnerProperty)),
+                Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(3))
+                );
+            var newExp = Expression.New(typeof(PropertyAndFields));
+            Assert.Throws<ArgumentException>(() => Expression.MemberInit(newExp, bind));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void InnerProperty(bool useInterpreter)
+        {
+            var exp = Expression.Lambda<Func<Outer>>(
+                Expression.MemberInit(
+                    Expression.New(typeof(Outer)),
+                    Expression.MemberBind(
+                        typeof(Outer).GetProperty(nameof(Outer.InnerProperty)),
+                        Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(3))
+                        )
+                    )
+                );
+            var func = exp.Compile(useInterpreter);
+            Assert.Equal(3, func().InnerProperty.Value);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void InnerField(bool useInterpreter)
+        {
+            var exp = Expression.Lambda<Func<Outer>>(
+                Expression.MemberInit(
+                    Expression.New(typeof(Outer)),
+                    Expression.MemberBind(
+                        typeof(Outer).GetField(nameof(Outer.InnerField)),
+                        Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(4))
+                        )
+                    )
+                );
+            var func = exp.Compile(useInterpreter);
+            Assert.Equal(4, func().InnerField.Value);
+        }
+
+        [Theory, InlineData(false)]
+        public void StaticInnerProperty(bool useInterpreter)
+        {
+            var exp = Expression.Lambda<Func<Outer>>(
+                Expression.MemberInit(
+                    Expression.New(typeof(Outer)),
+                    Expression.MemberBind(
+                        typeof(Outer).GetProperty(nameof(Outer.StaticInnerProperty)),
+                        Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(5))
+                        )
+                    )
+                );
+            Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
+        }
+
+        [Fact, ActiveIssue(5963)]
+        public void StaticInnerPropertyInterpreted()
+        {
+            // Mis-balances stack
+            StaticInnerProperty(true);
+        }
+
+        [Theory, InlineData(false)]
+        public void StaticInnerField(bool useInterpreter)
+        {
+            var exp = Expression.Lambda<Func<Outer>>(
+                Expression.MemberInit(
+                    Expression.New(typeof(Outer)),
+                    Expression.MemberBind(
+                        typeof(Outer).GetField(nameof(Outer.StaticInnerField)),
+                        Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(6))
+                        )
+                    )
+                );
+            Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
+        }
+
+        [Fact, ActiveIssue(5963)]
+        public void StaticInnerFieldInterpreted()
+        {
+            // Mis-balances stack
+            StaticInnerField(true);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void ReadonlyInnerProperty(bool useInterpreter)
+        {
+            var exp = Expression.Lambda<Func<Outer>>(
+                Expression.MemberInit(
+                    Expression.New(typeof(Outer)),
+                    Expression.MemberBind(
+                        typeof(Outer).GetProperty(nameof(Outer.ReadonlyInnerProperty)),
+                        Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(7))
+                        )
+                    )
+                );
+            var func = exp.Compile(useInterpreter);
+            Assert.Equal(7, func().ReadonlyInnerProperty.Value);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void ReadonlyInnerField(bool useInterpreter)
+        {
+            var exp = Expression.Lambda<Func<Outer>>(
+                Expression.MemberInit(
+                    Expression.New(typeof(Outer)),
+                    Expression.MemberBind(
+                        typeof(Outer).GetField(nameof(Outer.ReadonlyInnerField)),
+                        Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(8))
+                        )
+                    )
+                );
+            var func = exp.Compile(useInterpreter);
+            Assert.Equal(8, func().ReadonlyInnerField.Value);
+        }
+
+        [Theory, InlineData(false)]
+        public void StaticReadonlyInnerProperty(bool useInterpreter)
+        {
+            var exp = Expression.Lambda<Func<Outer>>(
+                Expression.MemberInit(
+                    Expression.New(typeof(Outer)),
+                    Expression.MemberBind(
+                        typeof(Outer).GetProperty(nameof(Outer.StaticReadonlyInnerProperty)),
+                        Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(5))
+                        )
+                    )
+                );
+            Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
+        }
+
+        [Fact, ActiveIssue(5963)]
+        public void StaticReadonlyInnerPropertyInterpreted()
+        {
+            StaticReadonlyInnerProperty(true);
+        }
+
+        [Theory, InlineData(false)]
+        public void StaticReadonlyInnerField(bool useInterpreter)
+        {
+            var exp = Expression.Lambda<Func<Outer>>(
+                Expression.MemberInit(
+                    Expression.New(typeof(Outer)),
+                    Expression.MemberBind(
+                        typeof(Outer).GetField(nameof(Outer.StaticReadonlyInnerField)),
+                        Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(6))
+                        )
+                    )
+                );
+            Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
+        }
+
+        [Fact, ActiveIssue(5963)]
+        public void StaticReadonlyInnerFieldInterpreted()
+        {
+            StaticReadonlyInnerField(true);
+        }
+
+        public void WriteOnlyInnerProperty()
+        {
+            var bind = Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(0));
+            var property = typeof(Outer).GetProperty(nameof(Outer.WriteonlyInnerProperty));
+            Assert.Throws<ArgumentException>(() => Expression.MemberBind(property, bind));
+        }
+
+        public void StaticWriteOnlyInnerProperty()
+        {
+            var bind = Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(0));
+            var property = typeof(Outer).GetProperty(nameof(Outer.StaticWriteonlyInnerProperty));
+            Assert.Throws<ArgumentException>(() => Expression.MemberBind(property, bind));
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
@@ -127,7 +127,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(4, func().InnerField.Value);
         }
 
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void StaticInnerProperty(bool useInterpreter)
         {
             var exp = Expression.Lambda<Func<Outer>>(
@@ -140,13 +140,6 @@ namespace System.Linq.Expressions.Tests
                     )
                 );
             Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
-        }
-
-        [Fact, ActiveIssue(5963)]
-        public void StaticInnerPropertyInterpreted()
-        {
-            // Mis-balances stack
-            StaticInnerProperty(true);
         }
 
         [Theory, InlineData(false)]
@@ -203,7 +196,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(8, func().ReadonlyInnerField.Value);
         }
 
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void StaticReadonlyInnerProperty(bool useInterpreter)
         {
             var exp = Expression.Lambda<Func<Outer>>(
@@ -216,12 +209,6 @@ namespace System.Linq.Expressions.Tests
                     )
                 );
             Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
-        }
-
-        [Fact, ActiveIssue(5963)]
-        public void StaticReadonlyInnerPropertyInterpreted()
-        {
-            StaticReadonlyInnerProperty(true);
         }
 
         [Theory, InlineData(false)]

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
@@ -142,7 +142,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
         }
 
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void StaticInnerField(bool useInterpreter)
         {
             var exp = Expression.Lambda<Func<Outer>>(
@@ -155,13 +155,6 @@ namespace System.Linq.Expressions.Tests
                     )
                 );
             Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
-        }
-
-        [Fact, ActiveIssue(5963)]
-        public void StaticInnerFieldInterpreted()
-        {
-            // Mis-balances stack
-            StaticInnerField(true);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
@@ -211,7 +204,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
         }
 
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void StaticReadonlyInnerField(bool useInterpreter)
         {
             var exp = Expression.Lambda<Func<Outer>>(
@@ -224,12 +217,6 @@ namespace System.Linq.Expressions.Tests
                     )
                 );
             Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
-        }
-
-        [Fact, ActiveIssue(5963)]
-        public void StaticReadonlyInnerFieldInterpreted()
-        {
-            StaticReadonlyInnerField(true);
         }
 
         public void WriteOnlyInnerProperty()


### PR DESCRIPTION
Fixes #5963.

Add/update tests to consider the compiler behaviour as correct with regard to the permutations mentioned in #5963, with `ActiveIssue` tests for those cases where the interpreter differs. Then have the interpreter act like the compiler for each such case.