### PR TITLE
Update System.Runtime.WindowsRuntime to use Task methods

### DIFF
--- a/src/System.Runtime.WindowsRuntime/src/System/IO/BufferedStream.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/BufferedStream.cs
@@ -342,7 +342,7 @@ namespace System.IO
     public override Task FlushAsync(CancellationToken cancellationToken) {
 
         if (cancellationToken.IsCancellationRequested)
-            return Task.FromCancellation<Int32>(cancellationToken);
+            return Task.FromCanceled<Int32>(cancellationToken);
 
         EnsureNotClosed();
 
@@ -687,7 +687,7 @@ namespace System.IO
 
         // Fast path check for cancellation already requested
         if (cancellationToken.IsCancellationRequested)
-            return Task.FromCancellation<Int32>(cancellationToken);
+            return Task.FromCanceled<Int32>(cancellationToken);
 
         EnsureNotClosed();
         EnsureCanRead();
@@ -1111,7 +1111,7 @@ namespace System.IO
 
             // Fast path check for cancellation already requested
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCancellation<Int32>(cancellationToken);
+                return Task.FromCanceled<Int32>(cancellationToken);
 
             EnsureNotClosed();
             EnsureCanWrite();

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/WinRtToNetFxStreamAdapter.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/WinRtToNetFxStreamAdapter.cs
@@ -792,7 +792,7 @@ namespace System.IO
 
             // Calling Flush in a non-writable stream is a no-op, not an error:
             if (!_canWrite)
-                return Helpers.CompletedTask;
+                return Task.CompletedTask;
 
 #if DEBUG
             AssertValidStream(wrtStr);

--- a/src/System.Runtime.WindowsRuntime/src/System/InternalHelpers.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/InternalHelpers.cs
@@ -43,38 +43,6 @@ namespace System.Runtime.WindowsRuntime.Internal
 
     internal class Helpers
     {
-        private static Task s_completedTask = null;
-
-        internal static Task CompletedTask
-        {
-            get
-            {
-                var completedTask = s_completedTask;
-                if (completedTask == null)
-                {
-                    var taskSource = new TaskCompletionSource<VoidValueTypeParameter>();
-                    taskSource.SetResult(default(VoidValueTypeParameter));
-                    s_completedTask = completedTask = taskSource.Task;
-                }
-                return completedTask;
-            }
-        }
-
-        internal static Task<TYPE> TaskFromException<TYPE>(Exception e)
-        {
-            var taskSource = new TaskCompletionSource<TYPE>();
-            taskSource.SetException(e);
-            return taskSource.Task;
-        }
-
-        internal static Task<TYPE> TaskFromCancellation<TYPE>(CancellationToken cancellationToken)
-        {
-            var taskSource = new TaskCompletionSource<TYPE>();
-            taskSource.SetCanceled();
-            taskSource.Task.Wait(cancellationToken);
-            return taskSource.Task;
-        }
-
         internal unsafe static void ZeroMemory(byte* src, long len)
         {
             while (len-- > 0)

--- a/src/System.Runtime.WindowsRuntime/src/System/WindowsRuntimeSystemExtensions.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/WindowsRuntimeSystemExtensions.cs
@@ -113,13 +113,13 @@ namespace System
             switch (source.Status)
             {
                 case AsyncStatus.Completed:
-                    return Helpers.CompletedTask;
+                    return Task.CompletedTask;
 
                 case AsyncStatus.Error:
-                    return Helpers.TaskFromException<VoidValueTypeParameter>(source.ErrorCode.AttachRestrictedErrorInfo());
+                    return Task.FromException<VoidValueTypeParameter>(source.ErrorCode.AttachRestrictedErrorInfo());
 
                 case AsyncStatus.Canceled:
-                    return Helpers.TaskFromCancellation<VoidValueTypeParameter>(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
+                    return Task.FromCanceled<VoidValueTypeParameter>(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
             }
 
             // Benign race: source may complete here. Things still work, just not taking the fast path.
@@ -198,10 +198,10 @@ namespace System
                     return Task.FromResult(source.GetResults());
 
                 case AsyncStatus.Error:
-                    return Helpers.TaskFromException<TResult>(source.ErrorCode.AttachRestrictedErrorInfo());
+                    return Task.FromException<TResult>(source.ErrorCode.AttachRestrictedErrorInfo());
 
                 case AsyncStatus.Canceled:
-                    return Helpers.TaskFromCancellation<TResult>(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
+                    return Task.FromCanceled<TResult>(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
             }
 
             // Benign race: source may complete here. Things still work, just not taking the fast path.
@@ -303,13 +303,13 @@ namespace System
             switch (source.Status)
             {
                 case AsyncStatus.Completed:
-                    return Helpers.CompletedTask;
+                    return Task.CompletedTask;
 
                 case AsyncStatus.Error:
-                    return Helpers.TaskFromException<VoidValueTypeParameter>(source.ErrorCode.AttachRestrictedErrorInfo());
+                    return Task.FromException<VoidValueTypeParameter>(source.ErrorCode.AttachRestrictedErrorInfo());
 
                 case AsyncStatus.Canceled:
-                    return Helpers.TaskFromCancellation<VoidValueTypeParameter>(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
+                    return Task.FromCanceled<VoidValueTypeParameter>(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
             }
 
             // Benign race: source may complete here. Things still work, just not taking the fast path.
@@ -420,10 +420,10 @@ namespace System
                     return Task.FromResult(source.GetResults());
 
                 case AsyncStatus.Error:
-                    return Helpers.TaskFromException<TResult>(source.ErrorCode.AttachRestrictedErrorInfo());
+                    return Task.FromException<TResult>(source.ErrorCode.AttachRestrictedErrorInfo());
 
                 case AsyncStatus.Canceled:
-                    return Helpers.TaskFromCancellation<TResult>(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
+                    return Task.FromCanceled<TResult>(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
             }
 
             // Benign race: source may complete here. Things still work, just not taking the fast path.

--- a/src/System.Runtime.WindowsRuntime/src/System/WindowsRuntimeSystemExtensions.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/WindowsRuntimeSystemExtensions.cs
@@ -116,10 +116,10 @@ namespace System
                     return Task.CompletedTask;
 
                 case AsyncStatus.Error:
-                    return Task.FromException<VoidValueTypeParameter>(source.ErrorCode.AttachRestrictedErrorInfo());
+                    return Task.FromException(source.ErrorCode.AttachRestrictedErrorInfo());
 
                 case AsyncStatus.Canceled:
-                    return Task.FromCanceled<VoidValueTypeParameter>(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
+                    return Task.FromCanceled(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
             }
 
             // Benign race: source may complete here. Things still work, just not taking the fast path.
@@ -306,10 +306,10 @@ namespace System
                     return Task.CompletedTask;
 
                 case AsyncStatus.Error:
-                    return Task.FromException<VoidValueTypeParameter>(source.ErrorCode.AttachRestrictedErrorInfo());
+                    return Task.FromException(source.ErrorCode.AttachRestrictedErrorInfo());
 
                 case AsyncStatus.Canceled:
-                    return Task.FromCanceled<VoidValueTypeParameter>(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
+                    return Task.FromCanceled(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
             }
 
             // Benign race: source may complete here. Things still work, just not taking the fast path.

--- a/src/System.Runtime.WindowsRuntime/src/System/WindowsRuntimeSystemExtensions.netstandard.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/WindowsRuntimeSystemExtensions.netstandard.cs
@@ -116,7 +116,7 @@ namespace System
                     return Task.FromException(RestrictedErrorInfoHelper.AttachRestrictedErrorInfo(source.ErrorCode));
 
                 case AsyncStatus.Canceled:
-                    return Task.FromCancellation(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
+                    return Task.FromCanceled(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
             }
 
             // Benign race: source may complete here. Things still work, just not taking the fast path.
@@ -192,7 +192,7 @@ namespace System
                     return Task.FromException<TResult>(RestrictedErrorInfoHelper.AttachRestrictedErrorInfo(source.ErrorCode));
 
                 case AsyncStatus.Canceled:
-                    return Task.FromCancellation<TResult>(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
+                    return Task.FromCanceled<TResult>(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
             }
 
             // Benign race: source may complete here. Things still work, just not taking the fast path.
@@ -295,7 +295,7 @@ namespace System
                     return Task.FromException(RestrictedErrorInfoHelper.AttachRestrictedErrorInfo(source.ErrorCode));
 
                 case AsyncStatus.Canceled:
-                    return Task.FromCancellation(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
+                    return Task.FromCanceled(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
             }
 
             // Benign race: source may complete here. Things still work, just not taking the fast path.
@@ -404,7 +404,7 @@ namespace System
                     return Task.FromException<TResult>(RestrictedErrorInfoHelper.AttachRestrictedErrorInfo(source.ErrorCode));
 
                 case AsyncStatus.Canceled:
-                    return Task.FromCancellation<TResult>(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
+                    return Task.FromCanceled<TResult>(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
             }
 
             // Benign race: source may complete here. Things still work, just not taking the fast path.


### PR DESCRIPTION
Remove Helpers.* and use Task.* methods instead.  Also use the public Task.FromCanceled instead of the internals-visible-to FromCancellation.