### PR TITLE
Add Support for EnvelopedCms (Step 1: Empty Package.)

### DIFF
--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -1337,6 +1337,13 @@
         ]
     },
     {
+        "Name": "System.Security.Cryptography.Pkcs",
+        "Description": "Provides support for PKCS and CMS algorithms.",
+        "CommonTypes": [
+            "System.Security.Cryptography.Pkcs.EnvelopedCms"
+        ]
+    },
+    {
         "Name": "System.Security.Cryptography.Primitives",
         "Description": "Provides common types for the cryptographic libraries.",
         "CommonTypes": [

--- a/src/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -21,6 +21,7 @@ internal static partial class Interop
         internal const string Eventing = "api-ms-win-eventing-provider-l1-1-0.dll";
         internal const string Handle = "api-ms-win-core-handle-l1-1-0.dll";
         internal const string Heap = "api-ms-win-core-heap-obsolete-l1-1-0.dll";
+        internal const string Heap_L1 = "api-ms-win-core-heap-l1-1-0.dll";
         internal const string IO = "api-ms-win-core-io-l1-1-0.dll";
         internal const string IpHlpApi = "iphlpapi.dll";
         internal const string Kernel32 = "kernel32.dll";
@@ -49,6 +50,7 @@ internal static partial class Interop
         internal const string RoBuffer = "api-ms-win-core-winrt-robuffer-l1-1-0.dll";
         internal const string SecurityBase = "api-ms-win-security-base-l1-1-0.dll";
         internal const string SecurityCpwl = "api-ms-win-security-cpwl-l1-1-0.dll";
+        internal const string SecurityCryptoApi = "api-ms-win-security-cryptoapi-l1-1-0.dll";
         internal const string SecurityLsa = "api-ms-win-security-lsalookup-l2-1-0.dll";
         internal const string SecurityLsaPolicy = "api-ms-win-security-lsapolicy-l1-1-0.dll";
         internal const string SecurityProvider = "api-ms-win-security-provider-l1-1-0.dll";

--- a/src/System.Security.Cryptography.Pkcs/System.Security.Cryptography.Pkcs.sln
+++ b/src/System.Security.Cryptography.Pkcs/System.Security.Cryptography.Pkcs.sln
@@ -1,0 +1,38 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.Cryptography.Pkcs", "src\System.Security.Cryptography.Pkcs.csproj", "{03D84CBD-896D-4B2F-9A22-07034F51E73D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.Cryptography.Pkcs.Tests", "tests\System.Security.Cryptography.Pkcs.Tests.csproj", "{2DD8DFFA-09FF-46C6-8313-4A9CC1849A44}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Windows_Debug|Any CPU = Windows_Debug|Any CPU
+		Windows_Release|Any CPU = Windows_Release|Any CPU
+		Windows_netcore50_Debug|Any CPU = Windows_netcore50_Debug|Any CPU
+		Windows_netcore50_Release|Any CPU = Windows_netcore50_Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{03D84CBD-896D-4B2F-9A22-07034F51E73D}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{03D84CBD-896D-4B2F-9A22-07034F51E73D}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{03D84CBD-896D-4B2F-9A22-07034F51E73D}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{03D84CBD-896D-4B2F-9A22-07034F51E73D}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{03D84CBD-896D-4B2F-9A22-07034F51E73D}.Windows_netcore50_Debug|Any CPU.ActiveCfg = Windows_netcore50_Debug|Any CPU
+		{03D84CBD-896D-4B2F-9A22-07034F51E73D}.Windows_netcore50_Debug|Any CPU.Build.0 = Windows_netcore50_Debug|Any CPU
+		{03D84CBD-896D-4B2F-9A22-07034F51E73D}.Windows_netcore50_Release|Any CPU.ActiveCfg = Windows_netcore50_Release|Any CPU
+		{03D84CBD-896D-4B2F-9A22-07034F51E73D}.Windows_netcore50_Release|Any CPU.Build.0 = Windows_netcore50_Release|Any CPU
+		{2DD8DFFA-09FF-46C6-8313-4A9CC1849A44}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{2DD8DFFA-09FF-46C6-8313-4A9CC1849A44}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{2DD8DFFA-09FF-46C6-8313-4A9CC1849A44}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{2DD8DFFA-09FF-46C6-8313-4A9CC1849A44}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{2DD8DFFA-09FF-46C6-8313-4A9CC1849A44}.Windows_netcore50_Debug|Any CPU.ActiveCfg = Windows_netcore50_Debug|Any CPU
+		{2DD8DFFA-09FF-46C6-8313-4A9CC1849A44}.Windows_netcore50_Debug|Any CPU.Build.0 = Windows_netcore50_Debug|Any CPU
+		{2DD8DFFA-09FF-46C6-8313-4A9CC1849A44}.Windows_netcore50_Release|Any CPU.ActiveCfg = Windows_netcore50_Release|Any CPU
+		{2DD8DFFA-09FF-46C6-8313-4A9CC1849A44}.Windows_netcore50_Release|Any CPU.Build.0 = Windows_netcore50_Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal
+

--- a/src/System.Security.Cryptography.Pkcs/pkg/System.Security.Cryptography.Pkcs.builds
+++ b/src/System.Security.Cryptography.Pkcs/pkg/System.Security.Cryptography.Pkcs.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Security.Cryptography.Pkcs.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Security.Cryptography.Pkcs/pkg/System.Security.Cryptography.Pkcs.pkgproj
+++ b/src/System.Security.Cryptography.Pkcs/pkg/System.Security.Cryptography.Pkcs.pkgproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Security.Cryptography.Pkcs.csproj">
+      <SupportedFramework>net46;netcore50;netstandardapp1.5</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Security.Cryptography.Pkcs.builds" />
+  </ItemGroup>
+  <ItemGroup>
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.csproj
+++ b/src/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.csproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Cryptography.Pkcs/ref/project.json
+++ b/src/System.Security.Cryptography.Pkcs/ref/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.0.0",
+    "System.Security.Cryptography.Encoding": "4.0.0-rc3-24022-00",
+    "System.Security.Cryptography.X509Certificates": "4.1.0-rc3-24022-00",
+  },
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": [ "dotnet5.4" ]
+    }
+  }
+}

--- a/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
@@ -1,0 +1,153 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Arg_EmptyOrNullString" xml:space="preserve">
+    <value>String cannot be empty or null.</value>
+  </data>
+  <data name="Arg_RankMultiDimNotSupported" xml:space="preserve">
+    <value>Only single dimensional arrays are supported for the requested action.</value>
+  </data>
+  <data name="Argument_InvalidOffLen" xml:space="preserve">
+    <value>Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.</value>
+  </data>
+  <data name="ArgumentOutOfRange_Index" xml:space="preserve">
+    <value>Index was out of range.  Must be non-negative and less than the size of the collection.</value>
+  </data>
+  <data name="Cryptography_Cms_Envelope_Empty_Content" xml:space="preserve">
+    <value>Cannot create CMS enveloped for empty content.</value>
+  </data>
+  <data name="Cryptography_Cms_Invalid_Subject_Identifier_Type" xml:space="preserve">
+    <value>The subject identifier type {0} is not valid.</value>
+  </data>
+  <data name="Cryptography_Cms_Key_Agree_Date_Not_Available" xml:space="preserve">
+    <value>The Date property is not available for none KID key agree recipient.</value>
+  </data>
+  <data name="Cryptography_Cms_MessageNotEncrypted" xml:space="preserve">
+    <value>The CMS message is not encrypted.</value>
+  </data>
+  <data name="Cryptography_Pkcs9_AttributeMismatch" xml:space="preserve">
+    <value>The parameter should be a PKCS 9 attribute.</value>
+  </data>
+  <data name="Cryptography_Pkcs9_MultipleSigningTimeNotAllowed" xml:space="preserve">
+    <value>Cannot add multiple PKCS 9 signing time attributes.</value>
+  </data>
+  <data name="InvalidOperation_DuplicateItemNotAllowed" xml:space="preserve">
+    <value>Duplicate items are not allowed in the collection.</value>
+  </data>
+</root>

--- a/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.builds
+++ b/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.builds
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Security.Cryptography.Pkcs.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="System.Security.Cryptography.Pkcs.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
+    <Project Include="System.Security.Cryptography.Pkcs.csproj">
+      <OSGroup>Unix</OSGroup>
+    </Project>
+    <Project Include="System.Security.Cryptography.Pkcs.csproj">
+      <TargetGroup>net46</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
+++ b/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{03D84CBD-896D-4B2F-9A22-07034F51E73D}</ProjectGuid>
+    <AssemblyName>System.Security.Cryptography.Pkcs</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLSCompliant>false</CLSCompliant>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
+    <ResourcesSourceOutputDirectory Condition="'$(IsPartialFacadeAssembly)' == 'true'">None</ResourcesSourceOutputDirectory>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
+    <UsePackageTargetRuntimeDefaults Condition="'$(IsPartialFacadeAssembly)' != 'true'">true</UsePackageTargetRuntimeDefaults>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)'==''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+  </PropertyGroup>
+
+  <!-- Don't delete these clauses even if they look useless. They tell the VS IDE that "Windows_Debug", etc., are
+       valid configuration for this project and stop it from trying to "fix up" the .sln file -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
+
+  <PropertyGroup>
+    <ProjectJson>project.json</ProjectJson>
+    <ProjectLockJson>project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50'">
+    <ProjectJson>netcore50/project.json</ProjectJson>
+    <ProjectLockJson>netcore50/project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
+    <TargetingPackReference Include="mscorlib" />
+    <TargetingPackReference Include="System.Security" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(ProjectJson)" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Cryptography.Pkcs/src/netcore50/project.json
+++ b/src/System.Security.Cryptography.Pkcs/src/netcore50/project.json
@@ -1,0 +1,26 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.0.1-rc3-24022-00",
+    "System.Collections": "4.0.10",
+    "System.Diagnostics.Contracts": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.ObjectModel": "4.0.10",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.Handles": "4.0.0",
+    "System.Runtime.InteropServices": "4.0.20",
+    "System.Runtime.WindowsRuntime": "4.0.10",
+    "System.Security.Cryptography.Encoding": "4.0.0-rc3-24022-00",
+    "System.Security.Cryptography.Primitives": "4.0.0-rc3-24022-00",
+    "System.Security.Cryptography.X509Certificates": "4.1.0-rc3-24022-00",
+    "System.Text.Encoding": "4.0.10",
+    "System.Threading": "4.0.10",
+  },
+  "frameworks": {
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win8-x86": {},
+    "win8-x64": {}
+  }
+}

--- a/src/System.Security.Cryptography.Pkcs/src/project.json
+++ b/src/System.Security.Cryptography.Pkcs/src/project.json
@@ -1,0 +1,29 @@
+{
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1-rc3-24022-00",
+        "System.Collections": "4.0.10",
+        "System.Diagnostics.Contracts": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.10",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Handles": "4.0.0",
+        "System.Runtime.InteropServices": "4.0.20",
+        "System.Security.Cryptography.Encoding": "4.0.0-rc3-24022-00",
+        "System.Security.Cryptography.Primitives": "4.0.0-rc3-24022-00",
+        "System.Security.Cryptography.X509Certificates": "4.1.0-rc3-24022-00",
+        "System.Text.Encoding": "4.0.10",
+        "System.Threading": "4.0.10",
+      }
+    },
+    "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
+    },
+  }
+}

--- a/src/System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.builds
+++ b/src/System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.builds
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Security.Cryptography.Pkcs.Tests.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj
+++ b/src/System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <ProjectGuid>{2DD8DFFA-09FF-46C6-8313-4A9CC1849A44}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.Security.Cryptography.Pkcs.Tests</AssemblyName>
+    <RootNamespace>System.Security.Cryptography.Pkcs.Tests</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLSCompliant>false</CLSCompliant>
+  </PropertyGroup>
+
+  <!-- Don't delete these clauses even if they look useless. They tell the VS IDE that "Windows_Debug", etc., are
+       valid configuration for this project and stop it from trying to "fix up" the .sln file -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Security.Cryptography.Pkcs.csproj">
+      <Project>{03D84CBD-896D-4B2F-9A22-07034F51E73D}</Project>
+      <Name>System.Security.Cryptography.Pkcs</Name>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
+      <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Cryptography.Pkcs/tests/project.json
+++ b/src/System.Security.Cryptography.Pkcs/tests/project.json
@@ -1,0 +1,32 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.0.1-rc3-24022-00",
+    "System.Collections": "4.0.10",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.Linq": "4.0.0",
+    "System.Runtime": "4.1.0-rc3-24022-00",
+    "System.Security.Cryptography.Encoding": "4.0.0-rc3-24022-00",
+    "System.Security.Cryptography.Primitives": "4.0.0-rc3-24022-00",
+    "System.Security.Cryptography.X509Certificates": "4.1.0-rc3-24022-00",
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    }
+  },
+  "frameworks": {
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
+  }
+}


### PR DESCRIPTION
Add Support for EnvelopedCms (Step 1: Empty Package.)

This class has been API reviewed and approved
   https://github.com/dotnet/corefx/issues/7830


For this first PR, the assembly has the actual code elided. As soon as this is merged, a followup PR will add the code. This is for pragmatic reasons, having learned the hard way that having a long PR open with a project.json in it turns a simple isolated PR into a daily merge and CI-break hassle due to the constantly changing package version numbers. I'd much rather have the project.json merged first so that gets taken care of for me. Also, the people likely to CR the packaging and dependency stuff aren't likely to be interested in the crypto code so they can sign off on this and don't need to deal with the monster PR that's coming up.

Also included in this PR (again, to avoid merging later) is addition of 

```
   internal const string Heap_L1 = "api-ms-win-core-heap-l1-1-0.dll";
   internal const string SecurityCryptoApi = "api-ms-win-security-cryptoapi-l1-1-0.dll";
```
to Interop.Libraries.cs


For time/cost reasons, only Windows is supported for now. Unix platforms get a PlatformNotSupported shim. OpenSSL support is planned for later and the code is structured with a Pal structure similar to what we used for X509.


Platform targets are netcore50, net46, net461

The parts I didn't understand (basically all of it,) I copy-pasted from the X509Certificate2 package
until things worked and the built binaries looked the way I wanted.




<b>Some preemptive PR answers:</b>

<b>Why does the .csproj file condition on "$(Configuration)=Unix_Debug" when the *.sln
doesn't have a Unix_Debug configuration?</b>

The .sln file doesn't include a Unix_Debug config because the Unix build is an autogenerated PlatformNotSupported assembly, which doesn't play well in a VS IDE.

The .csproj file still includes the magic "test for $(Configuration)=Unix_Debug" line as an investment into the future. Some day, someone will need to add that configuration to the .sln file and it'd be nice if they didn't have to play the "Why does VS keep removing my change" game."