### PR TITLE
Fixed typo in GetHostAddressesAsync test for Dns class

### DIFF
--- a/src/System.Net.NameResolution/tests/FunctionalTests/DnsTests.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/DnsTests.cs
@@ -21,7 +21,7 @@ namespace System.Net.NameResolution.Tests
             Task.WaitAll(hostAddressesTask1, hostAddressesTask2);
 
             var list1 = hostAddressesTask1.Result;
-            var list2 = hostAddressesTask1.Result;
+            var list2 = hostAddressesTask2.Result;
 
             Assert.NotNull(list1);
             Assert.NotNull(list2);


### PR DESCRIPTION
Fixed typo in GetHostAddressesAsync() test.