### PR TITLE
Fix ListDictionary.CopyTo throwing IndexOutOfRangeException

### DIFF
--- a/src/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
@@ -62,20 +62,6 @@ namespace System.Collections.Tests
         /// </summary>
         protected virtual bool ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowsArgumentException { get { return true; } }
 
-        /// <summary>
-        /// Used for the ICollection_NonGeneric_CopyTo_NonZeroLowerBound test where we try to call CopyTo
-        /// on an Array of a non-zero lower bound. Some implementations don't throw an ArgumentException
-        /// when the count is zero, others do.
-        /// </summary>
-        protected virtual bool ICollection_NonGeneric_CopyTo_NonZeroLowerBound_ZeroCountThrowsArgumentException { get { return true; } }
-
-        /// <summary>
-        /// Used for the ICollection_NonGeneric_CopyTo_NonZeroLowerBound test where we try to call CopyTo
-        /// on an Array of a non-zero lower bound. Some implementations don't throw an ArgumentException
-        /// when the count is one, others do.
-        /// </summary>
-        protected virtual bool ICollection_NonGeneric_CopyTo_NonZeroLowerBound_SingleCountThrowsArgumentException { get { return true; } }
-
         #endregion
 
         #region IEnumerable Helper Methods
@@ -175,11 +161,7 @@ namespace System.Collections.Tests
             Array arr = Array.CreateInstance(typeof(object), new int[1] { 2 }, new int[1] { 2 });
             Assert.Equal(1, arr.Rank);
             Assert.Equal(2, arr.GetLowerBound(0));
-
-            if (ICollection_NonGeneric_CopyTo_NonZeroLowerBound_SingleCountThrowsArgumentException && (ICollection_NonGeneric_CopyTo_NonZeroLowerBound_ZeroCountThrowsArgumentException || count > 0))
-            {
-                Assert.ThrowsAny<ArgumentException>(() => collection.CopyTo(arr, 0));
-            }
+            Assert.ThrowsAny<ArgumentException>(() => collection.CopyTo(arr, 0));
         }
 
         [Theory]

--- a/src/System.Collections.Specialized/src/Resources/Strings.resx
+++ b/src/System.Collections.Specialized/src/Resources/Strings.resx
@@ -135,6 +135,9 @@
   <data name="Arg_MultiRank" xml:space="preserve">
     <value>Multi dimension array is not supported on this operation.</value>
   </data>
+  <data name="Arg_NonZeroLowerBound" xml:space="preserve">
+    <value>The lower bound of target array must be zero.</value>
+  </data>
   <data name="Arg_InsufficientSpace" xml:space="preserve">
     <value>Insufficient space in the target location to copy the information.</value>
   </data>

--- a/src/System.Collections.Specialized/src/System/Collections/Specialized/ListDictionary.cs
+++ b/src/System.Collections.Specialized/src/System/Collections/Specialized/ListDictionary.cs
@@ -226,6 +226,10 @@ namespace System.Collections.Specialized
                 throw new ArgumentNullException(nameof(array));
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (array.Rank != 1)
+                throw new ArgumentException(SR.Arg_MultiRank, nameof(array));
+            if (array.GetLowerBound(0) != 0)
+                throw new ArgumentException(SR.Arg_NonZeroLowerBound, nameof(array));
 
             if (array.Length - index < _count)
                 throw new ArgumentException(SR.Arg_InsufficientSpace);
@@ -387,6 +391,14 @@ namespace System.Collections.Specialized
                     throw new ArgumentNullException(nameof(array));
                 if (index < 0)
                     throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum);
+                if (array.Rank != 1)
+                    throw new ArgumentException(SR.Arg_MultiRank, nameof(array));
+                if (array.GetLowerBound(0) != 0)
+                    throw new ArgumentException(SR.Arg_NonZeroLowerBound, nameof(array));
+
+                if (array.Length - index < _list.Count)
+                    throw new ArgumentException(SR.Arg_InsufficientSpace);
+
                 for (DictionaryNode node = _list._head; node != null; node = node.next)
                 {
                     array.SetValue(_isKeys ? node.key : node.value, index);

--- a/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionaryTests.cs
+++ b/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionaryTests.cs
@@ -22,9 +22,6 @@ namespace System.Collections.Specialized.Tests
         protected override bool ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType_ThrowsArgumentException => false;
         protected override bool ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowsArgumentException => false;
 
-        protected override bool ICollection_NonGeneric_CopyTo_NonZeroLowerBound_ZeroCountThrowsArgumentException => false;
-        protected override bool ICollection_NonGeneric_CopyTo_NonZeroLowerBound_SingleCountThrowsArgumentException => false;
-
         protected override object CreateTKey(int seed)
         {
             int stringLength = seed % 10 + 5;

--- a/src/System.Collections.Specialized/tests/ListDictionaryTests.cs
+++ b/src/System.Collections.Specialized/tests/ListDictionaryTests.cs
@@ -219,11 +219,17 @@ namespace System.Collections.Specialized.Tests
             Assert.Throws<ArgumentOutOfRangeException>("index", () => ld.CopyTo(data, -1));
             if (data.Length > 0)
             {
-                Assert.Throws<ArgumentException>(() => ld.CopyTo(new KeyValuePair<string, string>[1, data.Length], 0));
                 Assert.Throws<ArgumentException>(() => ld.CopyTo(new KeyValuePair<string, string>[0], data.Length - 1));
                 Assert.Throws<ArgumentException>(() => ld.CopyTo(new KeyValuePair<string, string>[data.Length - 1], 0));
                 Assert.Throws<InvalidCastException>(() => ld.CopyTo(new int[data.Length], 0));
             }
+
+            // Multidimensional array
+            Assert.Throws<ArgumentException>(() => ld.CopyTo(new KeyValuePair<string, string>[1, data.Length], 0));
+
+            // Invalid lower bound
+            Array arr = Array.CreateInstance(typeof(object), new int[] { 2 }, new int[] { 2 });
+            Assert.Throws<ArgumentException>(() => ld.CopyTo(arr, 0));
         }
 
         [Theory]
@@ -412,7 +418,15 @@ namespace System.Collections.Specialized.Tests
         public static void KeyCollection_CopyTo_InvalidArgument_Test(ListDictionary ld, KeyValuePair<string, string>[] data)
         {
             ICollection keys = ld.Keys;
-            Assert.Throws<ArgumentOutOfRangeException>("index", () => keys.CopyTo(new object[] { }, -1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => keys.CopyTo(new object[0], -1));
+            Assert.Throws<ArgumentException>(null, () => keys.CopyTo(new object[data.Length], 1));
+
+            // Multidimensional array
+            Assert.Throws<ArgumentException>("array", () => keys.CopyTo(new object[data.Length, data.Length], 0));
+
+            // Invalid lower bound
+            Array arr = Array.CreateInstance(typeof(object), new int[] { 2 }, new int[] { 2 });
+            Assert.Throws<ArgumentException>(() => keys.CopyTo(arr, 0));
         }
 
         [Theory]


### PR DESCRIPTION
- Now works as expected according to MSDN docs
- Found in #7997, and caused inconsistencies in HybridDictionary behaviour at different lengths

I got the impression that we should not throw an exception if count == 0, let me know if this is incorrect.

/cc @ianhays