### PR TITLE
Use ArrayPool for OrderedEnumerable temp arrays

### DIFF
--- a/src/System.Linq/src/System/Linq/Iterator.cs
+++ b/src/System.Linq/src/System/Linq/Iterator.cs
@@ -11,7 +11,7 @@ namespace System.Linq
     {
         internal abstract class Iterator<TSource> : IEnumerable<TSource>, IEnumerator<TSource>
         {
-            private readonly int _threadId;
+            protected readonly int _threadId;
             internal int _state;
             internal TSource _current;
 

--- a/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -9,66 +9,80 @@ using System.Threading;
 
 namespace System.Linq
 {
-    internal abstract class OrderedEnumerable<TElement> : IOrderedEnumerable<TElement>, IPartition<TElement>
+    internal abstract class OrderedEnumerable<TElement> : Enumerable.Iterator<TElement>, IOrderedEnumerable<TElement>, IPartition<TElement>
     {
+        private const int ArrayPoolUseThreshold = 32;
         internal IEnumerable<TElement> _source;
+        private Buffer<TElement> _buffer;
+        private int _index;
+        private int _maxIdx = int.MaxValue;
+        private int[] _map;
 
-        private int[] SortedMap(Buffer<TElement> buffer)
+        private int[] SortedMap(Buffer<TElement> buffer, bool rent)
         {
-            return GetEnumerableSorter().Sort(buffer._items, buffer._count);
+            return GetEnumerableSorter().Sort(buffer._items, buffer._count, rent);
         }
 
-        private int[] SortedMap(Buffer<TElement> buffer, int minIdx, int maxIdx)
+        private int[] SortedMap(Buffer<TElement> buffer, int minIdx, int maxIdx, bool rent)
         {
-            return GetEnumerableSorter().Sort(buffer._items, buffer._count, minIdx, maxIdx);
+            return GetEnumerableSorter().Sort(buffer._items, buffer._count, minIdx, maxIdx, rent);
         }
 
-        public IEnumerator<TElement> GetEnumerator()
+        public override bool MoveNext()
         {
-            Buffer<TElement> buffer = new Buffer<TElement>(_source);
-            if (buffer._count >= 32)
+            switch (_state)
             {
-                return GetLargeEnumerator(buffer);
+                case 1:
+                    Buffer<TElement> buffer = new Buffer<TElement>(_source);
+                    if (buffer._count > 0)
+                    {
+                        if (_index != 0 || _maxIdx != int.MaxValue)
+                        {
+                            _map = SortedMap(buffer, _index, _maxIdx, buffer._count >= ArrayPoolUseThreshold);
+                        }
+                        else
+                        {
+                            _map = SortedMap(buffer, buffer._count >= ArrayPoolUseThreshold);
+                        }
+
+                        _maxIdx = Math.Min(_maxIdx, buffer._count - 1);                        
+                        _buffer = buffer;
+                        _state = 2;
+                        goto case 2;
+                    }
+
+                    break;
+                case 2:
+                    if (_index <= _maxIdx)
+                    {
+                        _current = _buffer._items[_map[_index]];
+                        ++_index;
+                        return true;
+                    }
+                    break;
             }
-            else if (buffer._count > 0)
-            {
-                return GetSmallEnumerator(buffer);
-            }
 
-            return GetEmptyEnumerator();
+            Dispose();
+            return false;
         }
 
-        private IEnumerator<TElement> GetEmptyEnumerator()
+        public override void Dispose()
         {
-            yield break;
-        }
-
-        private IEnumerator<TElement> GetSmallEnumerator(Buffer<TElement> buffer)
-        {
-            int[] map = SortedMap(buffer);
-            for (int i = 0; i < buffer._count; i++)
+            base.Dispose();
+            if (_map != null)
             {
-                yield return buffer._items[map[i]];
-            }
-        }
-
-        private IEnumerator<TElement> GetLargeEnumerator(Buffer<TElement> buffer)
-        {
-            int[] map = null;
-            try
-            {
-                map = SortedMap(buffer);
-                for (int i = 0; i < buffer._count; i++)
+                _buffer = default(Buffer<TElement>);
+                if (_map.Length >= ArrayPoolUseThreshold)
                 {
-                    yield return buffer._items[map[i]];
+                    int[] rented = Interlocked.Exchange(ref _map, null);
+                    if (rented != null)
+                    {
+                        ArrayPool<int>.Shared.Return(rented);
+                    }
                 }
-            }
-            finally
-            {
-                var rentedMap = Interlocked.Exchange(ref map, null);
-                if (rentedMap != null)
+                else
                 {
-                    ArrayPool<int>.Shared.Return(rentedMap);
+                    _map = null;
                 }
             }
         }
@@ -84,17 +98,13 @@ namespace System.Linq
             }
 
             TElement[] array = new TElement[count];
-            int[] map = SortedMap(buffer);
+            int[] map = SortedMap(buffer, true);
             for (int i = 0; i != array.Length; i++)
             {
                 array[i] = buffer._items[map[i]];
             }
 
-            if (count >= 32)
-            {
-                ArrayPool<int>.Shared.Return(map);
-            }
-
+            ArrayPool<int>.Shared.Return(map);
             return array;
         }
 
@@ -105,16 +115,13 @@ namespace System.Linq
             List<TElement> list = new List<TElement>(count);
             if (count > 0)
             {
-                int[] map = SortedMap(buffer);
+                int[] map = SortedMap(buffer, true);
                 for (int i = 0; i != count; i++)
                 {
                     list.Add(buffer._items[map[i]]);
                 }
 
-                if (count >= 32)
-                {
-                    ArrayPool<int>.Shared.Return(map);
-                }
+                ArrayPool<int>.Shared.Return(map);
             }
 
             return list;
@@ -133,66 +140,13 @@ namespace System.Linq
 
         internal IEnumerator<TElement> GetEnumerator(int minIdx, int maxIdx)
         {
-            Buffer<TElement> buffer = new Buffer<TElement>(_source);
-            int count = buffer._count;
-            if (count > minIdx)
-            {
-                if (count <= maxIdx)
-                {
-                    maxIdx = count - 1;
-                }
-
-                if (minIdx == maxIdx)
-                {
-                    return GetSingleEnumerator(buffer, count, minIdx);
-                }
-                else if (count >= 32)
-                {
-                    return GetLargeEnumerator(buffer, count, minIdx, maxIdx);
-                }
-
-                return GetSmallEnumerator(buffer, count, minIdx, maxIdx);
-            }
-
-            return GetEmptyEnumerator();
+            OrderedEnumerable<TElement> enumerator = _state == 0 && _threadId == Environment.CurrentManagedThreadId ? this : (OrderedEnumerable<TElement>)Clone();
+            enumerator._state = 1;
+            enumerator._index = minIdx;
+            enumerator._maxIdx = maxIdx;
+            return enumerator;
         }
 
-        private IEnumerator<TElement> GetSingleEnumerator(Buffer<TElement> buffer, int count, int minIdx)
-        {
-            yield return GetEnumerableSorter().ElementAt(buffer._items, count, minIdx);
-        }
-
-        private IEnumerator<TElement> GetSmallEnumerator(Buffer<TElement> buffer, int count, int minIdx, int maxIdx)
-        {
-            int[] map = SortedMap(buffer, minIdx, maxIdx);
-            while (minIdx <= maxIdx)
-            {
-                yield return buffer._items[map[minIdx]];
-                ++minIdx;
-            }
-        }
-
-        private IEnumerator<TElement> GetLargeEnumerator(Buffer<TElement> buffer, int count, int minIdx, int maxIdx)
-        {
-            int[] map = null;
-            try
-            {
-                map = SortedMap(buffer, minIdx, maxIdx);
-                while (minIdx <= maxIdx)
-                {
-                    yield return buffer._items[map[minIdx]];
-                    ++minIdx;
-                }
-            }
-            finally
-            {
-                var rentedMap = Interlocked.Exchange(ref map, null);
-                if (rentedMap != null)
-                {
-                    ArrayPool<int>.Shared.Return(rentedMap);
-                }
-            }
-        }
         internal TElement[] ToArray(int minIdx, int maxIdx)
         {
             Buffer<TElement> buffer = new Buffer<TElement>(_source);
@@ -212,7 +166,7 @@ namespace System.Linq
                 return new TElement[] { GetEnumerableSorter().ElementAt(buffer._items, count, minIdx) };
             }
 
-            int[] map = SortedMap(buffer, minIdx, maxIdx);
+            int[] map = SortedMap(buffer, minIdx, maxIdx, true);
             TElement[] array = new TElement[maxIdx - minIdx + 1];
             int idx = 0;
             while (minIdx <= maxIdx)
@@ -222,11 +176,7 @@ namespace System.Linq
                 ++minIdx;
             }
 
-            if (idx >= 32)
-            {
-                ArrayPool<int>.Shared.Return(map);
-            }
-
+            ArrayPool<int>.Shared.Return(map);
             return array;
         }
 
@@ -249,7 +199,7 @@ namespace System.Linq
                 return new List<TElement>(1) { GetEnumerableSorter().ElementAt(buffer._items, count, minIdx) };
             }
 
-            int[] map = SortedMap(buffer, minIdx, maxIdx);
+            int[] map = SortedMap(buffer, minIdx, maxIdx, true);
             List<TElement> list = new List<TElement>(maxIdx - minIdx + 1);
             while (minIdx <= maxIdx)
             {
@@ -257,11 +207,7 @@ namespace System.Linq
                 ++minIdx;
             }
 
-            if (list.Count >= 32)
-            {
-                ArrayPool<int>.Shared.Return(map);
-            }
-
+            ArrayPool<int>.Shared.Return(map);
             return list;
         }
 
@@ -575,6 +521,11 @@ namespace System.Linq
             _descending = descending;
         }
 
+        public override Enumerable.Iterator<TElement> Clone()
+        {
+            return new OrderedEnumerable<TElement, TKey>(_source, _keySelector, _comparer, _descending, _parent);
+        }
+
         internal override EnumerableSorter<TElement> GetEnumerableSorter(EnumerableSorter<TElement> next)
         {
             EnumerableSorter<TElement> sorter = new EnumerableSorter<TElement, TKey>(_keySelector, _comparer, _descending, next);
@@ -678,10 +629,10 @@ namespace System.Linq
 
         internal abstract int CompareAnyKeys(int index1, int index2);
 
-        private int[] ComputeMap(TElement[] elements, int count)
+        private int[] ComputeMap(TElement[] elements, int count, bool rent)
         {
             ComputeKeys(elements, count);
-            int[] map = count >= 32 ? ArrayPool<int>.Shared.Rent(count) : new int[count];
+            int[] map = rent ? ArrayPool<int>.Shared.Rent(count) : new int[count];
             for (int i = 0; i < count; i++)
             {
                 map[i] = i;
@@ -690,30 +641,25 @@ namespace System.Linq
             return map;
         }
 
-        internal int[] Sort(TElement[] elements, int count)
+        internal int[] Sort(TElement[] elements, int count, bool rent)
         {
-            int[] map = ComputeMap(elements, count);
+            int[] map = ComputeMap(elements, count, rent);
             QuickSort(map, 0, count - 1);
             return map;
         }
 
-        internal int[] Sort(TElement[] elements, int count, int minIdx, int maxIdx)
+        internal int[] Sort(TElement[] elements, int count, int minIdx, int maxIdx, bool rent)
         {
-            int[] map = ComputeMap(elements, count);
+            int[] map = ComputeMap(elements, count, rent);
             PartialQuickSort(map, 0, count - 1, minIdx, maxIdx);
             return map;
         }
 
         internal TElement ElementAt(TElement[] elements, int count, int idx)
         {
-            int[] map = ComputeMap(elements, count);
+            int[] map = ComputeMap(elements, count, true);
             var index = QuickSelect(map, count - 1, idx);
-
-            if (count >= 32)
-            {
-                ArrayPool<int>.Shared.Return(map);
-            }
-
+            ArrayPool<int>.Shared.Return(map);
             return elements[index];
         }
 

--- a/src/System.Linq/src/project.json
+++ b/src/System.Linq/src/project.json
@@ -1,4 +1,7 @@
 {
+  "dependencies": {
+    "System.Buffers": "4.0.0-rc3-24022-00"
+  },
   "frameworks": {
     "netstandard1.5": {
       "dependencies": {

--- a/src/System.Linq/src/project.json
+++ b/src/System.Linq/src/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "System.Buffers": "4.0.0-rc3-24022-00"
+    "System.Buffers": "4.0.0-rc3-24117-00"
   },
   "frameworks": {
     "netstandard1.5": {


### PR DESCRIPTION
ComputeMap's int[] array is used in limited private scope and only temporary for calculating the sort order.