### PR TITLE
Do not get an async handle in File.ReadLines

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/ReadLinesIterator.cs
+++ b/src/System.IO.FileSystem/src/System/IO/ReadLinesIterator.cs
@@ -97,7 +97,7 @@ namespace System.IO
 
         private static ReadLinesIterator CreateIterator(string path, Encoding encoding, StreamReader reader)
         {
-            Stream stream = FileStream.InternalOpen(path);
+            Stream stream = FileStream.InternalOpen(path, useAsync: false);
 
             return new ReadLinesIterator(path, encoding, reader ?? new StreamReader(stream, encoding));
         }


### PR DESCRIPTION
I couldn't find a documented reason why opening the file for asynchronous access would be required, so I'm going with a theory that this is an omission, as opposed to a deliberate design choice.