### PR TITLE
Prohibit pointer types from variable and parameter expressions.

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -145,7 +145,10 @@
     <value>Bounds count cannot be less than 1</value>
   </data>
   <data name="TypeMustNotBeByRef" xml:space="preserve">
-    <value>type must not be ByRef</value>
+    <value>Type must not be ByRef</value>
+  </data>
+  <data name="TypeMustNotBePointer" xml:space="preserve">
+    <value>Type must not be a pointer type</value>
   </data>
   <data name="TypeDoesNotHaveConstructorForTheSignature" xml:space="preserve">
     <value>Type doesn't have constructor with a given signature</value>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -75,12 +75,21 @@ namespace System.Linq.Expressions
             return new ArgumentException(Strings.BoundsCannotBeLessThanOne);
         }
         /// <summary>
-        /// ArgumentException with message like "type must not be ByRef"
+        /// ArgumentException with message like "Type must not be ByRef"
         /// </summary>
         internal static Exception TypeMustNotBeByRef()
         {
             return new ArgumentException(Strings.TypeMustNotBeByRef);
         }
+
+        /// <summary>
+        /// ArgumentException with message like "Type must not be a pointer type"
+        /// </summary>
+        internal static Exception TypeMustNotBePointer()
+        {
+            return new ArgumentException(Strings.TypeMustNotBePointer, "type");
+        }
+
         /// <summary>
         /// ArgumentException with message like "Type doesn't have constructor with a given signature"
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
@@ -216,6 +216,11 @@ namespace System.Linq.Expressions
                 throw Error.ArgumentCannotBeOfTypeVoid();
             }
 
+            if (type.IsPointer)
+            {
+                throw Error.TypeMustNotBePointer();
+            }
+
             bool byref = type.IsByRef;
             if (byref)
             {
@@ -236,6 +241,12 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(type, nameof(type));
             if (type == typeof(void)) throw Error.ArgumentCannotBeOfTypeVoid();
             if (type.IsByRef) throw Error.TypeMustNotBeByRef();
+
+            if (type.IsPointer)
+            {
+                throw Error.TypeMustNotBePointer();
+            }
+
             return ParameterExpression.Make(type, name, false);
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -111,7 +111,7 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// A string like "type must not be ByRef"
+        /// A string like "Type must not be ByRef"
         /// </summary>
         internal static string TypeMustNotBeByRef
         {
@@ -120,6 +120,11 @@ namespace System.Linq.Expressions
                 return SR.TypeMustNotBeByRef;
             }
         }
+
+        /// <summary>
+        /// A string like "Type must not be a pointer type"
+        /// </summary>
+        internal static string TypeMustNotBePointer => SR.TypeMustNotBePointer;
 
         /// <summary>
         /// A string like "Type doesn't have constructor with a given signature"

--- a/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
@@ -128,5 +128,12 @@ namespace System.Linq.Expressions.Tests
             Assert.Same(param, param.Reduce());
             Assert.Throws<ArgumentException>(() => param.ReduceAndCheck());
         }
+
+        [Fact]
+        public void CannotBePointerType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Parameter(typeof(int*)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Parameter(typeof(int*), "pointer"));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Variables/VariableTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/VariableTests.cs
@@ -100,5 +100,12 @@ namespace System.Linq.Expressions.Tests
             Assert.Same(variable, variable.Reduce());
             Assert.Throws<ArgumentException>(() => variable.ReduceAndCheck());
         }
+
+        [Fact]
+        public void CannotBePointerType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Variable(typeof(int*)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Variable(typeof(int*), "pointer"));
+        }
     }
 }


### PR DESCRIPTION
Fixes #8074.

Possibility of backward-compatibility issue discussed at that issue.