### PR TITLE
Enable finalization of resources in CurlHandler

### DIFF
--- a/src/Common/src/System/Diagnostics/ExceptionExtensions.cs
+++ b/src/Common/src/System/Diagnostics/ExceptionExtensions.cs
@@ -10,10 +10,15 @@ namespace System.Diagnostics
         public static TException InitializeStackTrace<TException>(this TException e) where TException : Exception
         {
             Debug.Assert(e != null);
-            Debug.Assert(e.StackTrace == null);
 
-            try { throw e; }
-            catch { return e; }
+            // Ideally we'd be able to populate e.StackTrace with the current stack trace.
+            // We could throw the exception and catch it, but the populated StackTrace would
+            // not extend beyond this frame.  Instead, we grab a stack trace and store it into
+            // the exception's data dictionary, at least making the info available for debugging,
+            // albeit not part of the string returned by e.ToString() or e.StackTrace.
+            e.Data["StackTrace"] = Environment.StackTrace;
+
+            return e;
         }
     }
 }

--- a/src/Common/src/System/StrongToWeakReference.cs
+++ b/src/Common/src/System/StrongToWeakReference.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    /// <summary>Provides an object wrapper that can transition between strong and weak references to the object.</summary>
+    internal sealed class StrongToWeakReference<T> : WeakReference where T : class
+    {
+        private T _strongRef;
+
+        /// <summary>Initializes the instance with a strong reference to the specified object.</summary>
+        /// <param name="obj">The object to wrap.</param>
+        public StrongToWeakReference(T obj) : base(obj)
+        {
+            _strongRef = obj;
+        }
+
+        /// <summary>Drops the strong reference to the object, keeping only a weak reference.</summary>
+        public void MakeWeak() => _strongRef = null;
+
+        /// <summary>Restores the strong reference, assuming the object hasn't yet been collected.</summary>
+        public void MakeStrong() => _strongRef = WeakTarget;
+
+        /// <summary>Gets the wrapped object.</summary>
+        public new T Target => _strongRef ?? WeakTarget;
+
+        /// <summary>Gets the wrapped object via its weak reference.</summary>
+        private T WeakTarget => base.Target as T;
+    }
+}

--- a/src/Common/src/System/StrongToWeakReference.cs
+++ b/src/Common/src/System/StrongToWeakReference.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace System
 {
     /// <summary>Provides an object wrapper that can transition between strong and weak references to the object.</summary>
@@ -13,6 +15,7 @@ namespace System
         /// <param name="obj">The object to wrap.</param>
         public StrongToWeakReference(T obj) : base(obj)
         {
+            Debug.Assert(obj != null, "Expected non-null obj");
             _strongRef = obj;
         }
 
@@ -20,7 +23,11 @@ namespace System
         public void MakeWeak() => _strongRef = null;
 
         /// <summary>Restores the strong reference, assuming the object hasn't yet been collected.</summary>
-        public void MakeStrong() => _strongRef = WeakTarget;
+        public void MakeStrong()
+        {
+            _strongRef = WeakTarget;
+            Debug.Assert(_strongRef != null, $"Expected non-null {nameof(_strongRef)} after setting");
+        }
 
         /// <summary>Gets the wrapped object.</summary>
         public new T Target => _strongRef ?? WeakTarget;

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -31,7 +31,6 @@
       <TargetFramework>net46</TargetFramework>
     </PackageDestination>
   </ItemGroup>
-  
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
@@ -168,6 +167,9 @@
     <Compile Include="System\Net\Http\Unix\CurlHandler.CurlResponseMessage.cs" />
     <Compile Include="System\Net\Http\Unix\CurlResponseHeaderReader.cs" />
     <Compile Include="System\Net\Http\Unix\CurlTransportContext.cs" />
+    <Compile Include="$(CommonPath)\System\StrongToWeakReference.cs">
+      <Link>Common\Interop\Unix\StrongToWeakReference.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\SecurityProtocol.cs">
       <Link>Common\System\Net\SecurityProtocol.cs</Link>
     </Compile>

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
@@ -180,25 +180,15 @@ namespace System.Net.Http
             private static bool TryGetEasyRequest(IntPtr curlPtr, out EasyRequest easy)
             {
                 Debug.Assert(curlPtr != IntPtr.Zero, "curlPtr is not null");
+
                 IntPtr gcHandlePtr;
                 CURLcode getInfoResult = Interop.Http.EasyGetInfoPointer(curlPtr, CURLINFO.CURLINFO_PRIVATE, out gcHandlePtr);
-                Debug.Assert(getInfoResult == CURLcode.CURLE_OK, "Failed to get info on a completing easy handle");
                 if (getInfoResult == CURLcode.CURLE_OK)
                 {
-                    try
-                    {
-                        GCHandle handle = GCHandle.FromIntPtr(gcHandlePtr);
-                        easy = (EasyRequest)handle.Target;
-                        Debug.Assert(easy != null, "Expected non-null EasyRequest in GCHandle");
-                        return easy != null;
-                    }
-                    catch (Exception e)
-                    {
-                        EventSourceTrace("Error getting state from GCHandle: {0}", e);
-                        Debug.Fail($"Exception in {nameof(TryGetEasyRequest)}", e.ToString());
-                    }
+                    return MultiAgent.TryGetEasyRequestFromGCHandle(gcHandlePtr, out easy);
                 }
 
+                Debug.Fail($"Failed to get info on a completing easy handle: {getInfoResult}");
                 easy = null;
                 return false;
             }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -14,9 +15,11 @@ namespace System.Net.Http.Functional.Tests
 {
     public class HttpClientMiniStress
     {
-        [ConditionalTheory(nameof(HttpStressEnabled))] // Too stressful for CI; set "HTTP_STRESS"="1" env var
+        private static bool HttpStressEnabled => Environment.GetEnvironmentVariable("HTTP_STRESS") == "1";
+
+        [ConditionalTheory(nameof(HttpStressEnabled))]
         [MemberData(nameof(StressOptions))]
-        public void SingleClient_ManyRequests(int numRequests, int dop, HttpCompletionOption completionOption)
+        public void SingleClient_ManyRequests_Sync(int numRequests, int dop, HttpCompletionOption completionOption)
         {
             string responseText = CreateResponse("abcdefghijklmnopqrstuvwxyz");
             using (var client = new HttpClient())
@@ -28,7 +31,17 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalTheory(nameof(HttpStressEnabled))] // Too stressful for CI; set "HTTP_STRESS"="1" env var
+        [ConditionalTheory(nameof(HttpStressEnabled))]
+        public async Task SingleClient_ManyRequests_Async(int numRequests, int dop, HttpCompletionOption completionOption)
+        {
+            string responseText = CreateResponse("abcdefghijklmnopqrstuvwxyz");
+            using (var client = new HttpClient())
+            {
+                await ForCountAsync(numRequests, dop, i => CreateServerAndMakeRequestAsync(client, completionOption, responseText));
+            }
+        }
+
+        [ConditionalTheory(nameof(HttpStressEnabled))]
         [MemberData(nameof(StressOptions))]
         public void ManyClients_ManyRequests(int numRequests, int dop, HttpCompletionOption completionOption)
         {
@@ -40,6 +53,45 @@ namespace System.Net.Http.Functional.Tests
                     CreateServerAndMakeRequest(client, completionOption, responseText);
                 }
             });
+        }
+
+        [ConditionalTheory(nameof(HttpStressEnabled))]
+        [InlineData(1000000)]
+        public void CreateAndDestroyManyClients(int numClients)
+        {
+            for (int i = 0; i < numClients; i++)
+            {
+                new HttpClient().Dispose();
+            }
+        }
+
+        [ConditionalTheory(nameof(HttpStressEnabled))]
+        [InlineData(5000)]
+        public async Task MakeAndFaultManyRequests(int numRequests)
+        {
+            using (HttpClient client = new HttpClient())
+            using (var server = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                client.Timeout = Timeout.InfiniteTimeSpan;
+
+                server.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                server.Listen(numRequests);
+
+                var ep = (IPEndPoint)server.LocalEndPoint;
+                Task<string>[] tasks = 
+                    (from i in Enumerable.Range(0, numRequests)
+                     select client.GetStringAsync($"http://{ep.Address}:{ep.Port}"))
+                     .ToArray();
+
+                Assert.All(tasks, t => Assert.Equal(TaskStatus.WaitingForActivation, t.Status));
+
+                server.Dispose();
+
+                foreach (Task<string> task in tasks)
+                {
+                    await Assert.ThrowsAnyAsync<HttpRequestException>(() => task);
+                }
+            }
         }
 
         public static IEnumerable<object[]> StressOptions()
@@ -75,7 +127,31 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue(7962, PlatformID.AnyUnix)]
+        private static async Task CreateServerAndMakeRequestAsync(HttpClient client, HttpCompletionOption completionOption, string responseText)
+        {
+            using (var server = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                server.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                server.Listen(1);
+
+                var ep = (IPEndPoint)server.LocalEndPoint;
+                Task<HttpResponseMessage> getAsync = client.GetAsync($"http://{ep.Address}:{ep.Port}", completionOption);
+
+                using (Socket s = await server.AcceptAsync().ConfigureAwait(false))
+                using (var stream = new NetworkStream(s, ownsSocket: false))
+                using (var reader = new StreamReader(stream, Encoding.ASCII))
+                using (var writer = new StreamWriter(stream, Encoding.ASCII))
+                {
+                    while (!string.IsNullOrEmpty(reader.ReadLine())) ;
+                    await writer.WriteAsync(responseText).ConfigureAwait(false);
+                    await writer.FlushAsync().ConfigureAwait(false);
+                    s.Shutdown(SocketShutdown.Send);
+                }
+
+                (await getAsync.ConfigureAwait(false)).Dispose();
+            }
+        }
+
         [OuterLoop] // could take several seconds under load
         [Fact]
         public void UnreadResponseMessage_Collectible()
@@ -115,6 +191,25 @@ namespace System.Net.Http.Functional.Tests
         private static string CreateResponse(string asciiBody) =>
             $"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {asciiBody.Length}\r\n\r\n{asciiBody}\r\n";
 
+        private static Task ForCountAsync(int count, int dop, Func<int, Task> bodyAsync)
+        {
+            var sched = new ThreadPerTaskScheduler();
+            int nextAvailableIndex = 0;
+            return Task.WhenAll(Enumerable.Range(0, dop).Select(_ => Task.Factory.StartNew(async delegate
+            {
+                int index;
+                while ((index = Interlocked.Increment(ref nextAvailableIndex) - 1) < count)
+                {
+                    try { await bodyAsync(index); }
+                    catch
+                    {
+                        Volatile.Write(ref nextAvailableIndex, count); // avoid any further iterations
+                        throw;
+                    }
+                }
+            }, CancellationToken.None, TaskCreationOptions.None, sched).Unwrap()));
+        }
+
         private sealed class ThreadPerTaskScheduler : TaskScheduler
         {
             protected override void QueueTask(Task task) =>
@@ -124,7 +219,5 @@ namespace System.Net.Http.Functional.Tests
 
             protected override IEnumerable<Task> GetScheduledTasks() => null;
         }
-
-        private static bool HttpStressEnabled => Environment.GetEnvironmentVariable("HTTP_STRESS") == "1";
     }
 }


### PR DESCRIPTION
This change is primarily about enabling abandoned requests to be cleaned up.  Today, if you make a ResponseHeadersRead request on an HttpClient and then drop it without disposing it, the associated state will end up being leaked into the HttpClient until either the HttpClient is disposed or until the request times out, which by default is 60 seconds but could have been extended to never.  This change enables such requests to be finalized.  See the detailed comment in CurlHandler.cs for a description of the approach taken.

Fixes #7962 
cc: @ericeil, @bartonjs, @davidsh, @kapilash 