### PR TITLE
Condition imports so that users get the right message to run init-tools before building

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -56,7 +56,7 @@
     <UseRoslynCompilers Condition="'$(UseRoslynCompilers)'=='' and '$(OSEnvironment)'!='Windows_NT'">false</UseRoslynCompilers>
   </PropertyGroup>
 
-  <Import Project="$(ToolRuntimePath)BuildVersion.targets" />
+  <Import Project="$(ToolRuntimePath)BuildVersion.targets" Condition="Exists('$(ToolRuntimePath)BuildVersion.targets')" />
   
   <PropertyGroup>
     <!-- temporarily increase assembly version of corefx impl of desktop inbox contracts to allow folks 
@@ -70,10 +70,10 @@
   <PropertyGroup Condition="'$(UseRoslynCompilers)'!='false'">
     <UseSharedCompilation>true</UseSharedCompilation>
   </PropertyGroup>
-  <Import Project="$(ToolRuntimePath)/net45/roslyn/build/Microsoft.Net.Compilers.props" Condition="'$(UseRoslynCompilers)'!='false'" />
+  <Import Project="$(ToolRuntimePath)/net45/roslyn/build/Microsoft.Net.Compilers.props" Condition="'$(UseRoslynCompilers)'!='false' AND Exists('$(ToolRuntimePath)/net45/roslyn/build/Microsoft.Net.Compilers.props')" />
 
   <!-- Import Build tools common props file where repo-independent properties are found -->
-  <Import Project="$(ToolsDir)Build.Common.props" />
+  <Import Project="$(ToolsDir)Build.Common.props" Condition="Exists('$(ToolsDir)Build.Common.props')" />
 
   <!-- Enable the analyzers for this repo -->
   <PropertyGroup>

--- a/dir.targets
+++ b/dir.targets
@@ -17,7 +17,7 @@
   <Target Name="GenerateTestProjectJson" />
   <Target Name="GenerateAllTestProjectJsons" />
 
-  <Import Project="$(ToolsDir)/Build.Common.targets" />
+  <Import Project="$(ToolsDir)/Build.Common.targets" Condition="Exists('$(ToolsDir)/Build.Common.targets')" />
 
   <!-- permit a wrapping build system to contribute targets to this build -->
   <Import Condition="Exists('$(MSBuildThisFileDirectory)..\open.targets')" Project="$(MSBuildThisFileDirectory)..\open.targets" />


### PR DESCRIPTION
Thanks for reporting this issue @bdenison99! With this PR you will get the right error message saying that you need to run init-tools before building an individual project.

cc: @weshaggard @maririos @bdenison99

fixes: #8070 