### PR TITLE
Add WinHttpHandler NTLM auth type handling

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
@@ -15,13 +15,14 @@ namespace System.Net.Http
         //
         // Fast lookup table to convert WINHTTP_AUTH constants to strings.
         // WINHTTP_AUTH_SCHEME_BASIC = 0x00000001;
+        // WINHTTP_AUTH_SCHEME_NTLM = 0x00000002;
         // WINHTTP_AUTH_SCHEME_DIGEST = 0x00000008;
         // WINHTTP_AUTH_SCHEME_NEGOTIATE = 0x00000010;
         private static readonly string[] s_authSchemeStringMapping =
         {
             null,
             "Basic",
-            null,
+            "NTLM",
             null,
             null,
             null,
@@ -41,6 +42,7 @@ namespace System.Net.Http
         private static readonly uint[] s_authSchemePriorityOrder =
         {
             Interop.WinHttp.WINHTTP_AUTH_SCHEME_NEGOTIATE,
+            Interop.WinHttp.WINHTTP_AUTH_SCHEME_NTLM,
             Interop.WinHttp.WINHTTP_AUTH_SCHEME_DIGEST,
             Interop.WinHttp.WINHTTP_AUTH_SCHEME_BASIC
         };


### PR DESCRIPTION
After further discussions and feedback regarding app-compat with legacy
servers, it's been decided we don't need to remove NTLM from the auth
type list. This commit puts NTLM back into the ordered list of auth
types. A similar change was made to CurlHandler in PR #7923.

Due to current limitations with the Azure test server endpoints
regarding integrated auth, this change was tested manually.

cc: @stephentoub @joshfree @Petermarcu @CIPop @himadrisarkar 