### PR TITLE
Don't download nuget.exe in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -55,30 +55,6 @@ check_native_prereqs()
 
 prepare_managed_build()
 {
-    # Pull NuGet.exe down if we don't have it already
-    if [ ! -e "$__nugetpath" ]; then
-        which curl wget > /dev/null 2> /dev/null
-        if [ $? -ne 0 -a $? -ne 1 ]; then
-            echo "cURL or wget is required to build corefx. Please see https://github.com/dotnet/corefx/blob/master/Documentation/building/unix-instructions.md for more details."
-            exit 1
-        fi
-        echo "Restoring NuGet.exe..."
-
-        # curl has HTTPS CA trust-issues less often than wget, so lets try that first.
-        which curl > /dev/null 2> /dev/null
-        if [ $? -ne 0 ]; then
-           mkdir -p $__packageroot
-           wget -q -O $__nugetpath https://api.nuget.org/downloads/nuget.exe
-        else
-           curl -sSL --create-dirs -o $__nugetpath https://api.nuget.org/downloads/nuget.exe
-        fi
-
-        if [ $? -ne 0 ]; then
-            echo "Failed to restore NuGet.exe."
-            exit 1
-        fi
-    fi
-
     # Run Init-Tools to restore BuildTools and ToolRuntime
     $__scriptpath/init-tools.sh
 }
@@ -183,8 +159,6 @@ __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
 __nativeroot=$__scriptpath/src/Native
 __packageroot=$__scriptpath/packages
 __sourceroot=$__scriptpath/src
-__nugetpath=$__packageroot/NuGet.exe
-__nugetconfig=$__sourceroot/NuGet.Config
 __rootbinpath="$__scriptpath/bin"
 __msbuildpackageid="Microsoft.Build.Mono.Debug"
 __generateversionsource=false


### PR DESCRIPTION
We restore packages using the CLI now (which is obtained by running
init-tools.sh) so this logic we have to download NuGet.exe is no longer
needed.