### PR TITLE
Fix serialization perf test failures

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/Performance/PerformanceTestsCommon.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/Performance/PerformanceTestsCommon.cs
@@ -36,27 +36,56 @@ namespace System.Runtime.Serialization
         IPerfTestSerializer GetSerializer();
     }
 
+    public class PerfTestConfig
+    {
+        public readonly int NumberOfRuns;
+        public readonly TestType PerfTestType;
+        public readonly int TestSize;
+
+        public PerfTestConfig() { }
+
+        public PerfTestConfig(int numOfRuns, TestType testType, int testSize)
+        {
+            NumberOfRuns = numOfRuns;
+            PerfTestType = testType;
+            TestSize = testSize;
+        }
+
+        public object[] ToObjectArray()
+        {
+            return new object[] { NumberOfRuns, PerfTestType, TestSize };
+        }
+    }
+
     #endregion
 
     public class PerformanceTestCommon
     {
         #region Performance test configuration
 
+        public static IEnumerable<PerfTestConfig> PerformanceTestConfigurations()
+        {
+            yield return new PerfTestConfig(100, TestType.ByteArray, 1024);
+            yield return new PerfTestConfig(5, TestType.ByteArray, 1024 * 1024);
+            yield return new PerfTestConfig(10000, TestType.String, 128);
+            yield return new PerfTestConfig(10000, TestType.String, 1024);
+            yield return new PerfTestConfig(1000, TestType.ListOfInt, 128);
+            yield return new PerfTestConfig(1000, TestType.ListOfInt, 1024);
+            yield return new PerfTestConfig(1, TestType.ListOfInt, 1024 * 1024);
+            yield return new PerfTestConfig(1000, TestType.Dictionary, 128);
+            yield return new PerfTestConfig(100, TestType.Dictionary, 1024);
+            yield return new PerfTestConfig(10, TestType.SimpleType, 1);
+            yield return new PerfTestConfig(1, TestType.SimpleType, 15);
+            yield return new PerfTestConfig(10000, TestType.ISerializable, -1);
+            yield return new PerfTestConfig(10000, TestType.XmlElement, -1);
+        }
+
         public static IEnumerable<object[]> PerformanceMemberData()
         {
-            yield return new object[] { 100, TestType.ByteArray, 1024 };
-            yield return new object[] { 5, TestType.ByteArray, 1024 * 1024 };
-            yield return new object[] { 10000, TestType.String, 128 };
-            yield return new object[] { 10000, TestType.String, 1024 };
-            yield return new object[] { 1000, TestType.ListOfInt, 128 };
-            yield return new object[] { 1000, TestType.ListOfInt, 1024 };
-            yield return new object[] { 1, TestType.ListOfInt, 1024 * 1024 };
-            yield return new object[] { 1000, TestType.Dictionary, 128 };
-            yield return new object[] { 100, TestType.Dictionary, 1024 };
-            yield return new object[] { 10, TestType.SimpleType, 1 };
-            yield return new object[] { 1, TestType.SimpleType, 15 };
-            yield return new object[] { 10000, TestType.ISerializable, -1 };
-            yield return new object[] { 10000, TestType.XmlElement, -1 };
+            foreach (PerfTestConfig config in PerformanceTestConfigurations())
+            {
+                yield return config.ToObjectArray();
+            }
         }
 
         #endregion

--- a/src/System.Xml.XmlSerializer/tests/Performance/XsPerformanceTest.cs
+++ b/src/System.Xml.XmlSerializer/tests/Performance/XsPerformanceTest.cs
@@ -17,7 +17,12 @@ namespace System.Xml.XmlSerializer.Tests.Performance
     {
         public static IEnumerable<object[]> SerializeMemberData()
         {
-            return PerformanceTestCommon.PerformanceMemberData();
+            foreach (PerfTestConfig config in PerformanceTestCommon.PerformanceTestConfigurations())
+            {
+                // XmlSerializer doesn't support Dictionary type
+                if (config.PerfTestType == TestType.Dictionary) continue;
+                yield return config.ToObjectArray();
+            }
         }
 
         [Benchmark]


### PR DESCRIPTION
XmlSerializer doesn't support dictionary scenarios so skipping them in perf tests

cc: @shmao @SGuyGe @zhenlan 

Fix #7584