### PR TITLE
Remove --infer-runtimes restore argument

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -146,7 +146,6 @@
     <DnuRestoreCommand>$(DnuRestoreCommand) --packages "$(PackagesDir.TrimEnd('/\'.ToCharArray()))" $(DnuRestoreSource)</DnuRestoreCommand>
     <DnuRestoreCommand Condition="'$(LockDependencies)' == 'true'">$(DnuRestoreCommand) --lock</DnuRestoreCommand>
     <DnuRestoreCommand Condition="'$(NuGetConfigPath)'!=''">$(DnuRestoreCommand) --configfile $(NuGetConfigPath)</DnuRestoreCommand>
-    <DnuRestoreCommand Condition="'$(InferRuntimes)'!='false'">$(DnuRestoreCommand) --infer-runtimes</DnuRestoreCommand>
   </PropertyGroup>
 
   <!-- Create a collection of all project.json files for dependency updates. -->


### PR DESCRIPTION
Thanks to https://github.com/dotnet/corefx/pull/7651, we now have runtimes in our project.json files and shouldn't need to infer runtimes based on platform anymore. This lets us remove the temporary `--infer-runtimes` `dotnet restore` argument.

/cc @weshaggard @ericstj @mellinoe 