### PR TITLE
Fix two issues with delegate creation methods

### DIFF
--- a/src/Common/src/System/Linq/Expressions/Compiler/DelegateHelpers.Generated.cs
+++ b/src/Common/src/System/Linq/Expressions/Compiler/DelegateHelpers.Generated.cs
@@ -109,7 +109,8 @@ namespace System.Linq.Expressions.Compiler
 
                 for (int i = 0; i < types.Length; i++)
                 {
-                    if (types[i].IsByRef)
+                    Type type = types[i];
+                    if (type.IsByRef || type.IsPointer)
                     {
                         needCustom = true;
                         break;
@@ -135,6 +136,7 @@ namespace System.Linq.Expressions.Compiler
             {
                 result = GetFuncType(types);
             }
+
             Debug.Assert(result != null);
             return result;
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -602,25 +602,41 @@ namespace System.Linq.Expressions
             }
         }
 
-        private static bool ValidateTryGetFuncActionArgs(Type[] typeArgs)
+        private enum TryGetFuncActionArgsResult
+        {
+            Valid,
+            ArgumentNull,
+            ByRef,
+            PointerOrVoid
+        }
+
+        private static TryGetFuncActionArgsResult ValidateTryGetFuncActionArgs(Type[] typeArgs)
         {
             if (typeArgs == null)
             {
-                throw new ArgumentNullException(nameof(typeArgs));
+                return TryGetFuncActionArgsResult.ArgumentNull;
             }
-            for (int i = 0, n = typeArgs.Length; i < n; i++)
+
+            for (int i = 0; i < typeArgs.Length; i++)
             {
                 var a = typeArgs[i];
                 if (a == null)
                 {
-                    throw new ArgumentNullException(nameof(typeArgs));
+                    return TryGetFuncActionArgsResult.ArgumentNull;
                 }
+
                 if (a.IsByRef)
                 {
-                    return false;
+                    return TryGetFuncActionArgsResult.ByRef;
+                }
+
+                if (a == typeof(void) || a.IsPointer)
+                {
+                    return TryGetFuncActionArgsResult.PointerOrVoid;
                 }
             }
-            return true;
+
+            return TryGetFuncActionArgsResult.Valid;
         }
 
         /// <summary>
@@ -631,14 +647,24 @@ namespace System.Linq.Expressions
         /// <returns>The type of a System.Func delegate that has the specified type arguments.</returns>
         public static Type GetFuncType(params Type[] typeArgs)
         {
-            if (!ValidateTryGetFuncActionArgs(typeArgs)) throw Error.TypeMustNotBeByRef(nameof(typeArgs));
-
-            Type result = Compiler.DelegateHelpers.GetFuncType(typeArgs);
-            if (result == null)
+            switch (ValidateTryGetFuncActionArgs(typeArgs))
             {
-                throw Error.IncorrectNumberOfTypeArgsForFunc(nameof(typeArgs));
+                case TryGetFuncActionArgsResult.ArgumentNull:
+                    throw new ArgumentNullException(nameof(typeArgs));
+                case TryGetFuncActionArgsResult.ByRef:
+                    throw Error.TypeMustNotBeByRef(nameof(typeArgs));
+                default:
+
+                    // This includes pointers or void. We allow the exception that comes
+                    // from trying to use them as generic arguments to pass through.
+                    Type result = Compiler.DelegateHelpers.GetFuncType(typeArgs);
+                    if (result == null)
+                    {
+                        throw Error.IncorrectNumberOfTypeArgsForFunc(nameof(typeArgs));
+                    }
+
+                    return result;
             }
-            return result;
         }
 
         /// <summary>
@@ -650,10 +676,11 @@ namespace System.Linq.Expressions
         /// <returns>true if generic System.Func delegate type was created for specific <paramref name="typeArgs"/>; false otherwise.</returns>
         public static bool TryGetFuncType(Type[] typeArgs, out Type funcType)
         {
-            if (ValidateTryGetFuncActionArgs(typeArgs))
+            if (ValidateTryGetFuncActionArgs(typeArgs) == TryGetFuncActionArgsResult.Valid)
             {
                 return (funcType = Compiler.DelegateHelpers.GetFuncType(typeArgs)) != null;
             }
+
             funcType = null;
             return false;
         }
@@ -665,14 +692,24 @@ namespace System.Linq.Expressions
         /// <returns>The type of a System.Action delegate that has the specified type arguments.</returns>
         public static Type GetActionType(params Type[] typeArgs)
         {
-            if (!ValidateTryGetFuncActionArgs(typeArgs)) throw Error.TypeMustNotBeByRef(nameof(typeArgs));
-
-            Type result = Compiler.DelegateHelpers.GetActionType(typeArgs);
-            if (result == null)
+            switch (ValidateTryGetFuncActionArgs(typeArgs))
             {
-                throw Error.IncorrectNumberOfTypeArgsForAction(nameof(typeArgs));
+                case TryGetFuncActionArgsResult.ArgumentNull:
+                    throw new ArgumentNullException(nameof(typeArgs));
+                case TryGetFuncActionArgsResult.ByRef:
+                    throw Error.TypeMustNotBeByRef(nameof(typeArgs));
+                default:
+
+                    // This includes pointers or void. We allow the exception that comes
+                    // from trying to use them as generic arguments to pass through.
+                    Type result = Compiler.DelegateHelpers.GetActionType(typeArgs);
+                    if (result == null)
+                    {
+                        throw Error.IncorrectNumberOfTypeArgsForAction(nameof(typeArgs));
+                    }
+
+                    return result;
             }
-            return result;
         }
 
         /// <summary>
@@ -683,10 +720,11 @@ namespace System.Linq.Expressions
         /// <returns>true if generic System.Action delegate type was created for specific <paramref name="typeArgs"/>; false otherwise.</returns>
         public static bool TryGetActionType(Type[] typeArgs, out Type actionType)
         {
-            if (ValidateTryGetFuncActionArgs(typeArgs))
+            if (ValidateTryGetFuncActionArgs(typeArgs) == TryGetFuncActionArgsResult.Valid)
             {
                 return (actionType = Compiler.DelegateHelpers.GetActionType(typeArgs)) != null;
             }
+
             actionType = null;
             return false;
         }

--- a/src/System.Linq.Expressions/tests/DelegateType/ActionTypeTests.cs
+++ b/src/System.Linq.Expressions/tests/DelegateType/ActionTypeTests.cs
@@ -13,16 +13,12 @@ namespace System.Linq.Expressions.Tests
         public void NullTypeList()
         {
             Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.GetActionType(default(Type[])));
-            Type result;
-            Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.TryGetActionType(null, out result));
         }
 
         [Fact]
         public void NullInTypeList()
         {
             Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.GetActionType(typeof(int), null));
-            Type result;
-            Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.TryGetActionType(new[] { typeof(int), null }, out result));
         }
 
         [Theory]
@@ -96,9 +92,9 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(ExcessiveLengthTypeArgs))]
         [MemberData(nameof(ExcessiveLengthOpenGenericTypeArgs))]
         [MemberData(nameof(ByRefTypeArgs))]
-        // 8119 [MemberData(nameof(PointerTypeArgs))]
-        // 8119 [MemberData(nameof(ManagedPointerTypeArgs))]
-        // 8119 [MemberData(nameof(VoidTypeArgs), true)]
+        [MemberData(nameof(PointerTypeArgs))]
+        [MemberData(nameof(ManagedPointerTypeArgs))]
+        [MemberData(nameof(VoidTypeArgs), true)]
         public void UnsuccessfulTryGetActionType(Type[] typeArgs)
         {
             Type funcType;

--- a/src/System.Linq.Expressions/tests/DelegateType/ActionTypeTests.cs
+++ b/src/System.Linq.Expressions/tests/DelegateType/ActionTypeTests.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class ActionTypeTests : DelegateCreationTests
+    {
+        [Fact]
+        public void NullTypeList()
+        {
+            Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.GetActionType(default(Type[])));
+            Type result;
+            Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.TryGetActionType(null, out result));
+        }
+
+        [Fact]
+        public void NullInTypeList()
+        {
+            Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.GetActionType(typeof(int), null));
+            Type result;
+            Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.TryGetActionType(new[] { typeof(int), null }, out result));
+        }
+
+        [Theory]
+        [MemberData(nameof(EmptyTypeArgs))]
+        [MemberData(nameof(ValidTypeArgs), false)]
+        public void SuccessfulGetActionType(Type[] typeArgs)
+        {
+            Type funcType = Expression.GetActionType(typeArgs);
+            if (typeArgs.Length == 0)
+            {
+                Assert.Equal(typeof(Action), funcType);
+            }
+            else
+            {
+                Assert.StartsWith("System.Action`" + typeArgs.Length, funcType.FullName);
+                Assert.Equal(typeArgs, funcType.GetGenericArguments());
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(EmptyTypeArgs))]
+        [MemberData(nameof(ValidTypeArgs), false)]
+        public void SuccessfulTryGetActionType(Type[] typeArgs)
+        {
+            Type funcType;
+            Assert.True(Expression.TryGetActionType(typeArgs, out funcType));
+            if (typeArgs.Length == 0)
+            {
+                Assert.Equal(typeof(Action), funcType);
+            }
+            else
+            {
+                Assert.StartsWith("System.Action`" + typeArgs.Length, funcType.FullName);
+                Assert.Equal(typeArgs, funcType.GetGenericArguments());
+            }
+        }
+
+        // Open generic type args aren't useful directly with Expressions, but creating them is allowed.
+        [Theory, MemberData(nameof(OpenGenericTypeArgs), false)]
+        public void SuccessfulGetActionTypeOpenGeneric(Type[] typeArgs)
+        {
+            Type funcType = Expression.GetActionType(typeArgs);
+            Assert.Equal("Action`" + typeArgs.Length, funcType.Name);
+            Assert.Null(funcType.FullName);
+            Assert.Equal(typeArgs, funcType.GetGenericArguments());
+        }
+
+        [Theory, MemberData(nameof(OpenGenericTypeArgs), false)]
+        public void SuccessfulTryGetActionTypeWithOpenGeneric(Type[] typeArgs)
+        {
+            Type funcType;
+            Assert.True(Expression.TryGetActionType(typeArgs, out funcType));
+            Assert.Equal("Action`" + typeArgs.Length, funcType.Name);
+            Assert.Null(funcType.FullName);
+            Assert.Equal(typeArgs, funcType.GetGenericArguments());
+        }
+
+        [Theory]
+        [MemberData(nameof(ExcessiveLengthTypeArgs))]
+        [MemberData(nameof(ExcessiveLengthOpenGenericTypeArgs))]
+        [MemberData(nameof(ByRefTypeArgs))]
+        [MemberData(nameof(PointerTypeArgs))]
+        [MemberData(nameof(ManagedPointerTypeArgs))]
+        [MemberData(nameof(VoidTypeArgs), true)]
+        public void UnsuccessfulGetActionType(Type[] typeArgs)
+        {
+            Assert.Throws<ArgumentException>(() => Expression.GetActionType(typeArgs));
+        }
+
+        [Theory]
+        [MemberData(nameof(ExcessiveLengthTypeArgs))]
+        [MemberData(nameof(ExcessiveLengthOpenGenericTypeArgs))]
+        [MemberData(nameof(ByRefTypeArgs))]
+        // 8119 [MemberData(nameof(PointerTypeArgs))]
+        // 8119 [MemberData(nameof(ManagedPointerTypeArgs))]
+        // 8119 [MemberData(nameof(VoidTypeArgs), true)]
+        public void UnsuccessfulTryGetActionType(Type[] typeArgs)
+        {
+            Type funcType;
+            Assert.False(Expression.TryGetActionType(typeArgs, out funcType));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/DelegateType/DelegateCreationTests.cs
+++ b/src/System.Linq.Expressions/tests/DelegateType/DelegateCreationTests.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.Linq.Expressions.Tests
+{
+    public abstract class DelegateCreationTests
+    {
+        protected static IEnumerable<object[]> ValidTypeArgs(bool includesReturnType)
+        {
+            for (int i = 1; i <= (includesReturnType ? 17 : 16); ++i)
+            {
+                yield return new object[] { Enumerable.Repeat(typeof(bool), i).ToArray() };
+            }
+
+            yield return new object[] { new[] { typeof(int) } };
+            yield return new object[] { new[] { typeof(int), typeof(string) } };
+            yield return new object[] { new[] { typeof(string), typeof(int), typeof(decimal) } };
+            yield return new object[] { new[] { typeof(string), typeof(int), typeof(decimal), typeof(float) } };
+            yield return new object[] { new[] { typeof(NWindProxy.Customer), typeof(string), typeof(int), typeof(decimal), typeof(float) } };
+        }
+
+        protected static IEnumerable<object[]> OpenGenericTypeArgs(bool includesReturnType)
+        {
+            for (int i = 1; i <= (includesReturnType ? 17 : 16); ++i)
+            {
+                yield return new object[] { Enumerable.Repeat(typeof(List<>), i).ToArray() };
+            }
+        }
+
+        protected static IEnumerable<object> ExcessiveLengthTypeArgs()
+        {
+            yield return new object[] { Enumerable.Repeat(typeof(int), 18).ToArray() };
+        }
+
+        protected static IEnumerable<object> ExcessiveLengthOpenGenericTypeArgs()
+        {
+            yield return new object[] { Enumerable.Repeat(typeof(List<int>), 18).ToArray() };
+        }
+
+        protected static IEnumerable<object> EmptyTypeArgs()
+        {
+            yield return new object[] { Array.Empty<Type>() };
+        }
+
+        protected static IEnumerable<object> ByRefTypeArgs()
+        {
+            yield return new object[] { new[] { typeof(int), typeof(int).MakeByRefType(), typeof(string) } };
+            yield return new object[] { new[] { typeof(int).MakeByRefType() } };
+            yield return new object[] { Enumerable.Repeat(typeof(double).MakeByRefType(), 20).ToArray() };
+        }
+
+        protected static IEnumerable<object> PointerTypeArgs()
+        {
+            yield return new object[] { new[] { typeof(int).MakePointerType() } };
+            yield return new object[] { new[] { typeof(string), typeof(double).MakePointerType(), typeof(int) } };
+            yield return new object[] { Enumerable.Repeat(typeof(int).MakePointerType(), 20).ToArray() };
+        }
+
+        protected static IEnumerable<object> ManagedPointerTypeArgs()
+        {
+            yield return new object[] { new[] { typeof(string).MakePointerType() } };
+            yield return new object[] { new[] { typeof(int), typeof(string).MakePointerType(), typeof(double) } };
+            yield return new object[] { Enumerable.Repeat(typeof(string).MakePointerType(), 20).ToArray() };
+        }
+
+        protected static IEnumerable<object> VoidTypeArgs(bool includeSingleVoid)
+        {
+            if (includeSingleVoid)
+            {
+                yield return new object[] { new[] { typeof(void) } };
+            }
+
+            yield return new object[] { new[] { typeof(string), typeof(void), typeof(int) } };
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/DelegateType/FuncTypeTests.cs
+++ b/src/System.Linq.Expressions/tests/DelegateType/FuncTypeTests.cs
@@ -13,16 +13,12 @@ namespace System.Linq.Expressions.Tests
         public void NullTypeList()
         {
             Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.GetFuncType(default(Type[])));
-            Type result;
-            Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.TryGetFuncType(null, out result));
         }
 
         [Fact]
         public void NullInTypeList()
         {
             Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.GetFuncType(typeof(int), null));
-            Type result;
-            Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.TryGetFuncType(new[] { typeof(int), null }, out result));
         }
 
         [Theory, MemberData(nameof(ValidTypeArgs), true)]
@@ -78,9 +74,9 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(EmptyTypeArgs))]
         [MemberData(nameof(ExcessiveLengthTypeArgs))]
         [MemberData(nameof(ByRefTypeArgs))]
-        // 8119 [MemberData(nameof(PointerTypeArgs))]
-        // 8119 [MemberData(nameof(ManagedPointerTypeArgs))]
-        // 8119 [MemberData(nameof(VoidTypeArgs), true)]
+        [MemberData(nameof(PointerTypeArgs))]
+        [MemberData(nameof(ManagedPointerTypeArgs))]
+        [MemberData(nameof(VoidTypeArgs), true)]
         public void UnsuccessfulTryGetFuncType(Type[] typeArgs)
         {
             Type funcType;

--- a/src/System.Linq.Expressions/tests/DelegateType/FuncTypeTests.cs
+++ b/src/System.Linq.Expressions/tests/DelegateType/FuncTypeTests.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class FuncTypeTests : DelegateCreationTests
+    {
+        [Fact]
+        public void NullTypeList()
+        {
+            Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.GetFuncType(default(Type[])));
+            Type result;
+            Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.TryGetFuncType(null, out result));
+        }
+
+        [Fact]
+        public void NullInTypeList()
+        {
+            Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.GetFuncType(typeof(int), null));
+            Type result;
+            Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.TryGetFuncType(new[] { typeof(int), null }, out result));
+        }
+
+        [Theory, MemberData(nameof(ValidTypeArgs), true)]
+        public void SuccessfulGetFuncType(Type[] typeArgs)
+        {
+            Type funcType = Expression.GetFuncType(typeArgs);
+            Assert.StartsWith("System.Func`" + typeArgs.Length, funcType.FullName);
+            Assert.Equal(typeArgs, funcType.GetGenericArguments());
+        }
+
+        [Theory, MemberData(nameof(ValidTypeArgs), true)]
+        public void SuccessfulTryGetFuncType(Type[] typeArgs)
+        {
+            Type funcType;
+            Assert.True(Expression.TryGetFuncType(typeArgs, out funcType));
+            Assert.StartsWith("System.Func`" + typeArgs.Length, funcType.FullName);
+            Assert.Equal(typeArgs, funcType.GetGenericArguments());
+        }
+
+        // Open generic type args aren't useful directly with Expressions, but creating them is allowed.
+        [Theory, MemberData(nameof(OpenGenericTypeArgs), false)]
+        public void SuccessfulGetFuncTypeOpenGeneric(Type[] typeArgs)
+        {
+            Type funcType = Expression.GetFuncType(typeArgs);
+            Assert.Equal("Func`" + typeArgs.Length, funcType.Name);
+            Assert.Null(funcType.FullName);
+            Assert.Equal(typeArgs, funcType.GetGenericArguments());
+        }
+
+        [Theory, MemberData(nameof(OpenGenericTypeArgs), false)]
+        public void SuccessfulTryGetFuncTypeWithOpenGeneric(Type[] typeArgs)
+        {
+            Type funcType;
+            Assert.True(Expression.TryGetFuncType(typeArgs, out funcType));
+            Assert.Equal("Func`" + typeArgs.Length, funcType.Name);
+            Assert.Null(funcType.FullName);
+            Assert.Equal(typeArgs, funcType.GetGenericArguments());
+        }
+
+        [Theory]
+        [MemberData(nameof(EmptyTypeArgs))]
+        [MemberData(nameof(ExcessiveLengthTypeArgs))]
+        [MemberData(nameof(ByRefTypeArgs))]
+        [MemberData(nameof(PointerTypeArgs))]
+        [MemberData(nameof(ManagedPointerTypeArgs))]
+        [MemberData(nameof(VoidTypeArgs), true)]
+        public void UnsuccessfulGetFuncType(Type[] typeArgs)
+        {
+            Assert.Throws<ArgumentException>(() => Expression.GetFuncType(typeArgs));
+        }
+
+        [Theory]
+        [MemberData(nameof(EmptyTypeArgs))]
+        [MemberData(nameof(ExcessiveLengthTypeArgs))]
+        [MemberData(nameof(ByRefTypeArgs))]
+        // 8119 [MemberData(nameof(PointerTypeArgs))]
+        // 8119 [MemberData(nameof(ManagedPointerTypeArgs))]
+        // 8119 [MemberData(nameof(VoidTypeArgs), true)]
+        public void UnsuccessfulTryGetFuncType(Type[] typeArgs)
+        {
+            Type funcType;
+            Assert.False(Expression.TryGetFuncType(typeArgs, out funcType));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/DelegateType/GetDelegateTypeTests.cs
+++ b/src/System.Linq.Expressions/tests/DelegateType/GetDelegateTypeTests.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class GetDelegateTypeTests : DelegateCreationTests
+    {
+        [Fact]
+        public void NullTypeList()
+        {
+            Assert.Throws<ArgumentNullException>("typeArgs", () => Expression.GetDelegateType(default(Type[])));
+        }
+
+        [Fact]
+        public void NullInTypeList()
+        {
+            Assert.Throws<ArgumentNullException>("typeArgs[1]", () => Expression.GetDelegateType(typeof(int), null));
+        }
+
+        [Fact]
+        public void EmptyArgs()
+        {
+            Assert.Throws<ArgumentException>("typeArgs", () => Expression.GetDelegateType());
+        }
+
+        [Theory, MemberData(nameof(ValidTypeArgs), true)]
+        public void SuccessfulGetFuncType(Type[] typeArgs)
+        {
+            Type funcType = Expression.GetDelegateType(typeArgs);
+            Assert.StartsWith("System.Func`" + typeArgs.Length, funcType.FullName);
+            Assert.Equal(typeArgs, funcType.GetGenericArguments());
+        }
+
+        [Theory, MemberData(nameof(ValidTypeArgs), false)]
+        public void SuccessfulGetActionType(Type[] typeArgs)
+        {
+            Type funcType = Expression.GetDelegateType(typeArgs.Append(typeof(void)).ToArray());
+            Assert.StartsWith("System.Action`" + typeArgs.Length, funcType.FullName);
+            Assert.Equal(typeArgs, funcType.GetGenericArguments());
+        }
+
+        [Fact]
+        public void GetNullaryAction()
+        {
+            Assert.Equal(typeof(Action), Expression.GetDelegateType(typeof(void)));
+        }
+
+        [Theory]
+        [MemberData(nameof(ExcessiveLengthTypeArgs))]
+        [MemberData(nameof(ExcessiveLengthOpenGenericTypeArgs))]
+        [MemberData(nameof(ByRefTypeArgs))]
+        // 8121 [MemberData(nameof(PointerTypeArgs))]
+        // 8121 [MemberData(nameof(ManagedPointerTypeArgs))]
+        public void CantBeFunc(Type[] typeArgs)
+        {
+            Type delType = Expression.GetDelegateType(typeArgs);
+            Assert.True(typeof(MulticastDelegate).IsAssignableFrom(delType));
+            Assert.DoesNotMatch(new Regex(@"System\.Action"), delType.FullName);
+            Assert.DoesNotMatch(new Regex(@"System\.Func"), delType.FullName);
+            var method = delType.GetMethod("Invoke");
+            Assert.Equal(typeArgs.Last(), method.ReturnType);
+            Assert.Equal(typeArgs.Take(typeArgs.Length - 1), method.GetParameters().Select(p => p.ParameterType));
+        }
+
+        [Theory]
+        [MemberData(nameof(ExcessiveLengthTypeArgs))]
+        [MemberData(nameof(ExcessiveLengthOpenGenericTypeArgs))]
+        [MemberData(nameof(ByRefTypeArgs))]
+        // 8121 [MemberData(nameof(PointerTypeArgs))]
+        // 8121 [MemberData(nameof(ManagedPointerTypeArgs))]
+        public void CantBeAction(Type[] typeArgs)
+        {
+            Type delType = Expression.GetDelegateType(typeArgs.Append(typeof(void)).ToArray());
+            Assert.True(typeof(MulticastDelegate).IsAssignableFrom(delType));
+            Assert.DoesNotMatch(new Regex(@"System\.Action"), delType.FullName);
+            Assert.DoesNotMatch(new Regex(@"System\.Func"), delType.FullName);
+            var method = delType.GetMethod("Invoke");
+            Assert.Equal(typeof(void), method.ReturnType);
+            Assert.Equal(typeArgs, method.GetParameters().Select(p => p.ParameterType));
+        }
+
+        // Open generic type args aren't useful directly with Expressions, but creating them is allowed.
+        [Theory, MemberData(nameof(OpenGenericTypeArgs), false)]
+        public void SuccessfulGetFuncTypeOpenGeneric(Type[] typeArgs)
+        {
+            Type funcType = Expression.GetDelegateType(typeArgs);
+            Assert.Equal("Func`" + typeArgs.Length, funcType.Name);
+            Assert.Null(funcType.FullName);
+            Assert.Equal(typeArgs, funcType.GetGenericArguments());
+        }
+
+        [Theory, MemberData(nameof(OpenGenericTypeArgs), false)]
+        public void SuccessfulGetActionTypeOpenGeneric(Type[] typeArgs)
+        {
+            Type funcType = Expression.GetDelegateType(typeArgs.Append(typeof(void)).ToArray());
+            Assert.Equal("Action`" + typeArgs.Length, funcType.Name);
+            Assert.Null(funcType.FullName);
+            Assert.Equal(typeArgs, funcType.GetGenericArguments());
+        }
+
+        [Theory, MemberData(nameof(VoidTypeArgs), false)]
+        public void VoidArgToFuncTypeDelegate(Type[] typeArgs)
+        {
+            Assert.Throws<ArgumentException>(() => Expression.GetDelegateType(typeArgs));
+        }
+
+        [Theory, MemberData(nameof(VoidTypeArgs), false)]
+        public void VoidArgToActionTypeDelegate(Type[] typeArgs)
+        {
+            Assert.Throws<ArgumentException>(() => Expression.GetDelegateType(typeArgs.Append(typeof(void)).ToArray()));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/DelegateType/GetDelegateTypeTests.cs
+++ b/src/System.Linq.Expressions/tests/DelegateType/GetDelegateTypeTests.cs
@@ -54,8 +54,8 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(ExcessiveLengthTypeArgs))]
         [MemberData(nameof(ExcessiveLengthOpenGenericTypeArgs))]
         [MemberData(nameof(ByRefTypeArgs))]
-        // 8121 [MemberData(nameof(PointerTypeArgs))]
-        // 8121 [MemberData(nameof(ManagedPointerTypeArgs))]
+        [MemberData(nameof(PointerTypeArgs))]
+        [MemberData(nameof(ManagedPointerTypeArgs))]
         public void CantBeFunc(Type[] typeArgs)
         {
             Type delType = Expression.GetDelegateType(typeArgs);
@@ -71,8 +71,8 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(ExcessiveLengthTypeArgs))]
         [MemberData(nameof(ExcessiveLengthOpenGenericTypeArgs))]
         [MemberData(nameof(ByRefTypeArgs))]
-        // 8121 [MemberData(nameof(PointerTypeArgs))]
-        // 8121 [MemberData(nameof(ManagedPointerTypeArgs))]
+        [MemberData(nameof(PointerTypeArgs))]
+        [MemberData(nameof(ManagedPointerTypeArgs))]
         public void CantBeAction(Type[] typeArgs)
         {
             Type delType = Expression.GetDelegateType(typeArgs.Append(typeof(void)).ToArray());

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -97,6 +97,10 @@
     <Compile Include="Convert\ConvertCheckedTests.cs" />
     <Compile Include="Convert\ConvertTests.cs" />
     <Compile Include="Default\DefaultTests.cs" />
+    <Compile Include="DelegateType\ActionTypeTests.cs" />
+    <Compile Include="DelegateType\DelegateCreationTests.cs" />
+    <Compile Include="DelegateType\FuncTypeTests.cs" />
+    <Compile Include="DelegateType\GetDelegateTypeTests.cs" />
     <Compile Include="ExceptionHandling\ExceptionHandlingExpressions.cs" />
     <Compile Include="ExpressionTests.cs" />
     <Compile Include="Goto\Break.cs" />


### PR DESCRIPTION
**Add tests for delegate-creation methods in Linq.Expressions**

Move and simplify relevant tests from SequenceTests.cs into new file.

And add more relevant tests.

**Allow pointer-types in delegates with low arity.**

Fixes #8121

**Return false from TryGetFuncType/TryGetActionType on all failures.**

Fixes #8119