### PR TITLE
More HttpClient test fixes and additions

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/LoopbackServer.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/LoopbackServer.cs
@@ -2,17 +2,70 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
-using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.Net.Http.Functional.Tests
 {
     public class LoopbackServer
     {
+        public static Task CreateClientAndServerAsync(Func<HttpClientHandler, HttpClient, Socket, Uri, Task> funcAsync, int backlog = 1)
+        {
+            return CreateServerAsync(async (server, url) =>
+            {
+                using (var handler = new HttpClientHandler())
+                using (var client = new HttpClient(handler))
+                {
+                    await funcAsync(handler, client, server, url).ConfigureAwait(false);
+                }
+            });
+        }
+
+        public static Task CreateServerAsync(Func<Socket, Uri, Task> funcAsync)
+        {
+            IPEndPoint ignored;
+            return CreateServerAsync(funcAsync, out ignored);
+        }
+
+        public static Task CreateServerAsync(Func<Socket, Uri, Task> funcAsync, out IPEndPoint localEndPoint)
+        {
+            try
+            {
+                var server = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+                server.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                server.Listen(1);
+
+                localEndPoint = (IPEndPoint)server.LocalEndPoint;
+                var url = new Uri($"http://{localEndPoint.Address}:{localEndPoint.Port}/");
+
+                return funcAsync(server, url).ContinueWith(t =>
+                {
+                    server.Dispose();
+                    t.GetAwaiter().GetResult();
+                }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+            }
+            catch (Exception e)
+            {
+                localEndPoint = null;
+                return Task.FromException(e);
+            }
+        }
+
+        public static async Task AcceptSocketAsync(Socket server, Func<Socket, NetworkStream, StreamReader, StreamWriter, Task> funcAsync)
+        {
+            using (Socket s = await server.AcceptAsync().ConfigureAwait(false))
+            using (var stream = new NetworkStream(s, ownsSocket: false))
+            using (var reader = new StreamReader(stream, Encoding.ASCII))
+            using (var writer = new StreamWriter(stream, Encoding.ASCII))
+            {
+                await funcAsync(s, stream, reader, writer).ConfigureAwait(false);
+            }
+        }
+
         public enum TransferType
         {
             None = 0,
@@ -28,79 +81,62 @@ namespace System.Net.Http.Functional.Tests
             MissingChunkTerminator
         }
 
-        public static Task StartServer(
+        public static Task StartTransferTypeAndErrorServer(
             TransferType transferType,
             TransferError transferError,
-            out IPEndPoint serverEndPoint)
+            out IPEndPoint localEndPoint)
         {
-            var server = new TcpListener(IPAddress.Loopback, 0);
-            Task serverTask = ((Func<Task>)async delegate {
-                server.Start();
-                using (var client = await server.AcceptSocketAsync())
-                using (var stream = new NetworkStream(client))
-                using (var reader = new StreamReader(stream, Encoding.ASCII))
+            return CreateServerAsync((server, url) => AcceptSocketAsync(server, async (client, stream, reader, writer) =>
+            {
+                // Read past request headers.
+                string line;
+                while (!string.IsNullOrEmpty(line = reader.ReadLine())) ;
+
+                // Determine response transfer headers.
+                string transferHeader = null;
+                string content = "This is some response content.";
+                if (transferType == TransferType.ContentLength)
                 {
-                    // Read past request headers.
-                    string line;
-                    while (!string.IsNullOrEmpty(line = reader.ReadLine())) ;
-
-                    // Determine response transfer headers.
-                    string transferHeader = null;
-                    string content = "This is some response content.";
-                    if (transferType == TransferType.ContentLength)
-                    {
-                        if (transferError == TransferError.ContentLengthTooLarge)
-                        {
-                            transferHeader = $"Content-Length: {content.Length + 42}\r\n";
-                        }
-                        else
-                        {
-                            transferHeader = $"Content-Length: {content.Length}\r\n";
-                        }
-                    }
-                    else if (transferType == TransferType.Chunked)
-                    {
-                        transferHeader = "Transfer-Encoding: chunked\r\n";
-                    }
-
-                    // Write response.
-                    using (var writer = new StreamWriter(stream, Encoding.ASCII))
-                    {
-                        writer.Write("HTTP/1.1 200 OK\r\n");
-                        writer.Write($"Date: {DateTimeOffset.UtcNow:R}\r\n");
-                        writer.Write("Content-Type: text/plain\r\n");
-
-                        if (!string.IsNullOrEmpty(transferHeader))
-                        {
-                            writer.Write(transferHeader);
-                        }
-
-                        writer.Write("\r\n");
-                        if (transferType == TransferType.Chunked)
-                        {
-                            string chunkSizeInHex = string.Format(
-                                "{0:x}\r\n",
-                                content.Length + (transferError == TransferError.ChunkSizeTooLarge ? 42 : 0));
-                            writer.Write(chunkSizeInHex);
-                            writer.Write($"{content}\r\n");
-                            if (transferError != TransferError.MissingChunkTerminator)
-                            {
-                                writer.Write("0\r\n\r\n");
-                            }
-                        }
-                        else
-                        {
-                            writer.Write($"{content}\r\n");
-                        }
-                        writer.Flush();
-                    }
-
-                    client.Shutdown(SocketShutdown.Both);
+                    transferHeader = transferError == TransferError.ContentLengthTooLarge ?
+                        $"Content-Length: {content.Length + 42}\r\n" :
+                        $"Content-Length: {content.Length}\r\n";
                 }
-            })();
+                else if (transferType == TransferType.Chunked)
+                {
+                    transferHeader = "Transfer-Encoding: chunked\r\n";
+                }
 
-            serverEndPoint = (IPEndPoint)server.LocalEndpoint;
-            return serverTask;
+                // Write response header
+                await writer.WriteAsync("HTTP/1.1 200 OK\r\n").ConfigureAwait(false);
+                await writer.WriteAsync($"Date: {DateTimeOffset.UtcNow:R}\r\n").ConfigureAwait(false);
+                await writer.WriteAsync("Content-Type: text/plain\r\n").ConfigureAwait(false);
+                if (!string.IsNullOrEmpty(transferHeader))
+                {
+                    await writer.WriteAsync(transferHeader).ConfigureAwait(false);
+                }
+                await writer.WriteAsync("\r\n").ConfigureAwait(false);
+
+                // Write response body
+                if (transferType == TransferType.Chunked)
+                {
+                    string chunkSizeInHex = string.Format(
+                        "{0:x}\r\n",
+                        content.Length + (transferError == TransferError.ChunkSizeTooLarge ? 42 : 0));
+                    await writer.WriteAsync(chunkSizeInHex).ConfigureAwait(false);
+                    await writer.WriteAsync($"{content}\r\n").ConfigureAwait(false);
+                    if (transferError != TransferError.MissingChunkTerminator)
+                    {
+                        await writer.WriteAsync("0\r\n\r\n").ConfigureAwait(false);
+                    }
+                }
+                else
+                {
+                    await writer.WriteAsync($"{content}\r\n").ConfigureAwait(false);
+                }
+                await writer.FlushAsync().ConfigureAwait(false);
+
+                client.Shutdown(SocketShutdown.Both);
+            }), out localEndPoint);
         }
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -100,7 +100,7 @@ namespace System.Net.Http.Functional.Tests
             LoopbackServer.TransferError transferError)
         {
             IPEndPoint serverEndPoint;
-            Task serverTask = LoopbackServer.StartServer(transferType, transferError, out serverEndPoint);
+            Task serverTask = LoopbackServer.StartTransferTypeAndErrorServer(transferType, transferError, out serverEndPoint);
 
             await Assert.ThrowsAsync<IOException>(() => ReadAsStreamHelper(serverEndPoint));
 
@@ -116,7 +116,7 @@ namespace System.Net.Http.Functional.Tests
             LoopbackServer.TransferError transferError)
         {
             IPEndPoint serverEndPoint;
-            Task serverTask = LoopbackServer.StartServer(transferType, transferError, out serverEndPoint);
+            Task serverTask = LoopbackServer.StartTransferTypeAndErrorServer(transferType, transferError, out serverEndPoint);
 
             await ReadAsStreamHelper(serverEndPoint);
 


### PR DESCRIPTION
- The GetAsync_ResponseWithSetCookieHeaders_AllCookiesRead test has been failing with some regularity in CI, with strange GatewayTimeout errors.  I don't know why this particular test is so much more susceptible to that, but I've changed the test to use a local loopback server rather than an external site.

- The SendAsync_ReadFromSlowStreamingServer_PartialDataReturned test was relying on timings from the server that might not always be correct, and due to internal differences between curl and WinHttp were very frequently wrong on Unix such that the test was disabled there.  I reimplemented it with a local loopback server, too.

- I've added another mini-stress test, with posts instead of gets.

Fixes https://github.com/dotnet/corefx/issues/7234
Fixes https://github.com/dotnet/corefx/issues/4259

cc: @davidsh, @ericeil