### PR TITLE
Make System.Numerics.Vectors target netstandard1.0

### DIFF
--- a/src/System.Numerics.Vectors/pkg/System.Numerics.Vectors.pkgproj
+++ b/src/System.Numerics.Vectors/pkg/System.Numerics.Vectors.pkgproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Numerics.Vectors.csproj">
-      <SupportedFramework>net45;netcore45;netstandardapp1.5</SupportedFramework>
+      <SupportedFramework>net45;netcore45;wp8;wpa81;netstandardapp1.5</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Numerics.Vectors.builds" />
   </ItemGroup>

--- a/src/System.Numerics.Vectors/ref/System.Numerics.Vectors.csproj
+++ b/src/System.Numerics.Vectors/ref/System.Numerics.Vectors.csproj
@@ -4,19 +4,9 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.1</NuGetTargetMoniker>
-    <!-- remove when fixing https://github.com/dotnet/corefx/issues/5900 -->
-    <SkipValidatePackageTargetFramework>true</SkipValidatePackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.0</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.0</PackageTargetFramework>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(PackageTargetFramework)' == ''">
-    <PackageDestination Include="ref/netstandard1.1">
-      <TargetFramework>netstandard1.1</TargetFramework>
-    </PackageDestination>
-    <PackageDestination Include="ref/portable-net45+win8">
-      <TargetFramework>portable-net45+win8</TargetFramework>
-    </PackageDestination>
-  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="System.Numerics.Vectors.cs" />

--- a/src/System.Numerics.Vectors/ref/project.json
+++ b/src/System.Numerics.Vectors/ref/project.json
@@ -3,9 +3,9 @@
     "System.Runtime": "4.0.0"
   },
   "frameworks": {
-    "netstandard1.1": {
+    "netstandard1.0": {
       "imports": [
-        "dotnet5.2"
+        "dotnet5.1"
       ]
     }
   }

--- a/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
+++ b/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
@@ -9,15 +9,15 @@
     <DocumentationFile>$(OutputPath)System.Numerics.Vectors.xml</DocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46'">true</IsPartialFacadeAssembly>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.0</NuGetTargetMoniker>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(PackageTargetFramework)' == ''">
-    <PackageDestination Include="lib/netstandard1.3">
-      <TargetFramework>netstandard1.3</TargetFramework>
+    <PackageDestination Include="lib/netstandard1.0">
+      <TargetFramework>netstandard1.0</TargetFramework>
     </PackageDestination>
-    <PackageDestination Include="lib/portable-net45+win8">
-      <TargetFramework>portable-net45+win8</TargetFramework>
+    <PackageDestination Include="lib/portable-net45+win8+wp8+wpa81">
+      <TargetFramework>portable-net45+win8+wp8+wpa81</TargetFramework>
     </PackageDestination>
   </ItemGroup>
 

--- a/src/System.Numerics.Vectors/src/project.json
+++ b/src/System.Numerics.Vectors/src/project.json
@@ -1,6 +1,6 @@
 {
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.0": {
       "dependencies": {
         "System.Runtime": "4.0.0",
         "System.Resources.ResourceManager": "4.0.0",
@@ -10,7 +10,7 @@
         "System.Diagnostics.Contracts": "4.0.0"
       },
       "imports": [
-        "dotnet5.4"
+        "dotnet5.1"
       ]
     },
     "net46": {


### PR DESCRIPTION
Previously we targeted netstandard 1.3 because this contract was added
inbox to .NET 4.6, however we need not constrain this to 1.3 since the
implementation can be used back to NET 4.5/wp8/wpa81.

This updates BuildToolsVersion to stop forcing NS1.3 for this contract,
and retargets the library to netstandard1.0.

/cc @mellinoe @chcosta 

Fixes #5900 