### PR TITLE
Removed unsupported schemes from WebRequest.Create

### DIFF
--- a/src/System.Net.Requests/src/System/Net/WebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/WebRequest.cs
@@ -357,8 +357,6 @@ namespace System.Net
 
                             prefixList.Add(new WebRequestPrefixElement("http:", new HttpRequestCreator()));
                             prefixList.Add(new WebRequestPrefixElement("https:", new HttpRequestCreator()));
-                            prefixList.Add(new WebRequestPrefixElement("file:", new HttpRequestCreator()));
-                            prefixList.Add(new WebRequestPrefixElement("ftp:", new HttpRequestCreator()));
 
                             s_prefixList = prefixList;
                         }

--- a/src/System.Net.Requests/tests/WebRequestTest.cs
+++ b/src/System.Net.Requests/tests/WebRequestTest.cs
@@ -55,5 +55,26 @@ namespace System.Net.Tests
                 proxy.Credentials = oldCreds;
             }
         }
+
+        [Theory]
+        [InlineData("http")]
+        [InlineData("https")]
+        public void Create_ValidWebRequestUriScheme_Success(string scheme)
+        {
+            var uri = new Uri($"{scheme}://example.com/folder/resource.txt");
+            WebRequest request = WebRequest.Create(uri);
+        }
+
+        [Theory]
+        [InlineData("ws")]
+        [InlineData("wss")]
+        [InlineData("file")]
+        [InlineData("ftp")]
+        [InlineData("custom")]
+        public void Create_InvalidWebRequestUriScheme_Throws(string scheme)
+        {
+            var uri = new Uri($"{scheme}://example.com/folder/resource.txt");
+            Assert.Throws<NotSupportedException>(() => WebRequest.Create(uri));
+        }        
     }
 }


### PR DESCRIPTION
CoreFx doesn't support file: or ftp: schemes for WebRequest classes.
However, those schemes were left in the source code when it was ported
from .NET Framework.

Removed the file: and ftp: schemes. Added tests.

Fixes #7439.