### PR TITLE
Don't allocate substrings in IdnMapping

### DIFF
--- a/src/Common/src/Interop/Unix/System.Globalization.Native/Interop.Idna.cs
+++ b/src/Common/src/Interop/Unix/System.Globalization.Native/Interop.Idna.cs
@@ -13,9 +13,9 @@ internal static partial class Interop
         internal const int UseStd3AsciiRules = 0x2;
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ToAscii")]
-        internal static extern int ToAscii(uint flags, string src, int srcLen, char[] dstBuffer, int dstBufferCapacity);
+        internal static unsafe extern int ToAscii(uint flags, char* src, int srcLen, char[] dstBuffer, int dstBufferCapacity);
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ToUnicode")]
-        internal static extern int ToUnicode(uint flags, string src, int srcLen, char[] dstBuffer, int dstBufferCapacity);
+        internal static unsafe extern int ToUnicode(uint flags, char* src, int srcLen, char[] dstBuffer, int dstBufferCapacity);
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.Idna.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.Idna.cs
@@ -14,9 +14,9 @@ internal partial class Interop
         //
 
         [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern int IdnToAscii(
+        internal static unsafe extern int IdnToAscii(
                                         uint dwFlags,
-                                        string lpUnicodeCharStr,
+                                        char* lpUnicodeCharStr,
                                         int cchUnicodeChar,
                                         [System.Runtime.InteropServices.OutAttribute()]
 
@@ -24,9 +24,9 @@ internal partial class Interop
                                         int cchASCIIChar);
 
         [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern int IdnToUnicode(
+        internal static unsafe extern int IdnToUnicode(
                                         uint dwFlags,
-                                        string lpASCIICharStr,
+                                        char* lpASCIICharStr,
                                         int cchASCIIChar,
                                         [System.Runtime.InteropServices.OutAttribute()]
 

--- a/src/Common/src/System/Globalization/IdnMapping.Unix.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.Unix.cs
@@ -6,16 +6,16 @@ namespace System.Globalization
 {
     sealed partial class IdnMapping
     {
-        private string GetAsciiCore(string unicode)
+        private unsafe string GetAsciiCore(char* unicode, int count)
         {
             uint flags = Flags;
-            CheckInvalidIdnCharacters(unicode, flags, "unicode");
+            CheckInvalidIdnCharacters(unicode, count, flags, "unicode");
 
-            char[] buf = new char[unicode.Length];
+            char[] buf = new char[count];
 
             for (int attempts = 2; attempts > 0; attempts--)
             {
-                int realLen = Interop.GlobalizationNative.ToAscii(flags, unicode, unicode.Length, buf, buf.Length);
+                int realLen = Interop.GlobalizationNative.ToAscii(flags, unicode, count, buf, buf.Length);
 
                 if (realLen == 0)
                 {
@@ -33,16 +33,16 @@ namespace System.Globalization
             throw new ArgumentException(SR.Argument_IdnIllegalName, nameof(unicode));
         }
 
-        private string GetUnicodeCore(string ascii)
+        private unsafe string GetUnicodeCore(char* ascii, int count)
         {
             uint flags = Flags;
-            CheckInvalidIdnCharacters(ascii, flags, "ascii");
+            CheckInvalidIdnCharacters(ascii, count, flags, "ascii");
 
-            char[] buf = new char[ascii.Length];
+            char[] buf = new char[count];
 
             for (int attempts = 2; attempts > 0; attempts--)
             {
-                int realLen = Interop.GlobalizationNative.ToUnicode(flags, ascii, ascii.Length, buf, buf.Length);
+                int realLen = Interop.GlobalizationNative.ToUnicode(flags, ascii, count, buf, buf.Length);
 
                 if (realLen == 0)
                 {
@@ -82,11 +82,11 @@ namespace System.Globalization
         /// To match Windows behavior, we walk the string ourselves looking for these
         /// bad characters so we can continue to throw ArgumentException in these cases. 
         /// </summary>
-        private static void CheckInvalidIdnCharacters(string s, uint flags, string paramName)
+        private static unsafe void CheckInvalidIdnCharacters(char* s, int count, uint flags, string paramName)
         {
             if ((flags & Interop.GlobalizationNative.UseStd3AsciiRules) == 0)
             {
-                for (int i = 0; i < s.Length; i++)
+                for (int i = 0; i < count; i++)
                 {
                     char c = s[i];
 

--- a/src/Common/src/System/Globalization/IdnMapping.Windows.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.Windows.cs
@@ -8,12 +8,12 @@ namespace System.Globalization
 {
     sealed partial class IdnMapping
     {
-        private string GetAsciiCore(string unicode)
+        private unsafe string GetAsciiCore(char* unicode, int count)
         {
             uint flags = Flags;
             
             // Determine the required length
-            int length = Interop.mincore.IdnToAscii(flags, unicode, unicode.Length, null, 0);
+            int length = Interop.mincore.IdnToAscii(flags, unicode, count, null, 0);
             if (length == 0)
             {
                 ThrowForZeroLength("unicode", SR.Argument_IdnIllegalName, SR.Argument_InvalidCharSequenceNoIndex);
@@ -21,7 +21,7 @@ namespace System.Globalization
 
             // Do the conversion
             char[] output = new char[length];
-            length = Interop.mincore.IdnToAscii(flags, unicode, unicode.Length, output, length);
+            length = Interop.mincore.IdnToAscii(flags, unicode, count, output, length);
             if (length == 0)
             {
                 ThrowForZeroLength("unicode", SR.Argument_IdnIllegalName, SR.Argument_InvalidCharSequenceNoIndex);
@@ -30,12 +30,12 @@ namespace System.Globalization
             return new string(output, 0, length);
         }
 
-        private string GetUnicodeCore(string ascii)
+        private unsafe string GetUnicodeCore(char* ascii, int count)
         {
             uint flags = Flags;
 
             // Determine the required length
-            int length = Interop.mincore.IdnToUnicode(flags, ascii, ascii.Length, null, 0);
+            int length = Interop.mincore.IdnToUnicode(flags, ascii, count, null, 0);
             if (length == 0)
             {
                 ThrowForZeroLength("ascii", SR.Argument_IdnIllegalName, SR.Argument_IdnBadPunycode);
@@ -44,7 +44,7 @@ namespace System.Globalization
             char[] output = new char[length];
 
             // Do the conversion
-            length = Interop.mincore.IdnToUnicode(flags, ascii, ascii.Length, output, length);
+            length = Interop.mincore.IdnToUnicode(flags, ascii, count, output, length);
             if (length == 0)
             {
                 ThrowForZeroLength("ascii", SR.Argument_IdnIllegalName, SR.Argument_IdnBadPunycode);

--- a/src/Common/src/System/Globalization/IdnMapping.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.cs
@@ -80,20 +80,23 @@ namespace System.Globalization
             if (index > unicode.Length - count)
                 throw new ArgumentOutOfRangeException(nameof(unicode), SR.ArgumentOutOfRange_IndexCountBuffer);
             Contract.EndContractBlock();
-
-            // We're only using part of the string
-            unicode = unicode.Substring(index, count);
-
-            if (unicode.Length == 0)
+            
+            if (count == 0)
             {
                 throw new ArgumentException(SR.Argument_IdnBadLabelSize, nameof(unicode));
             }
-            if (unicode[unicode.Length - 1] == 0)
+            if (unicode[index + count - 1] == 0)
             {
-                throw new ArgumentException(SR.Format(SR.Argument_InvalidCharSequence, unicode.Length - 1), nameof(unicode));
+                throw new ArgumentException(SR.Format(SR.Argument_InvalidCharSequence, index + count - 1), nameof(unicode));
             }
 
-            return GetAsciiCore(unicode);
+            unsafe
+            {
+                fixed (char* pUnicode = unicode)
+                {
+                    return GetAsciiCore(pUnicode + index, count);
+                }
+            }
         }
 
         // Gets Unicode version of the string.  Normalized and limited to IDNA characters.
@@ -127,11 +130,14 @@ namespace System.Globalization
             if (count > 0 && ascii[index + count - 1] == (char)0)
                 throw new ArgumentException(SR.Argument_IdnBadPunycode, nameof(ascii));
             Contract.EndContractBlock();
-
-            // We're only using part of the string
-            ascii = ascii.Substring(index, count);
-
-            return GetUnicodeCore(ascii);
+            
+            unsafe
+            {
+                fixed (char* pAscii = ascii)
+                {
+                    return GetUnicodeCore(pAscii + index, count);
+                }
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/System.Globalization.Extensions/src/System.Globalization.Extensions.csproj
+++ b/src/System.Globalization.Extensions/src/System.Globalization.Extensions.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>System.Globalization.Extensions</RootNamespace>
     <AssemblyName>System.Globalization.Extensions</AssemblyName>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{2B96AA10-84C0-4927-8611-8D2474B990E8}</ProjectGuid>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>

--- a/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingGetUnicodeTests.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingGetUnicodeTests.cs
@@ -9,6 +9,27 @@ namespace System.Globalization.Tests
 {
     public class IdnMappingGetUnicodeTests
     {
+        public static IEnumerable<object[]> GetAscii_TestData()
+        {
+            yield return new object[] { "xn--yda", 0, 7, "\u0101", };
+            yield return new object[] { "axn--ydab", 1, 7, "\u0101" };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAscii_TestData))]
+        public void GetUnicode(string ascii, int index, int count, string expected)
+        {
+            if (index + count == ascii.Length)
+            {
+                if (index == 0)
+                {
+                    Assert.Equal(expected, new IdnMapping().GetUnicode(ascii));
+                }
+                Assert.Equal(expected, new IdnMapping().GetUnicode(ascii, index));
+            }
+            Assert.Equal(expected, new IdnMapping().GetUnicode(ascii, index, count));
+        }
+
         public static IEnumerable<object[]> GetUnicode_Invalid_TestData()
         {
             // Ascii is null

--- a/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingGetUnicodeTests.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingGetUnicodeTests.cs
@@ -9,14 +9,42 @@ namespace System.Globalization.Tests
 {
     public class IdnMappingGetUnicodeTests
     {
-        public static IEnumerable<object[]> GetAscii_TestData()
+        public static IEnumerable<object[]> GetUnicode_TestData()
         {
-            yield return new object[] { "xn--yda", 0, 7, "\u0101", };
+            yield return new object[] { "xn--yda", 0, 7, "\u0101" };
             yield return new object[] { "axn--ydab", 1, 7, "\u0101" };
+            
+            yield return new object[] { "xn--aa-cla", 0, 10, "\u0101\u0061a" };
+            yield return new object[] { "xn--ab-dla", 0, 10, "\u0061\u0101\u0062" };
+            yield return new object[] { "xn--ab-ela", 0, 10, "\u0061\u0062\u0101"  };
+
+            yield return new object[] { "xn--097ccd", 0, 10, "\uD800\uDF00\uD800\uDF01\uD800\uDF02" }; // Surrogate pairs
+            yield return new object[] { "xn--ab-ic6nfag", 0, 14, "\uD800\uDF00\u0061\uD800\uDF01b\uD800\uDF02" }; // Surrogate pairs separated by ASCII
+            yield return new object[] { "xn--yda263v6b6kfag", 0, 18, "\uD800\uDF00\u0101\uD800\uDF01\u305D\uD800\uDF02" }; // Surrogate pairs separated by non-ASCII
+            yield return new object[] { "xn--a-nha4529qfag", 0, 17, "\uD800\uDF00\u0101\uD800\uDF01\u0061\uD800\uDF02" }; // Surrogate pairs separated by ASCII and non-ASCII
+            yield return new object[] { "\u0061\u0062\u0063", 0, 3, "\u0061\u0062\u0063" }; // ASCII only code points
+            yield return new object[] { "xn--d9juau41awczczp", 0, 19, "\u305D\u306E\u30B9\u30D4\u30FC\u30C9\u3067" }; // Non-ASCII only code points
+            yield return new object[] { "xn--de-jg4avhby1noc0d", 0, 21, "\u30D1\u30D5\u30A3\u30FC\u0064\u0065\u30EB\u30F3\u30D0" }; // ASCII and non-ASCII code points
+            yield return new object[] { "abc.xn--d9juau41awczczp.xn--de-jg4avhby1noc0d", 0, 45, "\u0061\u0062\u0063.\u305D\u306E\u30B9\u30D4\u30FC\u30C9\u3067.\u30D1\u30D5\u30A3\u30FC\u0064\u0065\u30EB\u30F3\u30D0" }; // Fully qualified domain name
+
+            // Embedded domain name conversion (NLS + only)(Priority 1)
+            // Per the spec [7], "The index and count parameters (when provided) allow the 
+            // conversion to be done on a larger string where the domain name is embedded 
+            // (such as a URI or IRI). The output string is only the converted FQDN or 
+            // label, not the whole input string (if the input string contains more 
+            // character than the substring to convert)."
+            // Fully Qualified Domain Name (Label1.Label2.Label3)
+            yield return new object[] { "abc.xn--d9juau41awczczp.xn--de-jg4avhby1noc0d", 0, 45, "\u0061\u0062\u0063.\u305D\u306E\u30B9\u30D4\u30FC\u30C9\u3067.\u30D1\u30D5\u30A3\u30FC\u0064\u0065\u30EB\u30F3\u30D0" };
+            yield return new object[] { "abc.xn--d9juau41awczczp", 0, 23, "\u0061\u0062\u0063.\u305D\u306E\u30B9\u30D4\u30FC\u30C9\u3067" };
+            yield return new object[] { "abc.xn--d9juau41awczczp.", 0, 24, "\u0061\u0062\u0063.\u305D\u306E\u30B9\u30D4\u30FC\u30C9\u3067." };
+            yield return new object[] { "xn--d9juau41awczczp.xn--de-jg4avhby1noc0d", 0, 41, "\u305D\u306E\u30B9\u30D4\u30FC\u30C9\u3067.\u30D1\u30D5\u30A3\u30FC\u0064\u0065\u30EB\u30F3\u30D0" };
+            yield return new object[] { "xn--d9juau41awczczp", 0, 19, "\u305D\u306E\u30B9\u30D4\u30FC\u30C9\u3067" };
+            yield return new object[] { "xn--d9juau41awczczp.", 0, 20, "\u305D\u306E\u30B9\u30D4\u30FC\u30C9\u3067." };
+            yield return new object[] { "xn--de-jg4avhby1noc0d", 0, 21, "\u30D1\u30D5\u30A3\u30FC\u0064\u0065\u30EB\u30F3\u30D0" };
         }
 
         [Theory]
-        [MemberData(nameof(GetAscii_TestData))]
+        [MemberData(nameof(GetUnicode_TestData))]
         public void GetUnicode(string ascii, int index, int count, string expected)
         {
             if (index + count == ascii.Length)


### PR DESCRIPTION
- The Interop functions can take a `char*` param instead of `string`

Fixes #7457 

/cc @steveharter @tarekgh @jamesqo @svick