### PR TITLE
System.Net.Requests: Specify the capacity when creating the PrefixList

### DIFF
--- a/src/System.Net.Requests/src/System/Net/WebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/WebRequest.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.Net
@@ -353,10 +352,15 @@ namespace System.Net
                     {
                         if (s_prefixList == null)
                         {
-                            List<WebRequestPrefixElement> prefixList = new List<WebRequestPrefixElement>();
+                            var httpRequestCreator = new HttpRequestCreator();
 
-                            prefixList.Add(new WebRequestPrefixElement("http:", new HttpRequestCreator()));
-                            prefixList.Add(new WebRequestPrefixElement("https:", new HttpRequestCreator()));
+                            const int Count = 2;
+                            var prefixList = new List<WebRequestPrefixElement>(Count)
+                            {
+                                new WebRequestPrefixElement("http:", httpRequestCreator),
+                                new WebRequestPrefixElement("https:", httpRequestCreator)
+                            };
+                            Debug.Assert(prefixList.Count == Count);
 
                             s_prefixList = prefixList;
                         }

--- a/src/System.Net.Requests/src/System/Net/WebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/WebRequest.cs
@@ -14,18 +14,18 @@ namespace System.Net
     {
         internal class WebRequestPrefixElement
         {
-            public string Prefix;
-            public IWebRequestCreate Creator;
+            public readonly string Prefix;
+            public readonly IWebRequestCreate Creator;
 
-            public WebRequestPrefixElement(string P, IWebRequestCreate C)
+            public WebRequestPrefixElement(string prefix, IWebRequestCreate creator)
             {
-                Prefix = P;
-                Creator = C;
+                Prefix = prefix;
+                Creator = creator;
             }
         }
 
         private static volatile List<WebRequestPrefixElement> s_prefixList;
-        private static object s_internalSyncObject = new object();
+        private static readonly object s_internalSyncObject = new object();
 
         // Create a WebRequest.
         //

--- a/src/System.Net.Requests/src/System/Net/WebResponse.cs
+++ b/src/System.Net.Requests/src/System/Net/WebResponse.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.Contracts;
 using System.IO;
 
 namespace System.Net
@@ -83,7 +82,6 @@ namespace System.Net
             // read-only
             get
             {
-                Contract.Ensures(Contract.Result<WebHeaderCollection>() != null);
                 throw NotImplemented.ByDesignWithMessage(SR.net_PropertyNotImplementedException);
             }
         }

--- a/src/System.Net.Requests/src/project.json
+++ b/src/System.Net.Requests/src/project.json
@@ -4,6 +4,7 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-24026-00",
         "System.Collections": "4.0.10",
+        "System.Diagnostics.Debug": "4.0.0",
         "System.Diagnostics.Tracing": "4.0.0",
         "System.IO": "4.0.10",
         "System.IO.Compression": "4.1.0-rc3-24026-00",

--- a/src/System.Net.Requests/src/project.json
+++ b/src/System.Net.Requests/src/project.json
@@ -4,7 +4,6 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-24026-00",
         "System.Collections": "4.0.10",
-        "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Tracing": "4.0.0",
         "System.IO": "4.0.10",
         "System.IO.Compression": "4.1.0-rc3-24026-00",


### PR DESCRIPTION
Minor improvement: Specify the capacity when creating `WebRequest`'s `PrefixList` and reuse the same `HttpRequestCreator` instance for both http and https.

As part of that, I added an explicit dependency on `System.Diagnostics.Debug`, so I could add a `Debug.Assert` (it was already being pulled in by other dependencies).

While I was at it, I removed the dependency on `System.Diagnostics.Contracts` because it was only being used in one place and code contracts are not being maintained in .NET Core.

I also made a few fields readonly, along with fixing the naming/capitalization of a couple parameters in the same class.

cc: @davidsh, @stephentoub