### PR TITLE
Disable hanging OSX NetworkInformation test

### DIFF
--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkChangeTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkChangeTest.cs
@@ -9,6 +9,7 @@ namespace System.Net.NetworkInformation.Tests
     public class NetworkChangeTest
     {
         [Fact]
+        [ActiveIssue(8066, PlatformID.OSX)]
         public void NetworkAddressChanged_AddRemove_Success()
         {
             NetworkAddressChangedEventHandler handler = NetworkChange_NetworkAddressChanged;


### PR DESCRIPTION
Based on my very basic investigation, it looks like the thread running CFRunLoopRun is not being terminated properly, which should happen after the only listener unsubscribes on the third line of the test case. I'll have to do more in-depth investigation with a local machine.