### PR TITLE
Fix tarring on OSX

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -606,7 +606,13 @@ def supportedFullCyclePlatforms = ['Windows_NT', 'Ubuntu14.04', 'OSX']
                         def useServerGC = (configurationGroup == 'Release' && isPR) ? 'useServerGC' : ''
                         shell("HOME=\$WORKSPACE/tempHome ./build.sh ${useServerGC} ${configurationGroup.toLowerCase()} /p:ConfigurationGroup=${configurationGroup} /p:TestWithLocalLibraries=true /p:WithoutCategories=IgnoreForCI")
                         // Tar up the appropriate bits
-                        shell("tar -czf bin/build.tar.gz bin/*.${configurationGroup} bin/ref bin/packages --exclude=*.Tests")
+                        // It's unclear why, but on OSX the --exclude=*.Tests automatically gets quoted as '--exclude=*.Tests',
+                        // which doesn't stat because tar thinks its a directory.  For now, workaround this.
+                        def excludeArg = '--exclude=*.Tests'
+                        if (os == 'OSX') {
+                            excludeArg = ''
+                        }
+                        shell("tar -czf bin/build.tar.gz bin/*.${configurationGroup} bin/ref bin/packages ${excludeArg}")
                     }
                 }
             }


### PR DESCRIPTION
For some reason, there is automatic quoting of --exclude=*.Tests on OSX.  I am not sure whether this is coming from their shell implementation or Jenkins, but tar treats this as a directory sent to tar, which doesn't work.  Avoid doing this on OSX for now (though this increases the amount of data tar'd by about 3x).