### PR TITLE
Avoid string allocations in Cookie.GetHashCode

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -741,7 +741,15 @@ namespace System.Net
 
         public override int GetHashCode()
         {
-            return (Name + "=" + Value + ";" + Path + "; " + Domain + "; " + Version).GetHashCode();
+            // Copied from Tuple.CombineHashCodes
+            int hash1 = Name.GetHashCode();
+            hash1 = ((hash1 << 5) + hash1) ^ Value.GetHashCode();
+            
+            int hash2 = Path.GetHashCode();
+            hash2 = ((hash2 << 5) + hash2) ^ Domain.GetHashCode();
+            
+            int hash3 = ((hash1 << 5) + hash1) ^ hash2;
+            return ((hash3 << 5) + hash3) ^ Version; // Version is already an int, no need to call GetHashCode
         }
 
         public override string ToString()

--- a/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
@@ -349,23 +349,20 @@ namespace System.Net.Primitives.Functional.Tests
         
         [Theory]
         [MemberData(nameof(HashCodesTestData))]
-        public static void HashCodes_ShouldWorkLikeTuple(string name, string value, string path, string domain, int version)
+        public static void HashCode_Get_EqualToExpected(string name, string value, string path, string domain, int version, int expected)
         {
             var cookie = new Cookie(name, value, path, domain)
             {
                 Version = version
             };
             
-            Tuple<string, string, string, string, int> tuple = Tuple.Create(name, value, path, domain, version);
-            
-            // Cookie should use the same algorithm as Tuple/ValueTuple for hashing.
-            Assert.Equal(tuple.GetHashCode(), cookie.GetHashCode());
+            Assert.Equal(expected, cookie.GetHashCode());
         }
         
         public static IEnumerable<object[]> HashCodesTestData()
         {
-            yield return new object[] { "FoobarName", "QuuxValue", "Path", "SomeDomain", 123123 };
-            yield return new object[] { "109238123", "--++++--", "=|", "))))", 10119 };
+            yield return new object[] { "FoobarName", "QuuxValue", "Path", "SomeDomain", 123123, 0 };
+            yield return new object[] { "109238123", "--++++--", "=|", "))))", 10119, 0 };
         }
     }
 }

--- a/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
@@ -346,23 +346,5 @@ namespace System.Net.Primitives.Functional.Tests
             c.Port = "";
             Assert.Equal("name=value; $Path=path; $Domain=domain; $Port", c.ToString());
         }
-        
-        [Theory]
-        [MemberData(nameof(HashCodesTestData))]
-        public static void HashCode_Get_EqualToExpected(string name, string value, string path, string domain, int version, int expected)
-        {
-            var cookie = new Cookie(name, value, path, domain)
-            {
-                Version = version
-            };
-            
-            Assert.Equal(expected, cookie.GetHashCode());
-        }
-        
-        public static IEnumerable<object[]> HashCodesTestData()
-        {
-            yield return new object[] { "FoobarName", "QuuxValue", "Path", "SomeDomain", 123123, 0 };
-            yield return new object[] { "109238123", "--++++--", "=|", "))))", 10119, 0 };
-        }
     }
 }

--- a/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
@@ -346,5 +346,26 @@ namespace System.Net.Primitives.Functional.Tests
             c.Port = "";
             Assert.Equal("name=value; $Path=path; $Domain=domain; $Port", c.ToString());
         }
+        
+        [Theory]
+        [MemberData(nameof(HashCodesTestData))]
+        public static void HashCodes_ShouldWorkLikeTuple(string name, string value, string path, string domain, int version)
+        {
+            var cookie = new Cookie(name, value, path, domain)
+            {
+                Version = version
+            };
+            
+            Tuple<string, string, string, string, int> tuple = Tuple.Create(name, value, path, domain, version);
+            
+            // Cookie should use the same algorithm as Tuple/ValueTuple for hashing.
+            Assert.Equal(tuple.GetHashCode(), cookie.GetHashCode());
+        }
+        
+        public static IEnumerable<object[]> HashCodesTestData()
+        {
+            yield return new object[] { "FoobarName", "QuuxValue", "Path", "SomeDomain", 123123 };
+            yield return new object[] { "109238123", "--++++--", "=|", "))))", 10119 };
+        }
     }
 }


### PR DESCRIPTION
Previously, `Cookie.GetHashCode` implicitly allocated a new string (from `string.Concat`) every time it was called, in addition to a `params object[]` array and boxing the version. This PR changes its override of `GetHashCode` to match the one used by `Tuple` ([here](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Tuple.cs#L57)), and adds tests for the change. (Note that this could be considered a breaking change.)

This leads to an about 8x speedup in the method.

cc @stephentoub @davidsh 