### PR TITLE
Avoid unnecessary use of StringBuilder in FrameworkName

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Runtime/Versioning/FrameworkName.cs
+++ b/src/System.Runtime.Extensions/src/System/Runtime/Versioning/FrameworkName.cs
@@ -62,19 +62,22 @@ namespace System.Runtime.Versioning
             {
                 if (_fullName == null)
                 {
-                    StringBuilder sb = new StringBuilder();
-                    sb.Append(Identifier);
-                    sb.Append(c_componentSeparator);
-                    sb.Append(c_versionKey).Append(c_keyValueSeparator);
-                    sb.Append(c_versionValuePrefix);
-                    sb.Append(Version);
-                    if (!String.IsNullOrEmpty(Profile))
+                    if (string.IsNullOrEmpty(Profile))
                     {
-                        sb.Append(c_componentSeparator);
-                        sb.Append(c_profileKey).Append(c_keyValueSeparator);
-                        sb.Append(Profile);
+                        _fullName =
+                            Identifier +
+                            c_componentSeparator + c_versionKey + c_keyValueSeparator + c_versionValuePrefix +
+                            Version.ToString();
                     }
-                    _fullName = sb.ToString();
+                    else
+                    {
+                        _fullName =
+                            Identifier +
+                            c_componentSeparator + c_versionKey + c_keyValueSeparator + c_versionValuePrefix +
+                            Version.ToString() +
+                            c_componentSeparator + c_profileKey + c_keyValueSeparator +
+                            Profile;
+                    }
                 }
                 Debug.Assert(_fullName != null);
                 return _fullName;


### PR DESCRIPTION
Right now `FrameworkName.FullName` uses a `StringBuilder` to build the string result before returning it. This involves 3-4 allocations:

- the `StringBuilder` itself
- the `char[]` array for its backing store
- the string allocated by `StringBuilder.ToString`
- a buffer resize (since the name will likely be longer than 16, which is the default size if no capacity is passed in to the `StringBuilder`)

This PR eliminates the first, second, and fourth allocations for the case where `Profile` is null or empty, by simply using string concatenation. If it isn't, an additional string array needs to be allocated since `string.Concat` only supports allocation-free overloads of up to 4 parameters, then falls back to allocating a `params string[]` array.

cc @stephentoub 