### PR TITLE
Clean up ResponseStreamTest

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -26,48 +26,62 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task GetStreamAsync_ReadToEnd_Success()
         {
-            HttpClient client = GetHttpClient();
-            
+            var customHeaderValue = Guid.NewGuid().ToString("N");
+            var client = new HttpClient();
+            client.DefaultRequestHeaders.Add("X-ResponseStreamTest", customHeaderValue);
+
             Stream stream = await client.GetStreamAsync(HttpTestServers.RemoteEchoServer);
             using (var reader = new StreamReader(stream))
             {
                 string responseBody = reader.ReadToEnd();
                 _output.WriteLine(responseBody);
-                Assert.True(IsValidResponseBody(responseBody));
+
+                // Calling GetStreamAsync() means we don't have access to the HttpResponseMessage.
+                // So, we can't use the MD5 hash validation to verify receipt of the response body.
+                // For this test, we can use a simpler verification of a custom header echo'ing back.
+                Assert.True(responseBody.Contains(customHeaderValue));
             }
         }
 
         [Fact]
         public async Task GetAsync_UseResponseHeadersReadAndCallLoadIntoBuffer_Success()
         {
-            HttpClient client = GetHttpClient();
-            
+            var client = new HttpClient();
+
             HttpResponseMessage response =
                 await client.GetAsync(HttpTestServers.RemoteEchoServer, HttpCompletionOption.ResponseHeadersRead);
             await response.Content.LoadIntoBufferAsync();
 
             string responseBody = await response.Content.ReadAsStringAsync();
             _output.WriteLine(responseBody);
-            Assert.True(IsValidResponseBody(responseBody));
+            TestHelper.VerifyResponseBody(
+                responseBody,
+                response.Content.Headers.ContentMD5,
+                false,
+                null);
         }
 
         [Fact]
         public async Task GetAsync_UseResponseHeadersReadAndCopyToMemoryStream_Success()
         {
-            HttpClient client = GetHttpClient();
-            
+            var client = new HttpClient();
+
             HttpResponseMessage response =
                 await client.GetAsync(HttpTestServers.RemoteEchoServer, HttpCompletionOption.ResponseHeadersRead);
 
             var memoryStream = new MemoryStream();
             await response.Content.CopyToAsync(memoryStream);
             memoryStream.Position = 0;
-            
+
             using (var reader = new StreamReader(memoryStream))
             {
                 string responseBody = reader.ReadToEnd();
                 _output.WriteLine(responseBody);
-                Assert.True(IsValidResponseBody(responseBody));
+                TestHelper.VerifyResponseBody(
+                    responseBody,
+                    response.Content.Headers.ContentMD5,
+                    false,
+                    null);
             }
         }
 
@@ -136,38 +150,6 @@ namespace System.Net.Http.Functional.Tests
                     while (await stream.ReadAsync(buffer, 0, 1) > 0) ;
                 }
             }
-        }
-
-        // These methods help to validate the response body since the endpoint will echo
-        // all request headers.
-        //
-        // TODO (#7885): This validation will be improved in the future once the test server endpoint
-        // is able to provide a custom response header with a SHA1 hash of the expected response body.
-        private readonly string[] CustomHeaderValues = new string[] {"abcdefg", "12345678", "A1B2C3D4"};
-        private HttpClient GetHttpClient()
-        {
-            var client = new HttpClient();
-            int ndx = 1;
-            foreach (string headerValue in CustomHeaderValues)
-            {
-                client.DefaultRequestHeaders.Add("X-Custom" + ndx.ToString(), headerValue);
-                ndx++;
-            }
-
-            return client;
-        }
-
-        private bool IsValidResponseBody(string responseBody)
-        {
-            foreach (string headerValue in CustomHeaderValues)
-            {
-                if (!responseBody.Contains(headerValue))
-                {
-                    return false;
-                }
-            }            
-
-            return true;
         }
     }
 }


### PR DESCRIPTION
Used the MD5 hash verification when verifying correct response body
dowload.

Fixes #7885.