### PR TITLE
Use 14.04 test runtime package for Ubuntu16.04.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -24,7 +24,7 @@ def osGroupMap = ['Ubuntu14.04':'Linux',
 // Map of os -> nuget runtime
 def targetNugetRuntimeMap = ['OSX' : 'osx.10.10-x64',
                              'Ubuntu14.04' : 'ubuntu.14.04-x64',
-                             'Ubuntu16.04' : 'ubuntu.16.04-x64',
+                             'Ubuntu16.04' : 'ubuntu.14.04-x64',
                              'Debian8.2' : 'ubuntu.14.04-x64',
                              'CentOS7.1' : 'centos.7-x64',
                              'OpenSUSE13.2' : 'ubuntu.14.04-x64',


### PR DESCRIPTION
will fix failing Ubuntu16.04 runs. The runs fail because xunit.console.netcore.exe is not present, as we are trying to restore ubuntu16.04-x64 test-runtime which doesn't exist yet.

cc @joshfree @ellismg 