### PR TITLE
Prohibit null, open generic or address types on Default.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DefaultExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DefaultExpression.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Dynamic.Utils;
 
 namespace System.Linq.Expressions
 {
@@ -72,6 +73,18 @@ namespace System.Linq.Expressions
         /// </returns>
         public static DefaultExpression Default(Type type)
         {
+            ContractUtils.RequiresNotNull(type, nameof(type));
+            TypeUtils.ValidateType(type);
+            if (type.IsByRef)
+            {
+                throw Error.TypeMustNotBeByRef();
+            }
+
+            if (type.IsPointer)
+            {
+                throw Error.TypeMustNotBePointer();
+            }
+
             return new DefaultExpression(type);
         }
     }

--- a/src/System.Linq.Expressions/tests/Default/DefaultTests.cs
+++ b/src/System.Linq.Expressions/tests/Default/DefaultTests.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class DefaultTests
+    {
+        private enum MyEnum
+        {
+            Value
+        }
+
+        private class EnumOutLambdaClass
+        {
+            public static void BarRef(out MyEnum o)
+            {
+                o = MyEnum.Value;
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public void DefaultEnumRef(bool useInterpreter)
+        {
+            var x = Expression.Variable(typeof(MyEnum), "x");
+
+            var expression = Expression.Lambda<Action>(
+                            Expression.Block(
+                            new[] { x },
+                            Expression.Assign(x, Expression.Default(typeof(MyEnum))),
+                            Expression.Call(null, typeof(EnumOutLambdaClass).GetMethod(nameof(EnumOutLambdaClass.BarRef)), x)));
+
+            expression.Compile(useInterpreter)();
+        }
+
+        [Fact]
+        public void DefaultNotSingleton()
+        {
+            Assert.NotSame(Expression.Empty(), Expression.Empty());
+            Assert.NotSame(Expression.Default(typeof(void)), Expression.Default(typeof(void)));
+            Assert.NotSame(Expression.Default(typeof(object)), Expression.Default(typeof(object)));
+        }
+
+        [Fact]
+        public void NullType()
+        {
+            Assert.Throws<ArgumentNullException>("type", () => Expression.Default(null));
+        }
+
+        [Fact]
+        public void ByRefType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Default(typeof(int).MakeByRefType()));
+        }
+
+        [Fact]
+        public void PointerType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Default(typeof(int).MakePointerType()));
+        }
+
+        [Fact]
+        public void GenericType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Default(typeof(List<>)));
+        }
+
+        [Fact]
+        public void TypeContainsGenericParameters()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Default(typeof(List<>.Enumerator)));
+            Assert.Throws<ArgumentException>(() => Expression.Default(typeof(List<>).MakeGenericType(typeof(List<>))));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -2443,21 +2443,6 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [ClassData(typeof(CompilationTypes))]
-        public static void DefaultEnumRef(bool useInterpreter)
-        {
-            var x = Expression.Variable(typeof(MyEnum), "x");
-
-            var expression = Expression.Lambda<Action>(
-                            Expression.Block(
-                            new[] { x },
-                            Expression.Assign(x, Expression.Default(typeof(MyEnum))),
-                            Expression.Call(null, typeof(EnumOutLambdaClass).GetMethod("BarRef"), x)));
-
-            expression.Compile(useInterpreter)();
-        }
-
-        [Theory]
-        [ClassData(typeof(CompilationTypes))]
         public static void BinaryOperators(bool useInterpreter)
         {
             // AndAlso

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Constant\ConstantTests.cs" />
     <Compile Include="Convert\ConvertCheckedTests.cs" />
     <Compile Include="Convert\ConvertTests.cs" />
+    <Compile Include="Default\DefaultTests.cs" />
     <Compile Include="ExceptionHandling\ExceptionHandlingExpressions.cs" />
     <Compile Include="ExpressionTests.cs" />
     <Compile Include="Goto\Break.cs" />


### PR DESCRIPTION
Move existing default tests from SequenceTests.cs to new file and add more.

Throw on null type in call to Default(). Fixes #8190.

Throw on open generic, byref or pointer type to Default(). Contributes to #8081.