### PR TITLE
Prohibit open generic or address types on NewArrayBounds().

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
@@ -215,9 +215,20 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(type, nameof(type));
             ContractUtils.RequiresNotNull(bounds, nameof(bounds));
 
-            if (type.Equals(typeof(void)))
+            if (type == typeof(void))
             {
                 throw Error.ArgumentCannotBeOfTypeVoid();
+            }
+
+            TypeUtils.ValidateType(type);
+            if (type.IsByRef)
+            {
+                throw Error.TypeMustNotBeByRef();
+            }
+
+            if (type.IsPointer)
+            {
+                throw Error.TypeMustNotBePointer();
             }
 
             ReadOnlyCollection<Expression> boundsList = bounds.ToReadOnly();

--- a/src/System.Linq.Expressions/tests/Array/ArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayBoundsTests.cs
@@ -3361,5 +3361,69 @@ namespace System.Linq.Expressions.Tests
         #endregion
 
         #endregion
+
+        [Fact]
+        public static void NullType()
+        {
+            Assert.Throws<ArgumentNullException>("type", () => Expression.NewArrayBounds(null, Expression.Constant(2)));
+        }
+
+        [Fact]
+        public static void VoidType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.NewArrayBounds(typeof(void), Expression.Constant(2)));
+        }
+
+        [Fact]
+        public static void NullBounds()
+        {
+            Assert.Throws<ArgumentNullException>("bounds", () => Expression.NewArrayBounds(typeof(int), default(Expression[])));
+            Assert.Throws<ArgumentNullException>("bounds", () => Expression.NewArrayBounds(typeof(int), default(IEnumerable<Expression>)));
+        }
+
+        [Fact]
+        public static void NoBounds()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.NewArrayBounds(typeof(int)));
+        }
+
+        [Fact]
+        public static void NullBound()
+        {
+            Assert.Throws<ArgumentNullException>("bounds", () => Expression.NewArrayBounds(typeof(int), null, null));
+        }
+
+        [Fact]
+        public static void NonIntegralBounds()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.NewArrayBounds(typeof(int), Expression.Constant(2.0)));
+        }
+
+
+
+        [Fact]
+        public static void ByRefType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.NewArrayBounds(typeof(int).MakeByRefType(), Expression.Constant(2)));
+        }
+
+        [Fact]
+        public static void PointerType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.NewArrayBounds(typeof(int).MakePointerType(), Expression.Constant(2)));
+        }
+
+        [Fact]
+        public static void GenericType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.NewArrayBounds(typeof(List<>), Expression.Constant(2)));
+        }
+
+        [Fact]
+        public static void TypeContainsGenericParameters()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.NewArrayBounds(typeof(List<>.Enumerator), Expression.Constant(2)));
+            Assert.Throws<ArgumentException>(() => Expression.NewArrayBounds(typeof(List<>).MakeGenericType(typeof(List<>)), Expression.Constant(2)));
+        }
     }
 }


### PR DESCRIPTION
Throw on open generic, byref or pointer type to NewArrayBounds().

Contributes to #8081.

Also add further tests beyond this.

Note that on byref this already threw TypeLoadException, but AgumentException
would be more consistent.