### PR TITLE
Improve performance of IdnMapping

### DIFF
--- a/src/Common/src/Interop/Unix/System.Globalization.Native/Interop.Idna.cs
+++ b/src/Common/src/Interop/Unix/System.Globalization.Native/Interop.Idna.cs
@@ -13,9 +13,9 @@ internal static partial class Interop
         internal const int UseStd3AsciiRules = 0x2;
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ToAscii")]
-        internal static unsafe extern int ToAscii(uint flags, char* src, int srcLen, char[] dstBuffer, int dstBufferCapacity);
+        internal static unsafe extern int ToAscii(uint flags, char* src, int srcLen, char* dstBuffer, int dstBufferCapacity);
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ToUnicode")]
-        internal static unsafe extern int ToUnicode(uint flags, char* src, int srcLen, char[] dstBuffer, int dstBufferCapacity);
+        internal static unsafe extern int ToUnicode(uint flags, char* src, int srcLen, char* dstBuffer, int dstBufferCapacity);
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.Idna.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.Idna.cs
@@ -20,7 +20,7 @@ internal partial class Interop
                                         int cchUnicodeChar,
                                         [System.Runtime.InteropServices.OutAttribute()]
 
-                                        char[] lpASCIICharStr,
+                                        char* lpASCIICharStr,
                                         int cchASCIIChar);
 
         [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode, SetLastError = true)]
@@ -30,7 +30,7 @@ internal partial class Interop
                                         int cchASCIIChar,
                                         [System.Runtime.InteropServices.OutAttribute()]
 
-                                        char[] lpUnicodeCharStr,
+                                        char* lpUnicodeCharStr,
                                         int cchUnicodeChar);
 
         internal const int IDN_ALLOW_UNASSIGNED = 0x1;

--- a/src/Common/src/System/Globalization/IdnMapping.Unix.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.Unix.cs
@@ -9,7 +9,7 @@ namespace System.Globalization
         private unsafe string GetAsciiCore(char* unicode, int count)
         {
             uint flags = Flags;
-            CheckInvalidIdnCharacters(unicode, count, flags, "unicode");
+            CheckInvalidIdnCharacters(unicode, count, flags, nameof(unicode));
 
             const int StackAllocThreshold = 512;
             if (count < StackAllocThreshold)
@@ -31,19 +31,20 @@ namespace System.Globalization
         {
             int realLen = Interop.GlobalizationNative.ToAscii(flags, unicode, count, output, outputLength);
 
-            if (realLen != 0)
+            if (realLen == 0)
             {
-                if (realLen <= outputLength)
+                throw new ArgumentException(SR.Argument_IdnIllegalName, nameof(unicode));
+            }
+            else if (realLen <= outputLength)
+            {
+                return new string(output, 0, realLen);
+            }
+            else if (reattempt)
+            {
+                char[] newOutput = new char[realLen];
+                fixed (char* pNewOutput = newOutput)
                 {
-                    return new string(output, 0, realLen);
-                }
-                else if (reattempt)
-                {
-                    char[] newOutput = new char[realLen];
-                    fixed (char* pNewOutput = newOutput)
-                    {
-                        return GetAsciiCore(flags, unicode, count, pNewOutput, realLen, reattempt: false);
-                    }
+                    return GetAsciiCore(flags, unicode, count, pNewOutput, realLen, reattempt: false);
                 }
             }
 
@@ -53,7 +54,7 @@ namespace System.Globalization
         private unsafe string GetUnicodeCore(char* ascii, int count)
         {
             uint flags = Flags;
-            CheckInvalidIdnCharacters(ascii, count, flags, "ascii");
+            CheckInvalidIdnCharacters(ascii, count, flags, nameof(ascii));
 
             const int StackAllocThreshold = 512;
             if (count < StackAllocThreshold)
@@ -75,19 +76,20 @@ namespace System.Globalization
         {
             int realLen = Interop.GlobalizationNative.ToUnicode(flags, ascii, count, output, outputLength);
 
-            if (realLen != 0)
+            if (realLen == 0)
             {
-                if (realLen <= outputLength)
+                throw new ArgumentException(SR.Argument_IdnIllegalName, nameof(ascii));
+            }
+            else if (realLen <= outputLength)
+            {
+                return new string(output, 0, realLen);
+            }
+            else if (reattempt)
+            {
+                char[] newOutput = new char[realLen];
+                fixed (char* pNewOutput = newOutput)
                 {
-                    return new string(output, 0, realLen);
-                }
-                else if (reattempt)
-                {
-                    char[] newOutput = new char[realLen];
-                    fixed (char* pNewOutput = newOutput)
-                    {
-                        return GetUnicodeCore(flags, ascii, count, pNewOutput, realLen, reattempt: false);
-                    }
+                    return GetUnicodeCore(flags, ascii, count, pNewOutput, realLen, reattempt: false);
                 }
             }
 

--- a/src/Common/src/System/Globalization/IdnMapping.Unix.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.Unix.cs
@@ -15,21 +15,21 @@ namespace System.Globalization
             if (count < StackAllocThreshold)
             {
                 char* output = stackalloc char[count];
-                return GetAsciiCore(flags, unicode, count, output, count, reattempt: true);
+                return GetAsciiCore(unicode, count, flags, output, count, reattempt: true);
             }
             else
             {
                 char[] output = new char[count];
                 fixed (char* pOutput = output)
                 {
-                    return GetAsciiCore(flags, unicode, count, pOutput, count, reattempt: true);
+                    return GetAsciiCore(unicode, count, flags, pOutput, count, reattempt: true);
                 }
             }
         }
 
-        private unsafe string GetAsciiCore(uint flags, char* unicode, int count, char* output, int outputLength, bool reattempt)
+        private unsafe string GetAsciiCore(char* unicode, int count, uint flags, char* output, int outputLength, bool reattempt)
         {
-            int realLen = Interop.GlobalizationNative.ToAscii(flags, unicode, count, output, outputLength);
+            int realLen = Interop.GlobalizationNative.ToAscii(unicode, count, flags, output, outputLength);
 
             if (realLen == 0)
             {
@@ -44,7 +44,7 @@ namespace System.Globalization
                 char[] newOutput = new char[realLen];
                 fixed (char* pNewOutput = newOutput)
                 {
-                    return GetAsciiCore(flags, unicode, count, pNewOutput, realLen, reattempt: false);
+                    return GetAsciiCore(unicode, count, flags, pNewOutput, realLen, reattempt: false);
                 }
             }
 
@@ -60,21 +60,21 @@ namespace System.Globalization
             if (count < StackAllocThreshold)
             {
                 char* output = stackalloc char[count];
-                return GetUnicodeCore(flags, ascii, count, output, count, reattempt: true);
+                return GetUnicodeCore(ascii, count, flags, output, count, reattempt: true);
             }
             else
             {
                 char[] output = new char[count];
                 fixed (char* pOutput = output)
                 {
-                    return GetUnicodeCore(flags, ascii, count, pOutput, count, reattempt: true);
+                    return GetUnicodeCore(ascii, count, flags, pOutput, count, reattempt: true);
                 }
             }
         }
 
-        private unsafe string GetUnicodeCore(uint flags, char* ascii, int count, char* output, int outputLength, bool reattempt)
+        private unsafe string GetUnicodeCore(char* ascii, int count, uint flags, char* output, int outputLength, bool reattempt)
         {
-            int realLen = Interop.GlobalizationNative.ToUnicode(flags, ascii, count, output, outputLength);
+            int realLen = Interop.GlobalizationNative.ToUnicode(fascii, count, flags, output, outputLength);
 
             if (realLen == 0)
             {
@@ -89,7 +89,7 @@ namespace System.Globalization
                 char[] newOutput = new char[realLen];
                 fixed (char* pNewOutput = newOutput)
                 {
-                    return GetUnicodeCore(flags, ascii, count, pNewOutput, realLen, reattempt: false);
+                    return GetUnicodeCore(ascii, count, flags, pNewOutput, realLen, reattempt: false);
                 }
             }
 

--- a/src/Common/src/System/Globalization/IdnMapping.Unix.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.Unix.cs
@@ -29,7 +29,7 @@ namespace System.Globalization
 
         private unsafe string GetAsciiCore(char* unicode, int count, uint flags, char* output, int outputLength, bool reattempt)
         {
-            int realLen = Interop.GlobalizationNative.ToAscii(unicode, count, flags, output, outputLength);
+            int realLen = Interop.GlobalizationNative.ToAscii(flags, unicode, count, output, outputLength);
 
             if (realLen == 0)
             {
@@ -74,7 +74,7 @@ namespace System.Globalization
 
         private unsafe string GetUnicodeCore(char* ascii, int count, uint flags, char* output, int outputLength, bool reattempt)
         {
-            int realLen = Interop.GlobalizationNative.ToUnicode(fascii, count, flags, output, outputLength);
+            int realLen = Interop.GlobalizationNative.ToUnicode(flags, ascii, count, output, outputLength);
 
             if (realLen == 0)
             {

--- a/src/Common/src/System/Globalization/IdnMapping.Windows.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.Windows.cs
@@ -25,19 +25,19 @@ namespace System.Globalization
             if (length < StackAllocThreshold)
             {
                 char* output = stackalloc char[length];
-                return GetAsciiCore(flags, unicode, count, output, length);
+                return GetAsciiCore(unicode, count, flags, output, length);
             }
             else
             {
                 char[] output = new char[length];
                 fixed (char* pOutput = output)
                 {
-                    return GetAsciiCore(flags, unicode, count, pOutput, length);
+                    return GetAsciiCore(unicode, count, flags, pOutput, length);
                 }
             }
         }
 
-        private unsafe string GetAsciiCore(uint flags, char* unicode, int count, char* output, int outputLength)
+        private unsafe string GetAsciiCore(char* unicode, int count, uint flags, char* output, int outputLength)
         {
             int length = Interop.mincore.IdnToAscii(flags, unicode, count, output, outputLength);
             if (length == 0)
@@ -64,19 +64,19 @@ namespace System.Globalization
             if (length < StackAllocThreshold)
             {
                 char* output = stackalloc char[length];
-                return GetUnicodeCore(flags, ascii, count, output, length);
+                return GetUnicodeCore(ascii, count, flags, output, length);
             }
             else
             {
                 char[] output = new char[length];
                 fixed (char* pOutput = output)
                 {
-                    return GetUnicodeCore(flags, ascii, count, pOutput, length);
+                    return GetUnicodeCore(ascii, count, flags, pOutput, length);
                 }
             }
         }
 
-        private unsafe string GetUnicodeCore(uint flags, char* ascii, int count, char* output, int outputLength)
+        private unsafe string GetUnicodeCore(char* ascii, int count, uint flags, char* output, int outputLength)
         {
             int length = Interop.mincore.IdnToUnicode(flags, ascii, count, output, outputLength);
             if (length == 0)


### PR DESCRIPTION
- Use stack allocation when the length is relatively short
- The interop methods can take char*

Similar change to @stephentoub's BitConverter.ToString work in #7269 

/cc @ellismg @stephentoub @tarekgh @jamesqo