### PR TITLE
Disable Failed Globalization tests for Ubuntu 16.04

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -21,14 +21,15 @@ namespace System
 
         public static int WindowsVersion { get; } = GetWindowsVersion();
 
-        public static bool IsUbuntu1510 { get; } = GetIsUbuntu1510();
+        public static bool IsUbuntu1510 { get; } = GetIsUbuntu("15.10");
+        public static bool IsUbuntu1604 { get; } = GetIsUbuntu("16.04");
 
-        private static bool GetIsUbuntu1510()
+        private static bool GetIsUbuntu(string versionId)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 IdVersionPair v = ParseOsReleaseFile();
-                if (v.Id == "ubuntu" && v.VersionId == "15.10")
+                if (v.Id == "ubuntu" && v.VersionId == versionId)
                 {
                     return true;
                 }

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedDayName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedDayName.cs
@@ -17,7 +17,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new DateTimeFormatInfo(), englishAbbreviatedDayNames };
 
             // ActiveIssue(2103)
-            if (!PlatformDetection.IsUbuntu1510)
+            if (!PlatformDetection.IsUbuntu1510 && !PlatformDetection.IsUbuntu1604)
             {
                 yield return new object[] { new CultureInfo("fr-FR").DateTimeFormat, DateTimeFormatInfoData.FrFRAbbreviatedDayNames() };
             }

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedMonthName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedMonthName.cs
@@ -20,7 +20,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new DateTimeFormatInfo(), englishAbbreviatedMonthNames };
 
             // ActiveIssue(2103)
-            if (!PlatformDetection.IsUbuntu1510)
+            if (!PlatformDetection.IsUbuntu1510 && !PlatformDetection.IsUbuntu1604)
             {
                 yield return new object[] { new CultureInfo("fr-FR").DateTimeFormat, new string[] { "", "janv.", "f\u00E9vr.", "mars", "avr.", "mai", "juin", "juil.", "ao\u00FBt", "sept.", "oct.", "nov.", "d\u00E9c.", "" } };
             }

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetDayName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetDayName.cs
@@ -18,7 +18,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new DateTimeFormatInfo(), englishDayNames };
 
             // ActiveIssue(2103)
-            if (!PlatformDetection.IsUbuntu1510)
+            if (!PlatformDetection.IsUbuntu1510 && !PlatformDetection.IsUbuntu1604)
             {
                 yield return new object[] { new CultureInfo("fr-FR").DateTimeFormat, DateTimeFormatInfoData.FrFRDayNames() };
             }

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetMonthName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetMonthName.cs
@@ -20,7 +20,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("en-US").DateTimeFormat, englishMonthNames };
 
             // ActiveIssue(2103)
-            if (!PlatformDetection.IsUbuntu1510)
+            if (!PlatformDetection.IsUbuntu1510 && !PlatformDetection.IsUbuntu1604)
             {
                 yield return new object[] { new CultureInfo("fr-FR").DateTimeFormat, new string[] { "", "janvier", "f\u00E9vrier", "mars", "avril", "mai", "juin", "juillet", "ao\u00FBt", "septembre", "octobre", "novembre", "d\u00E9cembre", "" } };
             }

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNumberGroupSizes.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNumberGroupSizes.cs
@@ -15,7 +15,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("en-US").NumberFormat, new int[] { 3 } };
 
             // TODO: when dotnet/corefx#2103 is addressed, we should also check fr-FR
-            if (!PlatformDetection.IsUbuntu1510 && !PlatformDetection.IsWindows7)
+            if (!PlatformDetection.IsUbuntu1510 && !PlatformDetection.IsUbuntu1604 && !PlatformDetection.IsWindows7)
             {
                 yield return new object[] { new CultureInfo("ur-IN").NumberFormat, NumberFormatInfoData.UrINNumberGroupSizes() };
             }


### PR DESCRIPTION
There is other issue #2103 tracking to get this working so for now we are disabling the tests