### PR TITLE
Remove Hungarian notation from TypeKind

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -533,7 +533,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
 
             switch (pType.GetTypeKind())
             {
-                case TypeKind.TK_AggregateType:
+                case TypeKind.AggregateType:
                     {
                         AggregateType pAggType = pType.AsAggregateType();
 
@@ -568,7 +568,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                         break;
                     }
 
-                case TypeKind.TK_TypeParameterType:
+                case TypeKind.TypeParameterType:
                     if (null == pType.GetName())
                     {
                         // It's a standard type variable.
@@ -585,7 +585,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     }
                     break;
 
-                case TypeKind.TK_ErrorType:
+                case TypeKind.ErrorType:
                     if (pType.AsErrorType().HasParent())
                     {
                         Debug.Assert(pType.AsErrorType().nameText != null && pType.AsErrorType().typeArgs != null);
@@ -601,32 +601,32 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     }
                     break;
 
-                case TypeKind.TK_NullType:
+                case TypeKind.NullType:
                     // Load the string "<null>".
                     ErrAppendId(MessageID.NULL);
                     break;
 
-                case TypeKind.TK_OpenTypePlaceholderType:
+                case TypeKind.OpenTypePlaceholderType:
                     // Leave blank.
                     break;
 
-                case TypeKind.TK_BoundLambdaType:
+                case TypeKind.BoundLambdaType:
                     ErrAppendId(MessageID.AnonMethod);
                     break;
 
-                case TypeKind.TK_UnboundLambdaType:
+                case TypeKind.UnboundLambdaType:
                     ErrAppendId(MessageID.Lambda);
                     break;
 
-                case TypeKind.TK_MethodGroupType:
+                case TypeKind.MethodGroupType:
                     ErrAppendId(MessageID.MethodGroup);
                     break;
 
-                case TypeKind.TK_ArgumentListType:
+                case TypeKind.ArgumentListType:
                     ErrAppendString(TokenFacts.GetText(TokenKind.ArgList));
                     break;
 
-                case TypeKind.TK_ArrayType:
+                case TypeKind.ArrayType:
                     {
                         CType elementType = pType.AsArrayType().GetBaseElementType();
                         int rank;
@@ -670,11 +670,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                         break;
                     }
 
-                case TypeKind.TK_VoidType:
+                case TypeKind.VoidType:
                     ErrAppendName(GetNameManager().Lookup(TokenFacts.GetText(TokenKind.Void)));
                     break;
 
-                case TypeKind.TK_ParameterModifierType:
+                case TypeKind.ParameterModifierType:
                     // add ref or out
                     ErrAppendString(pType.AsParameterModifierType().isOut ? "out " : "ref ");
 
@@ -682,7 +682,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     ErrAppendType(pType.AsParameterModifierType().GetParameterType(), pctx);
                     break;
 
-                case TypeKind.TK_PointerType:
+                case TypeKind.PointerType:
                     // Generate the base type.
                     ErrAppendType(pType.AsPointerType().GetReferentType(), pctx);
                     {
@@ -691,12 +691,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                     }
                     break;
 
-                case TypeKind.TK_NullableType:
+                case TypeKind.NullableType:
                     ErrAppendType(pType.AsNullableType().GetUnderlyingType(), pctx);
                     ErrAppendChar('?');
                     break;
 
-                case TypeKind.TK_NaturalIntegerType:
+                case TypeKind.NaturalIntegerType:
                 default:
                     // Shouldn't happen.
                     Debug.Assert(false, "Bad type kind");

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -137,29 +137,29 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     default:
                         VSFAIL("Bad type kind");
                         return false;
-                    case TypeKind.TK_VoidType:
+                    case TypeKind.VoidType:
                         return false; // Can't convert to a method group or anon method.
-                    case TypeKind.TK_NullType:
+                    case TypeKind.NullType:
                         return false;  // Can never convert TO the null type.
-                    case TypeKind.TK_TypeParameterType:
+                    case TypeKind.TypeParameterType:
                         if (bindExplicitConversionToTypeVar())
                         {
                             return true;
                         }
                         break;
-                    case TypeKind.TK_ArrayType:
+                    case TypeKind.ArrayType:
                         if (bindExplicitConversionToArray(_typeDest.AsArrayType()))
                         {
                             return true;
                         }
                         break;
-                    case TypeKind.TK_PointerType:
+                    case TypeKind.PointerType:
                         if (bindExplicitConversionToPointer())
                         {
                             return true;
                         }
                         break;
-                    case TypeKind.TK_AggregateType:
+                    case TypeKind.AggregateType:
                         {
                             AggCastResult result = bindExplicitConversionToAggregate(_typeDest.AsAggregateType());
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -1065,13 +1065,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         LAgain:
             switch (typeSrc.GetTypeKind())
             {
-                case TypeKind.TK_NullableType:
+                case TypeKind.NullableType:
                     typeSrc = typeSrc.StripNubs();
                     goto LAgain;
-                case TypeKind.TK_TypeParameterType:
+                case TypeKind.TypeParameterType:
                     typeSrc = typeSrc.AsTypeParameterType().GetEffectiveBaseClass();
                     goto LAgain;
-                case TypeKind.TK_AggregateType:
+                case TypeKind.AggregateType:
                     if (!typeSrc.isClassType() && !typeSrc.isStructType() || typeSrc.AsAggregateType().getAggregate().IsSkipUDOps())
                         return null;
                     break;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 switch (_typeDest.GetTypeKind())
                 {
-                    case TypeKind.TK_ErrorType:
+                    case TypeKind.ErrorType:
                         Debug.Assert(_typeDest.AsErrorType().HasTypeParent() || _typeDest.AsErrorType().HasNSParent());
                         if (_typeSrc != _typeDest)
                         {
@@ -104,7 +104,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             _exprDest = _exprSrc;
                         }
                         return true;
-                    case TypeKind.TK_NullType:
+                    case TypeKind.NullType:
                         // Can only convert to the null type if src is null.
                         if (!_typeSrc.IsNullType())
                         {
@@ -115,13 +115,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             _exprDest = _exprSrc;
                         }
                         return true;
-                    case TypeKind.TK_MethodGroupType:
+                    case TypeKind.MethodGroupType:
                         VSFAIL("Something is wrong with Type.IsNeverSameType()");
                         return false;
-                    case TypeKind.TK_NaturalIntegerType:
-                    case TypeKind.TK_ArgumentListType:
+                    case TypeKind.NaturalIntegerType:
+                    case TypeKind.ArgumentListType:
                         return _typeSrc == _typeDest;
-                    case TypeKind.TK_VoidType:
+                    case TypeKind.VoidType:
                         return false;
                     default:
                         break;
@@ -172,7 +172,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     default:
                         VSFAIL("Bad type symbol kind");
                         break;
-                    case TypeKind.TK_MethodGroupType:
+                    case TypeKind.MethodGroupType:
                         if (_exprSrc.isMEMGRP())
                         {
                             EXPRCALL outExpr;
@@ -181,40 +181,40 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             return retVal;
                         }
                         return false;
-                    case TypeKind.TK_VoidType:
-                    case TypeKind.TK_ErrorType:
-                    case TypeKind.TK_ParameterModifierType:
-                    case TypeKind.TK_ArgumentListType:
+                    case TypeKind.VoidType:
+                    case TypeKind.ErrorType:
+                    case TypeKind.ParameterModifierType:
+                    case TypeKind.ArgumentListType:
                         return false;
-                    case TypeKind.TK_NullType:
+                    case TypeKind.NullType:
                         if (bindImplicitConversionFromNull())
                         {
                             return true;
                         }
                         // If not, try user defined implicit conversions.
                         break;
-                    case TypeKind.TK_ArrayType:
+                    case TypeKind.ArrayType:
                         if (bindImplicitConversionFromArray())
                         {
                             return true;
                         }
                         // If not, try user defined implicit conversions.
                         break;
-                    case TypeKind.TK_PointerType:
+                    case TypeKind.PointerType:
                         if (bindImplicitConversionFromPointer())
                         {
                             return true;
                         }
                         // If not, try user defined implicit conversions.
                         break;
-                    case TypeKind.TK_TypeParameterType:
+                    case TypeKind.TypeParameterType:
                         if (bindImplicitConversionFromTypeVar(_typeSrc.AsTypeParameterType()))
                         {
                             return true;
                         }
                         // If not, try user defined implicit conversions.
                         break;
-                    case TypeKind.TK_AggregateType:
+                    case TypeKind.AggregateType:
                         // TypeReference and ArgIterator can't be boxed (or converted to anything else)
                         if (_typeSrc.isSpecialByRefType())
                         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -3242,13 +3242,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 switch (type.GetTypeKind())
                 {
-                    case TypeKind.TK_NullableType:
+                    case TypeKind.NullableType:
                         type = type.StripNubs();
                         break;
-                    case TypeKind.TK_TypeParameterType:
+                    case TypeKind.TypeParameterType:
                         type = type.AsTypeParameterType().GetEffectiveBaseClass();
                         break;
-                    case TypeKind.TK_AggregateType:
+                    case TypeKind.AggregateType:
                         if ((type.isClassType() || type.isStructType()) && !type.AsAggregateType().getAggregate().IsSkipUDOps())
                         {
                             return type.AsAggregateType();

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
@@ -178,13 +178,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             switch (typeSym.GetTypeKind())
             {
-                case TypeKind.TK_AggregateType:
+                case TypeKind.AggregateType:
                     return typeSym.AsAggregateType();
-                case TypeKind.TK_ArrayType:
+                case TypeKind.ArrayType:
                     return GetReqPredefType(PredefinedType.PT_ARRAY);
-                case TypeKind.TK_TypeParameterType:
+                case TypeKind.TypeParameterType:
                     return typeSym.AsTypeParameterType().GetEffectiveBaseClass();
-                case TypeKind.TK_NullableType:
+                case TypeKind.NullableType:
                     return typeSym.AsNullableType().GetAts(ErrorContext);
             }
             Debug.Assert(false, "Bad typeSym!");

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
@@ -175,19 +175,19 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         default:
                             Debug.Assert(false, "Bad kind in CompareTypes");
                             break;
-                        case TypeKind.TK_TypeParameterType:
-                        case TypeKind.TK_ErrorType:
+                        case TypeKind.TypeParameterType:
+                        case TypeKind.ErrorType:
                             break;
 
-                        case TypeKind.TK_PointerType:
-                        case TypeKind.TK_ParameterModifierType:
-                        case TypeKind.TK_ArrayType:
-                        case TypeKind.TK_NullableType:
+                        case TypeKind.PointerType:
+                        case TypeKind.ParameterModifierType:
+                        case TypeKind.ArrayType:
+                        case TypeKind.NullableType:
                             type1 = type1.GetBaseOrParameterOrElementType();
                             type2 = type2.GetBaseOrParameterOrElementType();
                             goto LAgain;
 
-                        case TypeKind.TK_AggregateType:
+                        case TypeKind.AggregateType:
                             nParam = CompareTypes(type1.AsAggregateType().GetTypeArgsAll(), type2.AsAggregateType().GetTypeArgsAll());
                             break;
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
@@ -357,22 +357,22 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     Debug.Assert(false, "Unexpected type.");
                     return false;
 
-                case TypeKind.TK_VoidType:
-                case TypeKind.TK_PointerType:
-                case TypeKind.TK_ErrorType:
+                case TypeKind.VoidType:
+                case TypeKind.PointerType:
+                case TypeKind.ErrorType:
                     return false;
 
-                case TypeKind.TK_ArrayType:
-                case TypeKind.TK_TypeParameterType:
+                case TypeKind.ArrayType:
+                case TypeKind.TypeParameterType:
                     break;
 
-                case TypeKind.TK_NullableType:
+                case TypeKind.NullableType:
                     typeBnd = typeBnd.AsNullableType().GetAts(checker.GetErrorContext());
                     if (null == typeBnd)
                         return true;
                     break;
 
-                case TypeKind.TK_AggregateType:
+                case TypeKind.AggregateType:
                     break;
             }
 
@@ -382,18 +382,18 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 default:
                     return false;
-                case TypeKind.TK_ErrorType:
-                case TypeKind.TK_PointerType:
+                case TypeKind.ErrorType:
+                case TypeKind.PointerType:
                     return false;
-                case TypeKind.TK_NullableType:
+                case TypeKind.NullableType:
                     arg = arg.AsNullableType().GetAts(checker.GetErrorContext());
                     if (null == arg)
                         return true;
                     // Fall through.
-                    goto case TypeKind.TK_TypeParameterType;
-                case TypeKind.TK_TypeParameterType:
-                case TypeKind.TK_ArrayType:
-                case TypeKind.TK_AggregateType:
+                    goto case TypeKind.TypeParameterType;
+                case TypeKind.TypeParameterType:
+                case TypeKind.ArrayType:
+                case TypeKind.AggregateType:
                     return checker.GetSymbolLoader().HasBaseConversion(arg, typeBnd);
             }
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             switch (src.GetTypeKind())
             {
-                case TypeKind.TK_ArrayType:
+                case TypeKind.ArrayType:
                     ArrayType a = src.AsArrayType();
                     Type elementType = a.GetElementType().AssociatedSystemType;
                     if (a.rank == 1)
@@ -107,29 +107,29 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     break;
 
-                case TypeKind.TK_NullableType:
+                case TypeKind.NullableType:
                     NullableType n = src.AsNullableType();
                     Type underlyingType = n.GetUnderlyingType().AssociatedSystemType;
                     result = typeof(Nullable<>).MakeGenericType(underlyingType);
                     break;
 
-                case TypeKind.TK_PointerType:
+                case TypeKind.PointerType:
                     PointerType p = src.AsPointerType();
                     Type referentType = p.GetReferentType().AssociatedSystemType;
                     result = referentType.MakePointerType();
                     break;
 
-                case TypeKind.TK_ParameterModifierType:
+                case TypeKind.ParameterModifierType:
                     ParameterModifierType r = src.AsParameterModifierType();
                     Type parameterType = r.GetParameterType().AssociatedSystemType;
                     result = parameterType.MakeByRefType();
                     break;
 
-                case TypeKind.TK_AggregateType:
+                case TypeKind.AggregateType:
                     result = CalculateAssociatedSystemTypeForAggregate(src.AsAggregateType());
                     break;
 
-                case TypeKind.TK_TypeParameterType:
+                case TypeKind.TypeParameterType:
                     TypeParameterType t = src.AsTypeParameterType();
                     Type parentType = null;
                     if (t.IsMethodTypeParameter())
@@ -144,21 +144,21 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     break;
 
-                case TypeKind.TK_ArgumentListType:
-                case TypeKind.TK_BoundLambdaType:
-                case TypeKind.TK_ErrorType:
-                case TypeKind.TK_MethodGroupType:
-                case TypeKind.TK_NaturalIntegerType:
-                case TypeKind.TK_NullType:
-                case TypeKind.TK_OpenTypePlaceholderType:
-                case TypeKind.TK_UnboundLambdaType:
-                case TypeKind.TK_VoidType:
+                case TypeKind.ArgumentListType:
+                case TypeKind.BoundLambdaType:
+                case TypeKind.ErrorType:
+                case TypeKind.MethodGroupType:
+                case TypeKind.NaturalIntegerType:
+                case TypeKind.NullType:
+                case TypeKind.OpenTypePlaceholderType:
+                case TypeKind.UnboundLambdaType:
+                case TypeKind.VoidType:
 
                 default:
                     break;
             }
 
-            Debug.Assert(result != null || src.GetTypeKind() == TypeKind.TK_AggregateType);
+            Debug.Assert(result != null || src.GetTypeKind() == TypeKind.AggregateType);
             return result;
         }
 
@@ -229,21 +229,21 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             switch (GetTypeKind())
             {
-                case TypeKind.TK_ParameterModifierType:
-                case TypeKind.TK_PointerType:
-                case TypeKind.TK_ArrayType:
-                case TypeKind.TK_NullableType:
+                case TypeKind.ParameterModifierType:
+                case TypeKind.PointerType:
+                case TypeKind.ArrayType:
+                case TypeKind.NullableType:
                     if (GetBaseOrParameterOrElementType() != null)
                     {
                         fBogus = GetBaseOrParameterOrElementType().computeCurrentBogusState();
                     }
                     break;
 
-                case TypeKind.TK_ErrorType:
+                case TypeKind.ErrorType:
                     setBogus(false);
                     break;
 
-                case TypeKind.TK_AggregateType:
+                case TypeKind.AggregateType:
                     fBogus = AsAggregateType().getAggregate().computeCurrentBogusState();
                     for (int i = 0; !fBogus && i < AsAggregateType().GetTypeArgsAll().size; i++)
                     {
@@ -251,12 +251,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     break;
 
-                case TypeKind.TK_TypeParameterType:
-                case TypeKind.TK_VoidType:
-                case TypeKind.TK_NullType:
-                case TypeKind.TK_OpenTypePlaceholderType:
-                case TypeKind.TK_ArgumentListType:
-                case TypeKind.TK_NaturalIntegerType:
+                case TypeKind.TypeParameterType:
+                case TypeKind.VoidType:
+                case TypeKind.NullType:
+                case TypeKind.OpenTypePlaceholderType:
+                case TypeKind.ArgumentListType:
+                case TypeKind.NaturalIntegerType:
                     setBogus(false);
                     break;
 
@@ -282,16 +282,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             switch (GetTypeKind())
             {
-                case TypeKind.TK_ArrayType:
+                case TypeKind.ArrayType:
                     return AsArrayType().GetElementType();
 
-                case TypeKind.TK_PointerType:
+                case TypeKind.PointerType:
                     return AsPointerType().GetReferentType();
 
-                case TypeKind.TK_ParameterModifierType:
+                case TypeKind.ParameterModifierType:
                     return AsParameterModifierType().GetParameterType();
 
-                case TypeKind.TK_NullableType:
+                case TypeKind.NullableType:
                     return AsNullableType().GetUnderlyingType();
 
                 default:
@@ -353,7 +353,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             switch (this.GetTypeKind())
             {
-                case TypeKind.TK_AggregateType:
+                case TypeKind.AggregateType:
                     {
                         AggregateSymbol sym = this.AsAggregateType().getAggregate();
 
@@ -373,17 +373,17 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         return FUNDTYPE.FT_REF;  // Interfaces, classes, delegates are reference types.
                     }
 
-                case TypeKind.TK_TypeParameterType:
+                case TypeKind.TypeParameterType:
                     return FUNDTYPE.FT_VAR;
 
-                case TypeKind.TK_ArrayType:
-                case TypeKind.TK_NullType:
+                case TypeKind.ArrayType:
+                case TypeKind.NullType:
                     return FUNDTYPE.FT_REF;
 
-                case TypeKind.TK_PointerType:
+                case TypeKind.PointerType:
                     return FUNDTYPE.FT_PTR;
 
-                case TypeKind.TK_NullableType:
+                case TypeKind.NullableType:
                     return FUNDTYPE.FT_STRUCT;
 
                 default:
@@ -456,14 +456,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     default:
                         return type;
 
-                    case TypeKind.TK_NullableType:
+                    case TypeKind.NullableType:
                         if (!fStripNub)
                             return type;
                         type = type.GetBaseOrParameterOrElementType();
                         break;
-                    case TypeKind.TK_ArrayType:
-                    case TypeKind.TK_ParameterModifierType:
-                    case TypeKind.TK_PointerType:
+                    case TypeKind.ArrayType:
+                    case TypeKind.ParameterModifierType:
+                    case TypeKind.PointerType:
                         type = type.GetBaseOrParameterOrElementType();
                         break;
                 }
@@ -721,11 +721,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             switch (this.GetTypeKind())
             {
-                case TypeKind.TK_TypeParameterType:
+                case TypeKind.TypeParameterType:
                     return this.AsTypeParameterType().IsValueType();
-                case TypeKind.TK_AggregateType:
+                case TypeKind.AggregateType:
                     return this.AsAggregateType().getAggregate().IsValueType();
-                case TypeKind.TK_NullableType:
+                case TypeKind.NullableType:
                     return true;
                 default:
                     return false;
@@ -735,11 +735,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             switch (this.GetTypeKind())
             {
-                case TypeKind.TK_TypeParameterType:
+                case TypeKind.TypeParameterType:
                     return this.AsTypeParameterType().IsNonNullableValueType();
-                case TypeKind.TK_AggregateType:
+                case TypeKind.AggregateType:
                     return this.AsAggregateType().getAggregate().IsValueType();
-                case TypeKind.TK_NullableType:
+                case TypeKind.NullableType:
                     return false;
                 default:
                     return false;
@@ -749,12 +749,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             switch (this.GetTypeKind())
             {
-                case TypeKind.TK_ArrayType:
-                case TypeKind.TK_NullType:
+                case TypeKind.ArrayType:
+                case TypeKind.NullType:
                     return true;
-                case TypeKind.TK_TypeParameterType:
+                case TypeKind.TypeParameterType:
                     return this.AsTypeParameterType().IsReferenceType();
-                case TypeKind.TK_AggregateType:
+                case TypeKind.AggregateType:
                     return this.AsAggregateType().getAggregate().IsRefType();
                 default:
                     return false;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeFactory.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             type.SetTypeArgsThis(typeArgsThis);
             type.SetName(name);
 
-            type.SetTypeKind(TypeKind.TK_AggregateType);
+            type.SetTypeKind(TypeKind.AggregateType);
             return type;
         }
 
@@ -51,7 +51,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(pSymbol.GetTypeParameterType() == null);
             pSymbol.SetTypeParameterType(type);
 
-            type.SetTypeKind(TypeKind.TK_TypeParameterType);
+            type.SetTypeKind(TypeKind.TypeParameterType);
             return type;
         }
 
@@ -59,42 +59,42 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public VoidType CreateVoid()
         {
             VoidType type = new VoidType();
-            type.SetTypeKind(TypeKind.TK_VoidType);
+            type.SetTypeKind(TypeKind.VoidType);
             return type;
         }
 
         public NullType CreateNull()
         {
             NullType type = new NullType();
-            type.SetTypeKind(TypeKind.TK_NullType);
+            type.SetTypeKind(TypeKind.NullType);
             return type;
         }
 
         public OpenTypePlaceholderType CreateUnit()
         {
             OpenTypePlaceholderType type = new OpenTypePlaceholderType();
-            type.SetTypeKind(TypeKind.TK_OpenTypePlaceholderType);
+            type.SetTypeKind(TypeKind.OpenTypePlaceholderType);
             return type;
         }
 
         public BoundLambdaType CreateAnonMethod()
         {
             BoundLambdaType type = new BoundLambdaType();
-            type.SetTypeKind(TypeKind.TK_BoundLambdaType);
+            type.SetTypeKind(TypeKind.BoundLambdaType);
             return type;
         }
 
         public MethodGroupType CreateMethodGroup()
         {
             MethodGroupType type = new MethodGroupType();
-            type.SetTypeKind(TypeKind.TK_MethodGroupType);
+            type.SetTypeKind(TypeKind.MethodGroupType);
             return type;
         }
 
         public ArgumentListType CreateArgList()
         {
             ArgumentListType type = new ArgumentListType();
-            type.SetTypeKind(TypeKind.TK_ArgumentListType);
+            type.SetTypeKind(TypeKind.ArgumentListType);
             return type;
         }
 
@@ -112,7 +112,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             e.SetTypeParent(parent);
             e.SetNSParent(pParentNS);
 
-            e.SetTypeKind(TypeKind.TK_ErrorType);
+            e.SetTypeKind(TypeKind.ErrorType);
             return e;
         }
 
@@ -125,7 +125,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             type.rank = rank;
             type.SetElementType(pElementType);
 
-            type.SetTypeKind(TypeKind.TK_ArrayType);
+            type.SetTypeKind(TypeKind.ArrayType);
             return type;
         }
 
@@ -135,7 +135,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             type.SetName(name);
             type.SetReferentType(pReferentType);
 
-            type.SetTypeKind(TypeKind.TK_PointerType);
+            type.SetTypeKind(TypeKind.PointerType);
             return type;
         }
 
@@ -145,7 +145,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             type.SetName(name);
             type.SetParameterType(pParameterType);
 
-            type.SetTypeKind(TypeKind.TK_ParameterModifierType);
+            type.SetTypeKind(TypeKind.ParameterModifierType);
             return type;
         }
 
@@ -157,7 +157,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             type.symmgr = symmgr;
             type.typeManager = typeManager;
 
-            type.SetTypeKind(TypeKind.TK_NullableType);
+            type.SetTypeKind(TypeKind.NullableType);
             return type;
         }
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeKind.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeKind.cs
@@ -6,20 +6,20 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     internal enum TypeKind
     {
-        TK_AggregateType,
-        TK_VoidType,
-        TK_NullType,
-        TK_OpenTypePlaceholderType,
-        TK_BoundLambdaType,
-        TK_UnboundLambdaType,
-        TK_MethodGroupType,
-        TK_ErrorType,
-        TK_NaturalIntegerType,
-        TK_ArgumentListType,
-        TK_ArrayType,
-        TK_PointerType,
-        TK_ParameterModifierType,
-        TK_NullableType,
-        TK_TypeParameterType
+        AggregateType,
+        VoidType,
+        NullType,
+        OpenTypePlaceholderType,
+        BoundLambdaType,
+        UnboundLambdaType,
+        MethodGroupType,
+        ErrorType,
+        NaturalIntegerType,
+        ArgumentListType,
+        ArrayType,
+        PointerType,
+        ParameterModifierType,
+        NullableType,
+        TypeParameterType
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -84,21 +84,21 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     Debug.Assert(false, "Bad Symbol kind in TypeContainsAnonymousTypes");
                     return false;
 
-                case TypeKind.TK_NullType:
-                case TypeKind.TK_VoidType:
-                case TypeKind.TK_NullableType:
-                case TypeKind.TK_TypeParameterType:
-                case TypeKind.TK_UnboundLambdaType:
-                case TypeKind.TK_MethodGroupType:
+                case TypeKind.NullType:
+                case TypeKind.VoidType:
+                case TypeKind.NullableType:
+                case TypeKind.TypeParameterType:
+                case TypeKind.UnboundLambdaType:
+                case TypeKind.MethodGroupType:
                     return false;
 
-                case TypeKind.TK_ArrayType:
-                case TypeKind.TK_ParameterModifierType:
-                case TypeKind.TK_PointerType:
+                case TypeKind.ArrayType:
+                case TypeKind.ParameterModifierType:
+                case TypeKind.PointerType:
                     ctype = (CType)ctype.GetBaseOrParameterOrElementType();
                     goto LRecurse;
 
-                case TypeKind.TK_AggregateType:
+                case TypeKind.AggregateType:
                     if (ctype.AsAggregateType().getAggregate().IsAnonymousType())
                     {
                         return true;
@@ -116,7 +116,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     return false;
 
-                case TypeKind.TK_ErrorType:
+                case TypeKind.ErrorType:
                     if (ctype.AsErrorType().HasTypeParent())
                     {
                         ctype = ctype.AsErrorType().GetTypeParent();
@@ -553,33 +553,33 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     Debug.Assert(false);
                     return type;
 
-                case TypeKind.TK_NullType:
-                case TypeKind.TK_VoidType:
-                case TypeKind.TK_OpenTypePlaceholderType:
-                case TypeKind.TK_MethodGroupType:
-                case TypeKind.TK_BoundLambdaType:
-                case TypeKind.TK_UnboundLambdaType:
-                case TypeKind.TK_NaturalIntegerType:
-                case TypeKind.TK_ArgumentListType:
+                case TypeKind.NullType:
+                case TypeKind.VoidType:
+                case TypeKind.OpenTypePlaceholderType:
+                case TypeKind.MethodGroupType:
+                case TypeKind.BoundLambdaType:
+                case TypeKind.UnboundLambdaType:
+                case TypeKind.NaturalIntegerType:
+                case TypeKind.ArgumentListType:
                     return type;
 
-                case TypeKind.TK_ParameterModifierType:
+                case TypeKind.ParameterModifierType:
                     typeDst = SubstTypeCore(typeSrc = type.AsParameterModifierType().GetParameterType(), pctx);
                     return (typeDst == typeSrc) ? type : GetParameterModifier(typeDst, type.AsParameterModifierType().isOut);
 
-                case TypeKind.TK_ArrayType:
+                case TypeKind.ArrayType:
                     typeDst = SubstTypeCore(typeSrc = type.AsArrayType().GetElementType(), pctx);
                     return (typeDst == typeSrc) ? type : GetArray(typeDst, type.AsArrayType().rank);
 
-                case TypeKind.TK_PointerType:
+                case TypeKind.PointerType:
                     typeDst = SubstTypeCore(typeSrc = type.AsPointerType().GetReferentType(), pctx);
                     return (typeDst == typeSrc) ? type : GetPointer(typeDst);
 
-                case TypeKind.TK_NullableType:
+                case TypeKind.NullableType:
                     typeDst = SubstTypeCore(typeSrc = type.AsNullableType().GetUnderlyingType(), pctx);
                     return (typeDst == typeSrc) ? type : GetNullable(typeDst);
 
-                case TypeKind.TK_AggregateType:
+                case TypeKind.AggregateType:
                     if (type.AsAggregateType().GetTypeArgsAll().size > 0)
                     {
                         AggregateType ats = type.AsAggregateType();
@@ -590,7 +590,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     return type;
 
-                case TypeKind.TK_ErrorType:
+                case TypeKind.ErrorType:
                     if (type.AsErrorType().HasParent())
                     {
                         ErrorType err = type.AsErrorType();
@@ -610,7 +610,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     return type;
 
-                case TypeKind.TK_TypeParameterType:
+                case TypeKind.TypeParameterType:
                     {
                         TypeParameterSymbol tvs = type.AsTypeParameterType().GetTypeParameterSymbol();
                         int index = tvs.GetIndexInTotalParameters();
@@ -697,27 +697,27 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     Debug.Assert(false, "Bad Symbol kind in SubstEqualTypesCore");
                     return false;
 
-                case TypeKind.TK_NullType:
-                case TypeKind.TK_VoidType:
-                case TypeKind.TK_OpenTypePlaceholderType:
+                case TypeKind.NullType:
+                case TypeKind.VoidType:
+                case TypeKind.OpenTypePlaceholderType:
                     // There should only be a single instance of these.
                     Debug.Assert(typeDst.GetTypeKind() != typeSrc.GetTypeKind());
                     return false;
 
-                case TypeKind.TK_ArrayType:
-                    if (typeDst.GetTypeKind() != TypeKind.TK_ArrayType || typeDst.AsArrayType().rank != typeSrc.AsArrayType().rank)
+                case TypeKind.ArrayType:
+                    if (typeDst.GetTypeKind() != TypeKind.ArrayType || typeDst.AsArrayType().rank != typeSrc.AsArrayType().rank)
                         return false;
                     goto LCheckBases;
 
-                case TypeKind.TK_ParameterModifierType:
-                    if (typeDst.GetTypeKind() != TypeKind.TK_ParameterModifierType ||
+                case TypeKind.ParameterModifierType:
+                    if (typeDst.GetTypeKind() != TypeKind.ParameterModifierType ||
                         ((pctx.grfst & SubstTypeFlags.NoRefOutDifference) == 0 &&
                          typeDst.AsParameterModifierType().isOut != typeSrc.AsParameterModifierType().isOut))
                         return false;
                     goto LCheckBases;
 
-                case TypeKind.TK_PointerType:
-                case TypeKind.TK_NullableType:
+                case TypeKind.PointerType:
+                case TypeKind.NullableType:
                     if (typeDst.GetTypeKind() != typeSrc.GetTypeKind())
                         return false;
                     LCheckBases:
@@ -725,8 +725,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     typeDst = typeDst.GetBaseOrParameterOrElementType();
                     goto LRecurse;
 
-                case TypeKind.TK_AggregateType:
-                    if (typeDst.GetTypeKind() != TypeKind.TK_AggregateType)
+                case TypeKind.AggregateType:
+                    if (typeDst.GetTypeKind() != TypeKind.AggregateType)
                         return false;
                     { // BLOCK
                         AggregateType atsSrc = typeSrc.AsAggregateType();
@@ -746,7 +746,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     return true;
 
-                case TypeKind.TK_ErrorType:
+                case TypeKind.ErrorType:
                     if (!typeDst.IsErrorType() || !typeSrc.AsErrorType().HasParent() || !typeDst.AsErrorType().HasParent())
                         return false;
                     {
@@ -790,7 +790,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     return true;
 
-                case TypeKind.TK_TypeParameterType:
+                case TypeKind.TypeParameterType:
                     { // BLOCK
                         TypeParameterSymbol tvs = typeSrc.AsTypeParameterType().GetTypeParameterSymbol();
                         int index = tvs.GetIndexInTotalParameters();
@@ -851,21 +851,21 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     Debug.Assert(false, "Bad Symbol kind in TypeContainsType");
                     return false;
 
-                case TypeKind.TK_NullType:
-                case TypeKind.TK_VoidType:
-                case TypeKind.TK_OpenTypePlaceholderType:
+                case TypeKind.NullType:
+                case TypeKind.VoidType:
+                case TypeKind.OpenTypePlaceholderType:
                     // There should only be a single instance of these.
                     Debug.Assert(typeFind.GetTypeKind() != type.GetTypeKind());
                     return false;
 
-                case TypeKind.TK_ArrayType:
-                case TypeKind.TK_NullableType:
-                case TypeKind.TK_ParameterModifierType:
-                case TypeKind.TK_PointerType:
+                case TypeKind.ArrayType:
+                case TypeKind.NullableType:
+                case TypeKind.ParameterModifierType:
+                case TypeKind.PointerType:
                     type = type.GetBaseOrParameterOrElementType();
                     goto LRecurse;
 
-                case TypeKind.TK_AggregateType:
+                case TypeKind.AggregateType:
                     { // BLOCK
                         AggregateType ats = type.AsAggregateType();
 
@@ -877,7 +877,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     return false;
 
-                case TypeKind.TK_ErrorType:
+                case TypeKind.ErrorType:
                     if (type.AsErrorType().HasParent())
                     {
                         ErrorType err = type.AsErrorType();
@@ -896,7 +896,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     return false;
 
-                case TypeKind.TK_TypeParameterType:
+                case TypeKind.TypeParameterType:
                     return false;
             }
         }
@@ -910,22 +910,22 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     Debug.Assert(false, "Bad Symbol kind in TypeContainsTyVars");
                     return false;
 
-                case TypeKind.TK_UnboundLambdaType:
-                case TypeKind.TK_BoundLambdaType:
-                case TypeKind.TK_NullType:
-                case TypeKind.TK_VoidType:
-                case TypeKind.TK_OpenTypePlaceholderType:
-                case TypeKind.TK_MethodGroupType:
+                case TypeKind.UnboundLambdaType:
+                case TypeKind.BoundLambdaType:
+                case TypeKind.NullType:
+                case TypeKind.VoidType:
+                case TypeKind.OpenTypePlaceholderType:
+                case TypeKind.MethodGroupType:
                     return false;
 
-                case TypeKind.TK_ArrayType:
-                case TypeKind.TK_NullableType:
-                case TypeKind.TK_ParameterModifierType:
-                case TypeKind.TK_PointerType:
+                case TypeKind.ArrayType:
+                case TypeKind.NullableType:
+                case TypeKind.ParameterModifierType:
+                case TypeKind.PointerType:
                     type = type.GetBaseOrParameterOrElementType();
                     goto LRecurse;
 
-                case TypeKind.TK_AggregateType:
+                case TypeKind.AggregateType:
                     { // BLOCK
                         AggregateType ats = type.AsAggregateType();
 
@@ -939,7 +939,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     return false;
 
-                case TypeKind.TK_ErrorType:
+                case TypeKind.ErrorType:
                     if (type.AsErrorType().HasParent())
                     {
                         ErrorType err = type.AsErrorType();
@@ -960,7 +960,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     return false;
 
-                case TypeKind.TK_TypeParameterType:
+                case TypeKind.TypeParameterType:
                     if (typeVars != null && typeVars.Size > 0)
                     {
                         int ivar = type.AsTypeParameterType().GetIndexInTotalParameters();


### PR DESCRIPTION
This is the first of my attempts to make the Microsoft.CSharp codebase more readable, as part of #7458. A lot of enums in the assembly have their values unnecessarily prefixed with the initials of the enum; for example, `PredefinedName` has all its values prefixed with `PN_`, `PredefinedType` with `PT_`, and so on. This PR removes such notation for `TypeKind`, which is prefixed with `TK_`. (As these types are used in a bunch of different locations throughout the codebase, I'm going to be submitting separate PRs for each type to make code review easier.)

cc @VSadov 