### PR TITLE
Cookie: Set value to an empty string when null is passed in

### DIFF
--- a/src/System.Net.Http/src/netcore50/System/Net/cookie.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/cookie.cs
@@ -119,7 +119,7 @@ namespace System.Net
         public Cookie(string name, string value)
         {
             Name = name;
-            m_value = value;
+            Value = value;
         }
 
         /// <devdoc>

--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -103,7 +103,7 @@ namespace System.Net
         public Cookie(string name, string value)
         {
             Name = name;
-            _value = value;
+            Value = value;
         }
 
         public Cookie(string name, string value, string path)

--- a/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
@@ -244,7 +244,7 @@ namespace System.Net.Primitives.Functional.Tests
         public static void Value_StringEmptyIfNullPassedIn()
         {
             var cookie = new Cookie("SomeName", null);
-            Assert.Equal(string.Empty, cookie.Value)
+            Assert.Equal(string.Empty, cookie.Value);
         }
 
         [Fact]

--- a/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
@@ -240,6 +240,8 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Equal(string.Empty, c.Value);
         }
         
+        // NOTE: This test is expected to fail on the full desktop.
+        // The behavior this tests was only recently added in #8206.
         [Fact]
         public static void Value_PassNullToCtor_GetReturnsEmptyString()
         {

--- a/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
@@ -239,6 +239,13 @@ namespace System.Net.Primitives.Functional.Tests
             c.Value = null;
             Assert.Equal(string.Empty, c.Value);
         }
+        
+        [Fact]
+        public static void Value_StringEmptyIfNullPassedIn()
+        {
+            var cookie = new Cookie("SomeName", null);
+            Assert.Equal(string.Empty, cookie.Value)
+        }
 
         [Fact]
         public static void Version_GetSet_Success()

--- a/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
@@ -241,7 +241,7 @@ namespace System.Net.Primitives.Functional.Tests
         }
         
         [Fact]
-        public static void Value_StringEmptyIfNullPassedIn()
+        public static void Value_PassNullToCtor_GetReturnsEmptyString()
         {
             var cookie = new Cookie("SomeName", null);
             Assert.Equal(string.Empty, cookie.Value);


### PR DESCRIPTION
Addresses #8171 

cc @davidsh @hughbe