### PR TITLE
Prohibit null, open generic or address types on Constant

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ConstantExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ConstantExpression.cs
@@ -21,18 +21,6 @@ namespace System.Linq.Expressions
             _value = value;
         }
 
-        internal static ConstantExpression Make(object value, Type type)
-        {
-            if (value == null ? type == typeof(object) : value.GetType() == type)
-            {
-                return new ConstantExpression(value);
-            }
-            else
-            {
-                return new TypedConstantExpression(value, type);
-            }
-        }
-
         /// <summary>
         /// Gets the static type of the expression that this <see cref="Expression" /> represents.
         /// </summary>
@@ -105,7 +93,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static ConstantExpression Constant(object value)
         {
-            return ConstantExpression.Make(value, value == null ? typeof(object) : value.GetType());
+            return new ConstantExpression(value);
         }
 
         /// <summary>
@@ -133,12 +121,33 @@ namespace System.Linq.Expressions
                 throw Error.TypeMustNotBePointer();
             }
 
-            if (value == null ? type.GetTypeInfo().IsValueType && !TypeUtils.IsNullableType(type) : !type.IsAssignableFrom(value.GetType()))
+            if (value == null)
             {
-                throw Error.ArgumentTypesMustMatch();
+                if (type == typeof(object))
+                {
+                    return new ConstantExpression(null);
+                }
+
+                if (!type.GetTypeInfo().IsValueType || type.IsNullableType())
+                {
+                    return new TypedConstantExpression(null, type);
+                }
+            }
+            else
+            {
+                Type valueType = value.GetType();
+                if (type == valueType)
+                {
+                    return new ConstantExpression(value);
+                }
+
+                if (type.IsAssignableFrom(valueType))
+                {
+                    return new TypedConstantExpression(value, type);
+                }
             }
 
-            return ConstantExpression.Make(value, type);
+            throw Error.ArgumentTypesMustMatch();
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ConstantExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ConstantExpression.cs
@@ -122,6 +122,17 @@ namespace System.Linq.Expressions
         public static ConstantExpression Constant(object value, Type type)
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
+            TypeUtils.ValidateType(type);
+            if (type.IsByRef)
+            {
+                throw Error.TypeMustNotBeByRef();
+            }
+
+            if (type.IsPointer)
+            {
+                throw Error.TypeMustNotBePointer();
+            }
+
             if (value == null ? type.GetTypeInfo().IsValueType && !TypeUtils.IsNullableType(type) : !type.IsAssignableFrom(value.GetType()))
             {
                 throw Error.ArgumentTypesMustMatch();

--- a/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -775,6 +775,37 @@ namespace System.Linq.Expressions.Tests
         public static void InvalidTypeReferenceType()
         {
             Assert.Throws<ArgumentException>(() => Expression.Constant("hello", typeof(Expression)));
+        }
+
+        [Fact]
+        public static void NullType()
+        {
+            Assert.Throws<ArgumentNullException>("type", () => Expression.Constant("foo", null));
+        }
+
+        [Fact]
+        public static void ByRefType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Constant(null, typeof(string).MakeByRefType()));
+        }
+
+        [Fact]
+        public static void PointerType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.Constant(null, typeof(string).MakePointerType()));
+        }
+
+        [Fact]
+        public static void GenericType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Constant(null, typeof(List<>)));
+        }
+
+        [Fact]
+        public static void TypeContainsGenericParameters()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Constant(null, typeof(List<>.Enumerator)));
+            Assert.Throws<ArgumentException>(() => Expression.Constant(null, typeof(List<>).MakeGenericType(typeof(List<>))));
         }
     }
 }


### PR DESCRIPTION
Throw on open generic, byref or pointer type to `Expression.Constant()`. Contributes to #8081.

Reduce paths in `Expression.Constant()`

The untyped overload determines a type just to have that type tested in `ConstantExpression.Make()` resulting in the same constructor call either way. Just call that constructor directly.

This leaves a single caller to `Make()`. Since its type tests overlap with those in `Make()`, merge the logic in the caller, and remove `Make()`.