### PR TITLE
Fix FileSystemWatcher_Created_Negative test on OSX

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Created.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Created.cs
@@ -126,7 +126,7 @@ namespace System.IO.Tests
                     watcher.EnableRaisingEvents = true;
 
                     // change a file
-                    File.WriteAllText(testFile.Path, "change");
+                    File.AppendAllText(testFile.Path, "change");
 
                     // renaming a directory
                     //


### PR DESCRIPTION
I believe it's failing because the WriteAllText on OSX is being treated as a delete followed by a create.

Fixes #8154 
cc: @ianhays 