### PR TITLE
Remove TODO in HttpWebRequest RequestStream

### DIFF
--- a/src/System.Net.Requests/src/System/Net/RequestStream.cs
+++ b/src/System.Net.Requests/src/System/Net/RequestStream.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -111,12 +112,7 @@ namespace System.Net
             ArraySegment<byte> bytes;
 
             bool success = _buffer.TryGetBuffer(out bytes);
-
-            if (!success)
-            {
-                // TODO (#7890): Need to figure out how to log this and throw a good exception.
-                throw new Exception();
-            }
+            Debug.Assert(success); // Buffer should always be visible since default MemoryStream constructor was used.
 
             return bytes;
         }


### PR DESCRIPTION
Changed the TODO to an Assert(). TryGetBuffer() should always succeed
since the default MemoryStream() constructor is used and thus the buffer
is always visible.

Fixes #7890.