### PR TITLE
Remove ref/net46 placeholder from Numerics.Vectors

### DIFF
--- a/src/System.Numerics.Vectors/pkg/System.Numerics.Vectors.pkgproj
+++ b/src/System.Numerics.Vectors/pkg/System.Numerics.Vectors.pkgproj
@@ -14,7 +14,6 @@
   <ItemGroup>
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
-    <InboxOnTargetFramework Include="net46" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
     <InboxOnTargetFramework Include="xamarintvos10" />


### PR DESCRIPTION
This library ships an OOB implementation and reference for desktop so it
should not use a placeholder.

/cc @weshaggard @chcosta 

This is dev branch fix for #8189 