### PR TITLE
Add DbEnumerator contract to System.Data.Common

### DIFF
--- a/src/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/System.Data.Common/ref/System.Data.Common.cs
@@ -394,6 +394,13 @@ namespace System.Data.Common
         public abstract int GetValues(object[] values);
         public abstract bool IsDBNull(int i);
     }
+    public partial class DbEnumerator : System.Collections.IEnumerator
+    {
+        public DbEnumerator(DbDataReader reader, bool closeReader) { }
+        public object Current { get; }
+        public bool MoveNext() { return default(bool); }
+        public void Reset() { }
+    }
     public abstract partial class DbException : System.Exception
     {
         protected DbException() { }

--- a/src/System.Data.Common/ref/System.Data.Common.csproj
+++ b/src/System.Data.Common/ref/System.Data.Common.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <NuGetTargetMoniker>.NETStandard,Version=v1.2</NuGetTargetMoniker>
   </PropertyGroup>


### PR DESCRIPTION
DbEnumerator's APIs are supported in 4.0, so no change to the .NET target is required.