### PR TITLE
Add some more tests for Encoding and Encoder/Decoder Fallbacks

### DIFF
--- a/src/System.Text.Encoding/tests/Encoding/EncodingCtorTests.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingCtorTests.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Text.Tests
+{
+    public class EncodingCtorTests
+    {
+        [Fact]
+        public void Ctor_Empty()
+        {
+            CustomEncoding encoding = new CustomEncoding();
+            VerifyEncoding(encoding, 0, null, null);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(10)]
+        [InlineData(int.MaxValue)]
+        public void Ctor_Int(int codePage)
+        {
+            CustomEncoding encoding = new CustomEncoding(codePage);
+            VerifyEncoding(encoding, codePage, null, null);
+        }
+
+        public static IEnumerable<object[]> Ctor_Int_EncoderFallback_DecoderFallback_TestData()
+        {
+            yield return new object[] { 10, null, null };
+            yield return new object[] { int.MaxValue, new EncoderReplacementFallback("abc"), null };
+            yield return new object[] { 0, null, new DecoderReplacementFallback("abc") };
+            yield return new object[] { 65536, new EncoderReplacementFallback("abc"), new DecoderReplacementFallback("abc") };
+        }
+
+        [Theory]
+        [MemberData(nameof(Ctor_Int_EncoderFallback_DecoderFallback_TestData))]
+        public void Ctor_Int_EncoderFallback_DecoderFallback(int codePage, EncoderFallback encoderFallback, DecoderFallback decoderFallback)
+        {
+            CustomEncoding encoding = new CustomEncoding(codePage, encoderFallback, decoderFallback);
+            VerifyEncoding(encoding, codePage, encoderFallback, decoderFallback);
+        }
+
+        [Fact]
+        public void Ctor_NegativeCodePage_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("codePage", () => new CustomEncoding(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("codePage", () => new CustomEncoding(-1, null, null));
+        }
+
+        [Fact]
+        public void Ctor_Int_NoSuchCodePage_WebName_ThrowsNotSupportedException()
+        {
+            CustomEncoding encoding = new CustomEncoding(54321);
+            Assert.Throws<NotSupportedException>(() => encoding.WebName);
+        }
+
+        public static void VerifyEncoding(Encoding encoding, int codePage, EncoderFallback encoderFallback, DecoderFallback decoderFallback)
+        {
+            if (encoderFallback == null)
+            {
+                Assert.NotNull(encoding.EncoderFallback);
+                Assert.Equal(codePage, encoding.EncoderFallback.GetHashCode());
+            }
+            else
+            {
+                Assert.Same(encoderFallback, encoding.EncoderFallback);
+            }
+
+            if (decoderFallback == null)
+            {
+                Assert.NotNull(encoding.DecoderFallback);
+                Assert.Equal(codePage, encoding.DecoderFallback.GetHashCode());
+            }
+            else
+            {
+                Assert.Same(decoderFallback, encoding.DecoderFallback);
+            }
+
+            Assert.Empty(encoding.GetPreamble());
+            Assert.False(encoding.IsSingleByte);
+        }
+    }
+
+    public class CustomEncoding : Encoding
+    {
+        public CustomEncoding() : base() {}
+        public CustomEncoding(int codePage): base(codePage) { }
+        public CustomEncoding(int codePage, EncoderFallback encoderFallback, DecoderFallback decoderFallback) : base(codePage, encoderFallback, decoderFallback) { }
+
+        public override int GetByteCount(char[] chars, int index, int count) => 1;
+
+        public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) => 2;
+
+        public override int GetCharCount(byte[] bytes, int index, int count) => 3;
+
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex) => 4;
+
+        public override int GetMaxByteCount(int charCount) => 5;
+
+        public override int GetMaxCharCount(int byteCount) => 6;
+    }
+}

--- a/src/System.Text.Encoding/tests/Encoding/EncodingGetEncodingTests.cs
+++ b/src/System.Text.Encoding/tests/Encoding/EncodingGetEncodingTests.cs
@@ -25,6 +25,7 @@ namespace System.Text.Tests
 
             // Codepage doesn't exist
             Assert.Throws<ArgumentException>("codepage", () => Encoding.GetEncoding(42));
+            Assert.Throws<NotSupportedException>(() => Encoding.GetEncoding(54321));
         }
 
         public class CodePageMapping

--- a/src/System.Text.Encoding/tests/Fallback/DecoderExceptionFallbackTests.cs
+++ b/src/System.Text.Encoding/tests/Fallback/DecoderExceptionFallbackTests.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Text.Tests
+{
+    public class DecoderExceptionFallbackTests
+    {
+        [Fact]
+        public void Ctor_Empty()
+        {
+            DecoderExceptionFallback fallback = new DecoderExceptionFallback();
+            Assert.Equal(0, fallback.MaxCharCount);
+            Assert.Equal(879, fallback.GetHashCode());
+        }
+
+        public static IEnumerable<object[]> Equals_TestData()
+        {
+            yield return new object[] { new DecoderExceptionFallback(), new DecoderExceptionFallback(), true };
+            yield return new object[] { new DecoderExceptionFallback(), new object(), false };
+            yield return new object[] { new DecoderExceptionFallback(), null, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(Equals_TestData))]
+        public void Equals(DecoderExceptionFallback fallback, object value, bool expected)
+        {
+            Assert.Equal(expected, fallback.Equals(value));
+        }
+
+        [Fact]
+        public void CreateFallbackBuffer()
+        {
+            DecoderFallbackBuffer buffer = new DecoderExceptionFallback().CreateFallbackBuffer();
+
+            Assert.Equal((char)0, buffer.GetNextChar());
+            Assert.False(buffer.MovePrevious());
+            Assert.Equal(0, buffer.Remaining);
+
+            Assert.Throws<DecoderFallbackException>(() => buffer.Fallback(new byte[0], 0));
+            Assert.Throws<DecoderFallbackException>(() => buffer.Fallback(new byte[25], 0));
+        }
+    }
+}

--- a/src/System.Text.Encoding/tests/Fallback/DecoderReplacementFallbackTests.cs
+++ b/src/System.Text.Encoding/tests/Fallback/DecoderReplacementFallbackTests.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Text.Tests
+{
+    public class DecoderReplacementFallbackTests
+    {
+        [Fact]
+        public void Ctor_Empty()
+        {
+            DecoderReplacementFallback fallback = new DecoderReplacementFallback();
+            Assert.Equal(1, fallback.MaxCharCount);
+            Assert.Equal("?", fallback.DefaultString);
+            Assert.Equal("?".GetHashCode(), fallback.GetHashCode());
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("a")]
+        [InlineData("abc")]
+        [InlineData("\uD800\uDC00")]
+        public void Ctor_String(string replacement)
+        {
+            DecoderReplacementFallback exception = new DecoderReplacementFallback(replacement);
+            Assert.Equal(replacement.Length, exception.MaxCharCount);
+            Assert.Equal(replacement, exception.DefaultString);
+            Assert.Equal(replacement.GetHashCode(), exception.GetHashCode());
+        }
+
+        [Fact]
+        public void Ctor_Invalid()
+        {
+            Assert.Throws<ArgumentNullException>("replacement", () => new DecoderReplacementFallback(null));
+
+            // Invalid surrogate pair
+            Assert.Throws<ArgumentException>(() => new DecoderReplacementFallback("\uD800"));
+            Assert.Throws<ArgumentException>(() => new DecoderReplacementFallback("\uD800a"));
+            Assert.Throws<ArgumentException>(() => new DecoderReplacementFallback("\uDC00"));
+            Assert.Throws<ArgumentException>(() => new DecoderReplacementFallback("a\uDC00"));
+            Assert.Throws<ArgumentException>(() => new DecoderReplacementFallback("\uDC00\uDC00"));
+            Assert.Throws<ArgumentException>(() => new DecoderReplacementFallback("\uD800\uD800"));
+        }
+
+        public static IEnumerable<object[]> Equals_TestData()
+        {
+            yield return new object[] { new DecoderReplacementFallback(), new DecoderReplacementFallback(), true };
+            yield return new object[] { new DecoderReplacementFallback(), new DecoderReplacementFallback("?"), true };
+
+            yield return new object[] { new DecoderReplacementFallback("abc"), new DecoderReplacementFallback("abc"), true };
+            yield return new object[] { new DecoderReplacementFallback("abc"), new DecoderReplacementFallback("def"), false };
+
+            yield return new object[] { new DecoderReplacementFallback(), new object(), false };
+            yield return new object[] { new DecoderReplacementFallback(), null, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(Equals_TestData))]
+        public void Equals(DecoderReplacementFallback fallback, object value, bool expected)
+        {
+            Assert.Equal(expected, fallback.Equals(value));
+        }
+
+        [Fact]
+        public void CreateFallbackBuffer()
+        {
+            DecoderFallbackBuffer buffer = new DecoderReplacementFallback().CreateFallbackBuffer();
+            Assert.Equal((char)0, buffer.GetNextChar());
+            Assert.False(buffer.MovePrevious());
+            Assert.Equal(0, buffer.Remaining);
+        }
+
+        [Theory]
+        [InlineData("", new byte[0], false)]
+        [InlineData("", new byte[] { 1 }, false)]
+        [InlineData("?", new byte[0], true)]
+        [InlineData("?", new byte[] { 1 }, true)]
+        public void CreateFallbackBuffer_Fallback_Char(string replacement, byte[] bytesUnknown, bool expected)
+        {
+            DecoderFallbackBuffer buffer = new DecoderReplacementFallback(replacement).CreateFallbackBuffer();
+            Assert.Equal(expected, buffer.Fallback(bytesUnknown, 0));
+        }
+
+        [Theory]
+        [InlineData("?")]
+        [InlineData("\uD800\uDC00")]
+        public void CreateFallbackBuffer_MultipleFallback_ThrowsArgumentException(string replacement)
+        {
+            DecoderFallbackBuffer buffer = new DecoderReplacementFallback(replacement).CreateFallbackBuffer();
+            buffer.Fallback(new byte[] { 1 }, 0);
+
+            Assert.Throws<ArgumentException>("bytesUnknown", () => buffer.Fallback(new byte[] { 1 }, 0));
+        }
+    }
+}

--- a/src/System.Text.Encoding/tests/Fallback/EncoderExceptionFallbackTests.cs
+++ b/src/System.Text.Encoding/tests/Fallback/EncoderExceptionFallbackTests.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Text.Tests
+{
+    public class EncoderExceptionFallbackTests
+    {
+        [Fact]
+        public void Ctor_Empty()
+        {
+            EncoderExceptionFallback fallback = new EncoderExceptionFallback();
+            Assert.Equal(0, fallback.MaxCharCount);
+            Assert.Equal(654, fallback.GetHashCode());
+        }
+
+        public static IEnumerable<object[]> Equals_TestData()
+        {
+            yield return new object[] { new EncoderExceptionFallback(), new EncoderExceptionFallback(), true };
+            yield return new object[] { new EncoderExceptionFallback(), new object(), false };
+            yield return new object[] { new EncoderExceptionFallback(), null, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(Equals_TestData))]
+        public void Equals(EncoderExceptionFallback fallback, object value, bool expected)
+        {
+            Assert.Equal(expected, fallback.Equals(value));
+        }
+
+        [Fact]
+        public void CreateFallbackBuffer()
+        {
+            EncoderFallbackBuffer buffer = new EncoderExceptionFallback().CreateFallbackBuffer();
+
+            Assert.Equal((char)0, buffer.GetNextChar());
+            Assert.False(buffer.MovePrevious());
+            Assert.Equal(0, buffer.Remaining);
+
+            EncoderFallbackException ex = Assert.Throws<EncoderFallbackException>(() => buffer.Fallback('a', 0));
+            Assert.Equal('a', ex.CharUnknown);
+
+            ex = Assert.Throws<EncoderFallbackException>(() => buffer.Fallback('\uD800', '\uDC00', 0));
+            Assert.Equal('\uD800', ex.CharUnknownHigh);
+            Assert.Equal('\uDC00', ex.CharUnknownLow);
+        }
+
+        [Fact]
+        public void CreateFallbackBuffer_Fallback_InvalidSurrogateChars_ThrowsArgumentOutOfRangeException()
+        {
+            EncoderFallbackBuffer buffer = new EncoderExceptionFallback().CreateFallbackBuffer();
+
+            Assert.Throws<ArgumentOutOfRangeException>("charUnknownHigh", () => buffer.Fallback('a', '\uDC00', 0));
+            Assert.Throws<ArgumentOutOfRangeException>("CharUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
+        }
+    }
+}

--- a/src/System.Text.Encoding/tests/Fallback/EncoderReplacementFallbackTests.cs
+++ b/src/System.Text.Encoding/tests/Fallback/EncoderReplacementFallbackTests.cs
@@ -1,0 +1,115 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Text.Tests
+{
+    public class EncoderReplacementFallbackTests
+    {
+        [Fact]
+        public void Ctor_Empty()
+        {
+            EncoderReplacementFallback exception = new EncoderReplacementFallback();
+            Assert.Equal(1, exception.MaxCharCount);
+            Assert.Equal("?", exception.DefaultString);
+            Assert.Equal("?".GetHashCode(), exception.GetHashCode());
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("a")]
+        [InlineData("abc")]
+        [InlineData("\uD800\uDC00")]
+        public void Ctor_String(string replacement)
+        {
+            EncoderReplacementFallback fallback = new EncoderReplacementFallback(replacement);
+            Assert.Equal(replacement.Length, fallback.MaxCharCount);
+            Assert.Equal(replacement, fallback.DefaultString);
+            Assert.Equal(replacement.GetHashCode(), fallback.GetHashCode());
+        }
+
+        [Fact]
+        public void Ctor_Invalid()
+        {
+            Assert.Throws<ArgumentNullException>("replacement", () => new EncoderReplacementFallback(null));
+
+            // Invalid surrogate pair
+            Assert.Throws<ArgumentException>(() => new EncoderReplacementFallback("\uD800"));
+            Assert.Throws<ArgumentException>(() => new EncoderReplacementFallback("\uD800a"));
+            Assert.Throws<ArgumentException>(() => new EncoderReplacementFallback("\uDC00"));
+            Assert.Throws<ArgumentException>(() => new EncoderReplacementFallback("a\uDC00"));
+            Assert.Throws<ArgumentException>(() => new EncoderReplacementFallback("\uDC00\uDC00"));
+            Assert.Throws<ArgumentException>(() => new EncoderReplacementFallback("\uD800\uD800"));
+        }
+
+        public static IEnumerable<object[]> Equals_TestData()
+        {
+            yield return new object[] { new EncoderReplacementFallback(), new EncoderReplacementFallback(), true };
+            yield return new object[] { new EncoderReplacementFallback(), new EncoderReplacementFallback("?"), true };
+
+            yield return new object[] { new EncoderReplacementFallback("abc"), new EncoderReplacementFallback("abc"), true };
+            yield return new object[] { new EncoderReplacementFallback("abc"), new EncoderReplacementFallback("def"), false };
+
+            yield return new object[] { new EncoderReplacementFallback(), new object(), false };
+            yield return new object[] { new EncoderReplacementFallback(), null, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(Equals_TestData))]
+        public void Equals(EncoderReplacementFallback fallback, object value, bool expected)
+        {
+            Assert.Equal(expected, fallback.Equals(value));
+        }
+
+        [Fact]
+        public void CreateFallbackBuffer()
+        {
+            EncoderFallbackBuffer buffer = new EncoderReplacementFallback().CreateFallbackBuffer();
+            Assert.Equal((char)0, buffer.GetNextChar());
+            Assert.False(buffer.MovePrevious());
+            Assert.Equal(0, buffer.Remaining);
+        }
+
+        [Theory]
+        [InlineData("", 'a', false)]
+        [InlineData("?", 'a', true)]
+        public void CreateFallbackBuffer_Fallback_Char(string replacement, char charUnknown, bool expected)
+        {
+            EncoderFallbackBuffer buffer = new EncoderReplacementFallback(replacement).CreateFallbackBuffer();
+            Assert.Equal(expected, buffer.Fallback(charUnknown, 0));
+        }
+
+        [Theory]
+        [InlineData("?")]
+        [InlineData("\uD800\uDC00")]
+        public void CreateFallbackBuffer_MultipleFallback_ThrowsArgumentException(string replacement)
+        {
+            EncoderFallbackBuffer buffer = new EncoderReplacementFallback(replacement).CreateFallbackBuffer();
+            buffer.Fallback('a', 0);
+
+            Assert.Throws<ArgumentException>("chars", () => buffer.Fallback('a', 0));
+            Assert.Throws<ArgumentException>("chars", () => buffer.Fallback('\uD800', '\uDC00', 0));
+        }
+
+        [Theory]
+        [InlineData("", false)]
+        [InlineData("a", true)]
+        public void CreateFallbackBuffer_Fallback_Char_Char(string replacement, bool expected)
+        {
+            EncoderFallbackBuffer buffer = new EncoderReplacementFallback(replacement).CreateFallbackBuffer();
+            Assert.Equal(expected, buffer.Fallback('\uD800', '\uDC00', 0));
+        }
+
+        [Fact]
+        public void CreateFallbackBuffer_Fallback_InvalidSurrogateChars_ThrowsArgumentOutOfRangeException()
+        {
+            EncoderFallbackBuffer buffer = new EncoderReplacementFallback().CreateFallbackBuffer();
+
+            Assert.Throws<ArgumentOutOfRangeException>("charUnknownHigh", () => buffer.Fallback('a', '\uDC00', 0));
+            Assert.Throws<ArgumentOutOfRangeException>("CharUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
+        }
+    }
+}

--- a/src/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
+++ b/src/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
@@ -37,8 +37,13 @@
     <Compile Include="Encoder\EncoderCtor.cs" />
     <Compile Include="Encoder\EncoderGetByteCount2.cs" />
     <Compile Include="Encoder\EncoderGetBytes2.cs" />
+    <Compile Include="Encoding\EncodingCtorTests.cs" />
     <Compile Include="Encoding\EncodingGetEncodingTests.cs" />
     <Compile Include="Encoding\EncodingConvertTests.cs" />
+    <Compile Include="Fallback\DecoderReplacementFallbackTests.cs" />
+    <Compile Include="Fallback\EncoderReplacementFallbackTests.cs" />
+    <Compile Include="Fallback\EncoderExceptionFallbackTests.cs" />
+    <Compile Include="Fallback\DecoderExceptionFallbackTests.cs" />
     <Compile Include="NegativeEncodingTests.cs" />
     <Compile Include="EncodingTestHelpers.cs" />
     <Compile Include="Latin1Encoding\Latin1EncodingEncode.cs" />


### PR DESCRIPTION
- Encoding (ctor, GetEncoding)
- DecoderExceptionFallback
- EncoderExceptionFallback
- DecoderReplacementFallback
- EncoderReplacementFallback

Fills in some missing coverage gaps
/cc @tarekgh