### PR TITLE
Add cloudtest targets to tests.builds file

### DIFF
--- a/src/tests.builds
+++ b/src/tests.builds
@@ -12,5 +12,6 @@
       <FilterToOSGroup Condition="'$(_OriginalOSGroup)' == ''">$(OSEnvironment)</FilterToOSGroup>
     </Project>
   </ItemGroup>
+  <Import Project="$(ToolsDir)CloudTest.Targets" Condition="'$(EnableCloudTest)'=='true'" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>


### PR DESCRIPTION
I had believed that build.proj imported cloudtest.targets, but it does not.  Adding cloudtest.targets to tests.builds so that we can push changes to Helix.

My previous solution was to add this capability to buildtools, but adding it in corefx is another workable solution..
https://github.com/dotnet/buildtools/pull/680#issuecomment-215912765

/cc @weshaggard , @jhendrixMSFT 