### PR TITLE
Turn on ECMS decryption tests as outer loop tests.

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/tests/CertLoader.Settings.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/CertLoader.Settings.cs
@@ -18,7 +18,7 @@ namespace Test.Cryptography
         //
         //    TestMode = CertLoadMode.Disable
         //
-        //        Disable all tests that rely on private keys. Unfortunately, this has to be the default for checked in tests to avoid cluttering
+        //        Disable all tests that rely on private keys. Unfortunately, this has to be the default for inner-loop tests to avoid cluttering
         //        people's machines with leaked keys on disk every time they build.
         //
         //
@@ -41,7 +41,7 @@ namespace Test.Cryptography
         //
         // These fields are nominally private and readonly but intentionally not declared as such so that an ad-hoc test host can change them for convenience.
         //
-        public static CertLoadMode TestMode = CertLoadMode.Disable;
+        public static CertLoadMode TestMode = CertLoadMode.LoadFromPfx;
         public static string StoreName = "DotNetCoreFxTestCerts";  // Do not use "MY" here as that can break many test assumptions.
     }
 }

--- a/src/System.Security.Cryptography.Pkcs/tests/CertLoader.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/CertLoader.cs
@@ -52,7 +52,15 @@ namespace Test.Cryptography
                     return null;
 
                 case CertLoadMode.LoadFromPfx:
-                    return new X509Certificate2(PfxData, Password);
+                    {
+                        // Loading the same PFX in multiple threads can cause test failures due to races as Crypto tries to 
+                        // manipulate the stored keys on disk. To avoid this, serialize all loads of PFX's. It would probably
+                        // suffice to serialize loads of the same PFX's, but it's not worth adding that complexity for a test harness.
+                        lock (s_pfxMutex)
+                        {
+                            return new X509Certificate2(PfxData, Password);
+                        }
+                    }
 
                 case CertLoadMode.LoadFromStore:
                     {
@@ -116,6 +124,7 @@ namespace Test.Cryptography
         }
 
         private bool _alreadySearchedMyStore = false;
+        private static object s_pfxMutex = new object();
     }
 
     internal sealed class CertLoaderFromRawData : CertLoader

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
@@ -22,6 +22,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
     public static partial class DecryptTests
     {
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void Decrypt_IssuerAndSerial()
         {
             byte[] content = { 5, 112, 233, 43 };
@@ -30,6 +31,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void Decrypt_Ski()
         {
             byte[] content = { 6, 3, 128, 33, 44 };
@@ -38,6 +40,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void Decrypt_Capi()
         {
             byte[] content = { 5, 77, 32, 33, 2, 34 };
@@ -46,6 +49,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void Decrypt_256()
         {
             byte[] content = { 5, 77, 32, 33, 2, 34 };
@@ -54,6 +58,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void Decrypt_384()
         {
             byte[] content = { 5, 77, 32, 33, 2, 34 };
@@ -62,6 +67,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void Decrypt_512()
         {
             byte[] content = { 5, 77, 32, 33, 2, 34 };
@@ -70,6 +76,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void Decrypt_SignedWithinEnveloped()
         {
             byte[] content =
@@ -96,6 +103,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void Decrypt_EnvelopedWithinEnveloped()
         {
             byte[] content =
@@ -112,6 +120,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void DecryptMultipleRecipients()
         {
             // Force Decrypt() to try multiple recipients. Ensure that a failure to find a matching cert in one doesn't cause it to quit early.

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
@@ -22,6 +22,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
     public static partial class EdgeCasesTests
     {
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void ZeroLengthContent_RoundTrip()
         {
             ContentInfo contentInfo = new ContentInfo(Array.Empty<byte>());
@@ -43,6 +44,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void ZeroLengthContent_FixedValue()
         {
             byte[] encodedMessage =
@@ -56,6 +58,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void Rc4AndCngWrappersDontMixTest()
         {
             //
@@ -275,6 +278,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void EnvelopedCmsDecryptWithoutMatchingCert()
         {
             // You don't have the private key? No message for you.
@@ -302,6 +306,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void EnvelopedCmsDecryptWithoutMatchingCertSki()
         {
             // You don't have the private key? No message for you.

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/StateTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/StateTests.cs
@@ -227,6 +227,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         // State 4: Called Decode() + Decrypt()
         //
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void PostDecrypt_Encode()
         {
             byte[] expectedContent = { 6, 3, 128, 33, 44 };
@@ -259,6 +260,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void PostDecrypt_RecipientInfos()
         {
             byte[] expectedContent = { 6, 3, 128, 33, 44 };
@@ -297,6 +299,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [OuterLoop(/* Leaks key on disk if interrupted */)]
         public static void PostDecrypt_Decrypt()
         {
             byte[] expectedContent = { 6, 3, 128, 33, 44 };


### PR DESCRIPTION
This also serializes loads of PFX's to avoid intermittent
failures like we're seeing with a certain X509 test.