### PR TITLE
Add more binary nullable tests

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
@@ -179,7 +179,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type type)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(TypeUtils.IsArithmetic(type));
             switch (System.Dynamic.Utils.TypeExtensions.GetTypeCode(TypeUtils.GetNonNullableType(type)))
             {
                 case TypeCode.Int16: return s_int16 ?? (s_int16 = new AddInt16());
@@ -190,9 +190,8 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new AddUInt64());
                 case TypeCode.Single: return s_single ?? (s_single = new AddSingle());
                 case TypeCode.Double: return s_double ?? (s_double = new AddDouble());
-
                 default:
-                    throw Error.ExpressionNotSupportedForType("Add", type);
+                    throw ContractUtils.Unreachable;
             }
         }
 
@@ -334,7 +333,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type type)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(TypeUtils.IsArithmetic(type));
             switch (System.Dynamic.Utils.TypeExtensions.GetTypeCode(TypeUtils.GetNonNullableType(type)))
             {
                 case TypeCode.Int16: return s_int16 ?? (s_int16 = new AddOvfInt16());
@@ -343,12 +342,9 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new AddOvfUInt16());
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new AddOvfUInt32());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new AddOvfUInt64());
-                case TypeCode.Single:
-                case TypeCode.Double:
-                    return AddInstruction.Create(type);
 
                 default:
-                    throw Error.ExpressionNotSupportedForType("AddOvf", type);
+                    return AddInstruction.Create(type);
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
@@ -204,7 +204,7 @@ namespace System.Linq.Expressions.Interpreter
 
     internal abstract class AddOvfInstruction : Instruction
     {
-        private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
+        private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }
@@ -332,44 +332,6 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        internal sealed class AddOvfSingle : AddOvfInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
-                {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (Single)((Single)l + (Single)r);
-                }
-                frame.StackIndex--;
-                return +1;
-            }
-        }
-
-        internal sealed class AddOvfDouble : AddOvfInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
-                {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (Double)l + (Double)r;
-                }
-                frame.StackIndex--;
-                return +1;
-            }
-        }
-
         public static Instruction Create(Type type)
         {
             Debug.Assert(!type.GetTypeInfo().IsEnum);
@@ -381,8 +343,9 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new AddOvfUInt16());
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new AddOvfUInt32());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new AddOvfUInt64());
-                case TypeCode.Single: return s_single ?? (s_single = new AddOvfSingle());
-                case TypeCode.Double: return s_double ?? (s_double = new AddOvfDouble());
+                case TypeCode.Single:
+                case TypeCode.Double:
+                    return AddInstruction.Create(type);
 
                 default:
                     throw Error.ExpressionNotSupportedForType("AddOvf", type);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
@@ -177,7 +177,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type type)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(TypeUtils.IsArithmetic(type));
             switch (System.Dynamic.Utils.TypeExtensions.GetTypeCode(TypeUtils.GetNonNullableType(type)))
             {
                 case TypeCode.Int16: return s_int16 ?? (s_int16 = new MulInt16());
@@ -190,7 +190,7 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.Double: return s_double ?? (s_double = new MulDouble());
 
                 default:
-                    throw Error.ExpressionNotSupportedForType("Mul", type);
+                    throw ContractUtils.Unreachable;
             }
         }
 
@@ -330,7 +330,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type type)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(TypeUtils.IsArithmetic(type));
             switch (System.Dynamic.Utils.TypeExtensions.GetTypeCode(TypeUtils.GetNonNullableType(type)))
             {
                 case TypeCode.Int16: return s_int16 ?? (s_int16 = new MulOvfInt16());
@@ -339,12 +339,8 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new MulOvfUInt16());
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new MulOvfUInt32());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new MulOvfUInt64());
-                case TypeCode.Single:
-                case TypeCode.Double:
-                    return MulInstruction.Create(type);
-
                 default:
-                    throw Error.ExpressionNotSupportedForType("MulOvf", type);
+                    return MulInstruction.Create(type);
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
@@ -202,7 +202,7 @@ namespace System.Linq.Expressions.Interpreter
 
     internal abstract class MulOvfInstruction : Instruction
     {
-        private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
+        private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }
@@ -328,44 +328,6 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        internal sealed class MulOvfSingle : MulOvfInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
-                {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (Single)((Single)l * (Single)r);
-                }
-                frame.StackIndex--;
-                return +1;
-            }
-        }
-
-        internal sealed class MulOvfDouble : MulOvfInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
-                {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (Double)l * (Double)r;
-                }
-                frame.StackIndex--;
-                return +1;
-            }
-        }
-
         public static Instruction Create(Type type)
         {
             Debug.Assert(!type.GetTypeInfo().IsEnum);
@@ -377,8 +339,9 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new MulOvfUInt16());
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new MulOvfUInt32());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new MulOvfUInt64());
-                case TypeCode.Single: return s_single ?? (s_single = new MulOvfSingle());
-                case TypeCode.Double: return s_double ?? (s_double = new MulOvfDouble());
+                case TypeCode.Single:
+                case TypeCode.Double:
+                    return MulInstruction.Create(type);
 
                 default:
                     throw Error.ExpressionNotSupportedForType("MulOvf", type);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
@@ -202,7 +202,7 @@ namespace System.Linq.Expressions.Interpreter
 
     internal abstract class SubOvfInstruction : Instruction
     {
-        private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
+        private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64;
 
         public override int ConsumedStack { get { return 2; } }
         public override int ProducedStack { get { return 1; } }
@@ -328,44 +328,6 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        internal sealed class SubOvfSingle : SubOvfInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
-                {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (Single)((Single)l - (Single)r);
-                }
-                frame.StackIndex--;
-                return +1;
-            }
-        }
-
-        internal sealed class SubOvfDouble : SubOvfInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
-                {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (Double)l - (Double)r;
-                }
-                frame.StackIndex--;
-                return +1;
-            }
-        }
-
         public static Instruction Create(Type type)
         {
             Debug.Assert(!type.GetTypeInfo().IsEnum);
@@ -377,8 +339,9 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new SubOvfUInt16());
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new SubOvfUInt32());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new SubOvfUInt64());
-                case TypeCode.Single: return s_single ?? (s_single = new SubOvfSingle());
-                case TypeCode.Double: return s_double ?? (s_double = new SubOvfDouble());
+                case TypeCode.Single:
+                case TypeCode.Double:
+                    return SubInstruction.Create(type);
 
                 default:
                     throw Error.ExpressionNotSupportedForType("SubOvf", type);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
@@ -177,7 +177,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type type)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(TypeUtils.IsArithmetic(type));
             switch (System.Dynamic.Utils.TypeExtensions.GetTypeCode(TypeUtils.GetNonNullableType(type)))
             {
                 case TypeCode.Int16: return s_int16 ?? (s_int16 = new SubInt16());
@@ -188,9 +188,8 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new SubUInt64());
                 case TypeCode.Single: return s_single ?? (s_single = new SubSingle());
                 case TypeCode.Double: return s_double ?? (s_double = new SubDouble());
-
                 default:
-                    throw Error.ExpressionNotSupportedForType("Sub", type);
+                    throw ContractUtils.Unreachable;
             }
         }
 
@@ -330,7 +329,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type type)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(TypeUtils.IsArithmetic(type));
             switch (System.Dynamic.Utils.TypeExtensions.GetTypeCode(TypeUtils.GetNonNullableType(type)))
             {
                 case TypeCode.Int16: return s_int16 ?? (s_int16 = new SubOvfInt16());
@@ -339,12 +338,8 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new SubOvfUInt16());
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new SubOvfUInt32());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new SubOvfUInt64());
-                case TypeCode.Single:
-                case TypeCode.Double:
-                    return SubInstruction.Create(type);
-
                 default:
-                    throw Error.ExpressionNotSupportedForType("SubOvf", type);
+                    return SubInstruction.Create(type);
             }
         }
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableAddTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -14,7 +13,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckNullableByteAddTest()
         {
-            byte?[] array = new byte?[] { 0, 1, byte.MaxValue };
+            byte?[] array = { 0, 1, byte.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -27,7 +26,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckNullableSByteAddTest()
         {
-            sbyte?[] array = new sbyte?[] { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue };
+            sbyte?[] array = { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -40,12 +39,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableUShortAddTest(bool useInterpreter)
         {
-            ushort?[] array = new ushort?[] { 0, 1, ushort.MaxValue };
+            ushort?[] array = { 0, 1, ushort.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableUShortAdd(array[i], array[j], useInterpreter);
+                    VerifyNullableUShortAddOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -53,12 +53,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableShortAddTest(bool useInterpreter)
         {
-            short?[] array = new short?[] { 0, 1, -1, short.MinValue, short.MaxValue };
+            short?[] array = { 0, 1, -1, short.MinValue, short.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableShortAdd(array[i], array[j], useInterpreter);
+                    VerifyNullableShortAddOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -66,12 +67,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableUIntAddTest(bool useInterpreter)
         {
-            uint?[] array = new uint?[] { 0, 1, uint.MaxValue };
+            uint?[] array = { 0, 1, uint.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableUIntAdd(array[i], array[j], useInterpreter);
+                    VerifyNullableUIntAddOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -79,12 +81,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableIntAddTest(bool useInterpreter)
         {
-            int?[] array = new int?[] { 0, 1, -1, int.MinValue, int.MaxValue };
+            int?[] array = { 0, 1, -1, int.MinValue, int.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableIntAdd(array[i], array[j], useInterpreter);
+                    VerifyNullableIntAddOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -92,12 +95,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableULongAddTest(bool useInterpreter)
         {
-            ulong?[] array = new ulong?[] { 0, 1, ulong.MaxValue };
+            ulong?[] array = { 0, 1, ulong.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableULongAdd(array[i], array[j], useInterpreter);
+                    VerifyNullableULongAddOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -105,12 +109,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableLongAddTest(bool useInterpreter)
         {
-            long?[] array = new long?[] { 0, 1, -1, long.MinValue, long.MaxValue };
+            long?[] array = { 0, 1, -1, long.MinValue, long.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableLongAdd(array[i], array[j], useInterpreter);
+                    VerifyNullableLongAddOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -118,12 +123,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableFloatAddTest(bool useInterpreter)
         {
-            float?[] array = new float?[] { 0, 1, -1, float.MinValue, float.MaxValue, float.Epsilon, float.NegativeInfinity, float.PositiveInfinity, float.NaN };
+            float?[] array = { 0, 1, -1, float.MinValue, float.MaxValue, float.Epsilon, float.NegativeInfinity, float.PositiveInfinity, float.NaN, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableFloatAdd(array[i], array[j], useInterpreter);
+                    VerifyNullableFloatAddOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -131,12 +137,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableDoubleAddTest(bool useInterpreter)
         {
-            double?[] array = new double?[] { 0, 1, -1, double.MinValue, double.MaxValue, double.Epsilon, double.NegativeInfinity, double.PositiveInfinity, double.NaN };
+            double?[] array = { 0, 1, -1, double.MinValue, double.MaxValue, double.Epsilon, double.NegativeInfinity, double.PositiveInfinity, double.NaN, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableDoubleAdd(array[i], array[j], useInterpreter);
+                    VerifyNullableDoubleAddOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -144,12 +151,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableDecimalAddTest(bool useInterpreter)
         {
-            decimal?[] array = new decimal?[] { decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue };
+            decimal?[] array = { decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableDecimalAdd(array[i], array[j], useInterpreter);
+                    VerifyNullableDecimalAddOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -157,7 +165,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckNullableCharAddTest()
         {
-            char?[] array = new char?[] { '\0', '\b', 'A', '\uffff' };
+            char?[] array = { '\0', '\b', 'A', '\uffff', null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -176,6 +184,7 @@ namespace System.Linq.Expressions.Tests
             Expression aExp = Expression.Constant(a, typeof(byte?));
             Expression bExp = Expression.Constant(b, typeof(byte?));
             Assert.Throws<InvalidOperationException>(() => Expression.Add(aExp, bExp));
+            Assert.Throws<InvalidOperationException>(() => Expression.AddChecked(aExp, bExp));
         }
 
         private static void VerifyNullableSByteAdd(sbyte? a, sbyte? b)
@@ -183,6 +192,7 @@ namespace System.Linq.Expressions.Tests
             Expression aExp = Expression.Constant(a, typeof(sbyte?));
             Expression bExp = Expression.Constant(b, typeof(sbyte?));
             Assert.Throws<InvalidOperationException>(() => Expression.Add(aExp, bExp));
+            Assert.Throws<InvalidOperationException>(() => Expression.AddChecked(aExp, bExp));
         }
 
         private static void VerifyNullableUShortAdd(ushort? a, ushort? b, bool useInterpreter)
@@ -198,6 +208,23 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal((ushort?)(a + b), f());
         }
 
+        private static void VerifyNullableUShortAddOvf(ushort? a, ushort? b, bool useInterpreter)
+        {
+            Expression<Func<ushort?>> e =
+                Expression.Lambda<Func<ushort?>>(
+                    Expression.AddChecked(
+                        Expression.Constant(a, typeof(ushort?)),
+                        Expression.Constant(b, typeof(ushort?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<ushort?> f = e.Compile(useInterpreter);
+
+            int? expected = a + b;
+            if (expected < 0 || expected > ushort.MaxValue)
+                Assert.Throws<OverflowException>(() => f());
+            else
+                Assert.Equal(expected, f());
+        }
+
         private static void VerifyNullableShortAdd(short? a, short? b, bool useInterpreter)
         {
             Expression<Func<short?>> e =
@@ -209,6 +236,23 @@ namespace System.Linq.Expressions.Tests
             Func<short?> f = e.Compile(useInterpreter);
 
             Assert.Equal((short?)(a + b), f());
+        }
+
+        private static void VerifyNullableShortAddOvf(short? a, short? b, bool useInterpreter)
+        {
+            Expression<Func<short?>> e =
+                Expression.Lambda<Func<short?>>(
+                    Expression.AddChecked(
+                        Expression.Constant(a, typeof(short?)),
+                        Expression.Constant(b, typeof(short?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<short?> f = e.Compile(useInterpreter);
+
+            int? expected = a + b;
+            if (expected < short.MinValue || expected > short.MaxValue)
+                Assert.Throws<OverflowException>(() => f());
+            else
+                Assert.Equal(expected, f());
         }
 
         private static void VerifyNullableUIntAdd(uint? a, uint? b, bool useInterpreter)
@@ -224,6 +268,23 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(a + b, f());
         }
 
+        private static void VerifyNullableUIntAddOvf(uint? a, uint? b, bool useInterpreter)
+        {
+            Expression<Func<uint?>> e =
+                Expression.Lambda<Func<uint?>>(
+                    Expression.AddChecked(
+                        Expression.Constant(a, typeof(uint?)),
+                        Expression.Constant(b, typeof(uint?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<uint?> f = e.Compile(useInterpreter);
+
+            long? expected = a + (long?)b;
+            if (expected < 0 || expected > uint.MaxValue)
+                Assert.Throws<OverflowException>(() => f());
+            else
+                Assert.Equal(expected, f());
+        }
+
         private static void VerifyNullableIntAdd(int? a, int? b, bool useInterpreter)
         {
             Expression<Func<int?>> e =
@@ -235,6 +296,23 @@ namespace System.Linq.Expressions.Tests
             Func<int?> f = e.Compile(useInterpreter);
 
             Assert.Equal(a + b, f());
+        }
+
+        private static void VerifyNullableIntAddOvf(int? a, int? b, bool useInterpreter)
+        {
+            Expression<Func<int?>> e =
+                Expression.Lambda<Func<int?>>(
+                    Expression.AddChecked(
+                        Expression.Constant(a, typeof(int?)),
+                        Expression.Constant(b, typeof(int?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int?> f = e.Compile(useInterpreter);
+
+            long? expected = a + (long?)b;
+            if (expected < int.MinValue || expected > int.MaxValue)
+                Assert.Throws<OverflowException>(() => f());
+            else
+                Assert.Equal(expected, f());
         }
 
         private static void VerifyNullableULongAdd(ulong? a, ulong? b, bool useInterpreter)
@@ -250,6 +328,30 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(a + b, f());
         }
 
+        private static void VerifyNullableULongAddOvf(ulong? a, ulong? b, bool useInterpreter)
+        {
+            Expression<Func<ulong?>> e =
+                Expression.Lambda<Func<ulong?>>(
+                    Expression.AddChecked(
+                        Expression.Constant(a, typeof(ulong?)),
+                        Expression.Constant(b, typeof(ulong?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<ulong?> f = e.Compile(useInterpreter);
+
+            ulong? expected;
+            try
+            {
+                expected = checked(a + b);
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
+        }
+
         private static void VerifyNullableLongAdd(long? a, long? b, bool useInterpreter)
         {
             Expression<Func<long?>> e =
@@ -263,11 +365,48 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(a + b, f());
         }
 
+        private static void VerifyNullableLongAddOvf(long? a, long? b, bool useInterpreter)
+        {
+            Expression<Func<long?>> e =
+                Expression.Lambda<Func<long?>>(
+                    Expression.AddChecked(
+                        Expression.Constant(a, typeof(long?)),
+                        Expression.Constant(b, typeof(long?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<long?> f = e.Compile(useInterpreter);
+
+            long? expected;
+            try
+            {
+                expected = checked(a + b);
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
+        }
+
         private static void VerifyNullableFloatAdd(float? a, float? b, bool useInterpreter)
         {
             Expression<Func<float?>> e =
                 Expression.Lambda<Func<float?>>(
                     Expression.Add(
+                        Expression.Constant(a, typeof(float?)),
+                        Expression.Constant(b, typeof(float?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<float?> f = e.Compile(useInterpreter);
+
+            Assert.Equal(a + b, f());
+        }
+
+        private static void VerifyNullableFloatAddOvf(float? a, float? b, bool useInterpreter)
+        {
+            Expression<Func<float?>> e =
+                Expression.Lambda<Func<float?>>(
+                    Expression.AddChecked(
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
@@ -289,6 +428,19 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(a + b, f());
         }
 
+        private static void VerifyNullableDoubleAddOvf(double? a, double? b, bool useInterpreter)
+        {
+            Expression<Func<double?>> e =
+                Expression.Lambda<Func<double?>>(
+                    Expression.AddChecked(
+                        Expression.Constant(a, typeof(double?)),
+                        Expression.Constant(b, typeof(double?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<double?> f = e.Compile(useInterpreter);
+
+            Assert.Equal(a + b, f());
+        }
+
         private static void VerifyNullableDecimalAdd(decimal? a, decimal? b, bool useInterpreter)
         {
             Expression<Func<decimal?>> e =
@@ -299,7 +451,31 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<decimal?> f = e.Compile(useInterpreter);
 
-            decimal? expected = 0;
+            decimal? expected;
+            try
+            {
+                expected = a + b;
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
+        }
+
+        private static void VerifyNullableDecimalAddOvf(decimal? a, decimal? b, bool useInterpreter)
+        {
+            Expression<Func<decimal?>> e =
+                Expression.Lambda<Func<decimal?>>(
+                    Expression.AddChecked(
+                        Expression.Constant(a, typeof(decimal?)),
+                        Expression.Constant(b, typeof(decimal?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<decimal?> f = e.Compile(useInterpreter);
+
+            decimal? expected;
             try
             {
                 expected = a + b;
@@ -318,6 +494,7 @@ namespace System.Linq.Expressions.Tests
             Expression aExp = Expression.Constant(a, typeof(char?));
             Expression bExp = Expression.Constant(b, typeof(char?));
             Assert.Throws<InvalidOperationException>(() => Expression.Add(aExp, bExp));
+            Assert.Throws<InvalidOperationException>(() => Expression.AddChecked(aExp, bExp));
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableDivideTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -14,7 +13,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckNullableByteDivideTest()
         {
-            byte?[] array = new byte?[] { 0, 1, byte.MaxValue };
+            byte?[] array = { 0, 1, byte.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -27,7 +26,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckNullableSByteDivideTest()
         {
-            sbyte?[] array = new sbyte?[] { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue };
+            sbyte?[] array = { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -40,7 +39,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableUShortDivideTest(bool useInterpreter)
         {
-            ushort?[] array = new ushort?[] { 0, 1, ushort.MaxValue };
+            ushort?[] array = { 0, 1, ushort.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -53,7 +52,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableShortDivideTest(bool useInterpreter)
         {
-            short?[] array = new short?[] { 0, 1, -1, short.MinValue, short.MaxValue };
+            short?[] array = { 0, 1, -1, short.MinValue, short.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -66,7 +65,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableUIntDivideTest(bool useInterpreter)
         {
-            uint?[] array = new uint?[] { 0, 1, uint.MaxValue };
+            uint?[] array = { 0, 1, uint.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -79,7 +78,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableIntDivideTest(bool useInterpreter)
         {
-            int?[] array = new int?[] { 0, 1, -1, int.MinValue, int.MaxValue };
+            int?[] array = { 0, 1, -1, int.MinValue, int.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -92,7 +91,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableULongDivideTest(bool useInterpreter)
         {
-            ulong?[] array = new ulong?[] { 0, 1, ulong.MaxValue };
+            ulong?[] array = { 0, 1, ulong.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -105,7 +104,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableLongDivideTest(bool useInterpreter)
         {
-            long?[] array = new long?[] { 0, 1, -1, long.MinValue, long.MaxValue };
+            long?[] array = { 0, 1, -1, long.MinValue, long.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -118,7 +117,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableFloatDivideTest(bool useInterpreter)
         {
-            float?[] array = new float?[] { 0, 1, -1, float.MinValue, float.MaxValue, float.Epsilon, float.NegativeInfinity, float.PositiveInfinity, float.NaN };
+            float?[] array = { 0, 1, -1, float.MinValue, float.MaxValue, float.Epsilon, float.NegativeInfinity, float.PositiveInfinity, float.NaN, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -131,7 +130,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableDoubleDivideTest(bool useInterpreter)
         {
-            double?[] array = new double?[] { 0, 1, -1, double.MinValue, double.MaxValue, double.Epsilon, double.NegativeInfinity, double.PositiveInfinity, double.NaN };
+            double?[] array = { 0, 1, -1, double.MinValue, double.MaxValue, double.Epsilon, double.NegativeInfinity, double.PositiveInfinity, double.NaN, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -144,7 +143,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableDecimalDivideTest(bool useInterpreter)
         {
-            decimal?[] array = new decimal?[] { decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue };
+            decimal?[] array = { decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -157,7 +156,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckNullableCharDivideTest()
         {
-            char?[] array = new char?[] { '\0', '\b', 'A', '\uffff' };
+            char?[] array = { '\0', '\b', 'A', '\uffff', null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -195,10 +194,10 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            if (b == 0)
+            if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else
-                Assert.Equal((ushort)(a / b), f());
+                Assert.Equal((ushort?)(a / b), f());
         }
 
         private static void VerifyNullableShortDivide(short? a, short? b, bool useInterpreter)
@@ -211,10 +210,10 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            if (b == 0)
+            if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else
-                Assert.Equal((short)(a / b), f());
+                Assert.Equal((short?)(a / b), f());
         }
 
         private static void VerifyNullableUIntDivide(uint? a, uint? b, bool useInterpreter)
@@ -227,7 +226,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            if (b == 0)
+            if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else
                 Assert.Equal(a / b, f());
@@ -243,7 +242,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            if (b == 0)
+            if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else if (b == -1 && a == int.MinValue)
                 Assert.Throws<OverflowException>(() => f());
@@ -261,7 +260,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            if (b == 0)
+            if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else
                 Assert.Equal(a / b, f());
@@ -277,7 +276,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<long?> f = e.Compile(useInterpreter);
 
-            if (b == 0)
+            if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else if (b == -1 && a == long.MinValue)
                 Assert.Throws<OverflowException>(() => f());
@@ -321,7 +320,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<decimal?> f = e.Compile(useInterpreter);
 
-            if (b == 0)
+            if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else
                 Assert.Equal(a / b, f());

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableModuloTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -14,7 +13,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckNullableByteModuloTest()
         {
-            byte?[] array = new byte?[] { 0, 1, byte.MaxValue };
+            byte?[] array = { 0, 1, byte.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -27,7 +26,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckNullableSByteModuloTest()
         {
-            sbyte?[] array = new sbyte?[] { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue };
+            sbyte?[] array = { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -40,7 +39,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableUShortModuloTest(bool useInterpreter)
         {
-            ushort?[] array = new ushort?[] { 0, 1, ushort.MaxValue };
+            ushort?[] array = { 0, 1, ushort.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -53,7 +52,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableShortModuloTest(bool useInterpreter)
         {
-            short?[] array = new short?[] { 0, 1, -1, short.MinValue, short.MaxValue };
+            short?[] array = { 0, 1, -1, short.MinValue, short.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -66,7 +65,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableUIntModuloTest(bool useInterpreter)
         {
-            uint?[] array = new uint?[] { 0, 1, uint.MaxValue };
+            uint?[] array = { 0, 1, uint.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -79,7 +78,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableIntModuloTest(bool useInterpreter)
         {
-            int?[] array = new int?[] { 0, 1, -1, int.MinValue, int.MaxValue };
+            int?[] array = { 0, 1, -1, int.MinValue, int.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -92,7 +91,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableULongModuloTest(bool useInterpreter)
         {
-            ulong?[] array = new ulong?[] { 0, 1, ulong.MaxValue };
+            ulong?[] array = { 0, 1, ulong.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -105,7 +104,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableLongModuloTest(bool useInterpreter)
         {
-            long?[] array = new long?[] { 0, 1, -1, long.MinValue, long.MaxValue };
+            long?[] array = { 0, 1, -1, long.MinValue, long.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -118,7 +117,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableFloatModuloTest(bool useInterpreter)
         {
-            float?[] array = new float?[] { 0, 1, -1, float.MinValue, float.MaxValue, float.Epsilon, float.NegativeInfinity, float.PositiveInfinity, float.NaN };
+            float?[] array = { 0, 1, -1, float.MinValue, float.MaxValue, float.Epsilon, float.NegativeInfinity, float.PositiveInfinity, float.NaN, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -131,7 +130,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableDoubleModuloTest(bool useInterpreter)
         {
-            double?[] array = new double?[] { 0, 1, -1, double.MinValue, double.MaxValue, double.Epsilon, double.NegativeInfinity, double.PositiveInfinity, double.NaN };
+            double?[] array = { 0, 1, -1, double.MinValue, double.MaxValue, double.Epsilon, double.NegativeInfinity, double.PositiveInfinity, double.NaN, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -144,7 +143,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableDecimalModuloTest(bool useInterpreter)
         {
-            decimal?[] array = new decimal?[] { decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue };
+            decimal?[] array = { decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -157,7 +156,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckNullableCharModuloTest()
         {
-            char?[] array = new char?[] { '\0', '\b', 'A', '\uffff' };
+            char?[] array = { '\0', '\b', 'A', '\uffff', null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -195,7 +194,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            if (b == 0)
+            if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else
                 Assert.Equal(a % b, f());
@@ -211,7 +210,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            if (b == 0)
+            if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else
                 Assert.Equal(a % b, f());
@@ -227,7 +226,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            if (b == 0)
+            if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else
                 Assert.Equal(a % b, f());
@@ -243,7 +242,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            if (b == 0)
+            if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else if (b == -1 && a == int.MinValue)
                 Assert.Throws<OverflowException>(() => f());
@@ -261,7 +260,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            if (b == 0)
+            if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else
                 Assert.Equal(a % b, f());
@@ -277,7 +276,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<long?> f = e.Compile(useInterpreter);
 
-            if (b == 0)
+            if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else if (b == -1 && a == long.MinValue)
                 Assert.Throws<OverflowException>(() => f());
@@ -321,7 +320,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<decimal?> f = e.Compile(useInterpreter);
 
-            if (b == 0)
+            if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else
                 Assert.Equal(a % b, f());

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableMultiplyTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -14,7 +13,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckNullableByteMultiplyTest()
         {
-            byte?[] array = new byte?[] { 0, 1, byte.MaxValue };
+            byte?[] array = { 0, 1, byte.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -27,7 +26,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckNullableSByteMultiplyTest()
         {
-            sbyte?[] array = new sbyte?[] { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue };
+            sbyte?[] array = { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -40,12 +39,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableUShortMultiplyTest(bool useInterpreter)
         {
-            ushort?[] array = new ushort?[] { 0, 1, ushort.MaxValue };
+            ushort?[] array = { 0, 1, ushort.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableUShortMultiply(array[i], array[j], useInterpreter);
+                    VerifyNullableUShortMultiplyOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -53,12 +53,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableShortMultiplyTest(bool useInterpreter)
         {
-            short?[] array = new short?[] { 0, 1, -1, short.MinValue, short.MaxValue };
+            short?[] array = { 0, 1, -1, short.MinValue, short.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableShortMultiply(array[i], array[j], useInterpreter);
+                    VerifyNullableShortMultiplyOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -66,12 +67,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableUIntMultiplyTest(bool useInterpreter)
         {
-            uint?[] array = new uint?[] { 0, 1, uint.MaxValue };
+            uint?[] array = { 0, 1, uint.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableUIntMultiply(array[i], array[j], useInterpreter);
+                    VerifyNullableUIntMultiplyOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -79,12 +81,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableIntMultiplyTest(bool useInterpreter)
         {
-            int?[] array = new int?[] { 0, 1, -1, int.MinValue, int.MaxValue };
+            int?[] array = { 0, 1, -1, int.MinValue, int.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableIntMultiply(array[i], array[j], useInterpreter);
+                    VerifyNullableIntMultiplyOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -92,12 +95,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableULongMultiplyTest(bool useInterpreter)
         {
-            ulong?[] array = new ulong?[] { 0, 1, ulong.MaxValue };
+            ulong?[] array = { 0, 1, ulong.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableULongMultiply(array[i], array[j], useInterpreter);
+                    VerifyNullableULongMultiplyOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -105,12 +109,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableLongMultiplyTest(bool useInterpreter)
         {
-            long?[] array = new long?[] { 0, 1, -1, long.MinValue, long.MaxValue };
+            long?[] array = { 0, 1, -1, long.MinValue, long.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableLongMultiply(array[i], array[j], useInterpreter);
+                    VerifyNullableLongMultiplyOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -118,12 +123,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableFloatMultiplyTest(bool useInterpreter)
         {
-            float?[] array = new float?[] { 0, 1, -1, float.MinValue, float.MaxValue, float.Epsilon, float.NegativeInfinity, float.PositiveInfinity, float.NaN };
+            float?[] array = { 0, 1, -1, float.MinValue, float.MaxValue, float.Epsilon, float.NegativeInfinity, float.PositiveInfinity, float.NaN, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableFloatMultiply(array[i], array[j], useInterpreter);
+                    VerifyNullableFloatMultiplyOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -131,12 +137,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableDoubleMultiplyTest(bool useInterpreter)
         {
-            double?[] array = new double?[] { 0, 1, -1, double.MinValue, double.MaxValue, double.Epsilon, double.NegativeInfinity, double.PositiveInfinity, double.NaN };
+            double?[] array = { 0, 1, -1, double.MinValue, double.MaxValue, double.Epsilon, double.NegativeInfinity, double.PositiveInfinity, double.NaN, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableDoubleMultiply(array[i], array[j], useInterpreter);
+                    VerifyNullableDoubleMultiplyOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -144,12 +151,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableDecimalMultiplyTest(bool useInterpreter)
         {
-            decimal?[] array = new decimal?[] { decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue };
+            decimal?[] array = { decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableDecimalMultiply(array[i], array[j], useInterpreter);
+                    VerifyNullableDecimalMultiplyOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -157,7 +165,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckNullableCharMultiplyTest()
         {
-            char?[] array = new char?[] { '\0', '\b', 'A', '\uffff' };
+            char?[] array = { '\0', '\b', 'A', '\uffff', null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -176,6 +184,7 @@ namespace System.Linq.Expressions.Tests
             Expression aExp = Expression.Constant(a, typeof(byte?));
             Expression bExp = Expression.Constant(b, typeof(byte?));
             Assert.Throws<InvalidOperationException>(() => Expression.Multiply(aExp, bExp));
+            Assert.Throws<InvalidOperationException>(() => Expression.MultiplyChecked(aExp, bExp));
         }
 
         private static void VerifyNullableSByteMultiply(sbyte? a, sbyte? b)
@@ -183,6 +192,7 @@ namespace System.Linq.Expressions.Tests
             Expression aExp = Expression.Constant(a, typeof(sbyte?));
             Expression bExp = Expression.Constant(b, typeof(sbyte?));
             Assert.Throws<InvalidOperationException>(() => Expression.Multiply(aExp, bExp));
+            Assert.Throws<InvalidOperationException>(() => Expression.MultiplyChecked(aExp, bExp));
         }
 
         private static void VerifyNullableUShortMultiply(ushort? a, ushort? b, bool useInterpreter)
@@ -198,6 +208,29 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal((ushort?)(a * b), f());
         }
 
+        private static void VerifyNullableUShortMultiplyOvf(ushort? a, ushort? b, bool useInterpreter)
+        {
+            Expression<Func<ushort?>> e =
+                Expression.Lambda<Func<ushort?>>(
+                    Expression.MultiplyChecked(
+                        Expression.Constant(a, typeof(ushort?)),
+                        Expression.Constant(b, typeof(ushort?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<ushort?> f = e.Compile(useInterpreter);
+
+            ushort? expected;
+            try
+            {
+                expected = checked((ushort?)(a * b));
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
+        }
         private static void VerifyNullableShortMultiply(short? a, short? b, bool useInterpreter)
         {
             Expression<Func<short?>> e =
@@ -209,6 +242,30 @@ namespace System.Linq.Expressions.Tests
             Func<short?> f = e.Compile(useInterpreter);
 
             Assert.Equal((short?)(a * b), f());
+        }
+
+        private static void VerifyNullableShortMultiplyOvf(short? a, short? b, bool useInterpreter)
+        {
+            Expression<Func<short?>> e =
+                Expression.Lambda<Func<short?>>(
+                    Expression.MultiplyChecked(
+                        Expression.Constant(a, typeof(short?)),
+                        Expression.Constant(b, typeof(short?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<short?> f = e.Compile(useInterpreter);
+
+            short? expected;
+            try
+            {
+                expected = checked((short?)(a * b));
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
         }
 
         private static void VerifyNullableUIntMultiply(uint? a, uint? b, bool useInterpreter)
@@ -224,6 +281,30 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(a * b, f());
         }
 
+        private static void VerifyNullableUIntMultiplyOvf(uint? a, uint? b, bool useInterpreter)
+        {
+            Expression<Func<uint?>> e =
+                Expression.Lambda<Func<uint?>>(
+                    Expression.MultiplyChecked(
+                        Expression.Constant(a, typeof(uint?)),
+                        Expression.Constant(b, typeof(uint?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<uint?> f = e.Compile(useInterpreter);
+
+            uint? expected;
+            try
+            {
+                expected = checked(a * b);
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
+        }
+
         private static void VerifyNullableIntMultiply(int? a, int? b, bool useInterpreter)
         {
             Expression<Func<int?>> e =
@@ -235,6 +316,30 @@ namespace System.Linq.Expressions.Tests
             Func<int?> f = e.Compile(useInterpreter);
 
             Assert.Equal(a * b, f());
+        }
+
+        private static void VerifyNullableIntMultiplyOvf(int? a, int? b, bool useInterpreter)
+        {
+            Expression<Func<int?>> e =
+                Expression.Lambda<Func<int?>>(
+                    Expression.MultiplyChecked(
+                        Expression.Constant(a, typeof(int?)),
+                        Expression.Constant(b, typeof(int?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int?> f = e.Compile(useInterpreter);
+
+            int? expected;
+            try
+            {
+                expected = checked(a * b);
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
         }
 
         private static void VerifyNullableULongMultiply(ulong? a, ulong? b, bool useInterpreter)
@@ -250,6 +355,30 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(a * b, f());
         }
 
+        private static void VerifyNullableULongMultiplyOvf(ulong? a, ulong? b, bool useInterpreter)
+        {
+            Expression<Func<ulong?>> e =
+                Expression.Lambda<Func<ulong?>>(
+                    Expression.MultiplyChecked(
+                        Expression.Constant(a, typeof(ulong?)),
+                        Expression.Constant(b, typeof(ulong?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<ulong?> f = e.Compile(useInterpreter);
+
+            ulong? expected;
+            try
+            {
+                expected = checked(a * b);
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
+        }
+
         private static void VerifyNullableLongMultiply(long? a, long? b, bool useInterpreter)
         {
             Expression<Func<long?>> e =
@@ -263,11 +392,48 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(a * b, f());
         }
 
+        private static void VerifyNullableLongMultiplyOvf(long? a, long? b, bool useInterpreter)
+        {
+            Expression<Func<long?>> e =
+                Expression.Lambda<Func<long?>>(
+                    Expression.MultiplyChecked(
+                        Expression.Constant(a, typeof(long?)),
+                        Expression.Constant(b, typeof(long?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<long?> f = e.Compile(useInterpreter);
+
+            long? expected;
+            try
+            {
+                expected = checked(a * b);
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
+        }
+
         private static void VerifyNullableFloatMultiply(float? a, float? b, bool useInterpreter)
         {
             Expression<Func<float?>> e =
                 Expression.Lambda<Func<float?>>(
                     Expression.Multiply(
+                        Expression.Constant(a, typeof(float?)),
+                        Expression.Constant(b, typeof(float?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<float?> f = e.Compile(useInterpreter);
+
+            Assert.Equal(a * b, f());
+        }
+
+        private static void VerifyNullableFloatMultiplyOvf(float? a, float? b, bool useInterpreter)
+        {
+            Expression<Func<float?>> e =
+                Expression.Lambda<Func<float?>>(
+                    Expression.MultiplyChecked(
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
@@ -289,6 +455,19 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(a * b, f());
         }
 
+        private static void VerifyNullableDoubleMultiplyOvf(double? a, double? b, bool useInterpreter)
+        {
+            Expression<Func<double?>> e =
+                Expression.Lambda<Func<double?>>(
+                    Expression.MultiplyChecked(
+                        Expression.Constant(a, typeof(double?)),
+                        Expression.Constant(b, typeof(double?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<double?> f = e.Compile(useInterpreter);
+
+            Assert.Equal(a * b, f());
+        }
+
         private static void VerifyNullableDecimalMultiply(decimal? a, decimal? b, bool useInterpreter)
         {
             Expression<Func<decimal?>> e =
@@ -299,7 +478,31 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<decimal?> f = e.Compile(useInterpreter);
 
-            decimal? expected = null;
+            decimal? expected;
+            try
+            {
+                expected = a * b;
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
+        }
+
+        private static void VerifyNullableDecimalMultiplyOvf(decimal? a, decimal? b, bool useInterpreter)
+        {
+            Expression<Func<decimal?>> e =
+                Expression.Lambda<Func<decimal?>>(
+                    Expression.MultiplyChecked(
+                        Expression.Constant(a, typeof(decimal?)),
+                        Expression.Constant(b, typeof(decimal?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<decimal?> f = e.Compile(useInterpreter);
+
+            decimal? expected;
             try
             {
                 expected = a * b;
@@ -318,6 +521,7 @@ namespace System.Linq.Expressions.Tests
             Expression aExp = Expression.Constant(a, typeof(char?));
             Expression bExp = Expression.Constant(b, typeof(char?));
             Assert.Throws<InvalidOperationException>(() => Expression.Multiply(aExp, bExp));
+            Assert.Throws<InvalidOperationException>(() => Expression.MultiplyChecked(aExp, bExp));
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableSubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableSubtractTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -14,7 +13,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckNullableByteSubtractTest()
         {
-            byte?[] array = new byte?[] { 0, 1, byte.MaxValue };
+            byte?[] array = { 0, 1, byte.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -27,7 +26,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckNullableSByteSubtractTest()
         {
-            sbyte?[] array = new sbyte?[] { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue };
+            sbyte?[] array = { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -40,12 +39,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableUShortSubtractTest(bool useInterpreter)
         {
-            ushort?[] array = new ushort?[] { 0, 1, ushort.MaxValue };
+            ushort?[] array = { 0, 1, ushort.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableUShortSubtract(array[i], array[j], useInterpreter);
+                    VerifyNullableUShortSubtractOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -53,12 +53,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableShortSubtractTest(bool useInterpreter)
         {
-            short?[] array = new short?[] { 0, 1, -1, short.MinValue, short.MaxValue };
+            short?[] array = { 0, 1, -1, short.MinValue, short.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableShortSubtract(array[i], array[j], useInterpreter);
+                    VerifyNullableShortSubtractOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -66,12 +67,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableUIntSubtractTest(bool useInterpreter)
         {
-            uint?[] array = new uint?[] { 0, 1, uint.MaxValue };
+            uint?[] array = { 0, 1, uint.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableUIntSubtract(array[i], array[j], useInterpreter);
+                    VerifyNullableUIntSubtractOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -79,12 +81,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableIntSubtractTest(bool useInterpreter)
         {
-            int?[] array = new int?[] { 0, 1, -1, int.MinValue, int.MaxValue };
+            int?[] array = { 0, 1, -1, int.MinValue, int.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableIntSubtract(array[i], array[j], useInterpreter);
+                    VerifyNullableIntSubtractOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -92,12 +95,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableULongSubtractTest(bool useInterpreter)
         {
-            ulong?[] array = new ulong?[] { 0, 1, ulong.MaxValue };
+            ulong?[] array = { 0, 1, ulong.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableULongSubtract(array[i], array[j], useInterpreter);
+                    VerifyNullableULongSubtractOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -105,12 +109,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableLongSubtractTest(bool useInterpreter)
         {
-            long?[] array = new long?[] { 0, 1, -1, long.MinValue, long.MaxValue };
+            long?[] array = { 0, 1, -1, long.MinValue, long.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableLongSubtract(array[i], array[j], useInterpreter);
+                    VerifyNullableLongSubtractOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -118,12 +123,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableFloatSubtractTest(bool useInterpreter)
         {
-            float?[] array = new float?[] { 0, 1, -1, float.MinValue, float.MaxValue, float.Epsilon, float.NegativeInfinity, float.PositiveInfinity, float.NaN };
+            float?[] array = { 0, 1, -1, float.MinValue, float.MaxValue, float.Epsilon, float.NegativeInfinity, float.PositiveInfinity, float.NaN, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableFloatSubtract(array[i], array[j], useInterpreter);
+                    VerifyNullableFloatSubtractOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -131,12 +137,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableDoubleSubtractTest(bool useInterpreter)
         {
-            double?[] array = new double?[] { 0, 1, -1, double.MinValue, double.MaxValue, double.Epsilon, double.NegativeInfinity, double.PositiveInfinity, double.NaN };
+            double?[] array = { 0, 1, -1, double.MinValue, double.MaxValue, double.Epsilon, double.NegativeInfinity, double.PositiveInfinity, double.NaN, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableDoubleSubtract(array[i], array[j], useInterpreter);
+                    VerifyNullableDoubleSubtractOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -144,12 +151,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableDecimalSubtractTest(bool useInterpreter)
         {
-            decimal?[] array = new decimal?[] { decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue };
+            decimal?[] array = { decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue, null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
                 {
                     VerifyNullableDecimalSubtract(array[i], array[j], useInterpreter);
+                    VerifyNullableDecimalSubtractOvf(array[i], array[j], useInterpreter);
                 }
             }
         }
@@ -157,7 +165,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckNullableCharSubtractTest()
         {
-            char?[] array = new char?[] { '\0', '\b', 'A', '\uffff' };
+            char?[] array = { '\0', '\b', 'A', '\uffff', null };
             for (int i = 0; i < array.Length; i++)
             {
                 for (int j = 0; j < array.Length; j++)
@@ -176,6 +184,7 @@ namespace System.Linq.Expressions.Tests
             Expression aExp = Expression.Constant(a, typeof(byte?));
             Expression bExp = Expression.Constant(b, typeof(byte?));
             Assert.Throws<InvalidOperationException>(() => Expression.Subtract(aExp, bExp));
+            Assert.Throws<InvalidOperationException>(() => Expression.SubtractChecked(aExp, bExp));
         }
 
         private static void VerifyNullableSByteSubtract(sbyte? a, sbyte? b)
@@ -183,6 +192,7 @@ namespace System.Linq.Expressions.Tests
             Expression aExp = Expression.Constant(a, typeof(sbyte?));
             Expression bExp = Expression.Constant(b, typeof(sbyte?));
             Assert.Throws<InvalidOperationException>(() => Expression.Subtract(aExp, bExp));
+            Assert.Throws<InvalidOperationException>(() => Expression.SubtractChecked(aExp, bExp));
         }
 
         private static void VerifyNullableUShortSubtract(ushort? a, ushort? b, bool useInterpreter)
@@ -198,6 +208,30 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal((ushort?)(a - b), f());
         }
 
+        private static void VerifyNullableUShortSubtractOvf(ushort? a, ushort? b, bool useInterpreter)
+        {
+            Expression<Func<ushort?>> e =
+                Expression.Lambda<Func<ushort?>>(
+                    Expression.SubtractChecked(
+                        Expression.Constant(a, typeof(ushort?)),
+                        Expression.Constant(b, typeof(ushort?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<ushort?> f = e.Compile(useInterpreter);
+
+            ushort? expected;
+            try
+            {
+                expected = checked((ushort?)(a - b));
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
+        }
+
         private static void VerifyNullableShortSubtract(short? a, short? b, bool useInterpreter)
         {
             Expression<Func<short?>> e =
@@ -209,6 +243,30 @@ namespace System.Linq.Expressions.Tests
             Func<short?> f = e.Compile(useInterpreter);
 
             Assert.Equal((short?)(a - b), f());
+        }
+
+        private static void VerifyNullableShortSubtractOvf(short? a, short? b, bool useInterpreter)
+        {
+            Expression<Func<short?>> e =
+                Expression.Lambda<Func<short?>>(
+                    Expression.SubtractChecked(
+                        Expression.Constant(a, typeof(short?)),
+                        Expression.Constant(b, typeof(short?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<short?> f = e.Compile(useInterpreter);
+
+            short? expected;
+            try
+            {
+                expected = checked((short?)(a - b));
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
         }
 
         private static void VerifyNullableUIntSubtract(uint? a, uint? b, bool useInterpreter)
@@ -224,6 +282,30 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(a - b, f());
         }
 
+        private static void VerifyNullableUIntSubtractOvf(uint? a, uint? b, bool useInterpreter)
+        {
+            Expression<Func<uint?>> e =
+                Expression.Lambda<Func<uint?>>(
+                    Expression.SubtractChecked(
+                        Expression.Constant(a, typeof(uint?)),
+                        Expression.Constant(b, typeof(uint?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<uint?> f = e.Compile(useInterpreter);
+
+            uint? expected;
+            try
+            {
+                expected = checked(a - b);
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
+        }
+
         private static void VerifyNullableIntSubtract(int? a, int? b, bool useInterpreter)
         {
             Expression<Func<int?>> e =
@@ -235,6 +317,30 @@ namespace System.Linq.Expressions.Tests
             Func<int?> f = e.Compile(useInterpreter);
 
             Assert.Equal(a - b, f());
+        }
+
+        private static void VerifyNullableIntSubtractOvf(int? a, int? b, bool useInterpreter)
+        {
+            Expression<Func<int?>> e =
+                Expression.Lambda<Func<int?>>(
+                    Expression.SubtractChecked(
+                        Expression.Constant(a, typeof(int?)),
+                        Expression.Constant(b, typeof(int?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int?> f = e.Compile(useInterpreter);
+
+            int? expected;
+            try
+            {
+                expected = checked(a - b);
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
         }
 
         private static void VerifyNullableULongSubtract(ulong? a, ulong? b, bool useInterpreter)
@@ -250,6 +356,30 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(a - b, f());
         }
 
+        private static void VerifyNullableULongSubtractOvf(ulong? a, ulong? b, bool useInterpreter)
+        {
+            Expression<Func<ulong?>> e =
+                Expression.Lambda<Func<ulong?>>(
+                    Expression.SubtractChecked(
+                        Expression.Constant(a, typeof(ulong?)),
+                        Expression.Constant(b, typeof(ulong?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<ulong?> f = e.Compile(useInterpreter);
+
+            ulong? expected;
+            try
+            {
+                expected = checked(a - b);
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
+        }
+
         private static void VerifyNullableLongSubtract(long? a, long? b, bool useInterpreter)
         {
             Expression<Func<long?>> e =
@@ -263,11 +393,48 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(a - b, f());
         }
 
+        private static void VerifyNullableLongSubtractOvf(long? a, long? b, bool useInterpreter)
+        {
+            Expression<Func<long?>> e =
+                Expression.Lambda<Func<long?>>(
+                    Expression.SubtractChecked(
+                        Expression.Constant(a, typeof(long?)),
+                        Expression.Constant(b, typeof(long?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<long?> f = e.Compile(useInterpreter);
+
+            long? expected;
+            try
+            {
+                expected = checked(a - b);
+            }
+            catch (OverflowException)
+            {
+                Assert.Throws<OverflowException>(() => f());
+                return;
+            }
+
+            Assert.Equal(expected, f());
+        }
+
         private static void VerifyNullableFloatSubtract(float? a, float? b, bool useInterpreter)
         {
             Expression<Func<float?>> e =
                 Expression.Lambda<Func<float?>>(
                     Expression.Subtract(
+                        Expression.Constant(a, typeof(float?)),
+                        Expression.Constant(b, typeof(float?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<float?> f = e.Compile(useInterpreter);
+
+            Assert.Equal(a - b, f());
+        }
+
+        private static void VerifyNullableFloatSubtractOvf(float? a, float? b, bool useInterpreter)
+        {
+            Expression<Func<float?>> e =
+                Expression.Lambda<Func<float?>>(
+                    Expression.SubtractChecked(
                         Expression.Constant(a, typeof(float?)),
                         Expression.Constant(b, typeof(float?))),
                     Enumerable.Empty<ParameterExpression>());
@@ -289,6 +456,19 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(a - b, f());
         }
 
+        private static void VerifyNullableDoubleSubtractOvf(double? a, double? b, bool useInterpreter)
+        {
+            Expression<Func<double?>> e =
+                Expression.Lambda<Func<double?>>(
+                    Expression.SubtractChecked(
+                        Expression.Constant(a, typeof(double?)),
+                        Expression.Constant(b, typeof(double?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<double?> f = e.Compile(useInterpreter);
+
+            Assert.Equal(a - b, f());
+        }
+
         private static void VerifyNullableDecimalSubtract(decimal? a, decimal? b, bool useInterpreter)
         {
             Expression<Func<decimal?>> e =
@@ -301,7 +481,36 @@ namespace System.Linq.Expressions.Tests
 
             if (a.HasValue & b.HasValue)
             {
-                decimal? expected = null;
+                decimal? expected;
+                try
+                {
+                    expected = a - b;
+                }
+                catch (OverflowException)
+                {
+                    Assert.Throws<OverflowException>(() => f());
+                    return;
+                }
+
+                Assert.Equal(expected, f());
+            }
+            else
+                Assert.Null(f());
+        }
+
+        private static void VerifyNullableDecimalSubtractOvf(decimal? a, decimal? b, bool useInterpreter)
+        {
+            Expression<Func<decimal?>> e =
+                Expression.Lambda<Func<decimal?>>(
+                    Expression.SubtractChecked(
+                        Expression.Constant(a, typeof(decimal?)),
+                        Expression.Constant(b, typeof(decimal?))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<decimal?> f = e.Compile(useInterpreter);
+
+            if (a.HasValue & b.HasValue)
+            {
+                decimal? expected;
                 try
                 {
                     expected = a - b;
@@ -323,6 +532,7 @@ namespace System.Linq.Expressions.Tests
             Expression aExp = Expression.Constant(a, typeof(char?));
             Expression bExp = Expression.Constant(b, typeof(char?));
             Assert.Throws<InvalidOperationException>(() => Expression.Subtract(aExp, bExp));
+            Assert.Throws<InvalidOperationException>(() => Expression.SubtractChecked(aExp, bExp));
         }
 
         #endregion


### PR DESCRIPTION
Cover null inputs into nullable tests, and cover checked arithmetic with nullable inputs. (In particular note that null inputs result in a different branch in the interpreted implementation).

Remove checked arithmetic instructions for floating-point type.

Since checked contexts have no effect on floating-point arithmetic, the equivalent unchecked instruction can serve just as well, so use it.

Replace assertion that type is not enum with tighter assertion that type is arithmetic.

Replace runtime error with unreachable assertion in unreachable branch.