### PR TITLE
Remove redundant ToString() overrides in instructions.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
@@ -195,11 +195,6 @@ namespace System.Linq.Expressions.Interpreter
                     throw Error.ExpressionNotSupportedForType("Add", type);
             }
         }
-
-        public override string ToString()
-        {
-            return "Add()";
-        }
     }
 
     internal abstract class AddOvfInstruction : Instruction
@@ -387,11 +382,6 @@ namespace System.Linq.Expressions.Interpreter
                 default:
                     throw Error.ExpressionNotSupportedForType("AddOvf", type);
             }
-        }
-
-        public override string ToString()
-        {
-            return "AddOvf()";
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
@@ -194,11 +194,6 @@ namespace System.Linq.Expressions.Interpreter
                     throw Error.ExpressionNotSupportedForType("Div", type);
             }
         }
-
-        public override string ToString()
-        {
-            return "Div()";
-        }
     }
 
     internal abstract class ModuloInstruction : Instruction
@@ -385,11 +380,6 @@ namespace System.Linq.Expressions.Interpreter
                 default:
                     throw Error.ExpressionNotSupportedForType("Modulo", type);
             }
-        }
-
-        public override string ToString()
-        {
-            return "Modulo()";
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
@@ -325,11 +325,6 @@ namespace System.Linq.Expressions.Interpreter
                 }
             }
         }
-
-        public override string ToString()
-        {
-            return "LessThan()";
-        }
     }
 
     internal abstract class LessThanOrEqualInstruction : Instruction
@@ -645,11 +640,6 @@ namespace System.Linq.Expressions.Interpreter
                         throw Error.ExpressionNotSupportedForType("LessThanOrEqual", type);
                 }
             }
-        }
-
-        public override string ToString()
-        {
-            return "LessThanOrEqual()";
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
@@ -193,11 +193,6 @@ namespace System.Linq.Expressions.Interpreter
                     throw Error.ExpressionNotSupportedForType("Mul", type);
             }
         }
-
-        public override string ToString()
-        {
-            return "Mul()";
-        }
     }
 
     internal abstract class MulOvfInstruction : Instruction
@@ -383,11 +378,6 @@ namespace System.Linq.Expressions.Interpreter
                 default:
                     throw Error.ExpressionNotSupportedForType("MulOvf", type);
             }
-        }
-
-        public override string ToString()
-        {
-            return "MulOvf()";
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
@@ -594,11 +594,6 @@ namespace System.Linq.Expressions.Interpreter
                 }
             }
         }
-
-        public override string ToString()
-        {
-            return "NotEqual()";
-        }
     }
 }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
@@ -193,11 +193,6 @@ namespace System.Linq.Expressions.Interpreter
                     throw Error.ExpressionNotSupportedForType("Sub", type);
             }
         }
-
-        public override string ToString()
-        {
-            return "Sub()";
-        }
     }
 
     internal abstract class SubOvfInstruction : Instruction
@@ -383,11 +378,6 @@ namespace System.Linq.Expressions.Interpreter
                 default:
                     throw Error.ExpressionNotSupportedForType("SubOvf", type);
             }
-        }
-
-        public override string ToString()
-        {
-            return "SubOvf()";
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -421,11 +421,6 @@ namespace System.Linq.Expressions.Interpreter
                     throw Error.ExpressionNotSupportedForType("Negate", type);
             }
         }
-
-        public override string ToString()
-        {
-            return "Negate()";
-        }
     }
 
     internal abstract class NegateCheckedInstruction : Instruction
@@ -539,11 +534,6 @@ namespace System.Linq.Expressions.Interpreter
                 default:
                     throw Error.ExpressionNotSupportedForType("NegateChecked", type);
             }
-        }
-
-        public override string ToString()
-        {
-            return "NegateChecked()";
         }
     }
 
@@ -715,11 +705,6 @@ namespace System.Linq.Expressions.Interpreter
                     throw Error.ExpressionNotSupportedForType("OnesComplement", type);
             }
         }
-
-        public override string ToString()
-        {
-            return "OnesComplement()";
-        }
     }
 
     internal abstract class IncrementInstruction : Instruction
@@ -890,11 +875,6 @@ namespace System.Linq.Expressions.Interpreter
                     throw Error.ExpressionNotSupportedForType("Increment", type);
             }
         }
-
-        public override string ToString()
-        {
-            return "Increment()";
-        }
     }
 
     internal abstract class DecrementInstruction : Instruction
@@ -1064,11 +1044,6 @@ namespace System.Linq.Expressions.Interpreter
                 default:
                     throw Error.ExpressionNotSupportedForType("Decrement", type);
             }
-        }
-
-        public override string ToString()
-        {
-            return "Decrement()";
         }
     }
 
@@ -1251,11 +1226,6 @@ namespace System.Linq.Expressions.Interpreter
                     throw Error.ExpressionNotSupportedForType("LeftShift", type);
             }
         }
-
-        public override string ToString()
-        {
-            return "LeftShift()";
-        }
     }
 
     internal abstract class RightShiftInstruction : Instruction
@@ -1435,11 +1405,6 @@ namespace System.Linq.Expressions.Interpreter
                 default:
                     throw Error.ExpressionNotSupportedForType("RightShift", type);
             }
-        }
-
-        public override string ToString()
-        {
-            return "RightShift()";
         }
     }
 
@@ -1626,11 +1591,6 @@ namespace System.Linq.Expressions.Interpreter
         private static TypeCode GetTypeCode(Type type)
         {
             return System.Dynamic.Utils.TypeExtensions.GetTypeCode(type.GetTypeInfo().IsEnum ? Enum.GetUnderlyingType(type) : TypeUtils.GetNonNullableType(type));
-        }
-
-        public override string ToString()
-        {
-            return "ExclusiveOr()";
         }
     }
 
@@ -1825,11 +1785,6 @@ namespace System.Linq.Expressions.Interpreter
                     throw Error.ExpressionNotSupportedForType("Or", type);
             }
         }
-
-        public override string ToString()
-        {
-            return "Or()";
-        }
     }
 
     internal abstract class AndInstruction : Instruction
@@ -2022,11 +1977,6 @@ namespace System.Linq.Expressions.Interpreter
                 default:
                     throw Error.ExpressionNotSupportedForType("And", type);
             }
-        }
-
-        public override string ToString()
-        {
-            return "And()";
         }
     }
 


### PR DESCRIPTION
In many cases a class derived from Instruction has a `ToString()` that results in the same string as the base implementation.

While this would be a reasonable optimisation in a hot path, `ToString()` is mostly used in debug assertions in instructions, with the remaining cases also being debugging-related, so it's worth cutting it out as bloat.