### PR TITLE
Add parameter names to System.Linq.Expressions exceptions

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/Error.cs
+++ b/src/Common/src/System/Dynamic/Utils/Error.cs
@@ -28,16 +28,16 @@ namespace System.Dynamic.Utils
         /// <summary>
         /// ArgumentException with message like "Type {0} contains generic parameters"
         /// </summary>
-        internal static Exception TypeContainsGenericParameters(object p0)
+        internal static Exception TypeContainsGenericParameters(object p0, string paramName)
         {
-            return new ArgumentException(Strings.TypeContainsGenericParameters(p0));
+            return new ArgumentException(Strings.TypeContainsGenericParameters(p0), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Type {0} is a generic type definition"
         /// </summary>
-        internal static Exception TypeIsGeneric(object p0)
+        internal static Exception TypeIsGeneric(object p0, string paramName)
         {
-            return new ArgumentException(Strings.TypeIsGeneric(p0));
+            return new ArgumentException(Strings.TypeIsGeneric(p0), paramName);
         }
 
         /// <summary>

--- a/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
@@ -149,7 +149,7 @@ namespace System.Dynamic.Utils
             {
                 pType = pType.GetElementType();
             }
-            TypeUtils.ValidateType(pType);
+            TypeUtils.ValidateType(pType, nameof(pi));
             if (!TypeUtils.AreReferenceAssignable(pType, arguments.Type))
             {
                 if (!TryQuote(pType, ref arguments))

--- a/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
@@ -37,14 +37,14 @@ namespace System.Dynamic.Utils
             return AreEquivalent(type, subType) || subType.GetTypeInfo().IsSubclassOf(type);
         }
 
-        public static void ValidateType(Type type)
+        public static void ValidateType(Type type, string paramName)
         {
             if (type != typeof(void))
             {
                 // A check to avoid a bunch of reflection (currently not supported) during cctor
                 if (type.GetTypeInfo().ContainsGenericParameters)
                 {
-                    throw type.GetTypeInfo().IsGenericTypeDefinition ? Error.TypeIsGeneric(type) : Error.TypeContainsGenericParameters(type);
+                    throw type.GetTypeInfo().IsGenericTypeDefinition ? Error.TypeIsGeneric(type, paramName) : Error.TypeContainsGenericParameters(type, paramName);
                 }
             }
         }

--- a/src/System.Dynamic.Runtime/src/System/Linq/Expressions/DynamicExpression.cs
+++ b/src/System.Dynamic.Runtime/src/System/Linq/Expressions/DynamicExpression.cs
@@ -1219,7 +1219,7 @@ namespace System.Linq.Expressions
             ExpressionUtils.RequiresCanRead(arg, "arguments");
             var type = arg.Type;
             ContractUtils.RequiresNotNull(type, nameof(type));
-            TypeUtils.ValidateType(type);
+            TypeUtils.ValidateType(type, nameof(type));
             if (type == typeof(void)) throw Error.ArgumentTypeCannotBeVoid();
         }
     }

--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -195,9 +195,6 @@
   <data name="DefaultBodyMustBeSupplied" xml:space="preserve">
     <value>Default body must be supplied if case bodies are not System.Void.</value>
   </data>
-  <data name="MethodBuilderDoesNotHaveTypeBuilder" xml:space="preserve">
-    <value>MethodBuilder does not have a valid TypeBuilder</value>
-  </data>
   <data name="LabelMustBeVoidOrHaveExpression" xml:space="preserve">
     <value>Label type must be System.Void if an expression is not supplied</value>
   </data>
@@ -521,12 +518,6 @@
   </data>
   <data name="UnknownLiftType" xml:space="preserve">
     <value>unknown lift type: '{0}'.</value>
-  </data>
-  <data name="InvalidOutputDir" xml:space="preserve">
-    <value>Invalid output directory.</value>
-  </data>
-  <data name="InvalidAsmNameOrExtension" xml:space="preserve">
-    <value>Invalid assembly name or file extension.</value>
   </data>
   <data name="IllegalNewGenericParams" xml:space="preserve">
     <value>Cannot create instance of {0} because it contains generic parameters</value>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -623,8 +623,8 @@ namespace System.Linq.Expressions
         {
             RequiresCanWrite(left, nameof(left));
             RequiresCanRead(right, nameof(right));
-            TypeUtils.ValidateType(left.Type);
-            TypeUtils.ValidateType(right.Type);
+            TypeUtils.ValidateType(left.Type, nameof(left));
+            TypeUtils.ValidateType(right.Type, nameof(right));
             if (!TypeUtils.AreReferenceAssignable(left.Type, right.Type))
             {
                 throw Error.ExpressionTypeDoesNotMatchAssignment(right.Type, left.Type);
@@ -668,7 +668,7 @@ namespace System.Linq.Expressions
         private static BinaryExpression GetMethodBasedBinaryOperator(ExpressionType binaryType, Expression left, Expression right, MethodInfo method, bool liftToNull)
         {
             System.Diagnostics.Debug.Assert(method != null);
-            ValidateOperator(method);
+            ValidateOperator(method, nameof(method));
             ParameterInfo[] pms = method.GetParametersCached();
             if (pms.Length != 2)
                 throw Error.IncorrectNumberOfMethodCallArguments(method);
@@ -799,21 +799,21 @@ namespace System.Linq.Expressions
         }
 
 
-        private static void ValidateOperator(MethodInfo method)
+        private static void ValidateOperator(MethodInfo method, string paramName)
         {
             System.Diagnostics.Debug.Assert(method != null);
-            ValidateMethodInfo(method);
+            ValidateMethodInfo(method, nameof(method));
             if (!method.IsStatic)
-                throw Error.UserDefinedOperatorMustBeStatic(method);
+                throw Error.UserDefinedOperatorMustBeStatic(method, nameof(method));
             if (method.ReturnType == typeof(void))
-                throw Error.UserDefinedOperatorMustNotBeVoid(method);
+                throw Error.UserDefinedOperatorMustNotBeVoid(method, nameof(method));
         }
 
 
-        private static void ValidateMethodInfo(MethodInfo method)
+        private static void ValidateMethodInfo(MethodInfo method, string paramName)
         {
             if (method.ContainsGenericParameters)
-                throw method.IsGenericMethodDefinition ? Error.MethodIsGeneric(method) : Error.MethodContainsGenericParameters(method);
+                throw method.IsGenericMethodDefinition ? Error.MethodIsGeneric(method, paramName) : Error.MethodContainsGenericParameters(method, paramName);
         }
 
 
@@ -849,7 +849,7 @@ namespace System.Linq.Expressions
 
         private static void ValidateUserDefinedConditionalLogicOperator(ExpressionType nodeType, Type left, Type right, MethodInfo method)
         {
-            ValidateOperator(method);
+            ValidateOperator(method, nameof(method));
             ParameterInfo[] pms = method.GetParametersCached();
             if (pms.Length != 2)
                 throw Error.IncorrectNumberOfMethodCallArguments(method);
@@ -1492,7 +1492,7 @@ namespace System.Linq.Expressions
             MethodInfo method = delegateType.GetMethod("Invoke");
             if (method.ReturnType == typeof(void))
             {
-                throw Error.UserDefinedOperatorMustNotBeVoid(conversion);
+                throw Error.UserDefinedOperatorMustNotBeVoid(conversion, nameof(method));
             }
             ParameterInfo[] pms = method.GetParametersCached();
             Debug.Assert(pms.Length == conversion.Parameters.Count);
@@ -2954,13 +2954,13 @@ namespace System.Linq.Expressions
             RequiresCanRead(index, nameof(index));
             if (index.Type != typeof(int))
             {
-                throw Error.ArgumentMustBeArrayIndexType();
+                throw Error.ArgumentMustBeArrayIndexType(nameof(index));
             }
 
             Type arrayType = array.Type;
             if (!arrayType.IsArray)
             {
-                throw Error.ArgumentMustBeArray();
+                throw Error.ArgumentMustBeArray(nameof(array));
             }
             if (arrayType.GetArrayRank() != 1)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -969,11 +969,11 @@ namespace System.Linq.Expressions
                     }
                     if (v.IsByRef)
                     {
-                        throw Error.VariableMustNotBeByRef(v, v.Type);
+                        throw Error.VariableMustNotBeByRef(v, v.Type, $"{collectionName}[{i}]");
                     }
                     if (!set.Add(v))
                     {
-                        throw Error.DuplicateVariable(v);
+                        throw Error.DuplicateVariable(v, $"{collectionName}[{i}]");
                     }
                 }
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/CatchBlock.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/CatchBlock.cs
@@ -160,13 +160,13 @@ namespace System.Linq.Expressions
             ContractUtils.Requires(variable == null || TypeUtils.AreEquivalent(variable.Type, type), nameof(variable));
             if (variable != null && variable.IsByRef)
             {
-                throw Error.VariableMustNotBeByRef(variable, variable.Type);
+                throw Error.VariableMustNotBeByRef(variable, variable.Type, nameof(variable));
             }
             RequiresCanRead(body, nameof(body));
             if (filter != null)
             {
                 RequiresCanRead(filter, nameof(filter));
-                if (filter.Type != typeof(bool)) throw Error.ArgumentMustBeBoolean();
+                if (filter.Type != typeof(bool)) throw Error.ArgumentMustBeBoolean(nameof(filter));
             }
 
             return new CatchBlock(type, variable, body, filter);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -361,7 +361,7 @@ namespace System.Linq.Expressions.Compiler
 
             if (ci.DeclaringType.GetTypeInfo().ContainsGenericParameters)
             {
-                throw Error.IllegalNewGenericParams(ci.DeclaringType);
+                throw Error.IllegalNewGenericParams(ci.DeclaringType, nameof(ci));
             }
 
             il.Emit(OpCodes.Newobj, ci);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -113,7 +113,7 @@ namespace System.Linq.Expressions.Compiler
                         case ExpressionType.GreaterThanOrEqual:
                             if (mc.Type != typeof(bool))
                             {
-                                throw Error.ArgumentMustBeBoolean();
+                                throw Error.ArgumentMustBeBoolean(nameof(b));
                             }
                             resultType = typeof(bool);
                             break;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -1103,7 +1103,7 @@ namespace System.Linq.Expressions.Compiler
             if (fi != null) return fi.FieldType;
             PropertyInfo pi = member as PropertyInfo;
             if (pi != null) return pi.PropertyType;
-            throw Error.MemberNotFieldOrProperty(member);
+            throw Error.MemberNotFieldOrProperty(member, nameof(member));
         }
 
         #endregion

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ConditionalExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ConditionalExpression.cs
@@ -166,7 +166,7 @@ namespace System.Linq.Expressions
 
             if (test.Type != typeof(bool))
             {
-                throw Error.ArgumentMustBeBoolean();
+                throw Error.ArgumentMustBeBoolean(nameof(test));
             }
             if (!TypeUtils.AreEquivalent(ifTrue.Type, ifFalse.Type))
             {
@@ -199,7 +199,7 @@ namespace System.Linq.Expressions
 
             if (test.Type != typeof(bool))
             {
-                throw Error.ArgumentMustBeBoolean();
+                throw Error.ArgumentMustBeBoolean(nameof(test));
             }
 
             if (type != typeof(void))

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugInfoExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugInfoExpression.cs
@@ -254,19 +254,19 @@ namespace System.Linq.Expressions
         {
             if (startLine < 1)
             {
-                throw Error.OutOfRange("startLine", 1);
+                throw Error.OutOfRange(nameof(startLine), 1);
             }
             if (startColumn < 1)
             {
-                throw Error.OutOfRange("startColumn", 1);
+                throw Error.OutOfRange(nameof(startColumn), 1);
             }
             if (endLine < 1)
             {
-                throw Error.OutOfRange("endLine", 1);
+                throw Error.OutOfRange(nameof(endLine), 1);
             }
             if (endColumn < 1)
             {
-                throw Error.OutOfRange("endColumn", 1);
+                throw Error.OutOfRange(nameof(endColumn), 1);
             }
             if (startLine > endLine)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DefaultExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DefaultExpression.cs
@@ -74,15 +74,15 @@ namespace System.Linq.Expressions
         public static DefaultExpression Default(Type type)
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
-            TypeUtils.ValidateType(type);
+            TypeUtils.ValidateType(type, nameof(type));
             if (type.IsByRef)
             {
-                throw Error.TypeMustNotBeByRef();
+                throw Error.TypeMustNotBeByRef(nameof(type));
             }
 
             if (type.IsPointer)
             {
-                throw Error.TypeMustNotBePointer();
+                throw Error.TypeMustNotBePointer(nameof(type));
             }
 
             return new DefaultExpression(type);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ElementInit.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ElementInit.cs
@@ -107,32 +107,32 @@ namespace System.Linq.Expressions
             var argumentsRO = arguments.ToReadOnly();
 
             RequiresCanRead(argumentsRO, nameof(arguments));
-            ValidateElementInitAddMethodInfo(addMethod);
+            ValidateElementInitAddMethodInfo(addMethod, nameof(addMethod));
             ValidateArgumentTypes(addMethod, ExpressionType.Call, ref argumentsRO);
             return new ElementInit(addMethod, argumentsRO);
         }
 
-        private static void ValidateElementInitAddMethodInfo(MethodInfo addMethod)
+        private static void ValidateElementInitAddMethodInfo(MethodInfo addMethod, string paramName)
         {
-            ValidateMethodInfo(addMethod);
+            ValidateMethodInfo(addMethod, nameof(addMethod));
             ParameterInfo[] pis = addMethod.GetParametersCached();
             if (pis.Length == 0)
             {
-                throw Error.ElementInitializerMethodWithZeroArgs();
+                throw Error.ElementInitializerMethodWithZeroArgs(paramName);
             }
             if (!addMethod.Name.Equals("Add", StringComparison.OrdinalIgnoreCase))
             {
-                throw Error.ElementInitializerMethodNotAdd();
+                throw Error.ElementInitializerMethodNotAdd(paramName);
             }
             if (addMethod.IsStatic)
             {
-                throw Error.ElementInitializerMethodStatic();
+                throw Error.ElementInitializerMethodStatic(paramName);
             }
             foreach (ParameterInfo pi in pis)
             {
                 if (pi.ParameterType.IsByRef)
                 {
-                    throw Error.ElementInitializerMethodNoRefOutParam(pi.Name, addMethod.Name);
+                    throw Error.ElementInitializerMethodNoRefOutParam(pi.Name, addMethod.Name, paramName);
                 }
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -35,59 +35,59 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "Setter must have parameters."
         /// </summary>
-        internal static Exception SetterHasNoParams()
+        internal static Exception SetterHasNoParams(string paramName)
         {
-            return new ArgumentException(Strings.SetterHasNoParams);
+            return new ArgumentException(Strings.SetterHasNoParams, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Property cannot have a managed pointer type."
         /// </summary>
-        internal static Exception PropertyCannotHaveRefType()
+        internal static Exception PropertyCannotHaveRefType(string paramName)
         {
-            return new ArgumentException(Strings.PropertyCannotHaveRefType);
+            return new ArgumentException(Strings.PropertyCannotHaveRefType, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Indexing parameters of getter and setter must match."
         /// </summary>
-        internal static Exception IndexesOfSetGetMustMatch()
+        internal static Exception IndexesOfSetGetMustMatch(string paramName)
         {
-            return new ArgumentException(Strings.IndexesOfSetGetMustMatch);
+            return new ArgumentException(Strings.IndexesOfSetGetMustMatch, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Accessor method should not have VarArgs."
         /// </summary>
-        internal static Exception AccessorsCannotHaveVarArgs()
+        internal static Exception AccessorsCannotHaveVarArgs(string paramName)
         {
-            return new ArgumentException(Strings.AccessorsCannotHaveVarArgs);
+            return new ArgumentException(Strings.AccessorsCannotHaveVarArgs, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Accessor indexes cannot be passed ByRef."
         /// </summary>
-        internal static Exception AccessorsCannotHaveByRefArgs()
+        internal static Exception AccessorsCannotHaveByRefArgs(string paramName)
         {
-            return new ArgumentException(Strings.AccessorsCannotHaveByRefArgs);
+            return new ArgumentException(Strings.AccessorsCannotHaveByRefArgs, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Bounds count cannot be less than 1"
         /// </summary>
-        internal static Exception BoundsCannotBeLessThanOne()
+        internal static Exception BoundsCannotBeLessThanOne(string paramName)
         {
-            return new ArgumentException(Strings.BoundsCannotBeLessThanOne);
+            return new ArgumentException(Strings.BoundsCannotBeLessThanOne, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Type must not be ByRef"
         /// </summary>
-        internal static Exception TypeMustNotBeByRef()
+        internal static Exception TypeMustNotBeByRef(string paramName)
         {
-            return new ArgumentException(Strings.TypeMustNotBeByRef);
+            return new ArgumentException(Strings.TypeMustNotBeByRef, paramName);
         }
 
         /// <summary>
         /// ArgumentException with message like "Type must not be a pointer type"
         /// </summary>
-        internal static Exception TypeMustNotBePointer()
+        internal static Exception TypeMustNotBePointer(string paramName)
         {
-            return new ArgumentException(Strings.TypeMustNotBePointer, "type");
+            return new ArgumentException(Strings.TypeMustNotBePointer, paramName);
         }
 
         /// <summary>
@@ -100,23 +100,23 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "Setter should have void type."
         /// </summary>
-        internal static Exception SetterMustBeVoid()
+        internal static Exception SetterMustBeVoid(string paramName)
         {
-            return new ArgumentException(Strings.SetterMustBeVoid);
+            return new ArgumentException(Strings.SetterMustBeVoid, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Property type must match the value type of setter"
         /// </summary>
-        internal static Exception PropertyTypeMustMatchSetter()
+        internal static Exception PropertyTypeMustMatchSetter(string paramName)
         {
             return new ArgumentException(Strings.PropertyTypeMustMatchSetter);
         }
         /// <summary>
         /// ArgumentException with message like "Both accessors must be static."
         /// </summary>
-        internal static Exception BothAccessorsMustBeStatic()
+        internal static Exception BothAccessorsMustBeStatic(string paramName)
         {
-            return new ArgumentException(Strings.BothAccessorsMustBeStatic);
+            return new ArgumentException(Strings.BothAccessorsMustBeStatic, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Static method requires null instance, non-static method requires non-null instance."
@@ -128,23 +128,23 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "Property cannot have a void type."
         /// </summary>
-        internal static Exception PropertyTypeCannotBeVoid()
+        internal static Exception PropertyTypeCannotBeVoid(string paramName)
         {
-            return new ArgumentException(Strings.PropertyTypeCannotBeVoid);
+            return new ArgumentException(Strings.PropertyTypeCannotBeVoid, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Can only unbox from an object or interface type to a value type."
         /// </summary>
-        internal static Exception InvalidUnboxType()
+        internal static Exception InvalidUnboxType(string paramName)
         {
-            return new ArgumentException(Strings.InvalidUnboxType);
+            return new ArgumentException(Strings.InvalidUnboxType, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Argument must not have a value type."
         /// </summary>
-        internal static Exception ArgumentMustNotHaveValueType()
+        internal static Exception ArgumentMustNotHaveValueType(string paramName)
         {
-            return new ArgumentException(Strings.ArgumentMustNotHaveValueType);
+            return new ArgumentException(Strings.ArgumentMustNotHaveValueType, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "must be reducible node"
@@ -156,51 +156,44 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "Default body must be supplied if case bodies are not System.Void."
         /// </summary>
-        internal static Exception DefaultBodyMustBeSupplied()
+        internal static Exception DefaultBodyMustBeSupplied(string paramName)
         {
-            return new ArgumentException(Strings.DefaultBodyMustBeSupplied);
-        }
-        /// <summary>
-        /// ArgumentException with message like "MethodBuilder does not have a valid TypeBuilder"
-        /// </summary>
-        internal static Exception MethodBuilderDoesNotHaveTypeBuilder()
-        {
-            return new ArgumentException(Strings.MethodBuilderDoesNotHaveTypeBuilder);
+            return new ArgumentException(Strings.DefaultBodyMustBeSupplied, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Label type must be System.Void if an expression is not supplied"
         /// </summary>
-        internal static Exception LabelMustBeVoidOrHaveExpression()
+        internal static Exception LabelMustBeVoidOrHaveExpression(string paramName)
         {
-            return new ArgumentException(Strings.LabelMustBeVoidOrHaveExpression);
+            return new ArgumentException(Strings.LabelMustBeVoidOrHaveExpression, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Type must be System.Void for this label argument"
         /// </summary>
-        internal static Exception LabelTypeMustBeVoid()
+        internal static Exception LabelTypeMustBeVoid(string paramName)
         {
-            return new ArgumentException(Strings.LabelTypeMustBeVoid);
+            return new ArgumentException(Strings.LabelTypeMustBeVoid, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Quoted expression must be a lambda"
         /// </summary>
-        internal static Exception QuotedExpressionMustBeLambda()
+        internal static Exception QuotedExpressionMustBeLambda(string paramName)
         {
-            return new ArgumentException(Strings.QuotedExpressionMustBeLambda);
+            return new ArgumentException(Strings.QuotedExpressionMustBeLambda, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Variable '{0}' uses unsupported type '{1}'. Reference types are not supported for variables."
         /// </summary>
-        internal static Exception VariableMustNotBeByRef(object p0, object p1)
+        internal static Exception VariableMustNotBeByRef(object p0, object p1, string paramName)
         {
-            return new ArgumentException(Strings.VariableMustNotBeByRef(p0, p1));
+            return new ArgumentException(Strings.VariableMustNotBeByRef(p0, p1), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Found duplicate parameter '{0}'. Each ParameterExpression in the list must be a unique object."
         /// </summary>
-        internal static Exception DuplicateVariable(object p0)
+        internal static Exception DuplicateVariable(object p0, string paramName)
         {
-            return new ArgumentException(Strings.DuplicateVariable(p0));
+            return new ArgumentException(Strings.DuplicateVariable(p0), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Start and End must be well ordered"
@@ -212,9 +205,9 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "fault cannot be used with catch or finally clauses"
         /// </summary>
-        internal static Exception FaultCannotHaveCatchOrFinally()
+        internal static Exception FaultCannotHaveCatchOrFinally(string paramName)
         {
-            return new ArgumentException(Strings.FaultCannotHaveCatchOrFinally);
+            return new ArgumentException(Strings.FaultCannotHaveCatchOrFinally, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "try must have at least one catch, finally, or fault clause"
@@ -240,16 +233,16 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "User-defined operator method '{0}' must be static."
         /// </summary>
-        internal static Exception UserDefinedOperatorMustBeStatic(object p0)
+        internal static Exception UserDefinedOperatorMustBeStatic(object p0, string paramName)
         {
-            return new ArgumentException(Strings.UserDefinedOperatorMustBeStatic(p0));
+            return new ArgumentException(Strings.UserDefinedOperatorMustBeStatic(p0), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "User-defined operator method '{0}' must not be void."
         /// </summary>
-        internal static Exception UserDefinedOperatorMustNotBeVoid(object p0)
+        internal static Exception UserDefinedOperatorMustNotBeVoid(object p0, string paramName)
         {
-            return new ArgumentException(Strings.UserDefinedOperatorMustNotBeVoid(p0));
+            return new ArgumentException(Strings.UserDefinedOperatorMustNotBeVoid(p0), paramName);
         }
         /// <summary>
         /// InvalidOperationException with message like "No coercion operator is defined between types '{0}' and '{1}'."
@@ -303,65 +296,65 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "Argument must be array"
         /// </summary>
-        internal static Exception ArgumentMustBeArray()
+        internal static Exception ArgumentMustBeArray(string paramName)
         {
-            return new ArgumentException(Strings.ArgumentMustBeArray);
+            return new ArgumentException(Strings.ArgumentMustBeArray, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Argument must be boolean"
         /// </summary>
-        internal static Exception ArgumentMustBeBoolean()
+        internal static Exception ArgumentMustBeBoolean(string paramName)
         {
-            return new ArgumentException(Strings.ArgumentMustBeBoolean);
+            return new ArgumentException(Strings.ArgumentMustBeBoolean, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "The user-defined equality method '{0}' must return a boolean value."
         /// </summary>
-        internal static Exception EqualityMustReturnBoolean(object p0)
+        internal static Exception EqualityMustReturnBoolean(object p0, string paramName)
         {
-            return new ArgumentException(Strings.EqualityMustReturnBoolean(p0));
+            return new ArgumentException(Strings.EqualityMustReturnBoolean(p0), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Argument must be either a FieldInfo or PropertyInfo"
         /// </summary>
-        internal static Exception ArgumentMustBeFieldInfoOrPropertyInfo()
+        internal static Exception ArgumentMustBeFieldInfoOrPropertyInfo(string paramName)
         {
-            return new ArgumentException(Strings.ArgumentMustBeFieldInfoOrPropertyInfo);
+            return new ArgumentException(Strings.ArgumentMustBeFieldInfoOrPropertyInfo, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Argument must be either a FieldInfo, PropertyInfo or MethodInfo"
         /// </summary>
-        internal static Exception ArgumentMustBeFieldInfoOrPropertyInfoOrMethod()
+        internal static Exception ArgumentMustBeFieldInfoOrPropertyInfoOrMethod(string paramName)
         {
-            return new ArgumentException(Strings.ArgumentMustBeFieldInfoOrPropertyInfoOrMethod);
+            return new ArgumentException(Strings.ArgumentMustBeFieldInfoOrPropertyInfoOrMethod, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Argument must be an instance member"
         /// </summary>
-        internal static Exception ArgumentMustBeInstanceMember()
+        internal static Exception ArgumentMustBeInstanceMember(string paramName)
         {
-            return new ArgumentException(Strings.ArgumentMustBeInstanceMember);
+            return new ArgumentException(Strings.ArgumentMustBeInstanceMember, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Argument must be of an integer type"
         /// </summary>
-        internal static Exception ArgumentMustBeInteger()
+        internal static Exception ArgumentMustBeInteger(string paramName)
         {
-            return new ArgumentException(Strings.ArgumentMustBeInteger);
+            return new ArgumentException(Strings.ArgumentMustBeInteger, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Argument for array index must be of type Int32"
         /// </summary>
-        internal static Exception ArgumentMustBeArrayIndexType()
+        internal static Exception ArgumentMustBeArrayIndexType(string paramName)
         {
-            return new ArgumentException(Strings.ArgumentMustBeArrayIndexType);
+            return new ArgumentException(Strings.ArgumentMustBeArrayIndexType, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Argument must be single dimensional array type"
         /// </summary>
-        internal static Exception ArgumentMustBeSingleDimensionalArrayType()
+        internal static Exception ArgumentMustBeSingleDimensionalArrayType(string paramName)
         {
-            return new ArgumentException(Strings.ArgumentMustBeSingleDimensionalArrayType);
+            return new ArgumentException(Strings.ArgumentMustBeSingleDimensionalArrayType, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Argument types do not match"
@@ -387,9 +380,9 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "The type used in TypeAs Expression must be of reference or nullable type, {0} is neither"
         /// </summary>
-        internal static Exception IncorrectTypeForTypeAs(object p0)
+        internal static Exception IncorrectTypeForTypeAs(object p0, string paramName)
         {
-            return new ArgumentException(Strings.IncorrectTypeForTypeAs(p0));
+            return new ArgumentException(Strings.IncorrectTypeForTypeAs(p0), paramName);
         }
         /// <summary>
         /// InvalidOperationException with message like "Coalesce used with type that cannot be null"
@@ -457,9 +450,9 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "Expression of type '{0}' cannot be invoked"
         /// </summary>
-        internal static Exception ExpressionTypeNotInvocable(object p0)
+        internal static Exception ExpressionTypeNotInvocable(object p0, string paramName)
         {
-            return new ArgumentException(Strings.ExpressionTypeNotInvocable(p0));
+            return new ArgumentException(Strings.ExpressionTypeNotInvocable(p0), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Field '{0}' is not defined for type '{1}'"
@@ -534,51 +527,51 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "Member '{0}' not field or property"
         /// </summary>
-        internal static Exception MemberNotFieldOrProperty(object p0)
+        internal static Exception MemberNotFieldOrProperty(object p0, string paramName)
         {
-            return new ArgumentException(Strings.MemberNotFieldOrProperty(p0));
+            return new ArgumentException(Strings.MemberNotFieldOrProperty(p0), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Method {0} contains generic parameters"
         /// </summary>
-        internal static Exception MethodContainsGenericParameters(object p0)
+        internal static Exception MethodContainsGenericParameters(object p0, string paramName)
         {
-            return new ArgumentException(Strings.MethodContainsGenericParameters(p0));
+            return new ArgumentException(Strings.MethodContainsGenericParameters(p0), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Method {0} is a generic method definition"
         /// </summary>
-        internal static Exception MethodIsGeneric(object p0)
+        internal static Exception MethodIsGeneric(object p0, string paramName)
         {
-            return new ArgumentException(Strings.MethodIsGeneric(p0));
+            return new ArgumentException(Strings.MethodIsGeneric(p0), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "The method '{0}.{1}' is not a property accessor"
         /// </summary>
-        internal static Exception MethodNotPropertyAccessor(object p0, object p1)
+        internal static Exception MethodNotPropertyAccessor(object p0, object p1, string paramName)
         {
-            return new ArgumentException(Strings.MethodNotPropertyAccessor(p0, p1));
+            return new ArgumentException(Strings.MethodNotPropertyAccessor(p0, p1), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "The property '{0}' has no 'get' accessor"
         /// </summary>
-        internal static Exception PropertyDoesNotHaveGetter(object p0)
+        internal static Exception PropertyDoesNotHaveGetter(object p0, string paramName)
         {
-            return new ArgumentException(Strings.PropertyDoesNotHaveGetter(p0));
+            return new ArgumentException(Strings.PropertyDoesNotHaveGetter(p0), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "The property '{0}' has no 'set' accessor"
         /// </summary>
-        internal static Exception PropertyDoesNotHaveSetter(object p0)
+        internal static Exception PropertyDoesNotHaveSetter(object p0, string paramName)
         {
-            return new ArgumentException(Strings.PropertyDoesNotHaveSetter(p0));
+            return new ArgumentException(Strings.PropertyDoesNotHaveSetter(p0), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "The property '{0}' has no 'get' or 'set' accessors"
         /// </summary>
-        internal static Exception PropertyDoesNotHaveAccessor(object p0)
+        internal static Exception PropertyDoesNotHaveAccessor(object p0, string paramName)
         {
-            return new ArgumentException(Strings.PropertyDoesNotHaveAccessor(p0));
+            return new ArgumentException(Strings.PropertyDoesNotHaveAccessor(p0), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "'{0}' is not a member of type '{1}'"
@@ -647,45 +640,45 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "Type '{0}' does not have a default constructor"
         /// </summary>
-        internal static Exception TypeMissingDefaultConstructor(object p0)
+        internal static Exception TypeMissingDefaultConstructor(object p0, string paramName)
         {
-            return new ArgumentException(Strings.TypeMissingDefaultConstructor(p0));
+            return new ArgumentException(Strings.TypeMissingDefaultConstructor(p0), paramName);
         }
 
         /// <summary>
         /// ArgumentException with message like "Element initializer method must be named 'Add'"
         /// </summary>
-        internal static Exception ElementInitializerMethodNotAdd()
+        internal static Exception ElementInitializerMethodNotAdd(string paramName)
         {
-            return new ArgumentException(Strings.ElementInitializerMethodNotAdd);
+            return new ArgumentException(Strings.ElementInitializerMethodNotAdd, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Parameter '{0}' of element initializer method '{1}' must not be a pass by reference parameter"
         /// </summary>
-        internal static Exception ElementInitializerMethodNoRefOutParam(object p0, object p1)
+        internal static Exception ElementInitializerMethodNoRefOutParam(object p0, object p1, string paramName)
         {
-            return new ArgumentException(Strings.ElementInitializerMethodNoRefOutParam(p0, p1));
+            return new ArgumentException(Strings.ElementInitializerMethodNoRefOutParam(p0, p1), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Element initializer method must have at least 1 parameter"
         /// </summary>
-        internal static Exception ElementInitializerMethodWithZeroArgs()
+        internal static Exception ElementInitializerMethodWithZeroArgs(string paramName)
         {
-            return new ArgumentException(Strings.ElementInitializerMethodWithZeroArgs);
+            return new ArgumentException(Strings.ElementInitializerMethodWithZeroArgs, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Element initializer method must be an instance method"
         /// </summary>
-        internal static Exception ElementInitializerMethodStatic()
+        internal static Exception ElementInitializerMethodStatic(string paramName)
         {
-            return new ArgumentException(Strings.ElementInitializerMethodStatic);
+            return new ArgumentException(Strings.ElementInitializerMethodStatic, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Type '{0}' is not IEnumerable"
         /// </summary>
-        internal static Exception TypeNotIEnumerable(object p0)
+        internal static Exception TypeNotIEnumerable(object p0, string paramName)
         {
-            return new ArgumentException(Strings.TypeNotIEnumerable(p0));
+            return new ArgumentException(Strings.TypeNotIEnumerable(p0), paramName);
         }
         /// <summary>
         /// InvalidOperationException with message like "Unexpected coalesce operator."
@@ -809,30 +802,30 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "An incorrect number of type args were specified for the declaration of a Func type."
         /// </summary>
-        internal static Exception IncorrectNumberOfTypeArgsForFunc()
+        internal static Exception IncorrectNumberOfTypeArgsForFunc(string paramName)
         {
-            return new ArgumentException(Strings.IncorrectNumberOfTypeArgsForFunc);
+            return new ArgumentException(Strings.IncorrectNumberOfTypeArgsForFunc, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "An incorrect number of type args were specified for the declaration of an Action type."
         /// </summary>
-        internal static Exception IncorrectNumberOfTypeArgsForAction()
+        internal static Exception IncorrectNumberOfTypeArgsForAction(string paramName)
         {
-            return new ArgumentException(Strings.IncorrectNumberOfTypeArgsForAction);
+            return new ArgumentException(Strings.IncorrectNumberOfTypeArgsForAction, paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Argument type cannot be System.Void."
         /// </summary>
-        internal static Exception ArgumentCannotBeOfTypeVoid()
+        internal static Exception ArgumentCannotBeOfTypeVoid(string paramName)
         {
-            return new ArgumentException(Strings.ArgumentCannotBeOfTypeVoid);
+            return new ArgumentException(Strings.ArgumentCannotBeOfTypeVoid, paramName);
         }
         /// <summary>
         /// ArgumentOutOfRangeException with message like "{0} must be greater than or equal to {1}"
         /// </summary>
-        internal static Exception OutOfRange(object p0, object p1)
+        internal static Exception OutOfRange(string paramName, object p1)
         {
-            return new ArgumentOutOfRangeException(Strings.OutOfRange(p0, p1));
+            return new ArgumentOutOfRangeException(Strings.OutOfRange(paramName, p1), paramName);
         }
         /// <summary>
         /// InvalidOperationException with message like "Cannot redefine label '{0}' in an inner block."
@@ -933,25 +926,11 @@ namespace System.Linq.Expressions
             return new InvalidOperationException(Strings.UnknownLiftType(p0));
         }
         /// <summary>
-        /// ArgumentException with message like "Invalid output directory."
-        /// </summary>
-        internal static Exception InvalidOutputDir()
-        {
-            return new ArgumentException(Strings.InvalidOutputDir);
-        }
-        /// <summary>
-        /// ArgumentException with message like "Invalid assembly name or file extension."
-        /// </summary>
-        internal static Exception InvalidAsmNameOrExtension()
-        {
-            return new ArgumentException(Strings.InvalidAsmNameOrExtension);
-        }
-        /// <summary>
         /// ArgumentException with message like "Cannot create instance of {0} because it contains generic parameters"
         /// </summary>
-        internal static Exception IllegalNewGenericParams(object p0)
+        internal static Exception IllegalNewGenericParams(object p0, string paramName)
         {
-            return new ArgumentException(Strings.IllegalNewGenericParams(p0));
+            return new ArgumentException(Strings.IllegalNewGenericParams(p0), paramName);
         }
         /// <summary>
         /// InvalidOperationException with message like "variable '{0}' of type '{1}' referenced from scope '{2}', but it is not defined"
@@ -1082,9 +1061,9 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "The constructor should not be static"
         /// </summary>
-        internal static Exception NonStaticConstructorRequired()
+        internal static Exception NonStaticConstructorRequired(string paramName)
         {
-            return new ArgumentException(Strings.NonStaticConstructorRequired);
+            return new ArgumentException(Strings.NonStaticConstructorRequired, paramName);
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/GotoExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/GotoExpression.cs
@@ -363,7 +363,7 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(target, targetParameter);
             if (value == null)
             {
-                if (target.Type != typeof(void)) throw Error.LabelMustBeVoidOrHaveExpression();
+                if (target.Type != typeof(void)) throw Error.LabelMustBeVoidOrHaveExpression(nameof(target));
             }
             else
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
@@ -186,7 +186,7 @@ namespace System.Linq.Expressions
             Type arrayType = array.Type;
             if (!arrayType.IsArray)
             {
-                throw Error.ArgumentMustBeArray();
+                throw Error.ArgumentMustBeArray(nameof(array));
             }
 
             var indexList = indexes.ToReadOnly();
@@ -200,7 +200,7 @@ namespace System.Linq.Expressions
                 RequiresCanRead(e, nameof(indexes));
                 if (e.Type != typeof(int))
                 {
-                    throw Error.ArgumentMustBeArrayIndexType();
+                    throw Error.ArgumentMustBeArrayIndexType(nameof(indexes));
                 }
             }
 
@@ -390,8 +390,8 @@ namespace System.Linq.Expressions
             // Accessor parameters cannot be ByRef.
 
             ContractUtils.RequiresNotNull(property, nameof(property));
-            if (property.PropertyType.IsByRef) throw Error.PropertyCannotHaveRefType();
-            if (property.PropertyType == typeof(void)) throw Error.PropertyTypeCannotBeVoid();
+            if (property.PropertyType.IsByRef) throw Error.PropertyCannotHaveRefType(nameof(property));
+            if (property.PropertyType == typeof(void)) throw Error.PropertyTypeCannotBeVoid(nameof(property));
 
             ParameterInfo[] getParameters = null;
             MethodInfo getter = property.GetGetMethod(true);
@@ -405,22 +405,22 @@ namespace System.Linq.Expressions
             if (setter != null)
             {
                 ParameterInfo[] setParameters = setter.GetParametersCached();
-                if (setParameters.Length == 0) throw Error.SetterHasNoParams();
+                if (setParameters.Length == 0) throw Error.SetterHasNoParams(nameof(property));
 
                 // valueType is the type of the value passed to the setter (last parameter)
                 Type valueType = setParameters[setParameters.Length - 1].ParameterType;
-                if (valueType.IsByRef) throw Error.PropertyCannotHaveRefType();
-                if (setter.ReturnType != typeof(void)) throw Error.SetterMustBeVoid();
-                if (property.PropertyType != valueType) throw Error.PropertyTypeMustMatchSetter();
+                if (valueType.IsByRef) throw Error.PropertyCannotHaveRefType(nameof(property));
+                if (setter.ReturnType != typeof(void)) throw Error.SetterMustBeVoid(nameof(property));
+                if (property.PropertyType != valueType) throw Error.PropertyTypeMustMatchSetter(nameof(property));
 
                 if (getter != null)
                 {
-                    if (getter.IsStatic ^ setter.IsStatic) throw Error.BothAccessorsMustBeStatic();
-                    if (getParameters.Length != setParameters.Length - 1) throw Error.IndexesOfSetGetMustMatch();
+                    if (getter.IsStatic ^ setter.IsStatic) throw Error.BothAccessorsMustBeStatic(nameof(property));
+                    if (getParameters.Length != setParameters.Length - 1) throw Error.IndexesOfSetGetMustMatch(nameof(property));
 
                     for (int i = 0; i < getParameters.Length; i++)
                     {
-                        if (getParameters[i].ParameterType != setParameters[i].ParameterType) throw Error.IndexesOfSetGetMustMatch();
+                        if (getParameters[i].ParameterType != setParameters[i].ParameterType) throw Error.IndexesOfSetGetMustMatch(nameof(property));
                     }
                 }
                 else
@@ -431,7 +431,7 @@ namespace System.Linq.Expressions
 
             if (getter == null && setter == null)
             {
-                throw Error.PropertyDoesNotHaveAccessor(property);
+                throw Error.PropertyDoesNotHaveAccessor(property, nameof(property));
             }
         }
 
@@ -439,8 +439,8 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(arguments, nameof(arguments));
 
-            ValidateMethodInfo(method);
-            if ((method.CallingConvention & CallingConventions.VarArgs) != 0) throw Error.AccessorsCannotHaveVarArgs();
+            ValidateMethodInfo(method, nameof(method));
+            if ((method.CallingConvention & CallingConventions.VarArgs) != 0) throw Error.AccessorsCannotHaveVarArgs(nameof(method));
             if (method.IsStatic)
             {
                 if (instance != null) throw Error.OnlyStaticMethodsHaveNullInstance();
@@ -471,8 +471,8 @@ namespace System.Linq.Expressions
                     RequiresCanRead(arg, nameof(arguments));
 
                     Type pType = pi.ParameterType;
-                    if (pType.IsByRef) throw Error.AccessorsCannotHaveByRefArgs();
-                    TypeUtils.ValidateType(pType);
+                    if (pType.IsByRef) throw Error.AccessorsCannotHaveByRefArgs($"{nameof(indexes)}[{i}]");
+                    TypeUtils.ValidateType(pType, $"{nameof(indexes)}[{i}]");
 
                     if (!TypeUtils.AreReferenceAssignable(pType, arg.Type))
                     {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
@@ -809,7 +809,7 @@ namespace System.Linq.Expressions
                 Type exprType = TypeUtils.FindGenericType(typeof(Expression<>), expression.Type);
                 if (exprType == null)
                 {
-                    throw Error.ExpressionTypeNotInvocable(expression.Type);
+                    throw Error.ExpressionTypeNotInvocable(expression.Type, nameof(expression));
                 }
                 delegateType = exprType.GetGenericArguments()[0];
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelTarget.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelTarget.cs
@@ -90,7 +90,7 @@ namespace System.Linq.Expressions
         public static LabelTarget Label(Type type, string name)
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
-            TypeUtils.ValidateType(type);
+            TypeUtils.ValidateType(type, nameof(type));
             return new LabelTarget(type, name);
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -490,7 +490,7 @@ namespace System.Linq.Expressions
                     typeArgs[i] = param.IsByRef ? param.Type.MakeByRefType() : param.Type;
                     if (!set.Add(param))
                     {
-                        throw Error.DuplicateVariable(param);
+                        throw Error.DuplicateVariable(param, $"parameters[{i}]");
                     }
                 }
             }
@@ -585,7 +585,7 @@ namespace System.Linq.Expressions
                     }
                     if (!set.Add(pex))
                     {
-                        throw Error.DuplicateVariable(pex);
+                        throw Error.DuplicateVariable(pex, $"parameters[{i}]");
                     }
                 }
             }
@@ -631,12 +631,12 @@ namespace System.Linq.Expressions
         /// <returns>The type of a System.Func delegate that has the specified type arguments.</returns>
         public static Type GetFuncType(params Type[] typeArgs)
         {
-            if (!ValidateTryGetFuncActionArgs(typeArgs)) throw Error.TypeMustNotBeByRef();
+            if (!ValidateTryGetFuncActionArgs(typeArgs)) throw Error.TypeMustNotBeByRef(nameof(typeArgs));
 
             Type result = Compiler.DelegateHelpers.GetFuncType(typeArgs);
             if (result == null)
             {
-                throw Error.IncorrectNumberOfTypeArgsForFunc();
+                throw Error.IncorrectNumberOfTypeArgsForFunc(nameof(typeArgs));
             }
             return result;
         }
@@ -665,12 +665,12 @@ namespace System.Linq.Expressions
         /// <returns>The type of a System.Action delegate that has the specified type arguments.</returns>
         public static Type GetActionType(params Type[] typeArgs)
         {
-            if (!ValidateTryGetFuncActionArgs(typeArgs)) throw Error.TypeMustNotBeByRef();
+            if (!ValidateTryGetFuncActionArgs(typeArgs)) throw Error.TypeMustNotBeByRef(nameof(typeArgs));
 
             Type result = Compiler.DelegateHelpers.GetActionType(typeArgs);
             if (result == null)
             {
-                throw Error.IncorrectNumberOfTypeArgsForAction();
+                throw Error.IncorrectNumberOfTypeArgsForAction(nameof(typeArgs));
             }
             return result;
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
@@ -219,7 +219,7 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(newExpression, nameof(newExpression));
             ContractUtils.RequiresNotNull(initializers, nameof(initializers));
             var initializerlist = initializers.ToReadOnly();
-            ValidateListInitArgs(newExpression.Type, initializerlist);
+            ValidateListInitArgs(newExpression.Type, initializerlist, nameof(newExpression));
             return new ListInitExpression(newExpression, initializerlist);
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LoopExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LoopExpression.cs
@@ -128,7 +128,7 @@ namespace System.Linq.Expressions
         public static LoopExpression Loop(Expression body, LabelTarget @break, LabelTarget @continue)
         {
             RequiresCanRead(body, nameof(body));
-            if (@continue != null && @continue.Type != typeof(void)) throw Error.LabelTypeMustBeVoid();
+            if (@continue != null && @continue.Type != typeof(void)) throw Error.LabelTypeMustBeVoid(nameof(@continue));
             return new LoopExpression(body, @break, @continue);
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberAssignment.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberAssignment.cs
@@ -78,8 +78,8 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(propertyAccessor, nameof(propertyAccessor));
             ContractUtils.RequiresNotNull(expression, nameof(expression));
-            ValidateMethodInfo(propertyAccessor);
-            return Bind(GetProperty(propertyAccessor), expression);
+            ValidateMethodInfo(propertyAccessor, nameof(propertyAccessor));
+            return Bind(GetProperty(propertyAccessor, nameof(propertyAccessor)), expression);
         }
 
 
@@ -91,11 +91,11 @@ namespace System.Linq.Expressions
                 PropertyInfo pi = member as PropertyInfo;
                 if (pi == null)
                 {
-                    throw Error.ArgumentMustBeFieldInfoOrPropertyInfo();
+                    throw Error.ArgumentMustBeFieldInfoOrPropertyInfo(nameof(member));
                 }
                 if (!pi.CanWrite)
                 {
-                    throw Error.PropertyDoesNotHaveSetter(pi);
+                    throw Error.PropertyDoesNotHaveSetter(pi, nameof(member));
                 }
                 memberType = pi.PropertyType;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -289,7 +289,7 @@ namespace System.Linq.Expressions
 
                 if (mi == null)
                 {
-                    throw Error.PropertyDoesNotHaveAccessor(property);
+                    throw Error.PropertyDoesNotHaveAccessor(property, nameof(property));
                 }
                 else if (mi.GetParametersCached().Length != 1)
                 {
@@ -327,11 +327,11 @@ namespace System.Linq.Expressions
         public static MemberExpression Property(Expression expression, MethodInfo propertyAccessor)
         {
             ContractUtils.RequiresNotNull(propertyAccessor, nameof(propertyAccessor));
-            ValidateMethodInfo(propertyAccessor);
-            return Property(expression, GetProperty(propertyAccessor));
+            ValidateMethodInfo(propertyAccessor, nameof(propertyAccessor));
+            return Property(expression, GetProperty(propertyAccessor, nameof(propertyAccessor)));
         }
 
-        private static PropertyInfo GetProperty(MethodInfo mi)
+        private static PropertyInfo GetProperty(MethodInfo mi, string paramName)
         {
             Type type = mi.DeclaringType;
             BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic;
@@ -348,7 +348,7 @@ namespace System.Linq.Expressions
                     return pi;
                 }
             }
-            throw Error.MethodNotPropertyAccessor(mi.DeclaringType, mi.Name);
+            throw Error.MethodNotPropertyAccessor(mi.DeclaringType, mi.Name, paramName);
         }
 
         private static bool CheckMethod(MethodInfo method, MethodInfo propertyMethod)
@@ -416,7 +416,7 @@ namespace System.Linq.Expressions
             {
                 return Expression.Property(expression, pi);
             }
-            throw Error.MemberNotFieldOrProperty(member);
+            throw Error.MemberNotFieldOrProperty(member, nameof(member));
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
@@ -81,7 +81,7 @@ namespace System.Linq.Expressions
             Type memberType;
             ValidateGettableFieldOrPropertyMember(member, out memberType);
             var initList = initializers.ToReadOnly();
-            ValidateListInitArgs(memberType, initList);
+            ValidateListInitArgs(memberType, initList, nameof(member));
             return new MemberListBinding(member, initList);
         }
 
@@ -110,14 +110,14 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(propertyAccessor, nameof(propertyAccessor));
             ContractUtils.RequiresNotNull(initializers, nameof(initializers));
-            return ListBind(GetProperty(propertyAccessor), initializers);
+            return ListBind(GetProperty(propertyAccessor, nameof(propertyAccessor)), initializers);
         }
 
-        private static void ValidateListInitArgs(Type listType, ReadOnlyCollection<ElementInit> initializers)
+        private static void ValidateListInitArgs(Type listType, ReadOnlyCollection<ElementInit> initializers, string listTypeParamName)
         {
             if (!typeof(IEnumerable).IsAssignableFrom(listType))
             {
-                throw Error.TypeNotIEnumerable(listType);
+                throw Error.TypeNotIEnumerable(listType, listTypeParamName);
             }
             for (int i = 0, n = initializers.Count; i < n; i++)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
@@ -112,7 +112,7 @@ namespace System.Linq.Expressions
         public static MemberMemberBinding MemberBind(MethodInfo propertyAccessor, IEnumerable<MemberBinding> bindings)
         {
             ContractUtils.RequiresNotNull(propertyAccessor, nameof(propertyAccessor));
-            return MemberBind(GetProperty(propertyAccessor), bindings);
+            return MemberBind(GetProperty(propertyAccessor, nameof(propertyAccessor)), bindings);
         }
 
         private static void ValidateGettableFieldOrPropertyMember(MemberInfo member, out Type memberType)
@@ -123,11 +123,11 @@ namespace System.Linq.Expressions
                 PropertyInfo pi = member as PropertyInfo;
                 if (pi == null)
                 {
-                    throw Error.ArgumentMustBeFieldInfoOrPropertyInfo();
+                    throw Error.ArgumentMustBeFieldInfoOrPropertyInfo(nameof(member));
                 }
                 if (!pi.CanRead)
                 {
-                    throw Error.PropertyDoesNotHaveGetter(pi);
+                    throw Error.PropertyDoesNotHaveGetter(pi, nameof(member));
                 }
                 memberType = pi.PropertyType;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -1082,7 +1082,7 @@ namespace System.Linq.Expressions
 
             ReadOnlyCollection<Expression> argList = arguments.ToReadOnly();
 
-            ValidateMethodInfo(method);
+            ValidateMethodInfo(method, nameof(method));
             ValidateStaticOrInstanceMethod(instance, method);
             ValidateArgumentTypes(method, ExpressionType.Call, ref argList);
 
@@ -1098,7 +1098,7 @@ namespace System.Linq.Expressions
 
         private static ParameterInfo[] ValidateMethodAndGetParameters(Expression instance, MethodInfo method)
         {
-            ValidateMethodInfo(method);
+            ValidateMethodInfo(method, nameof(method));
             ValidateStaticOrInstanceMethod(instance, method);
 
             return GetParametersForValidation(method, ExpressionType.Call);
@@ -1273,7 +1273,7 @@ namespace System.Linq.Expressions
             Type arrayType = array.Type;
             if (!arrayType.IsArray)
             {
-                throw Error.ArgumentMustBeArray();
+                throw Error.ArgumentMustBeArray(nameof(array));
             }
 
             ReadOnlyCollection<Expression> indexList = indexes.ToReadOnly();
@@ -1287,7 +1287,7 @@ namespace System.Linq.Expressions
                 RequiresCanRead(e, nameof(indexes));
                 if (e.Type != typeof(int))
                 {
-                    throw Error.ArgumentMustBeArrayIndexType();
+                    throw Error.ArgumentMustBeArrayIndexType(nameof(indexList));
                 }
             }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
@@ -151,15 +151,15 @@ namespace System.Linq.Expressions
                 throw Error.ArgumentCannotBeOfTypeVoid(nameof(type));
             }
 
-            TypeUtils.ValidateType(type);
+            TypeUtils.ValidateType(type, nameof(type));
             if (type.IsByRef)
             {
-                throw Error.TypeMustNotBeByRef();
+                throw Error.TypeMustNotBeByRef(nameof(type));
             }
 
             if (type.IsPointer)
             {
-                throw Error.TypeMustNotBePointer();
+                throw Error.TypeMustNotBePointer(nameof(type));
             }
 
             ReadOnlyCollection<Expression> initializerList = initializers.ToReadOnly();
@@ -231,15 +231,15 @@ namespace System.Linq.Expressions
                 throw Error.ArgumentCannotBeOfTypeVoid(nameof(type));
             }
 
-            TypeUtils.ValidateType(type);
+            TypeUtils.ValidateType(type, nameof(type));
             if (type.IsByRef)
             {
-                throw Error.TypeMustNotBeByRef();
+                throw Error.TypeMustNotBeByRef(nameof(type));
             }
 
             if (type.IsPointer)
             {
-                throw Error.TypeMustNotBePointer();
+                throw Error.TypeMustNotBePointer(nameof(type));
             }
 
             ReadOnlyCollection<Expression> boundsList = bounds.ToReadOnly();
@@ -253,7 +253,7 @@ namespace System.Linq.Expressions
                 RequiresCanRead(expr, nameof(bounds));
                 if (!TypeUtils.IsInteger(expr.Type))
                 {
-                    throw Error.ArgumentMustBeInteger($"bounds[{i}]");
+                    throw Error.ArgumentMustBeInteger($"{nameof(bounds)}[{i}]");
                 }
             }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
@@ -148,7 +148,7 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(initializers, nameof(initializers));
             if (type == typeof(void))
             {
-                throw Error.ArgumentCannotBeOfTypeVoid();
+                throw Error.ArgumentCannotBeOfTypeVoid(nameof(type));
             }
 
             TypeUtils.ValidateType(type);
@@ -228,7 +228,7 @@ namespace System.Linq.Expressions
 
             if (type == typeof(void))
             {
-                throw Error.ArgumentCannotBeOfTypeVoid();
+                throw Error.ArgumentCannotBeOfTypeVoid(nameof(type));
             }
 
             TypeUtils.ValidateType(type);
@@ -245,7 +245,7 @@ namespace System.Linq.Expressions
             ReadOnlyCollection<Expression> boundsList = bounds.ToReadOnly();
 
             int dimensions = boundsList.Count;
-            if (dimensions <= 0) throw Error.BoundsCannotBeLessThanOne();
+            if (dimensions <= 0) throw Error.BoundsCannotBeLessThanOne(nameof(bounds));
 
             for (int i = 0; i < dimensions; i++)
             {
@@ -253,7 +253,7 @@ namespace System.Linq.Expressions
                 RequiresCanRead(expr, nameof(bounds));
                 if (!TypeUtils.IsInteger(expr.Type))
                 {
-                    throw Error.ArgumentMustBeInteger();
+                    throw Error.ArgumentMustBeInteger($"bounds[{i}]");
                 }
             }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -164,8 +164,8 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(constructor, nameof(constructor));
             ContractUtils.RequiresNotNull(constructor.DeclaringType, nameof(constructor) + "." + nameof(constructor.DeclaringType));
-            TypeUtils.ValidateType(constructor.DeclaringType);
-            ValidateConstructor(constructor);
+            TypeUtils.ValidateType(constructor.DeclaringType, nameof(constructor));
+            ValidateConstructor(constructor, nameof(constructor));
             var argList = arguments.ToReadOnly();
             ValidateArgumentTypes(constructor, ExpressionType.New, ref argList);
 
@@ -183,7 +183,7 @@ namespace System.Linq.Expressions
         public static NewExpression New(ConstructorInfo constructor, IEnumerable<Expression> arguments, IEnumerable<MemberInfo> members)
         {
             ContractUtils.RequiresNotNull(constructor, nameof(constructor));
-            ValidateConstructor(constructor);
+            ValidateConstructor(constructor, nameof(constructor));
             var memberList = members.ToReadOnly();
             var argList = arguments.ToReadOnly();
             ValidateNewArgs(constructor, ref argList, ref memberList);
@@ -214,7 +214,7 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(type, nameof(type));
             if (type == typeof(void))
             {
-                throw Error.ArgumentCannotBeOfTypeVoid();
+                throw Error.ArgumentCannotBeOfTypeVoid(nameof(type));
             }
             ConstructorInfo ci = null;
             if (!type.GetTypeInfo().IsValueType)
@@ -222,7 +222,7 @@ namespace System.Linq.Expressions
                 ci = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Where(c => c.GetParameters().Length == 0).SingleOrDefault();
                 if (ci == null)
                 {
-                    throw Error.TypeMissingDefaultConstructor(type);
+                    throw Error.TypeMissingDefaultConstructor(type, nameof(type));
                 }
                 return New(ci);
             }
@@ -332,7 +332,7 @@ namespace System.Linq.Expressions
             {
                 if (field.IsStatic)
                 {
-                    throw Error.ArgumentMustBeInstanceMember();
+                    throw Error.ArgumentMustBeInstanceMember(nameof(member));
                 }
                 memberType = field.FieldType;
                 return;
@@ -343,11 +343,11 @@ namespace System.Linq.Expressions
             {
                 if (!pi.CanRead)
                 {
-                    throw Error.PropertyDoesNotHaveGetter(pi);
+                    throw Error.PropertyDoesNotHaveGetter(pi, nameof(member));
                 }
                 if (pi.GetGetMethod().IsStatic)
                 {
-                    throw Error.ArgumentMustBeInstanceMember();
+                    throw Error.ArgumentMustBeInstanceMember(nameof(member));
                 }
                 memberType = pi.PropertyType;
                 return;
@@ -358,21 +358,21 @@ namespace System.Linq.Expressions
             {
                 if (method.IsStatic)
                 {
-                    throw Error.ArgumentMustBeInstanceMember();
+                    throw Error.ArgumentMustBeInstanceMember(nameof(member));
                 }
 
-                PropertyInfo prop = GetProperty(method);
+                PropertyInfo prop = GetProperty(method, nameof(member));
                 member = prop;
                 memberType = prop.PropertyType;
                 return;
             }
-            throw Error.ArgumentMustBeFieldInfoOrPropertyInfoOrMethod();
+            throw Error.ArgumentMustBeFieldInfoOrPropertyInfoOrMethod(nameof(member));
         }
 
-        private static void ValidateConstructor(ConstructorInfo constructor)
+        private static void ValidateConstructor(ConstructorInfo constructor, string paramName)
         {
             if (constructor.IsStatic)
-                throw Error.NonStaticConstructorRequired();
+                throw Error.NonStaticConstructorRequired(paramName);
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
@@ -213,12 +213,12 @@ namespace System.Linq.Expressions
 
             if (type == typeof(void))
             {
-                throw Error.ArgumentCannotBeOfTypeVoid();
+                throw Error.ArgumentCannotBeOfTypeVoid(nameof(type));
             }
 
             if (type.IsPointer)
             {
-                throw Error.TypeMustNotBePointer();
+                throw Error.TypeMustNotBePointer(nameof(type));
             }
 
             bool byref = type.IsByRef;
@@ -239,12 +239,12 @@ namespace System.Linq.Expressions
         public static ParameterExpression Variable(Type type, string name)
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
-            if (type == typeof(void)) throw Error.ArgumentCannotBeOfTypeVoid();
-            if (type.IsByRef) throw Error.TypeMustNotBeByRef();
+            if (type == typeof(void)) throw Error.ArgumentCannotBeOfTypeVoid(nameof(type));
+            if (type.IsByRef) throw Error.TypeMustNotBeByRef(nameof(type));
 
             if (type.IsPointer)
             {
-                throw Error.TypeMustNotBePointer();
+                throw Error.TypeMustNotBePointer(nameof(type));
             }
 
             return ParameterExpression.Make(type, name, false);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -292,17 +292,6 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// A string like "MethodBuilder does not have a valid TypeBuilder"
-        /// </summary>
-        internal static string MethodBuilderDoesNotHaveTypeBuilder
-        {
-            get
-            {
-                return SR.MethodBuilderDoesNotHaveTypeBuilder;
-            }
-        }
-
-        /// <summary>
         /// A string like "Label type must be System.Void if an expression is not supplied"
         /// </summary>
         internal static string LabelMustBeVoidOrHaveExpression
@@ -1256,29 +1245,6 @@ namespace System.Linq.Expressions
         {
             return SR.Format(SR.UnknownLiftType, p0);
         }
-
-        /// <summary>
-        /// A string like "Invalid output directory."
-        /// </summary>
-        internal static string InvalidOutputDir
-        {
-            get
-            {
-                return SR.InvalidOutputDir;
-            }
-        }
-
-        /// <summary>
-        /// A string like "Invalid assembly name or file extension."
-        /// </summary>
-        internal static string InvalidAsmNameOrExtension
-        {
-            get
-            {
-                return SR.InvalidAsmNameOrExtension;
-            }
-        }
-
 
         /// <summary>
         /// A string like "Cannot create instance of {0} because it contains generic parameters"

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchExpression.cs
@@ -200,7 +200,7 @@ namespace System.Linq.Expressions
         public static SwitchExpression Switch(Type type, Expression switchValue, Expression defaultBody, MethodInfo comparison, IEnumerable<SwitchCase> cases)
         {
             RequiresCanRead(switchValue, nameof(switchValue));
-            if (switchValue.Type == typeof(void)) throw Error.ArgumentCannotBeOfTypeVoid();
+            if (switchValue.Type == typeof(void)) throw Error.ArgumentCannotBeOfTypeVoid(nameof(switchValue));
 
             var caseList = cases.ToReadOnly();
             ContractUtils.RequiresNotNullItems(caseList, nameof(cases));
@@ -265,7 +265,7 @@ namespace System.Linq.Expressions
                 // if we have a non-boolean user-defined equals, we don't want it.
                 if (comparison.ReturnType != typeof(bool))
                 {
-                    throw Error.EqualityMustReturnBoolean(comparison);
+                    throw Error.EqualityMustReturnBoolean(comparison, nameof(comparison));
                 }
             }
             else if (caseList.Count != 0)
@@ -298,7 +298,7 @@ namespace System.Linq.Expressions
 
             if (defaultBody == null)
             {
-                if (resultType != typeof(void)) throw Error.DefaultBodyMustBeSupplied();
+                if (resultType != typeof(void)) throw Error.DefaultBodyMustBeSupplied(nameof(defaultBody));
             }
             else
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TryExpression.cs
@@ -184,7 +184,7 @@ namespace System.Linq.Expressions
             {
                 if (@finally != null || @catch.Count > 0)
                 {
-                    throw Error.FaultCannotHaveCatchOrFinally();
+                    throw Error.FaultCannotHaveCatchOrFinally(nameof(fault));
                 }
                 RequiresCanRead(fault, nameof(fault));
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
@@ -201,7 +201,7 @@ namespace System.Linq.Expressions
         {
             RequiresCanRead(expression, nameof(expression));
             ContractUtils.RequiresNotNull(type, nameof(type));
-            if (type.IsByRef) throw Error.TypeMustNotBeByRef();
+            if (type.IsByRef) throw Error.TypeMustNotBeByRef(nameof(type));
 
             return new TypeBinaryExpression(expression, type, ExpressionType.TypeIs);
         }
@@ -216,7 +216,7 @@ namespace System.Linq.Expressions
         {
             RequiresCanRead(expression, nameof(expression));
             ContractUtils.RequiresNotNull(type, nameof(type));
-            if (type.IsByRef) throw Error.TypeMustNotBeByRef();
+            if (type.IsByRef) throw Error.TypeMustNotBeByRef(nameof(type));
 
             return new TypeBinaryExpression(expression, type, ExpressionType.TypeEqual);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -420,7 +420,7 @@ namespace System.Linq.Expressions
         private static UnaryExpression GetMethodBasedUnaryOperator(ExpressionType unaryType, Expression operand, MethodInfo method)
         {
             System.Diagnostics.Debug.Assert(method != null);
-            ValidateOperator(method);
+            ValidateOperator(method, nameof(method));
             ParameterInfo[] pms = method.GetParametersCached();
             if (pms.Length != 1)
                 throw Error.IncorrectNumberOfMethodCallArguments(method);
@@ -466,7 +466,7 @@ namespace System.Linq.Expressions
         private static UnaryExpression GetMethodBasedCoercionOperator(ExpressionType unaryType, Expression operand, Type convertToType, MethodInfo method)
         {
             System.Diagnostics.Debug.Assert(method != null);
-            ValidateOperator(method);
+            ValidateOperator(method, nameof(method));
             ParameterInfo[] pms = method.GetParametersCached();
             if (pms.Length != 1)
             {
@@ -731,11 +731,11 @@ namespace System.Linq.Expressions
         {
             RequiresCanRead(expression, nameof(expression));
             ContractUtils.RequiresNotNull(type, nameof(type));
-            TypeUtils.ValidateType(type);
+            TypeUtils.ValidateType(type, nameof(type));
 
             if (type.GetTypeInfo().IsValueType && !TypeUtils.IsNullableType(type))
             {
-                throw Error.IncorrectTypeForTypeAs(type);
+                throw Error.IncorrectTypeForTypeAs(type, nameof(type));
             }
             return new UnaryExpression(ExpressionType.TypeAs, expression, type, null);
         }
@@ -752,10 +752,10 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(type, nameof(type));
             if (!expression.Type.GetTypeInfo().IsInterface && expression.Type != typeof(object))
             {
-                throw Error.InvalidUnboxType();
+                throw Error.InvalidUnboxType(nameof(expression));
             }
-            if (!type.GetTypeInfo().IsValueType) throw Error.InvalidUnboxType();
-            TypeUtils.ValidateType(type);
+            if (!type.GetTypeInfo().IsValueType) throw Error.InvalidUnboxType(nameof(type));
+            TypeUtils.ValidateType(type, nameof(type));
             return new UnaryExpression(ExpressionType.Unbox, expression, type, null);
         }
 
@@ -786,7 +786,7 @@ namespace System.Linq.Expressions
         {
             RequiresCanRead(expression, nameof(expression));
             ContractUtils.RequiresNotNull(type, nameof(type));
-            TypeUtils.ValidateType(type);
+            TypeUtils.ValidateType(type, nameof(type));
 
             if (method == null)
             {
@@ -827,7 +827,7 @@ namespace System.Linq.Expressions
         {
             RequiresCanRead(expression, nameof(expression));
             ContractUtils.RequiresNotNull(type, nameof(type));
-            TypeUtils.ValidateType(type);
+            TypeUtils.ValidateType(type, nameof(type));
 
             if (method == null)
             {
@@ -856,11 +856,11 @@ namespace System.Linq.Expressions
             ContractUtils.RequiresNotNull(array, nameof(array));
             if (!array.Type.IsArray || !typeof(Array).IsAssignableFrom(array.Type))
             {
-                throw Error.ArgumentMustBeArray();
+                throw Error.ArgumentMustBeArray(nameof(array));
             }
             if (!array.Type.IsVector())
             {
-                throw Error.ArgumentMustBeSingleDimensionalArrayType();
+                throw Error.ArgumentMustBeSingleDimensionalArrayType(nameof(array));
             }
             return new UnaryExpression(ExpressionType.ArrayLength, array, typeof(int), null);
         }
@@ -874,7 +874,7 @@ namespace System.Linq.Expressions
         {
             RequiresCanRead(expression, nameof(expression));
             bool validQuote = expression is LambdaExpression;
-            if (!validQuote) throw Error.QuotedExpressionMustBeLambda();
+            if (!validQuote) throw Error.QuotedExpressionMustBeLambda(nameof(expression));
             return new UnaryExpression(ExpressionType.Quote, expression, expression.GetType(), null);
         }
 
@@ -916,12 +916,12 @@ namespace System.Linq.Expressions
         public static UnaryExpression Throw(Expression value, Type type)
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
-            TypeUtils.ValidateType(type);
+            TypeUtils.ValidateType(type, nameof(type));
 
             if (value != null)
             {
                 RequiresCanRead(value, nameof(value));
-                if (value.Type.GetTypeInfo().IsValueType) throw Error.ArgumentMustNotHaveValueType();
+                if (value.Type.GetTypeInfo().IsValueType) throw Error.ArgumentMustNotHaveValueType(nameof(value));
             }
             return new UnaryExpression(ExpressionType.Throw, value, type, null);
         }

--- a/src/System.Linq.Expressions/tests/Array/ArrayArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayArrayLengthTests.cs
@@ -1936,7 +1936,7 @@ namespace System.Linq.Expressions.Tests
         {
             foreach (var e in new Expression[] { Expression.Parameter(typeof(int).MakeArrayType(1)), Expression.Constant(new int[2, 2]) })
             {
-                Assert.Throws<ArgumentException>(() => Expression.ArrayLength(e));
+                Assert.Throws<ArgumentException>("array", () => Expression.ArrayLength(e));
             }
         }
 

--- a/src/System.Linq.Expressions/tests/Array/ArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayBoundsTests.cs
@@ -3371,7 +3371,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void VoidType()
         {
-            Assert.Throws<ArgumentException>(() => Expression.NewArrayBounds(typeof(void), Expression.Constant(2)));
+            Assert.Throws<ArgumentException>("type", () => Expression.NewArrayBounds(typeof(void), Expression.Constant(2)));
         }
 
         [Fact]
@@ -3384,7 +3384,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void NoBounds()
         {
-            Assert.Throws<ArgumentException>(() => Expression.NewArrayBounds(typeof(int)));
+            Assert.Throws<ArgumentException>("bounds", () => Expression.NewArrayBounds(typeof(int)));
         }
 
         [Fact]
@@ -3396,15 +3396,13 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void NonIntegralBounds()
         {
-            Assert.Throws<ArgumentException>(() => Expression.NewArrayBounds(typeof(int), Expression.Constant(2.0)));
+            Assert.Throws<ArgumentException>("bounds[0]", () => Expression.NewArrayBounds(typeof(int), Expression.Constant(2.0)));
         }
-
-
 
         [Fact]
         public static void ByRefType()
         {
-            Assert.Throws<ArgumentException>(() => Expression.NewArrayBounds(typeof(int).MakeByRefType(), Expression.Constant(2)));
+            Assert.Throws<ArgumentException>("type", () => Expression.NewArrayBounds(typeof(int).MakeByRefType(), Expression.Constant(2)));
         }
 
         [Fact]
@@ -3416,14 +3414,14 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void GenericType()
         {
-            Assert.Throws<ArgumentException>(() => Expression.NewArrayBounds(typeof(List<>), Expression.Constant(2)));
+            Assert.Throws<ArgumentException>("type", () => Expression.NewArrayBounds(typeof(List<>), Expression.Constant(2)));
         }
 
         [Fact]
         public static void TypeContainsGenericParameters()
         {
-            Assert.Throws<ArgumentException>(() => Expression.NewArrayBounds(typeof(List<>.Enumerator), Expression.Constant(2)));
-            Assert.Throws<ArgumentException>(() => Expression.NewArrayBounds(typeof(List<>).MakeGenericType(typeof(List<>)), Expression.Constant(2)));
+            Assert.Throws<ArgumentException>("type", () => Expression.NewArrayBounds(typeof(List<>.Enumerator), Expression.Constant(2)));
+            Assert.Throws<ArgumentException>("type", () => Expression.NewArrayBounds(typeof(List<>).MakeGenericType(typeof(List<>)), Expression.Constant(2)));
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
@@ -139,19 +139,19 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void LeftMustBeWritable()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Assign(Expression.Constant(0), Expression.Constant(1)));
+            Assert.Throws<ArgumentException>("left", () => Expression.Assign(Expression.Constant(0), Expression.Constant(1)));
         }
 
         [Fact]
         public void MismatchTypes()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Assign(Expression.Variable(typeof(int)), Expression.Constant("Hello")));
+            Assert.Throws<ArgumentException>(null, () => Expression.Assign(Expression.Variable(typeof(int)), Expression.Constant("Hello")));
         }
 
         [Fact]
         public void AssignableButOnlyWithConversion()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Assign(Expression.Variable(typeof(long)), Expression.Constant(1)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Assign(Expression.Variable(typeof(long)), Expression.Constant(1)));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
@@ -171,7 +171,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, MemberData(nameof(ReadOnlyExpressions))]
         public void AttemptToAssignToNonWritable(Expression readonlyExp)
         {
-            Assert.Throws<ArgumentException>(() => Expression.Assign(readonlyExp, Expression.Default(readonlyExp.Type)));
+            Assert.Throws<ArgumentException>("left", () => Expression.Assign(readonlyExp, Expression.Default(readonlyExp.Type)));
         }
 
         [Theory, MemberData(nameof(WriteOnlyExpressions))]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/OpAssign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/OpAssign.cs
@@ -176,7 +176,7 @@ namespace System.Linq.Expressions.Tests
         {
             Func<Expression, Expression, Expression> withAssignment = (Func<Expression, Expression, Expression>)assign.CreateDelegate(typeof(Func<Expression, Expression, Expression>));
 
-            Assert.Throws<ArgumentException>(() => withAssignment(Expression.Default(type), Expression.Default(type)));
+            Assert.Throws<ArgumentException>("left", () => withAssignment(Expression.Default(type), Expression.Default(type)));
         }
 
         [Theory]
@@ -226,7 +226,7 @@ namespace System.Linq.Expressions.Tests
 
             Type unreadableType = typeof(Unreadable<>).MakeGenericType(type);
             Expression property = Expression.Property(null, unreadableType.GetProperty("WriteOnly"));
-            Assert.Throws<ArgumentException>(() => withAssignment(property, Expression.Default(type)));
+            Assert.Throws<ArgumentException>("left", () => withAssignment(property, Expression.Default(type)));
         }
 
         [Theory]
@@ -238,7 +238,7 @@ namespace System.Linq.Expressions.Tests
             Type unreadableType = typeof(Unreadable<>).MakeGenericType(type);
             Expression property = Expression.Property(null, unreadableType.GetProperty("WriteOnly"));
             Expression variable = Expression.Variable(type);
-            Assert.Throws<ArgumentException>(() => withAssignment(variable, property));
+            Assert.Throws<ArgumentException>("right", () => withAssignment(variable, property));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/GeneralBinaryTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/GeneralBinaryTests.cs
@@ -44,9 +44,9 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(NonBinaryTypesIncludingInvalidData))]
         public void MakeBinaryInvalidType(ExpressionType type)
         {
-            Assert.Throws<ArgumentException>(() => Expression.MakeBinary(type, Expression.Constant(0), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(() => Expression.MakeBinary(type, Expression.Constant(0), Expression.Constant(0), false, null));
-            Assert.Throws<ArgumentException>(() => Expression.MakeBinary(type, Expression.Constant(0), Expression.Constant(0), false, null, null));
+            Assert.Throws<ArgumentException>(null, () => Expression.MakeBinary(type, Expression.Constant(0), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(null, () => Expression.MakeBinary(type, Expression.Constant(0), Expression.Constant(0), false, null));
+            Assert.Throws<ArgumentException>(null, () => Expression.MakeBinary(type, Expression.Constant(0), Expression.Constant(0), false, null, null));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Block/BlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockTests.cs
@@ -179,7 +179,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void EmptyBlockWrongExplicitType()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Block(typeof(int)));
         }
 
         [Theory]
@@ -205,7 +205,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void EmptyScopeExplicitWrongType()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Block(
+            Assert.Throws<ArgumentException>(null, () => Expression.Block(
                 typeof(int),
                 new[] { Expression.Parameter(typeof(int), "x") },
                 new Expression[0]));

--- a/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
@@ -259,8 +259,8 @@ namespace System.Linq.Expressions.Tests
         {
             ConstantExpression constant = Expression.Constant(0);
             IEnumerable<Expression> expressions = PadBlock(blockSize - 1, Expression.Constant(0));
-            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(string), expressions));
-            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(string), expressions.ToArray()));
+            Assert.Throws<ArgumentException>(null, () => Expression.Block(typeof(string), expressions));
+            Assert.Throws<ArgumentException>(null, (() => Expression.Block(typeof(string), expressions.ToArray())));
         }
 
         [Theory]
@@ -275,8 +275,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void EmptyBlockWithNonVoidTypeNotAllowed()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int)));
-            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int), Enumerable.Empty<Expression>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.Block(typeof(int)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Block(typeof(int), Enumerable.Empty<Expression>()));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
@@ -118,8 +118,8 @@ namespace System.Linq.Expressions.Tests
         {
             ConstantExpression constant = Expression.Constant(0);
             IEnumerable<Expression> expressions = PadBlock(blockSize - 1, Expression.Constant(0));
-            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(string), SingleParameter, expressions));
-            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(string), SingleParameter, expressions.ToArray()));
+            Assert.Throws<ArgumentException>(null, () => Expression.Block(typeof(string), SingleParameter, expressions));
+            Assert.Throws<ArgumentException>(null, () => Expression.Block(typeof(string), SingleParameter, expressions.ToArray()));
         }
 
         [Theory]
@@ -150,8 +150,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void EmptyBlockWithParametersAndNonVoidTypeNotAllowed()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int), SingleParameter));
-            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int), SingleParameter, Enumerable.Empty<Expression>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.Block(typeof(int), SingleParameter));
+            Assert.Throws<ArgumentException>(null, () => Expression.Block(typeof(int), SingleParameter, Enumerable.Empty<Expression>()));
         }
 
         [Theory]
@@ -289,10 +289,10 @@ namespace System.Linq.Expressions.Tests
             IEnumerable<Expression> expressions = PadBlock(blockSize - 1, Expression.Constant(0));
             IEnumerable<ParameterExpression> vars = Enumerable.Repeat(default(ParameterExpression), 1);
 
-            Assert.Throws<ArgumentNullException>(() => Expression.Block(vars, expressions));
-            Assert.Throws<ArgumentNullException>(() => Expression.Block(vars, expressions.ToArray()));
-            Assert.Throws<ArgumentNullException>(() => Expression.Block(typeof(object), vars, expressions));
-            Assert.Throws<ArgumentNullException>(() => Expression.Block(typeof(object), vars, expressions.ToArray()));
+            Assert.Throws<ArgumentNullException>("variables[0]", () => Expression.Block(vars, expressions));
+            Assert.Throws<ArgumentNullException>("variables[0]", () => Expression.Block(vars, expressions.ToArray()));
+            Assert.Throws<ArgumentNullException>("variables[0]", () => Expression.Block(typeof(object), vars, expressions));
+            Assert.Throws<ArgumentNullException>("variables[0]", () => Expression.Block(typeof(object), vars, expressions.ToArray()));
         }
 
         [Theory]
@@ -302,10 +302,10 @@ namespace System.Linq.Expressions.Tests
             IEnumerable<Expression> expressions = PadBlock(blockSize - 1, Expression.Constant(0));
             IEnumerable<ParameterExpression> vars = Enumerable.Repeat(Expression.Parameter(typeof(int).MakeByRefType()), 1);
 
-            Assert.Throws<ArgumentException>(() => Expression.Block(vars, expressions));
-            Assert.Throws<ArgumentException>(() => Expression.Block(vars, expressions.ToArray()));
-            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(object), vars, expressions));
-            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(object), vars, expressions.ToArray()));
+            Assert.Throws<ArgumentException>("variables[0]", () => Expression.Block(vars, expressions));
+            Assert.Throws<ArgumentException>("variables[0]", () => Expression.Block(vars, expressions.ToArray()));
+            Assert.Throws<ArgumentException>("variables[0]", () => Expression.Block(typeof(object), vars, expressions));
+            Assert.Throws<ArgumentException>("variables[0]", () => Expression.Block(typeof(object), vars, expressions.ToArray()));
         }
 
         [Theory]
@@ -316,10 +316,10 @@ namespace System.Linq.Expressions.Tests
             ParameterExpression variable = Expression.Variable(typeof(int));
             IEnumerable<ParameterExpression> vars = Enumerable.Repeat(variable, 2);
 
-            Assert.Throws<ArgumentException>(() => Expression.Block(vars, expressions));
-            Assert.Throws<ArgumentException>(() => Expression.Block(vars, expressions.ToArray()));
-            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(object), vars, expressions));
-            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(object), vars, expressions.ToArray()));
+            Assert.Throws<ArgumentException>("variables[1]", () => Expression.Block(vars, expressions));
+            Assert.Throws<ArgumentException>("variables[1]", () => Expression.Block(vars, expressions.ToArray()));
+            Assert.Throws<ArgumentException>("variables[1]", () => Expression.Block(typeof(object), vars, expressions));
+            Assert.Throws<ArgumentException>("variables[1]", () => Expression.Block(typeof(object), vars, expressions.ToArray()));
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Conditional/ConditionalTests.cs
+++ b/src/System.Linq.Expressions/tests/Conditional/ConditionalTests.cs
@@ -95,47 +95,47 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void NonBooleanTest()
         {
-            Assert.Throws<ArgumentException>(() => Expression.IfThen(Expression.Constant(0), Expression.Empty()));
-            Assert.Throws<ArgumentException>(() => Expression.IfThenElse(Expression.Constant(0), Expression.Empty(), Expression.Empty()));
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Constant(0), Expression.Empty(), Expression.Empty()));
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Constant(0), Expression.Empty(), Expression.Empty(), typeof(void)));
+            Assert.Throws<ArgumentException>("test", () => Expression.IfThen(Expression.Constant(0), Expression.Empty()));
+            Assert.Throws<ArgumentException>("test", () => Expression.IfThenElse(Expression.Constant(0), Expression.Empty(), Expression.Empty()));
+            Assert.Throws<ArgumentException>("test", () => Expression.Condition(Expression.Constant(0), Expression.Empty(), Expression.Empty()));
+            Assert.Throws<ArgumentException>("test", () => Expression.Condition(Expression.Constant(0), Expression.Empty(), Expression.Empty(), typeof(void)));
 
-            Assert.Throws<ArgumentException>(() => Expression.IfThen(Expression.Empty(), Expression.Empty()));
-            Assert.Throws<ArgumentException>(() => Expression.IfThenElse(Expression.Empty(), Expression.Empty(), Expression.Empty()));
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Empty(), Expression.Empty(), Expression.Empty()));
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Empty(), Expression.Empty(), Expression.Empty(), typeof(void)));
+            Assert.Throws<ArgumentException>("test", () => Expression.IfThen(Expression.Empty(), Expression.Empty()));
+            Assert.Throws<ArgumentException>("test", () => Expression.IfThenElse(Expression.Empty(), Expression.Empty(), Expression.Empty()));
+            Assert.Throws<ArgumentException>("test", () => Expression.Condition(Expression.Empty(), Expression.Empty(), Expression.Empty()));
+            Assert.Throws<ArgumentException>("test", () => Expression.Condition(Expression.Empty(), Expression.Empty(), Expression.Empty(), typeof(void)));
 
-            Assert.Throws<ArgumentException>(() => Expression.IfThen(Expression.Constant(true, typeof(bool?)), Expression.Empty()));
-            Assert.Throws<ArgumentException>(() => Expression.IfThenElse(Expression.Constant(true, typeof(bool?)), Expression.Empty(), Expression.Empty()));
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Constant(true, typeof(bool?)), Expression.Empty(), Expression.Empty()));
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Constant(true, typeof(bool?)), Expression.Empty(), Expression.Empty(), typeof(void)));
+            Assert.Throws<ArgumentException>("test", () => Expression.IfThen(Expression.Constant(true, typeof(bool?)), Expression.Empty()));
+            Assert.Throws<ArgumentException>("test", () => Expression.IfThenElse(Expression.Constant(true, typeof(bool?)), Expression.Empty(), Expression.Empty()));
+            Assert.Throws<ArgumentException>("test", () => Expression.Condition(Expression.Constant(true, typeof(bool?)), Expression.Empty(), Expression.Empty()));
+            Assert.Throws<ArgumentException>("test", () => Expression.Condition(Expression.Constant(true, typeof(bool?)), Expression.Empty(), Expression.Empty(), typeof(void)));
 
             ConstantExpression truthyConstant = Expression.Constant(new Truthiness(true));
 
-            Assert.Throws<ArgumentException>(() => Expression.IfThen(Expression.Constant(truthyConstant), Expression.Empty()));
-            Assert.Throws<ArgumentException>(() => Expression.IfThenElse(Expression.Constant(truthyConstant), Expression.Empty(), Expression.Empty()));
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Constant(truthyConstant), Expression.Empty(), Expression.Empty()));
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Constant(truthyConstant), Expression.Empty(), Expression.Empty(), typeof(void)));
+            Assert.Throws<ArgumentException>("test", () => Expression.IfThen(Expression.Constant(truthyConstant), Expression.Empty()));
+            Assert.Throws<ArgumentException>("test", () => Expression.IfThenElse(Expression.Constant(truthyConstant), Expression.Empty(), Expression.Empty()));
+            Assert.Throws<ArgumentException>("test", () => Expression.Condition(Expression.Constant(truthyConstant), Expression.Empty(), Expression.Empty()));
+            Assert.Throws<ArgumentException>("test", () => Expression.Condition(Expression.Constant(truthyConstant), Expression.Empty(), Expression.Empty(), typeof(void)));
         }
 
         [Fact]
         public void IncompatibleImplicitTypes()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Constant(true), Expression.Constant(0), Expression.Constant(0L)));
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Constant(true), Expression.Constant(0L), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Constant(true), Expression.Constant("hello"), Expression.Constant(new object())));
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Constant(true), Expression.Constant(new object()), Expression.Constant("hello")));
+            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0), Expression.Constant(0L)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0L), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant("hello"), Expression.Constant(new object())));
+            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(new object()), Expression.Constant("hello")));
         }
 
         [Fact]
         public void IncompatibleExplicitTypes()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Constant(true), Expression.Constant(0), Expression.Constant(0L), typeof(int)));
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Constant(true), Expression.Constant(0L), Expression.Constant(0), typeof(int)));
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Constant(true), Expression.Constant(0), Expression.Constant(0L), typeof(long)));
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Constant(true), Expression.Constant(0L), Expression.Constant(0), typeof(long)));
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Constant(true), Expression.Constant(0), Expression.Constant("hello"), typeof(object)));
-            Assert.Throws<ArgumentException>(() => Expression.Condition(Expression.Constant(true), Expression.Constant("hello"), Expression.Constant(0), typeof(object)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0), Expression.Constant(0L), typeof(int)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0L), Expression.Constant(0), typeof(int)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0), Expression.Constant(0L), typeof(long)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0L), Expression.Constant(0), typeof(long)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant(0), Expression.Constant("hello"), typeof(object)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Condition(Expression.Constant(true), Expression.Constant("hello"), Expression.Constant(0), typeof(object)));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]

--- a/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
@@ -768,13 +768,13 @@ namespace System.Linq.Expressions.Tests
         public static void InvalidTypeValueType()
         {
             // implicit cast, but not reference assignable.
-            Assert.Throws<ArgumentException>(() => Expression.Constant(0, typeof(long)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Constant(0, typeof(long)));
         }
 
         [Fact]
         public static void InvalidTypeReferenceType()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Constant("hello", typeof(Expression)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Constant("hello", typeof(Expression)));
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Default/DefaultTests.cs
+++ b/src/System.Linq.Expressions/tests/Default/DefaultTests.cs
@@ -55,7 +55,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void ByRefType()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Default(typeof(int).MakeByRefType()));
+            Assert.Throws<ArgumentException>("type", () => Expression.Default(typeof(int).MakeByRefType()));
         }
 
         [Fact]
@@ -67,14 +67,14 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void GenericType()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Default(typeof(List<>)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Default(typeof(List<>)));
         }
 
         [Fact]
         public void TypeContainsGenericParameters()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Default(typeof(List<>.Enumerator)));
-            Assert.Throws<ArgumentException>(() => Expression.Default(typeof(List<>).MakeGenericType(typeof(List<>))));
+            Assert.Throws<ArgumentException>("type", () => Expression.Default(typeof(List<>.Enumerator)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Default(typeof(List<>).MakeGenericType(typeof(List<>))));
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -223,7 +223,7 @@ namespace System.Linq.Expressions.Tests
             UnaryExpression throwExp = Expression.Throw(Expression.Constant(new TestException()));
             Assert.False(throwExp.CanReduce);
             Assert.Same(throwExp, throwExp.Reduce());
-            Assert.Throws<ArgumentException>(() => throwExp.ReduceAndCheck());
+            Assert.Throws<ArgumentException>(null, () => throwExp.ReduceAndCheck());
         }
 
         [Fact]
@@ -232,13 +232,13 @@ namespace System.Linq.Expressions.Tests
             TryExpression tryExp = Expression.TryFault(Expression.Empty(), Expression.Empty());
             Assert.False(tryExp.CanReduce);
             Assert.Same(tryExp, tryExp.Reduce());
-            Assert.Throws<ArgumentException>(() => tryExp.ReduceAndCheck());
+            Assert.Throws<ArgumentException>(null, () => tryExp.ReduceAndCheck());
         }
 
         [Fact]
         public void CannotThrowValueType()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Throw(Expression.Constant(1)));
+            Assert.Throws<ArgumentException>("value", () => Expression.Throw(Expression.Constant(1)));
         }
 
         [Fact]
@@ -255,19 +255,19 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void MustHaveCatchFinallyOrFault()
         {
-            Assert.Throws<ArgumentException>(() => Expression.MakeTry(typeof(int), Expression.Constant(1), null, null, null));
+            Assert.Throws<ArgumentException>(null, () => Expression.MakeTry(typeof(int), Expression.Constant(1), null, null, null));
         }
 
         [Fact]
         public void FaultMustNotBeWithCatch()
         {
-            Assert.Throws<ArgumentException>(() => Expression.MakeTry(typeof(int), Expression.Constant(1), null, Expression.Constant(2), new[] { Expression.Catch(typeof(object), Expression.Constant(3)) }));
+            Assert.Throws<ArgumentException>("fault", () => Expression.MakeTry(typeof(int), Expression.Constant(1), null, Expression.Constant(2), new[] { Expression.Catch(typeof(object), Expression.Constant(3)) }));
         }
 
         [Fact]
         public void FaultMustNotBeWithFinally()
         {
-            Assert.Throws<ArgumentException>(() => Expression.MakeTry(typeof(int), Expression.Constant(1), Expression.Constant(2), Expression.Constant(3), null));
+            Assert.Throws<ArgumentException>("fault", () => Expression.MakeTry(typeof(int), Expression.Constant(1), Expression.Constant(2), Expression.Constant(3), null));
         }
 
         [Fact]
@@ -597,8 +597,8 @@ namespace System.Linq.Expressions.Tests
         public void ByRefExceptionType()
         {
             ParameterExpression variable = Expression.Parameter(typeof(Exception).MakeByRefType());
-            Assert.Throws<ArgumentException>(() => Expression.Catch(variable, Expression.Empty()));
-            Assert.Throws<ArgumentException>(() => Expression.Catch(variable, Expression.Empty(), Expression.Constant(true)));
+            Assert.Throws<ArgumentException>("variable", () => Expression.Catch(variable, Expression.Empty()));
+            Assert.Throws<ArgumentException>("variable", () => Expression.Catch(variable, Expression.Empty(), Expression.Constant(true)));
         }
 
         [Fact]
@@ -645,8 +645,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void FilterMustBeBoolean()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Catch(typeof(Exception), Expression.Empty(), Expression.Constant(42)));
-            Assert.Throws<ArgumentException>(() => Expression.Catch(Expression.Parameter(typeof(Exception)), Expression.Empty(), Expression.Constant(42)));
+            Assert.Throws<ArgumentException>("filter", () => Expression.Catch(typeof(Exception), Expression.Empty(), Expression.Constant(42)));
+            Assert.Throws<ArgumentException>("filter", () => Expression.Catch(Expression.Parameter(typeof(Exception)), Expression.Empty(), Expression.Constant(42)));
         }
 
         [Theory]
@@ -977,19 +977,19 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void NonAssignableTryAndCatchTypes()
         {
-            Assert.Throws<ArgumentException>(() => Expression.TryCatch(Expression.Constant(new Uri("http://example.net/")), Expression.Catch(typeof(Exception), Expression.Constant("hello"))));
+            Assert.Throws<ArgumentException>(null, () => Expression.TryCatch(Expression.Constant(new Uri("http://example.net/")), Expression.Catch(typeof(Exception), Expression.Constant("hello"))));
         }
 
         [Fact]
         public void BodyTypeNotAssignableToTryType()
         {
-            Assert.Throws<ArgumentException>(() => Expression.MakeTry(typeof(int), Expression.Constant("hello"), Expression.Empty(), null, null));
+            Assert.Throws<ArgumentException>(null, () => Expression.MakeTry(typeof(int), Expression.Constant("hello"), Expression.Empty(), null, null));
         }
 
         [Fact]
         public void CatchTypeNotAssignableToTryType()
         {
-            Assert.Throws<ArgumentException>(() => Expression.MakeTry(typeof(int), Expression.Constant(2), null, null, new[] { Expression.Catch(typeof(InvalidCastException), Expression.Constant("")) }));
+            Assert.Throws<ArgumentException>(null, () => Expression.MakeTry(typeof(int), Expression.Constant(2), null, null, new[] { Expression.Catch(typeof(InvalidCastException), Expression.Constant("")) }));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/ExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ExpressionTests.cs
@@ -222,7 +222,7 @@ namespace System.Linq.Expressions.Tests
         public void VisitChildrenThrowsAsNotReducible()
         {
             var exp = new IncompleteExpressionOverride();
-            Assert.Throws<ArgumentException>(() => exp.VisitChildren());
+            Assert.Throws<ArgumentException>(null, () => exp.VisitChildren());
         }
 
         [Fact]
@@ -242,42 +242,42 @@ namespace System.Linq.Expressions.Tests
         public void ReduceAndCheckThrowsByDefault()
         {
             var exp = new IncompleteExpressionOverride();
-            Assert.Throws<ArgumentException>(() => exp.ReduceAndCheck());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
         public void ReduceExtensionsThrowsByDefault()
         {
             var exp = new IncompleteExpressionOverride();
-            Assert.Throws<ArgumentException>(() => exp.ReduceAndCheck());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
         public void IfClaimCanReduceMustReduce()
         {
             var exp = new ClaimedReducibleOverride();
-            Assert.Throws<ArgumentException>(() => exp.Reduce());
+            Assert.Throws<ArgumentException>(null, () => exp.Reduce());
         }
 
         [Fact]
         public void ReduceAndCheckThrowOnReduceToSame()
         {
             var exp = new ReducesToSame();
-            Assert.Throws<ArgumentException>(() => exp.ReduceAndCheck());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
         public void ReduceAndCheckThrowOnReduceToNull()
         {
             var exp = new ReducesToNull();
-            Assert.Throws<ArgumentException>(() => exp.ReduceAndCheck());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Fact]
         public void ReduceAndCheckThrowOnReducedTypeNotAssignable()
         {
             var exp = new ReducesToLongTyped();
-            Assert.Throws<ArgumentException>(() => exp.ReduceAndCheck());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
 #pragma warning disable 0169, 0414 // Accessed through reflection.
@@ -420,14 +420,14 @@ namespace System.Linq.Expressions.Tests
         public void CompileIrreduciebleExtension(bool useInterpreter)
         {
             var exp = Expression.Lambda<Action>(new IrreducibleWithTypeAndNodeType());
-            Assert.Throws<ArgumentException>(() => exp.Compile(useInterpreter));
+            Assert.Throws<ArgumentException>(null, () => exp.Compile(useInterpreter));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public void CompileIrreduciebleStrangeNodeTypeExtension(bool useInterpreter)
         {
             var exp = Expression.Lambda<Action>(new IrreduceibleWithTypeAndStrangeNodeType());
-            Assert.Throws<ArgumentException>(() => exp.Compile(useInterpreter));
+            Assert.Throws<ArgumentException>(null, () => exp.Compile(useInterpreter));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]

--- a/src/System.Linq.Expressions/tests/Goto/Break.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Break.cs
@@ -57,7 +57,7 @@ namespace System.Linq.Expressions.Tests
         public void NonVoidTargetBreakHasNoValue(Type type)
         {
             LabelTarget target = Expression.Label(type);
-            Assert.Throws<ArgumentException>(() => Expression.Break(target));
+            Assert.Throws<ArgumentException>("target", () => Expression.Break(target));
         }
 
         [Theory]
@@ -65,7 +65,7 @@ namespace System.Linq.Expressions.Tests
         public void NonVoidTargetBreakHasNoValueTypeExplicit(Type type)
         {
             LabelTarget target = Expression.Label(type);
-            Assert.Throws<ArgumentException>(() => Expression.Break(target, type));
+            Assert.Throws<ArgumentException>("target", () => Expression.Break(target, type));
         }
 
         [Theory]
@@ -98,16 +98,16 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(TypesData))]
         public void NullValueOnNonVoidBreak(Type type)
         {
-            Assert.Throws<ArgumentException>(() => Expression.Break(Expression.Label(type)));
-            Assert.Throws<ArgumentException>(() => Expression.Break(Expression.Label(type), default(Expression)));
-            Assert.Throws<ArgumentException>(() => Expression.Break(Expression.Label(type), null, type));
+            Assert.Throws<ArgumentException>("target", () => Expression.Break(Expression.Label(type)));
+            Assert.Throws<ArgumentException>("target", () => Expression.Break(Expression.Label(type), default(Expression)));
+            Assert.Throws<ArgumentException>("target", () => Expression.Break(Expression.Label(type), null, type));
         }
 
         [Theory]
         [MemberData(nameof(ConstantValueData))]
         public void ExplicitNullTypeWithValue(object value)
         {
-            Assert.Throws<ArgumentException>(() => Expression.Break(Expression.Label(value.GetType()), default(Type)));
+            Assert.Throws<ArgumentException>("target", () => Expression.Break(Expression.Label(value.GetType()), default(Type)));
         }
 
         [Fact]
@@ -136,7 +136,7 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(NonObjectAssignableConstantValueData))]
         public void CannotAssignValueTypesToObject(object value)
         {
-            Assert.Throws<ArgumentException>(() => Expression.Break(Expression.Label(typeof(object)), Expression.Constant(value)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Break(Expression.Label(typeof(object)), Expression.Constant(value)));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Goto/Continue.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Continue.cs
@@ -15,7 +15,7 @@ namespace System.Linq.Expressions.Tests
         public void NonVoidTargetContinueHasNoValue(Type type)
         {
             LabelTarget target = Expression.Label(type);
-            Assert.Throws<ArgumentException>(() => Expression.Continue(target));
+            Assert.Throws<ArgumentException>("target", () => Expression.Continue(target));
         }
 
         [Theory]
@@ -23,7 +23,7 @@ namespace System.Linq.Expressions.Tests
         public void NonVoidTargetContinueHasNoValueTypeExplicit(Type type)
         {
             LabelTarget target = Expression.Label(type);
-            Assert.Throws<ArgumentException>(() => Expression.Continue(target, type));
+            Assert.Throws<ArgumentException>("target", () => Expression.Continue(target, type));
         }
 
         [Theory]
@@ -56,14 +56,14 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(TypesData))]
         public void NullValueOnNonVoidContinue(Type type)
         {
-            Assert.Throws<ArgumentException>(() => Expression.Continue(Expression.Label(type)));
+            Assert.Throws<ArgumentException>("target", () => Expression.Continue(Expression.Label(type)));
         }
 
         [Theory]
         [MemberData(nameof(ConstantValueData))]
         public void ExplicitNullTypeWithValue(object value)
         {
-            Assert.Throws<ArgumentException>(() => Expression.Continue(Expression.Label(value.GetType()), default(Type)));
+            Assert.Throws<ArgumentException>("target", () => Expression.Continue(Expression.Label(value.GetType()), default(Type)));
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Goto/Goto.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Goto.cs
@@ -57,7 +57,7 @@ namespace System.Linq.Expressions.Tests
         public void NonVoidTargetGotoHasNoValue(Type type)
         {
             LabelTarget target = Expression.Label(type);
-            Assert.Throws<ArgumentException>(() => Expression.Goto(target));
+            Assert.Throws<ArgumentException>("target", () => Expression.Goto(target));
         }
 
         [Theory]
@@ -65,7 +65,7 @@ namespace System.Linq.Expressions.Tests
         public void NonVoidTargetGotoHasNoValueTypeExplicit(Type type)
         {
             LabelTarget target = Expression.Label(type);
-            Assert.Throws<ArgumentException>(() => Expression.Goto(target, type));
+            Assert.Throws<ArgumentException>("target", () => Expression.Goto(target, type));
         }
 
         [Theory]
@@ -98,16 +98,16 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(TypesData))]
         public void NullValueOnNonVoidGoto(Type type)
         {
-            Assert.Throws<ArgumentException>(() => Expression.Goto(Expression.Label(type)));
-            Assert.Throws<ArgumentException>(() => Expression.Goto(Expression.Label(type), default(Expression)));
-            Assert.Throws<ArgumentException>(() => Expression.Goto(Expression.Label(type), null, type));
+            Assert.Throws<ArgumentException>("target", () => Expression.Goto(Expression.Label(type)));
+            Assert.Throws<ArgumentException>("target", () => Expression.Goto(Expression.Label(type), default(Expression)));
+            Assert.Throws<ArgumentException>("target", () => Expression.Goto(Expression.Label(type), null, type));
         }
 
         [Theory]
         [MemberData(nameof(ConstantValueData))]
         public void ExplicitNullTypeWithValue(object value)
         {
-            Assert.Throws<ArgumentException>(() => Expression.Goto(Expression.Label(value.GetType()), default(Type)));
+            Assert.Throws<ArgumentException>("target", () => Expression.Goto(Expression.Label(value.GetType()), default(Type)));
         }
 
         [Fact]
@@ -136,7 +136,7 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(NonObjectAssignableConstantValueData))]
         public void CannotAssignValueTypesToObject(object value)
         {
-            Assert.Throws<ArgumentException>(() => Expression.Goto(Expression.Label(typeof(object)), Expression.Constant(value)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Goto(Expression.Label(typeof(object)), Expression.Constant(value)));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Goto/Return.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Return.cs
@@ -57,7 +57,7 @@ namespace System.Linq.Expressions.Tests
         public void NonVoidTargetReturnHasNoValue(Type type)
         {
             LabelTarget target = Expression.Label(type);
-            Assert.Throws<ArgumentException>(() => Expression.Return(target));
+            Assert.Throws<ArgumentException>("target", () => Expression.Return(target));
         }
 
         [Theory]
@@ -65,7 +65,7 @@ namespace System.Linq.Expressions.Tests
         public void NonVoidTargetReturnHasNoValueTypeExplicit(Type type)
         {
             LabelTarget target = Expression.Label(type);
-            Assert.Throws<ArgumentException>(() => Expression.Return(target, type));
+            Assert.Throws<ArgumentException>("target", () => Expression.Return(target, type));
         }
 
         [Theory]
@@ -98,16 +98,16 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(TypesData))]
         public void NullValueOnNonVoidReturn(Type type)
         {
-            Assert.Throws<ArgumentException>(() => Expression.Return(Expression.Label(type)));
-            Assert.Throws<ArgumentException>(() => Expression.Return(Expression.Label(type), default(Expression)));
-            Assert.Throws<ArgumentException>(() => Expression.Return(Expression.Label(type), null, type));
+            Assert.Throws<ArgumentException>("target", () => Expression.Return(Expression.Label(type)));
+            Assert.Throws<ArgumentException>("target", () => Expression.Return(Expression.Label(type), default(Expression)));
+            Assert.Throws<ArgumentException>("target", () => Expression.Return(Expression.Label(type), null, type));
         }
 
         [Theory]
         [MemberData(nameof(ConstantValueData))]
         public void ExplicitNullTypeWithValue(object value)
         {
-            Assert.Throws<ArgumentException>(() => Expression.Return(Expression.Label(value.GetType()), default(Type)));
+            Assert.Throws<ArgumentException>("target", () => Expression.Return(Expression.Label(value.GetType()), default(Type)));
         }
 
         [Fact]
@@ -136,7 +136,7 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(NonObjectAssignableConstantValueData))]
         public void CannotAssignValueTypesToObject(object value)
         {
-            Assert.Throws<ArgumentException>(() => Expression.Return(Expression.Label(typeof(object)), Expression.Constant(value)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Return(Expression.Label(typeof(object)), Expression.Constant(value)));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Label/LabelTargetTests.cs
+++ b/src/System.Linq.Expressions/tests/Label/LabelTargetTests.cs
@@ -70,8 +70,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void GenericType()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Label(typeof(List<>)));
-            Assert.Throws<ArgumentException>(() => Expression.Label(typeof(List<>), null));
+            Assert.Throws<ArgumentException>("type", () => Expression.Label(typeof(List<>)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Label(typeof(List<>), null));
         }
 
         [Fact]
@@ -79,8 +79,8 @@ namespace System.Linq.Expressions.Tests
         {
             Type listType = typeof(List<>);
             Type listListListType = listType.MakeGenericType(listType.MakeGenericType(listType));
-            Assert.Throws<ArgumentException>(() => Expression.Label(listListListType));
-            Assert.Throws<ArgumentException>(() => Expression.Label(listListListType, null));
+            Assert.Throws<ArgumentException>("type", () => Expression.Label(listListListType));
+            Assert.Throws<ArgumentException>("type", () => Expression.Label(listListListType, null));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Label/LabelTests.cs
+++ b/src/System.Linq.Expressions/tests/Label/LabelTests.cs
@@ -41,13 +41,13 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void NullDefaultValueNotAllowedWithTypedTarget()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Label(Expression.Label(typeof(int)), null));
+            Assert.Throws<ArgumentException>("target", () => Expression.Label(Expression.Label(typeof(int)), null));
         }
 
         [Fact]
         public void DefaultMustMatchLabelType()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Label(Expression.Label(typeof(int)), Expression.Constant("hello")));
+            Assert.Throws<ArgumentException>(null, () => Expression.Label(Expression.Label(typeof(int)), Expression.Constant("hello")));
         }
 
         [Fact]
@@ -59,7 +59,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void AssignableOnlyReferenceAssignableNotImplicitConversion()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Label(Expression.Label(typeof(long)), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Label(Expression.Label(typeof(long)), Expression.Constant(0)));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -149,27 +149,27 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void LambdaTypeMustBeDelegate()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Lambda<object>(Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda<int>(Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda<object>(Expression.Constant(0), true));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda<object>(Expression.Constant(0), true, Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda<object>(Expression.Constant(0), "foo", Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda(typeof(object), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda(typeof(int), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda(typeof(object), Expression.Constant(0), true));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda(typeof(object), Expression.Constant(0), true, Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda(typeof(object), Expression.Constant(0), "foo", Enumerable.Empty<ParameterExpression>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<object>(Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<int>(Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<object>(Expression.Constant(0), true));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<object>(Expression.Constant(0), true, Enumerable.Empty<ParameterExpression>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<object>(Expression.Constant(0), "foo", Enumerable.Empty<ParameterExpression>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(object), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(int), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(object), Expression.Constant(0), true));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(object), Expression.Constant(0), true, Enumerable.Empty<ParameterExpression>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(object), Expression.Constant(0), "foo", Enumerable.Empty<ParameterExpression>()));
 
             // Note, be derived from MulticastDelegate, not merely actually MulticastDelegate or Delegate.
-            Assert.Throws<ArgumentException>(() => Expression.Lambda<Delegate>(Expression.Constant(0), true, Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda<Delegate>(Expression.Constant(0), "foo", Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda(typeof(Delegate), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda(typeof(Delegate), Expression.Constant(0), true));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<Delegate>(Expression.Constant(0), true, Enumerable.Empty<ParameterExpression>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<Delegate>(Expression.Constant(0), "foo", Enumerable.Empty<ParameterExpression>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(Delegate), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(Delegate), Expression.Constant(0), true));
 
-            Assert.Throws<ArgumentException>(() => Expression.Lambda<MulticastDelegate>(Expression.Constant(0), true, Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda<MulticastDelegate>(Expression.Constant(0), "foo", Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda(typeof(MulticastDelegate), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda(typeof(MulticastDelegate), Expression.Constant(0), true));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<MulticastDelegate>(Expression.Constant(0), true, Enumerable.Empty<ParameterExpression>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<MulticastDelegate>(Expression.Constant(0), "foo", Enumerable.Empty<ParameterExpression>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(MulticastDelegate), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(MulticastDelegate), Expression.Constant(0), true));
         }
 
         [Fact]
@@ -323,42 +323,42 @@ namespace System.Linq.Expressions.Tests
         public void DuplicateParameters()
         {
             var param = Expression.Parameter(typeof(int));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda(Expression.Empty(), false, param, param));
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>("parameters[1]", () => Expression.Lambda(Expression.Empty(), false, param, param));
+            Assert.Throws<ArgumentException>("parameters[1]",
                 () => Expression.Lambda<Func<int, int, int>>(Expression.Constant(0), false, param, param));
         }
 
         [Fact]
         public void IncorrectArgumentCount()
         {
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(null,
                 () => Expression.Lambda<Action>(Expression.Empty(), Expression.Parameter(typeof(int))));
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(null,
                 () => Expression.Lambda<Action<int, int>>(Expression.Empty(), "nullary or binary?", Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(null,
                 () => Expression.Lambda<Func<int>>(Expression.Constant(1), Expression.Parameter(typeof(int))));
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(null,
                 () => Expression.Lambda<Func<int, int, int>>(Expression.Constant(1), "nullary or binary?", Enumerable.Empty<ParameterExpression>()));
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(null,
                 () => Expression.Lambda(typeof(Action), Expression.Empty(), Expression.Parameter(typeof(int))));
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(null,
                 () => Expression.Lambda(typeof(Func<int, int, int>), Expression.Constant(1), "nullary or binary?", Enumerable.Empty<ParameterExpression>()));
         }
 
         [Fact]
         public void ByRefParameterForValueDelegateParameter()
         {
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(null,
                 () => Expression.Lambda<Action<int>>(Expression.Empty(), Expression.Parameter(typeof(int).MakeByRefType())));
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(null,
                 () => Expression.Lambda<Func<int, bool, int, string>>(
                     Expression.Constant(""),
                     Expression.Parameter(typeof(int)),
                     Expression.Parameter(typeof(bool).MakeByRefType()),
                     Expression.Parameter(typeof(int))));
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(null,
                 () => Expression.Lambda(typeof(Action<int>), Expression.Empty(), Expression.Parameter(typeof(int).MakeByRefType())));
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(null,
                 () => Expression.Lambda(
                     typeof(Func<int, bool, int, string>),
                     Expression.Constant(""),
@@ -385,8 +385,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void IncorrectReturnTypes()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Lambda<Func<int>>(Expression.Constant(typeof(long))));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda(typeof(Func<int>), Expression.Constant(typeof(long))));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<Func<int>>(Expression.Constant(typeof(long))));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda(typeof(Func<int>), Expression.Constant(typeof(long))));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]

--- a/src/System.Linq.Expressions/tests/ListInit/ElementInitTests.cs
+++ b/src/System.Linq.Expressions/tests/ListInit/ElementInitTests.cs
@@ -64,72 +64,72 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void NoArguments()
         {
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add")));
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Enumerable.Empty<Expression>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.ElementInit(typeof(List<int>).GetMethod("Add")));
+            Assert.Throws<ArgumentException>(null, () => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Enumerable.Empty<Expression>()));
         }
 
         [Fact]
         public void ArgumentCountWrong()
         {
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(0), Expression.Constant(1)));
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 2)));
+            Assert.Throws<ArgumentException>(null, () => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(0), Expression.Constant(1)));
+            Assert.Throws<ArgumentException>(null, () => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 2)));
         }
 
         [Fact]
         public void ArgumentTypeMisMatch()
         {
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant("Hello")));
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Enumerable.Repeat(Expression.Constant("Hello"), 1)));
+            Assert.Throws<ArgumentException>(null, () => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant("Hello")));
+            Assert.Throws<ArgumentException>(null, () => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Enumerable.Repeat(Expression.Constant("Hello"), 1)));
         }
 
         [Fact]
         public void UnreadableArgument()
         {
             Expression argument = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), argument));
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Enumerable.Repeat(argument, 1)));
+            Assert.Throws<ArgumentException>("arguments", () => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), argument));
+            Assert.Throws<ArgumentException>("arguments", () => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Enumerable.Repeat(argument, 1)));
         }
 
         [Fact]
         public void ParameterlessAddProhibited()
         {
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(ParameterlessAdd).GetMethod("Add"), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(ParameterlessAdd).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ElementInit(typeof(ParameterlessAdd).GetMethod("Add"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ElementInit(typeof(ParameterlessAdd).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
         }
 
         [Fact]
         public void StaticAddProhibited()
         {
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(StaticAdd).GetMethod("Add"), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(StaticAdd).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ElementInit(typeof(StaticAdd).GetMethod("Add"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ElementInit(typeof(StaticAdd).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
         }
 
         [Fact]
         public void ByRefAddProhibited()
         {
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(ByRefAdd).GetMethod("Add"), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(ByRefAdd).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ElementInit(typeof(ByRefAdd).GetMethod("Add"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ElementInit(typeof(ByRefAdd).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
         }
 
         [Fact]
         public void GenericAddProhibited()
         {
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(GenericAdd).GetMethod("Add"), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(GenericAdd).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ElementInit(typeof(GenericAdd).GetMethod("Add"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ElementInit(typeof(GenericAdd).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
         }
 
         [Fact]
         public void GenericParameterAddProhibited()
         {
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<>).GetMethod("Add"), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<>).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ElementInit(typeof(List<>).GetMethod("Add"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ElementInit(typeof(List<>).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
         }
 
         [Fact]
         public void AddMethodNotCalledAdd()
         {
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Remove"), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Remove"), Enumerable.Repeat(Expression.Constant(0), 1)));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ElementInit(typeof(List<int>).GetMethod("Remove"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ElementInit(typeof(List<int>).GetMethod("Remove"), Enumerable.Repeat(Expression.Constant(0), 1)));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
@@ -111,7 +111,7 @@ namespace System.Linq.Expressions.Tests
         {
             // () => new NonEnumerableAddable { 1, 2, 4, 16, 42 } isn't allowed because list initialization
             // is allowed only with enumerable types.
-            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(Expression.New(typeof(NonEnumerableAddable)), Expression.Constant(1)));
+            Assert.Throws<ArgumentException>("newExpression", () => Expression.ListInit(Expression.New(typeof(NonEnumerableAddable)), Expression.Constant(1)));
         }
 
         [Fact]
@@ -119,10 +119,10 @@ namespace System.Linq.Expressions.Tests
         {
             var newExp = Expression.New(typeof(EnumerableStaticAdd));
             var adder = typeof(EnumerableStaticAdd).GetMethod(nameof(EnumerableStaticAdd.Add));
-            Assert.Throws<ArgumentException>(() => Expression.ListInit(newExp, Expression.Constant("")));
-            Assert.Throws<ArgumentException>(() => Expression.ListInit(newExp, adder, Expression.Constant("")));
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(adder, Expression.Constant("")));
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(adder, Enumerable.Repeat(Expression.Constant(""), 1)));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ListInit(newExp, Expression.Constant("")));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ListInit(newExp, adder, Expression.Constant("")));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ElementInit(adder, Expression.Constant("")));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ElementInit(adder, Enumerable.Repeat(Expression.Constant(""), 1)));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Loop/LoopTests.cs
+++ b/src/System.Linq.Expressions/tests/Loop/LoopTests.cs
@@ -48,7 +48,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void NonVoidContinue()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Loop(Expression.Empty(), null, Expression.Label(typeof(int))));
+            Assert.Throws<ArgumentException>("continue", () => Expression.Loop(Expression.Empty(), null, Expression.Label(typeof(int))));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -323,13 +323,13 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void AccessIndexedPropertyWithoutIndex()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Property(Expression.Default(typeof(List<int>)), typeof(List<int>).GetProperty("Item")));
+            Assert.Throws<ArgumentException>(null, () => Expression.Property(Expression.Default(typeof(List<int>)), typeof(List<int>).GetProperty("Item")));
         }
 
         [Fact]
         public static void AccessIndexedPropertyWithoutIndexWriteOnly()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Property(Expression.Default(typeof(UnreadableIndexableClass)), typeof(UnreadableIndexableClass).GetProperty("Item")));
+            Assert.Throws<ArgumentException>(null, () => Expression.Property(Expression.Default(typeof(UnreadableIndexableClass)), typeof(UnreadableIndexableClass).GetProperty("Item")));
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
@@ -54,8 +54,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void ReadOnlyMember()
         {
-            Assert.Throws<ArgumentException>(null, () => Expression.Bind(typeof(string).GetProperty(nameof(string.Length)), Expression.Constant(0)));
-            Assert.Throws<ArgumentException>(null, () => Expression.Bind(typeof(string).GetMember(nameof(string.Length))[0], Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("member", () => Expression.Bind(typeof(string).GetProperty(nameof(string.Length)), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>("member", () => Expression.Bind(typeof(string).GetMember(nameof(string.Length))[0], Expression.Constant(0)));
         }
 
         [Fact]
@@ -73,8 +73,8 @@ namespace System.Linq.Expressions.Tests
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember(nameof(object.ToString))[0];
             MethodInfo method = typeof(PropertyAndFields).GetMethod(nameof(object.ToString));
-            Assert.Throws<ArgumentException>(null, () => Expression.Bind(member, Expression.Constant("")));
-            Assert.Throws<ArgumentException>(null, () => Expression.Bind(method, Expression.Constant("")));
+            Assert.Throws<ArgumentException>("member", () => Expression.Bind(member, Expression.Constant("")));
+            Assert.Throws<ArgumentException>("propertyAccessor", () => Expression.Bind(method, Expression.Constant("")));
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace System.Linq.Expressions.Tests
                 typeof(PropertyAndFields).GetProperty(nameof(PropertyAndFields.StringProperty)),
                 Expression.Constant("value")
                 );
-            Assert.Throws<ArgumentException>(() => Expression.MemberInit(newExp, bind));
+            Assert.Throws<ArgumentException>(null, () => Expression.MemberInit(newExp, bind));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
@@ -148,7 +148,7 @@ namespace System.Linq.Expressions.Tests
         public void ConstantField()
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember("Constant")[0];
-            Assert.Throws<ArgumentException>(() => Expression.Bind(member, Expression.Constant("")));
+            Assert.Throws<ArgumentException>("member", () => Expression.Bind(member, Expression.Constant("")));
         }
 
         [Fact]
@@ -156,7 +156,7 @@ namespace System.Linq.Expressions.Tests
         public void ReadonlyField()
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember("ReadonlyStringField")[0];
-            Assert.Throws<ArgumentException>(() => Expression.Bind(member, Expression.Constant("")));
+            Assert.Throws<ArgumentException>("member", () => Expression.Bind(member, Expression.Constant("")));
         }
 
         [Fact]
@@ -164,8 +164,8 @@ namespace System.Linq.Expressions.Tests
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember("ReadonlyStringProperty")[0];
             PropertyInfo property = typeof(PropertyAndFields).GetProperty("ReadonlyStringProperty");
-            Assert.Throws<ArgumentException>(() => Expression.Bind(member, Expression.Constant("")));
-            Assert.Throws<ArgumentException>(() => Expression.Bind(property, Expression.Constant("")));
+            Assert.Throws<ArgumentException>("member", () => Expression.Bind(member, Expression.Constant("")));
+            Assert.Throws<ArgumentException>("member", () => Expression.Bind(property, Expression.Constant("")));
         }
 
         [Fact]
@@ -173,7 +173,7 @@ namespace System.Linq.Expressions.Tests
         public void StaticField()
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember("StaticStringField")[0];
-            Assert.Throws<ArgumentException>(() => Expression.Bind(member, Expression.Constant("")));
+            Assert.Throws<ArgumentException>("member", () => Expression.Bind(member, Expression.Constant("")));
         }
 
         [Fact]
@@ -182,8 +182,8 @@ namespace System.Linq.Expressions.Tests
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember("StaticStringProperty")[0];
             PropertyInfo property = typeof(PropertyAndFields).GetProperty("StaticStringProperty");
-            Assert.Throws<ArgumentException>(() => Expression.Bind(member, Expression.Constant("")));
-            Assert.Throws<ArgumentException>(() => Expression.Bind(property, Expression.Constant("")));
+            Assert.Throws<ArgumentException>("member", () => Expression.Bind(member, Expression.Constant("")));
+            Assert.Throws<ArgumentException>("member", () => Expression.Bind(property, Expression.Constant("")));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
@@ -72,10 +72,10 @@ namespace System.Linq.Expressions.Tests
             MethodInfo method = typeof(ListWrapper<int>).GetMethod(nameof(ListWrapper<int>.GetList));
             MemberInfo member = typeof(ListWrapper<int>).GetMember(nameof(ListWrapper<int>.GetList))[0];
             ElementInit elInit = Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(0));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(method, elInit));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(method, Enumerable.Repeat(elInit, 1)));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(member, elInit));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(member, Enumerable.Repeat(elInit, 1)));
+            Assert.Throws<ArgumentException>("propertyAccessor", () => Expression.ListBind(method, elInit));
+            Assert.Throws<ArgumentException>("propertyAccessor", () => Expression.ListBind(method, Enumerable.Repeat(elInit, 1)));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(member, elInit));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(member, Enumerable.Repeat(elInit, 1)));
         }
 
         [Fact]
@@ -83,10 +83,10 @@ namespace System.Linq.Expressions.Tests
         {
             PropertyInfo property = typeof(string).GetProperty(nameof(string.Length));
             MemberInfo member = typeof(string).GetMember(nameof(string.Length))[0];
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(property));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(property, Enumerable.Empty<ElementInit>()));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(member));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(member, Enumerable.Empty<ElementInit>()));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(property));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(property, Enumerable.Empty<ElementInit>()));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(member));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(member, Enumerable.Empty<ElementInit>()));
         }
 
         private static IEnumerable<object> NonAddableListExpressions()
@@ -114,13 +114,13 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void NullElement()
         {
-            Assert.Throws<ArgumentNullException>(() => Expression.ListBind(typeof(ListWrapper<int>).GetMethod(nameof(ListWrapper<int>.GetList)), null));
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListBind(typeof(ListWrapper<int>).GetMethod(nameof(ListWrapper<int>.GetList)), null));
         }
 
         [Fact]
         public void MismatchingElement()
         {
-            Assert.Throws<ArgumentException>(() => Expression.ListBind(typeof(ListWrapper<int>).GetMethod(nameof(ListWrapper<int>.GetList)), Expression.ElementInit(typeof(HashSet<int>).GetMethod("Add"), Expression.Constant(1))));
+            Assert.Throws<ArgumentException>("propertyAccessor", () => Expression.ListBind(typeof(ListWrapper<int>).GetMethod(nameof(ListWrapper<int>.GetList)), Expression.ElementInit(typeof(HashSet<int>).GetMethod("Add"), Expression.Constant(1))));
         }
 
         [Fact]
@@ -128,10 +128,10 @@ namespace System.Linq.Expressions.Tests
         {
             MemberInfo toString = typeof(object).GetMember(nameof(ToString))[0];
             MethodInfo toStringMeth = typeof(object).GetMethod(nameof(ToString));
-            Assert.Throws<ArgumentException>(() => Expression.ListBind(toString));
-            Assert.Throws<ArgumentException>(() => Expression.ListBind(toString, Enumerable.Empty<ElementInit>()));
-            Assert.Throws<ArgumentException>(() => Expression.ListBind(toStringMeth));
-            Assert.Throws<ArgumentException>(() => Expression.ListBind(toStringMeth, Enumerable.Empty<ElementInit>()));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(toString));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(toString, Enumerable.Empty<ElementInit>()));
+            Assert.Throws<ArgumentException>("propertyAccessor", () => Expression.ListBind(toStringMeth));
+            Assert.Throws<ArgumentException>("propertyAccessor", () => Expression.ListBind(toStringMeth, Enumerable.Empty<ElementInit>()));
         }
 
         public static IEnumerable<object[]> ZeroInitializerExpressions()
@@ -165,10 +165,10 @@ namespace System.Linq.Expressions.Tests
         {
             PropertyInfo property = typeof(ListWrapper<int>).GetProperty(nameof(ListWrapper<int>.WriteOnlyList));
             MemberInfo member = typeof(ListWrapper<int>).GetMember(nameof(ListWrapper<int>.WriteOnlyList))[0];
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(property, new ElementInit[0]));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(property, Enumerable.Empty<ElementInit>()));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(member, new ElementInit[0]));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(member, Enumerable.Empty<ElementInit>()));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(property, new ElementInit[0]));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(property, Enumerable.Empty<ElementInit>()));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(member, new ElementInit[0]));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(member, Enumerable.Empty<ElementInit>()));
         }
 
         [Fact]
@@ -177,10 +177,10 @@ namespace System.Linq.Expressions.Tests
         {
             PropertyInfo property = typeof(ListWrapper<int>).GetProperty(nameof(ListWrapper<int>.StaticListProperty));
             MemberInfo member = typeof(ListWrapper<int>).GetMember(nameof(ListWrapper<int>.StaticListProperty))[0];
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(property, new ElementInit[0]));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(property, Enumerable.Empty<ElementInit>()));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(member, new ElementInit[0]));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(member, Enumerable.Empty<ElementInit>()));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(property, new ElementInit[0]));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(property, Enumerable.Empty<ElementInit>()));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(member, new ElementInit[0]));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(member, Enumerable.Empty<ElementInit>()));
         }
 
         [Fact]
@@ -188,8 +188,8 @@ namespace System.Linq.Expressions.Tests
         public void StaticListField()
         {
             MemberInfo member = typeof(ListWrapper<int>).GetMember(nameof(ListWrapper<int>.StaticListProperty))[0];
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(member, new ElementInit[0]));
-            Assert.Throws<ArgumentException>(null, () => Expression.ListBind(member, Enumerable.Empty<ElementInit>()));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(member, new ElementInit[0]));
+            Assert.Throws<ArgumentException>("member", () => Expression.ListBind(member, Enumerable.Empty<ElementInit>()));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
@@ -59,10 +59,10 @@ namespace System.Linq.Expressions.Tests
         {
             MemberInfo toString = typeof(object).GetMember(nameof(ToString))[0];
             MethodInfo toStringMeth = typeof(object).GetMethod(nameof(ToString));
-            Assert.Throws<ArgumentException>(() => Expression.MemberBind(toString));
-            Assert.Throws<ArgumentException>(() => Expression.MemberBind(toString, Enumerable.Empty<MemberBinding>()));
-            Assert.Throws<ArgumentException>(() => Expression.MemberBind(toStringMeth));
-            Assert.Throws<ArgumentException>(() => Expression.MemberBind(toStringMeth, Enumerable.Empty<MemberBinding>()));
+            Assert.Throws<ArgumentException>("member", () => Expression.MemberBind(toString));
+            Assert.Throws<ArgumentException>("member", () => Expression.MemberBind(toString, Enumerable.Empty<MemberBinding>()));
+            Assert.Throws<ArgumentException>("propertyAccessor", () => Expression.MemberBind(toStringMeth));
+            Assert.Throws<ArgumentException>("propertyAccessor", () => Expression.MemberBind(toStringMeth, Enumerable.Empty<MemberBinding>()));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/New/NewTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewTests.cs
@@ -267,7 +267,7 @@ namespace System.Linq.Expressions.Tests
         public static void CheckNewWithStaticCtor()
         {
             var cctor = typeof(StaticCtor).GetTypeInfo().DeclaredConstructors.Single(c => c.IsStatic);
-            Assert.Throws<ArgumentException>(() => Expression.New(cctor));
+            Assert.Throws<ArgumentException>("constructor", () => Expression.New(cctor));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -34,7 +34,7 @@ namespace System.Linq.Expressions.Tests
             MethodInfo mi1 = typeof(Expression_Tests).GetMethod("Add");
             ConstantExpression ce1 = Expression.Constant(4, typeof(int));
 
-            Assert.Throws<ArgumentException>(() => Expression.ElementInit(mi1, new Expression[] { ce1 }));
+            Assert.Throws<ArgumentException>("addMethod", () => Expression.ElementInit(mi1, new Expression[] { ce1 }));
         }
 
         public class Atom
@@ -160,7 +160,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ConstantNullWithValueTypeIsInvalid()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Constant(null, typeof(int)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Constant(null, typeof(int)));
         }
 
         [Fact]
@@ -437,7 +437,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void TestGetFuncTypeWithTooManyArgsFails()
         {
-            Assert.Throws<ArgumentException>(() => Expression.GetFuncType(new Type[] { typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int) }));
+            Assert.Throws<ArgumentException>("typeArgs", () => Expression.GetFuncType(new Type[] { typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int) }));
         }
 
         [Fact]
@@ -718,7 +718,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(f2().Value.Name, "lhs");
 
             var constant = Expression.Constant(1.0, typeof(double));
-            Assert.Throws<ArgumentException>(() => Expression.Lambda<Func<double?>>(constant, null));
+            Assert.Throws<ArgumentException>(null, () => Expression.Lambda<Func<double?>>(constant, null));
         }
 
         public static int GetBound()
@@ -1792,7 +1792,7 @@ namespace System.Linq.Expressions.Tests
         public static void InvokeNonTypedLambdaFails()
         {
             Expression call = Expression.Call(null, typeof(Compiler_Tests).GetMethod("ComputeDynamicLambda", BindingFlags.Static | BindingFlags.Public), new Expression[] { });
-            Assert.Throws<ArgumentException>(() => Expression.Invoke(call, null));
+            Assert.Throws<ArgumentException>("expression", () => Expression.Invoke(call, null));
         }
 
         public static LambdaExpression ComputeDynamicLambda()
@@ -1804,7 +1804,7 @@ namespace System.Linq.Expressions.Tests
         public static void InvokeNonTypedDelegateFails()
         {
             Expression call = Expression.Call(null, typeof(Compiler_Tests).GetMethod("ComputeDynamicDelegate", BindingFlags.Static | BindingFlags.Public), new Expression[] { });
-            Assert.Throws<ArgumentException>(() => Expression.Invoke(call, null));
+            Assert.Throws<ArgumentException>("expression", () => Expression.Invoke(call, null));
         }
 
         public static Delegate ComputeDynamicDelegate()

--- a/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
+++ b/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
@@ -255,7 +255,7 @@ namespace System.Linq.Expressions.Tests
         {
             var p = Expression.Parameter(typeof(int));
             // A SwitchExpression with neither a defaultBody nor any cases can not be any type except void.
-            Assert.Throws<ArgumentException>(() => Expression.Switch(typeof(int), p, null, null));
+            Assert.Throws<ArgumentException>("defaultBody", () => Expression.Switch(typeof(int), p, null, null));
         }
 
         private delegate int RefSettingDelegate(ref bool changed);
@@ -350,12 +350,12 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void VoidSwitchValue()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Switch(Expression.Empty()));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(Expression.Empty(), Expression.Empty()));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(Expression.Empty(), Expression.Empty(), default(MethodInfo)));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(Expression.Empty(), Expression.Empty(), default(MethodInfo), Enumerable.Empty<SwitchCase>()));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(typeof(int), Expression.Empty(), Expression.Constant(1), default(MethodInfo)));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(typeof(int), Expression.Empty(), Expression.Constant(1), default(MethodInfo), Enumerable.Empty<SwitchCase>()));
+            Assert.Throws<ArgumentException>("switchValue", () => Expression.Switch(Expression.Empty()));
+            Assert.Throws<ArgumentException>("switchValue", () => Expression.Switch(Expression.Empty(), Expression.Empty()));
+            Assert.Throws<ArgumentException>("switchValue", () => Expression.Switch(Expression.Empty(), Expression.Empty(), default(MethodInfo)));
+            Assert.Throws<ArgumentException>("switchValue", () => Expression.Switch(Expression.Empty(), Expression.Empty(), default(MethodInfo), Enumerable.Empty<SwitchCase>()));
+            Assert.Throws<ArgumentException>("switchValue", () => Expression.Switch(typeof(int), Expression.Empty(), Expression.Constant(1), default(MethodInfo)));
+            Assert.Throws<ArgumentException>("switchValue", () => Expression.Switch(typeof(int), Expression.Empty(), Expression.Constant(1), default(MethodInfo), Enumerable.Empty<SwitchCase>()));
         }
 
         private static IEnumerable<object[]> ComparisonsWithInvalidParmeterCounts()
@@ -373,10 +373,10 @@ namespace System.Linq.Expressions.Tests
         [Theory, MemberData(nameof(ComparisonsWithInvalidParmeterCounts))]
         public void InvalidComparisonMethodParameterCount(MethodInfo comparer)
         {
-            Assert.Throws<ArgumentException>(() => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Enumerable.Empty<SwitchCase>()));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer, Enumerable.Empty<SwitchCase>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer));
+            Assert.Throws<ArgumentException>(null, () => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Enumerable.Empty<SwitchCase>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer));
+            Assert.Throws<ArgumentException>(null, () => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer, Enumerable.Empty<SwitchCase>()));
         }
 
         [Fact]
@@ -384,10 +384,10 @@ namespace System.Linq.Expressions.Tests
         {
             Func<string, int, bool> isLength = (x, y) => (x?.Length).GetValueOrDefault() == y;
             MethodInfo comparer = isLength.GetMethodInfo();
-            Assert.Throws<ArgumentException>(() => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Enumerable.Empty<SwitchCase>()));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer, Enumerable.Empty<SwitchCase>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer));
+            Assert.Throws<ArgumentException>(null, () => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Enumerable.Empty<SwitchCase>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer));
+            Assert.Throws<ArgumentException>(null, () => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer, Enumerable.Empty<SwitchCase>()));
         }
 
         [Fact]
@@ -395,10 +395,10 @@ namespace System.Linq.Expressions.Tests
         {
             Func<int, string, bool> isLength = (x, y) => (y?.Length).GetValueOrDefault() == x;
             MethodInfo comparer = isLength.GetMethodInfo();
-            Assert.Throws<ArgumentException>(() => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Expression.SwitchCase(Expression.Empty(), Expression.Constant(0))));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Enumerable.Repeat(Expression.SwitchCase(Expression.Empty(), Expression.Constant(0)), 1)));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer, Expression.SwitchCase(Expression.Empty(), Expression.Constant(0))));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer, Enumerable.Repeat(Expression.SwitchCase(Expression.Empty(), Expression.Constant(0)), 1)));
+            Assert.Throws<ArgumentException>(null, () => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Expression.SwitchCase(Expression.Empty(), Expression.Constant(0))));
+            Assert.Throws<ArgumentException>(null, () => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Enumerable.Repeat(Expression.SwitchCase(Expression.Empty(), Expression.Constant(0)), 1)));
+            Assert.Throws<ArgumentException>("cases", () => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer, Expression.SwitchCase(Expression.Empty(), Expression.Constant(0))));
+            Assert.Throws<ArgumentException>("cases", () => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer, Enumerable.Repeat(Expression.SwitchCase(Expression.Empty(), Expression.Constant(0)), 1)));
         }
 
         static bool WithinTen(int x, int y) => Math.Abs(x - y) < 10;
@@ -423,7 +423,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void LeftLiftedCall()
         {
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<ArgumentException>(null, () =>
                 Expression.Switch(
                     Expression.Constant(30, typeof(int?)),
                     Expression.Constant(0),
@@ -436,14 +436,14 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void CaseTypeMisMatch()
         {
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<ArgumentException>("cases", () =>
                 Expression.Switch(
                     Expression.Constant(30),
                     Expression.SwitchCase(Expression.Constant(1), Expression.Constant(0)),
                     Expression.SwitchCase(Expression.Constant(2), Expression.Constant("Foo"))
                     )
                 );
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<ArgumentException>("cases", () =>
                 Expression.Switch(
                     Expression.Constant(30),
                     Expression.SwitchCase(Expression.Constant(1), Expression.Constant(0), Expression.Constant("Foo"))
@@ -457,10 +457,10 @@ namespace System.Linq.Expressions.Tests
         public void NonBooleanComparer()
         {
             MethodInfo comparer = typeof(SwitchTests).GetMethod(nameof(NonBooleanMethod), BindingFlags.Static | BindingFlags.NonPublic);
-            Assert.Throws<ArgumentException>(() => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Expression.SwitchCase(Expression.Empty(), Expression.Constant(0))));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Enumerable.Repeat(Expression.SwitchCase(Expression.Empty(), Expression.Constant(0)), 1)));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer, Expression.SwitchCase(Expression.Empty(), Expression.Constant(0))));
-            Assert.Throws<ArgumentException>(() => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer, Enumerable.Repeat(Expression.SwitchCase(Expression.Empty(), Expression.Constant(0)), 1)));
+            Assert.Throws<ArgumentException>("comparison", () => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Expression.SwitchCase(Expression.Empty(), Expression.Constant(0))));
+            Assert.Throws<ArgumentException>("comparison", () => Expression.Switch(Expression.Constant(0), Expression.Empty(), comparer, Enumerable.Repeat(Expression.SwitchCase(Expression.Empty(), Expression.Constant(0)), 1)));
+            Assert.Throws<ArgumentException>("cases", () => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer, Expression.SwitchCase(Expression.Empty(), Expression.Constant(0))));
+            Assert.Throws<ArgumentException>("cases", () => Expression.Switch(typeof(int), Expression.Constant(0), Expression.Constant(1), comparer, Enumerable.Repeat(Expression.SwitchCase(Expression.Empty(), Expression.Constant(0)), 1)));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
@@ -28,7 +28,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression exp = Expression.Constant(0);
             Type byRef = typeof(int).MakeByRefType();
-            Assert.Throws<ArgumentException>(() => Expression.TypeEqual(exp, byRef));
+            Assert.Throws<ArgumentException>("type", () => Expression.TypeEqual(exp, byRef));
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.TypeIs(Expression.Constant(0), typeof(int));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(() => exp.ReduceAndCheck());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeIs.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeIs.cs
@@ -28,7 +28,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression exp = Expression.Constant(0);
             Type byRef = typeof(int).MakeByRefType();
-            Assert.Throws<ArgumentException>(() => Expression.TypeIs(exp, byRef));
+            Assert.Throws<ArgumentException>("type", () => Expression.TypeIs(exp, byRef));
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace System.Linq.Expressions.Tests
             Expression exp = Expression.TypeIs(Expression.Constant(0), typeof(int));
             Assert.False(exp.CanReduce);
             Assert.Same(exp, exp.Reduce());
-            Assert.Throws<ArgumentException>(() => exp.ReduceAndCheck());
+            Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostDecrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostDecrementAssignTests.cs
@@ -179,7 +179,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression variable = Expression.Variable(typeof(string));
             MethodInfo method = typeof(object).GetTypeInfo().GetDeclaredMethod("ReferenceEquals");
-            Assert.Throws<ArgumentException>(() => Expression.PostDecrementAssign(variable, method));
+            Assert.Throws<ArgumentException>(null, () => Expression.PostDecrementAssign(variable, method));
         }
 
         [Fact]
@@ -187,7 +187,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression variable = Expression.Variable(typeof(int));
             MethodInfo method = typeof(IncDecAssignTests).GetTypeInfo().GetDeclaredMethod("GetString");
-            Assert.Throws<ArgumentException>(() => Expression.PostDecrementAssign(variable, method));
+            Assert.Throws<ArgumentException>(null, () => Expression.PostDecrementAssign(variable, method));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostIncrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostIncrementAssignTests.cs
@@ -179,7 +179,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression variable = Expression.Variable(typeof(string));
             MethodInfo method = typeof(object).GetTypeInfo().GetDeclaredMethod("ReferenceEquals");
-            Assert.Throws<ArgumentException>(() => Expression.PostIncrementAssign(variable, method));
+            Assert.Throws<ArgumentException>(null, () => Expression.PostIncrementAssign(variable, method));
         }
 
         [Fact]
@@ -187,7 +187,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression variable = Expression.Variable(typeof(int));
             MethodInfo method = typeof(IncDecAssignTests).GetTypeInfo().GetDeclaredMethod("GetString");
-            Assert.Throws<ArgumentException>(() => Expression.PostIncrementAssign(variable, method));
+            Assert.Throws<ArgumentException>(null, () => Expression.PostIncrementAssign(variable, method));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreDecrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreDecrementAssignTests.cs
@@ -179,7 +179,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression variable = Expression.Variable(typeof(string));
             MethodInfo method = typeof(object).GetTypeInfo().GetDeclaredMethod("ReferenceEquals");
-            Assert.Throws<ArgumentException>(() => Expression.PreDecrementAssign(variable, method));
+            Assert.Throws<ArgumentException>(null, () => Expression.PreDecrementAssign(variable, method));
         }
 
         [Fact]
@@ -187,7 +187,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression variable = Expression.Variable(typeof(int));
             MethodInfo method = typeof(IncDecAssignTests).GetTypeInfo().GetDeclaredMethod("GetString");
-            Assert.Throws<ArgumentException>(() => Expression.PreDecrementAssign(variable, method));
+            Assert.Throws<ArgumentException>(null, () => Expression.PreDecrementAssign(variable, method));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreIncrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreIncrementAssignTests.cs
@@ -179,7 +179,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression variable = Expression.Variable(typeof(string));
             MethodInfo method = typeof(object).GetTypeInfo().GetDeclaredMethod("ReferenceEquals");
-            Assert.Throws<ArgumentException>(() => Expression.PreIncrementAssign(variable, method));
+            Assert.Throws<ArgumentException>(null, () => Expression.PreIncrementAssign(variable, method));
         }
 
         [Fact]
@@ -187,7 +187,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression variable = Expression.Variable(typeof(int));
             MethodInfo method = typeof(IncDecAssignTests).GetTypeInfo().GetDeclaredMethod("GetString");
-            Assert.Throws<ArgumentException>(() => Expression.PreIncrementAssign(variable, method));
+            Assert.Throws<ArgumentException>(null, () => Expression.PreIncrementAssign(variable, method));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Unary/UnboxTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnboxTests.cs
@@ -129,14 +129,14 @@ namespace System.Linq.Expressions.Tests
         public void CannotUnboxToNonInterfaceExceptObject()
         {
             Expression value = Expression.Constant(0);
-            Assert.Throws<ArgumentException>(() => Expression.Unbox(value, typeof(int)));
+            Assert.Throws<ArgumentException>("expression", () => Expression.Unbox(value, typeof(int)));
         }
 
         [Fact]
         public void CannotUnboxReferenceType()
         {
             Expression value = Expression.Constant("", typeof(IComparable<string>));
-            Assert.Throws<ArgumentException>(() => Expression.Unbox(value, typeof(string)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Unbox(value, typeof(string)));
         }
 
         private static class Unreadable
@@ -182,7 +182,7 @@ namespace System.Linq.Expressions.Tests
             Expression unbox = Expression.Unbox(Expression.Constant(0, typeof(object)), typeof(int));
             Assert.False(unbox.CanReduce);
             Assert.Same(unbox, unbox.Reduce());
-            Assert.Throws<ArgumentException>(() => unbox.ReduceAndCheck());
+            Assert.Throws<ArgumentException>(null, () => unbox.ReduceAndCheck());
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
@@ -40,8 +40,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void ParameterCannotBeTypeVoid()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Parameter(typeof(void)));
-            Assert.Throws<ArgumentException>(() => Expression.Parameter(typeof(void), "var"));
+            Assert.Throws<ArgumentException>("type", () => Expression.Parameter(typeof(void)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Parameter(typeof(void), "var"));
         }
 
         [Fact]
@@ -126,7 +126,7 @@ namespace System.Linq.Expressions.Tests
             ParameterExpression param = Expression.Parameter(typeof(int));
             Assert.False(param.CanReduce);
             Assert.Same(param, param.Reduce());
-            Assert.Throws<ArgumentException>(() => param.ReduceAndCheck());
+            Assert.Throws<ArgumentException>(null, () => param.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
@@ -138,7 +138,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void NullVariableInList()
         {
-            Assert.Throws<ArgumentNullException>(() => Expression.RuntimeVariables(Expression.Variable(typeof(int)), null));
+            Assert.Throws<ArgumentNullException>("variables[1]", () => Expression.RuntimeVariables(Expression.Variable(typeof(int)), null));
         }
 
         [Theory]
@@ -157,7 +157,7 @@ namespace System.Linq.Expressions.Tests
             RuntimeVariablesExpression vars = Expression.RuntimeVariables(Expression.Variable(typeof(int)));
             Assert.False(vars.CanReduce);
             Assert.Same(vars, vars.Reduce());
-            Assert.Throws<ArgumentException>(() => vars.ReduceAndCheck());
+            Assert.Throws<ArgumentException>(null, () => vars.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Variables/VariableTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/VariableTests.cs
@@ -40,8 +40,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void VariableCannotBeTypeVoid()
         {
-            Assert.Throws<ArgumentException>(() => Expression.Variable(typeof(void)));
-            Assert.Throws<ArgumentException>(() => Expression.Variable(typeof(void), "var"));
+            Assert.Throws<ArgumentException>("type", () => Expression.Variable(typeof(void)));
+            Assert.Throws<ArgumentException>("type", () => Expression.Variable(typeof(void), "var"));
         }
 
         [Fact]
@@ -55,8 +55,8 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(ByRefTypeData))]
         public void VariableCannotBeByRef(Type type)
         {
-            Assert.Throws<ArgumentException>(() => Expression.Variable(type));
-            Assert.Throws<ArgumentException>(() => Expression.Variable(type, "var"));
+            Assert.Throws<ArgumentException>("type", () => Expression.Variable(type));
+            Assert.Throws<ArgumentException>("type", () => Expression.Variable(type, "var"));
         }
 
         [Theory]
@@ -98,7 +98,7 @@ namespace System.Linq.Expressions.Tests
             ParameterExpression variable = Expression.Variable(typeof(int));
             Assert.False(variable.CanReduce);
             Assert.Same(variable, variable.Reduce());
-            Assert.Throws<ArgumentException>(() => variable.ReduceAndCheck());
+            Assert.Throws<ArgumentException>(null, () => variable.ReduceAndCheck());
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Visitor/VisitorTests.cs
+++ b/src/System.Linq.Expressions/tests/Visitor/VisitorTests.cs
@@ -167,19 +167,19 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void VisitNullCollection()
         {
-            Assert.Throws<ArgumentNullException>(() => new DefaultVisitor().Visit(default(ReadOnlyCollection<Expression>)));
+            Assert.Throws<ArgumentNullException>("nodes", () => new DefaultVisitor().Visit(default(ReadOnlyCollection<Expression>)));
         }
 
         [Fact]
         public void VisitNullCollectionWithVisitorFunction()
         {
-            Assert.Throws<ArgumentNullException>(() => ExpressionVisitor.Visit(null, (Expression i) => i));
+            Assert.Throws<ArgumentNullException>("nodes", () => ExpressionVisitor.Visit(null, (Expression i) => i));
         }
 
         [Fact]
         public void VisitCollectionVisitorWithNullFunction()
         {
-            Assert.Throws<ArgumentNullException>(() => ExpressionVisitor.Visit(new List<Expression> { Expression.Empty() }.AsReadOnly(), null));
+            Assert.Throws<ArgumentNullException>("elementVisitor", () => ExpressionVisitor.Visit(new List<Expression> { Expression.Empty() }.AsReadOnly(), null));
         }
 
         [Fact]
@@ -191,7 +191,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void VisitAndConvertNullCollection()
         {
-            Assert.Throws<ArgumentNullException>(() => new DefaultVisitor().VisitAndConvert(default(ReadOnlyCollection<Expression>), ""));
+            Assert.Throws<ArgumentNullException>("nodes", () => new DefaultVisitor().VisitAndConvert(default(ReadOnlyCollection<Expression>), ""));
         }
 
         [Fact]


### PR DESCRIPTION
Also removed 3 unused errors and their accompanying string resources (contributing to #3836)

/cc @JonHanna @VSadov