### PR TITLE
Fix incorrect linux-x64 import

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -162,7 +162,7 @@
             "#import": [ "unix" ]
         },
         "linux-x64": {
-            "#import": [ "unix", "unix-x64" ]
+            "#import": [ "linux", "unix-x64" ]
         },
 
         "rhel": {


### PR DESCRIPTION
We should import "linux" not "unix" so we can pick up artifacts which
are linux specific but processor agnostic.