### PR TITLE
Throw on open generic, byref or pointer type to NewArrayInit().

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
@@ -146,9 +146,20 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
             ContractUtils.RequiresNotNull(initializers, nameof(initializers));
-            if (type.Equals(typeof(void)))
+            if (type == typeof(void))
             {
                 throw Error.ArgumentCannotBeOfTypeVoid();
+            }
+
+            TypeUtils.ValidateType(type);
+            if (type.IsByRef)
+            {
+                throw Error.TypeMustNotBeByRef();
+            }
+
+            if (type.IsPointer)
+            {
+                throw Error.TypeMustNotBePointer();
             }
 
             ReadOnlyCollection<Expression> initializerList = initializers.ToReadOnly();

--- a/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
@@ -1623,5 +1622,101 @@ namespace System.Linq.Expressions.Tests
         }
 
         #endregion
+        [Fact]
+        public static void NullType()
+        {
+            Assert.Throws<ArgumentNullException>("type", () => Expression.NewArrayInit(null));
+        }
+
+        [Fact]
+        public static void VoidType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.NewArrayInit(typeof(void)));
+        }
+
+        [Fact]
+        public static void NullInitializers()
+        {
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.NewArrayInit(typeof(int), default(Expression[])));
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.NewArrayInit(typeof(int), default(IEnumerable<Expression>)));
+        }
+
+        [Fact]
+        public static void NullInitializer()
+        {
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.NewArrayInit(typeof(int), null, null));
+        }
+
+        [Fact]
+        public static void ByRefType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.NewArrayInit(typeof(int).MakeByRefType()));
+        }
+
+        [Fact]
+        public static void PointerType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.NewArrayInit(typeof(int).MakePointerType()));
+        }
+
+        [Fact]
+        public static void GenericType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.NewArrayInit(typeof(List<>)));
+        }
+
+        [Fact]
+        public static void TypeContainsGenericParameters()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.NewArrayInit(typeof(List<>.Enumerator)));
+            Assert.Throws<ArgumentException>(() => Expression.NewArrayInit(typeof(List<>).MakeGenericType(typeof(List<>))));
+        }
+
+        [Fact]
+        public static void NotAssignable()
+        {
+            Assert.Throws<InvalidOperationException>(() => Expression.NewArrayInit(typeof(string), Expression.Constant(2)));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void AutoQuote(bool useInterpreter)
+        {
+            Expression<Func<int, int>> doubleIt = x => x * 2;
+            var quoted = Expression.Lambda<Func<Expression<Func<int, int>>[]>>(
+                Expression.NewArrayInit(
+                    typeof(Expression<Func<int, int>>),
+                    doubleIt
+                    )
+                );
+            var del = quoted.Compile(useInterpreter);
+            Assert.Equal(new [] {doubleIt}, del());
+
+            quoted = Expression.Lambda<Func<Expression<Func<int, int>>[]>>(
+                Expression.NewArrayInit(
+                    typeof(Expression<Func<int, int>>),
+                    Expression.Constant(doubleIt),
+                    doubleIt,
+                    Expression.Constant(doubleIt)
+                    )
+                );
+            del = quoted.Compile(useInterpreter);
+            Assert.Equal(new [] {doubleIt, doubleIt, doubleIt}, del());
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void NestedCompile(bool useInterpreter)
+        {
+            Expression<Func<int, int>> doubleIt = x => x * 2;
+            var unquoted = Expression.Lambda<Func<Func<int, int>[]>>(
+                Expression.NewArrayInit(
+                    typeof(Func<int, int>),
+                    doubleIt
+                    )
+                );
+            var del = unquoted.Compile(useInterpreter);
+            var arr = del();
+            Assert.Equal(1, arr.Length);
+            Assert.Equal(26, arr[0](13));
+        }
     }
 }


### PR DESCRIPTION
Contributes to #8081.

Also add further tests beyond this.

Note that on byref this already threw `TypeLoadException`, but `ArgumentException` would be more consistent.