### PR TITLE
Add tests for Condition rejecting open generic, byref or pointer type

### DIFF
--- a/src/System.Linq.Expressions/tests/Conditional/ConditionalTests.cs
+++ b/src/System.Linq.Expressions/tests/Conditional/ConditionalTests.cs
@@ -184,6 +184,52 @@ namespace System.Linq.Expressions.Tests
             Assert.Same(expected, func());
         }
 
+        [Fact]
+        public void ByRefType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Condition(
+                Expression.Constant(true),
+                Expression.Constant(null),
+                Expression.Constant(null),
+                typeof(string).MakeByRefType()));
+        }
+
+        [Fact]
+        public void PointerType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Condition(
+                Expression.Constant(true),
+                Expression.Constant(null),
+                Expression.Constant(null),
+                typeof(string).MakePointerType()));
+        }
+
+        [Fact]
+        public void GenericType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Condition(
+                Expression.Constant(true),
+                Expression.Constant(null),
+                Expression.Constant(null),
+                typeof(List<>)));
+        }
+
+        [Fact]
+        public void TypeContainsGenericParameters()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Condition(
+                Expression.Constant(true),
+                Expression.Constant(null),
+                Expression.Constant(null),
+                typeof(List<>.Enumerator)));
+            Assert.Throws<ArgumentException>(() => Expression.Condition(
+                Expression.Constant(true),
+                Expression.Constant(null),
+                Expression.Constant(null),
+                typeof(List<>).MakeGenericType(typeof(List<>))));
+        }
+
+
         private static IEnumerable<object[]> ConditionalValues()
         {
             yield return new object[] { true, "yes", "no", "yes" };


### PR DESCRIPTION
Contributes to #8081.

Just tests that it isn't accepted along with null constants (typed as `object`). Currently it is possible to create a `ConditionalExpression` that violates this rule, but it requires an other expression type to do so, so when the rest of #8081 is dealt with then coerced null would be the only remaining possibility that wouldn't have already thrown in creating a child expression.