### PR TITLE
Update CI to prepare for Universal Runner changes

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -123,9 +123,9 @@ def osShortName = ['Windows 10': 'win10',
 
 			def newBuildJob = job(Utilities.getFullJobName(project, newBuildJobName, isPR)) {
         		steps {
-            		batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd /p:OSGroup=Windows_NT /p:ConfigurationGroup=${configurationGroup} /p:SkipTests=true")
+            		batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd /p:OSGroup=Windows_NT /p:ConfigurationGroup=${configurationGroup} /p:SkipTests=true /p:Outerloop=true /p:WithoutCategories=IgnoreForCI")
             		// Package up the results.
-            		batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack .\\bin")
+            		batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack .\\ bin packages")
         		}
 			}
 
@@ -134,7 +134,7 @@ def osShortName = ['Windows 10': 'win10',
             // Set up standard options.
             Utilities.standardJobSetup(newBuildJob, project, isPR, "*/${branch}")
             // Archive the results
-            Utilities.addArchival(newBuildJob, "bin/build.pack,run-test.cmd,bin/osGroup.AnyCPU.${configurationGroup}/**,bin/ref/**,bin/packages/**,msbuild.log")
+            Utilities.addArchival(newBuildJob, "bin/build.pack,run-test.cmd,msbuild.log")
             
             def fullCoreFXBuildJobName = projectFolder + '/' + newBuildJob.name
             def newTestJobName =  "outerloop_${osShortName[os]}_${configurationGroup.toLowerCase()}_tst"
@@ -150,7 +150,7 @@ def osShortName = ['Windows 10': 'win10',
 	                }
 
 	                // Unpack the build data
-	                batchFile("PowerShell -command \"\"C:\\Packer\\unpacker.ps1 .\\bin\\build.pack .\\bin > .\\bin\\unpacker.log\"\"")
+	                batchFile("PowerShell -command \"\"C:\\Packer\\unpacker.ps1 .\\bin\\build.pack .\\ > .\\bin\\unpacker.log\"\"")
 	                // Run the tests
 	                batchFile("run-test.cmd .\\bin\\tests\\Windows_NT.AnyCPU.${configurationGroup}")
                     // Run the tests
@@ -234,9 +234,9 @@ def outerloopLinuxOSes = ['Ubuntu16.04', 'CentOS7.1', 'OpenSUSE13.2', 'RHEL7.2']
 
             def newBuildJob = job(Utilities.getFullJobName(project, newBuildJobName, isPR)) {
                 steps {
-                    batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd /p:ConfigurationGroup=${configurationGroup} /p:OSGroup=${osGroup} /p:SkipTests=true /p:TestNugetRuntimeId=${targetNugetRuntimeMap[os]}")
+                    batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd /p:ConfigurationGroup=${configurationGroup} /p:TargetOS=${osGroup} /p:OSGroup=${osGroup} /p:SkipTests=true /p:TestNugetRuntimeId=${targetNugetRuntimeMap[os]} /p:WithoutCategories=IgnoreForCI /p:TestWithoutNativeImages=true /p:Outerloop=true")
                     // Package up the results.
-                    batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack .\\bin")
+                    batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack .\\ bin packages")
                 }
             }
 
@@ -245,7 +245,7 @@ def outerloopLinuxOSes = ['Ubuntu16.04', 'CentOS7.1', 'OpenSUSE13.2', 'RHEL7.2']
             // Set up standard options.
             Utilities.standardJobSetup(newBuildJob, project, isPR, "*/${branch}")
             // Archive the results
-            Utilities.addArchival(newBuildJob, "bin/build.pack,bin/osGroup.AnyCPU.${configurationGroup}/**,bin/ref/**,bin/packages/**,msbuild.log")
+            Utilities.addArchival(newBuildJob, "bin/build.pack,msbuild.log")
 
             //
             // Then we set up a job that runs the test on the target OS
@@ -323,7 +323,7 @@ def outerloopLinuxOSes = ['Ubuntu16.04', 'CentOS7.1', 'OpenSUSE13.2', 'RHEL7.2']
             def newJob = job(Utilities.getFullJobName(project, newJobName, isPR)) {
                 steps {
                     if (os == 'Windows 10' || os == 'Windows 7' || os == 'Windows_NT') {
-                        batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && Build.cmd /p:ConfigurationGroup=${configurationGroup} /p:Outerloop=true /p:WithoutCategories=IgnoreForCI")
+                        batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd /p:ConfigurationGroup=${configurationGroup} /p:Outerloop=true /p:WithoutCategories=IgnoreForCI")
                     }
                     else if (os == 'OSX') {
                         shell("HOME=\$WORKSPACE/tempHome ./build.sh /p:ConfigurationGroup=${configurationGroup} /p:Outerloop=true /p:TestWithLocalLibraries=true /p:WithoutCategories=IgnoreForCI")
@@ -436,7 +436,7 @@ def static addCopyCoreClrAndRunTestSteps(def job, def coreclrBranch, String os, 
             }
 
             // Unpack the build data
-            shell("unpacker ./bin/build.pack ./bin")
+            shell("unpacker ./bin/build.pack .")
             // Export the LTTNG environment variable and then run the tests
             shell("""export LTTNG_HOME=/home/dotnet-bot
             ${isOuterLoop ? 'sudo' : '' } ./run-test.sh \\
@@ -498,9 +498,9 @@ def innerLoopNonWindowsOSs = ['Ubuntu16.04', 'Debian8.2', 'CentOS7.1', 'OpenSUSE
 
             def newBuildJob = job(Utilities.getFullJobName(project, newBuildJobName, isPR)) {
                 steps {
-                    batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd /p:ConfigurationGroup=${configurationGroup} /p:OSGroup=${osGroup} /p:SkipTests=true /p:TestNugetRuntimeId=${targetNugetRuntimeMap[os]} /p:WithoutCategories=IgnoreForCI")
+                    batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd /p:ConfigurationGroup=${configurationGroup} /p:TargetOS=${osGroup} /p:OSGroup=${osGroup} /p:SkipTests=true /p:TestNugetRuntimeId=${targetNugetRuntimeMap[os]} /p:WithoutCategories=IgnoreForCI /p:TestWithoutNativeImages=true")
                     // Package up the results.
-                    batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack .\\bin")
+                    batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack .\\ bin packages")
                 }
             }
 
@@ -509,7 +509,7 @@ def innerLoopNonWindowsOSs = ['Ubuntu16.04', 'Debian8.2', 'CentOS7.1', 'OpenSUSE
             // Set up standard options.
             Utilities.standardJobSetup(newBuildJob, project, isPR, "*/${branch}")
             // Archive the results
-            Utilities.addArchival(newBuildJob, "bin/build.pack,bin/osGroup.AnyCPU.${configurationGroup}/**,bin/ref/**,bin/packages/**,msbuild.log")
+            Utilities.addArchival(newBuildJob, "bin/build.pack,msbuild.log")
 
             //
             // Then we set up a job that runs the test on the target OS


### PR DESCRIPTION
The universal runner changes going into buildtools soon will impact how
we do our cross build testing.

Previously, the build would produce a complete test layout, which we
could then copy over to another machine and then use corerun to invoke
xunit.

With the universal runner changes, this will change such that the build
instead generates a RunTests script which copies all the assets the
tests consumes from packages into the execution directory and then
invokes the tests.

This implies we need to do the following changes:

- We need to start to archive both the bin folder and the packages
  folder and copy them over (since the universal runner RunTests.sh needs
  the packages folder in order to deploy test assets)

- We need to pass additional arguments like Outerloop and IgnoreForCI to
  build itself, as the build process uses these when generating the
  RunTests.sh file, since the script includes the xunit invocation
  command.

This impacts any run where we build the tests and then run them on
different machine (i.e. Windows Nano, certain Linux runs).

These are forward compatible changes to CI definitions so when we go to
make the updates, the builds happen as we expect and the CI system can
check that we are doing the right things.