### PR TITLE
Consolidate unreachable assertions in Expressions.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -994,7 +994,7 @@ namespace System.Linq.Expressions.Interpreter
                 case ExpressionType.LessThanOrEqual: _instructions.EmitLessThanOrEqual(left.Type, node.IsLiftedToNull); break;
                 case ExpressionType.GreaterThan: _instructions.EmitGreaterThan(left.Type, node.IsLiftedToNull); break;
                 case ExpressionType.GreaterThanOrEqual: _instructions.EmitGreaterThanOrEqual(left.Type, node.IsLiftedToNull); break;
-                default: throw Assert.Unreachable;
+                default: throw ContractUtils.Unreachable;
             }
         }
 
@@ -1013,7 +1013,7 @@ namespace System.Linq.Expressions.Interpreter
                 case ExpressionType.MultiplyChecked: _instructions.EmitMul(left.Type, true); break;
                 case ExpressionType.Divide: _instructions.EmitDiv(left.Type); break;
                 case ExpressionType.Modulo: _instructions.EmitModulo(left.Type); break;
-                default: throw Assert.Unreachable;
+                default: throw ContractUtils.Unreachable;
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
@@ -37,7 +37,7 @@ namespace System.Linq.Expressions.Interpreter
                     // We cannot have null in a non-lifted numeric context. Throw the exception
                     // about not Nullable object requiring a value.
                     converted = (int)(int?)obj;
-                    throw Assert.Unreachable;
+                    throw ContractUtils.Unreachable;
                 }
             }
             else
@@ -89,7 +89,7 @@ namespace System.Linq.Expressions.Interpreter
                     case TypeCode.UInt64: return ConvertUInt64((UInt64)obj);
                     case TypeCode.Single: return ConvertDouble((Single)obj);
                     case TypeCode.Double: return ConvertDouble((Double)obj);
-                    default: throw Assert.Unreachable;
+                    default: throw ContractUtils.Unreachable;
                 }
             }
 
@@ -110,7 +110,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.UInt64: return (UInt64)obj;
                         case TypeCode.Single: return (Single)obj;
                         case TypeCode.Double: return (Double)obj;
-                        default: throw Assert.Unreachable;
+                        default: throw ContractUtils.Unreachable;
                     }
                 }
             }
@@ -132,7 +132,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.UInt64: return (UInt64)obj;
                         case TypeCode.Single: return (Single)obj;
                         case TypeCode.Double: return (Double)obj;
-                        default: throw Assert.Unreachable;
+                        default: throw ContractUtils.Unreachable;
                     }
                 }
             }
@@ -154,7 +154,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.UInt64: return (UInt64)obj;
                         case TypeCode.Single: return (Single)obj;
                         case TypeCode.Double: return (Double)obj;
-                        default: throw Assert.Unreachable;
+                        default: throw ContractUtils.Unreachable;
                     }
                 }
             }
@@ -176,7 +176,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.UInt64: return (UInt64)obj;
                         case TypeCode.Single: return (Single)obj;
                         case TypeCode.Double: return (Double)obj;
-                        default: throw Assert.Unreachable;
+                        default: throw ContractUtils.Unreachable;
                     }
                 }
             }
@@ -208,7 +208,7 @@ namespace System.Linq.Expressions.Interpreter
                     case TypeCode.UInt64: return ConvertUInt64((UInt64)obj);
                     case TypeCode.Single: return ConvertDouble((Single)obj);
                     case TypeCode.Double: return ConvertDouble((Double)obj);
-                    default: throw Assert.Unreachable;
+                    default: throw ContractUtils.Unreachable;
                 }
             }
 
@@ -229,7 +229,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.UInt64: return (UInt64)obj;
                         case TypeCode.Single: return (Single)obj;
                         case TypeCode.Double: return (Double)obj;
-                        default: throw Assert.Unreachable;
+                        default: throw ContractUtils.Unreachable;
                     }
                 }
             }
@@ -251,7 +251,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.UInt64: return (UInt64)obj;
                         case TypeCode.Single: return (Single)obj;
                         case TypeCode.Double: return (Double)obj;
-                        default: throw Assert.Unreachable;
+                        default: throw ContractUtils.Unreachable;
                     }
                 }
             }
@@ -273,7 +273,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.UInt64: return (UInt64)obj;
                         case TypeCode.Single: return (Single)obj;
                         case TypeCode.Double: return (Double)obj;
-                        default: throw Assert.Unreachable;
+                        default: throw ContractUtils.Unreachable;
                     }
                 }
             }
@@ -295,7 +295,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.UInt64: return (UInt64)obj;
                         case TypeCode.Single: return (Single)obj;
                         case TypeCode.Double: return (Double)obj;
-                        default: throw Assert.Unreachable;
+                        default: throw ContractUtils.Unreachable;
                     }
                 }
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -2185,7 +2185,7 @@ namespace System.Linq.Expressions.Interpreter
                 case "ToString": return s_toString ?? (s_toString = new ToStringClass());
                 default:
                     // System.Nullable doesn't have other instance methods 
-                    throw Assert.Unreachable;
+                    throw ContractUtils.Unreachable;
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -434,15 +434,6 @@ namespace System.Linq.Expressions.Interpreter
 
     internal static class Assert
     {
-        internal static Exception Unreachable
-        {
-            get
-            {
-                Debug.Assert(false, "Unreachable");
-                return new InvalidOperationException("Code supposed to be unreachable");
-            }
-        }
-
         [Conditional("DEBUG")]
         public static void NotNull(object var)
         {


### PR DESCRIPTION
Expressions has two identical ways of asserting code is unreachable.

Remove the more specifically scoped, replacing calls to it with calls to the other.