### PR TITLE
Fix 7437

### DIFF
--- a/src/System.Runtime.Loader/tests/ResourceAssemblyLoadContext.cs
+++ b/src/System.Runtime.Loader/tests/ResourceAssemblyLoadContext.cs
@@ -43,7 +43,12 @@ namespace System.Runtime.Loader.Tests
                 // This custom load context will extract that resource and store it at the %temp% path at runtime.
                 // This prevents the corerun from adding the test assembly to the TPA list.                
                 // Once loaded it is not possible to unload the assembly, therefore it cannot be deleted.
-                string path = Path.Combine(Path.GetTempPath(), assembly);
+                var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+                // Create the folder since it will not exist already
+                Directory.CreateDirectory(tempPath);
+                
+                string path = Path.Combine(tempPath, assembly);
                 using (FileStream output = File.OpenWrite(path))
                 {
                     asmStream.CopyTo(output);


### PR DESCRIPTION
The test copies a file to temp location and load it from there. If multiple instances of tests are running on the same machine, it could lock the binary resulting in one of the test processes failing when it attempts to clean the temp location.

This change attempts to copy the test binary to a randomly generated subfolder in the temp location.