### PR TITLE
Simplify crefs in XML Doc Comments for System.Collections.Immutable

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
@@ -415,7 +415,7 @@ namespace System.Collections.Immutable
         /// than any of the elements in array, a negative number which is the bitwise
         /// complement of (the index of the last element plus 1).
         /// </returns>
-        /// <exception cref="System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// <paramref name="value"/> does not implement the <see cref="IComparable{T}"/> generic interface, and
         /// the search encounters an element that does not implement the <see cref="IComparable{T}"/>
         /// generic interface.
@@ -446,7 +446,7 @@ namespace System.Collections.Immutable
         /// than any of the elements in array, a negative number which is the bitwise
         /// complement of (the index of the last element plus 1).
         /// </returns>
-        /// <exception cref="System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// <paramref name="comparer"/> is null, <paramref name="value"/> does not implement the <see cref="IComparable{T}"/> generic interface, and
         /// the search encounters an element that does not implement the <see cref="IComparable{T}"/>
         /// generic interface.
@@ -475,7 +475,7 @@ namespace System.Collections.Immutable
         /// than any of the elements in <paramref name="array"/>, a negative number which is the bitwise
         /// complement of (the index of the last element plus 1).
         /// </returns>
-        /// <exception cref="System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// <paramref name="value"/> does not implement the <see cref="IComparable{T}"/> generic interface, and
         /// the search encounters an element that does not implement the <see cref="IComparable{T}"/>
         /// generic interface.
@@ -515,7 +515,7 @@ namespace System.Collections.Immutable
         /// than any of the elements in <paramref name="array"/>, a negative number which is the bitwise
         /// complement of (the index of the last element plus 1).
         /// </returns>
-        /// <exception cref="System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// <paramref name="comparer"/> is null, <paramref name="value"/> does not implement the <see cref="IComparable{T}"/> generic
         /// interface, and the search encounters an element that does not implement the
         /// <see cref="IComparable{T}"/> generic interface.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
@@ -133,7 +133,7 @@ namespace System.Collections.Immutable
             /// </summary>
             /// <param name="index">The index.</param>
             /// <returns></returns>
-            /// <exception cref="System.IndexOutOfRangeException">
+            /// <exception cref="IndexOutOfRangeException">
             /// </exception>
             public T this[int index]
             {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -1047,11 +1047,11 @@ namespace System.Collections.Immutable
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.
+        /// Determines whether the specified <see cref="Object"/> is equal to this instance.
         /// </summary>
-        /// <param name="obj">The <see cref="System.Object"/> to compare with this instance.</param>
+        /// <param name="obj">The <see cref="Object"/> to compare with this instance.</param>
         /// <returns>
-        ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
+        ///   <c>true</c> if the specified <see cref="Object"/> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         [Pure]
         public override bool Equals(object obj)

--- a/src/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
+++ b/src/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
@@ -668,7 +668,7 @@ namespace System.Linq
         /// <summary>
         /// Returns the first element in the collection.
         /// </summary>
-        /// <exception cref="System.InvalidOperationException">Thrown if the collection is empty.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if the collection is empty.</exception>
         [Pure]
         public static T First<T>(this ImmutableArray<T>.Builder builder)
         {
@@ -696,7 +696,7 @@ namespace System.Linq
         /// <summary>
         /// Returns the last element in the collection.
         /// </summary>
-        /// <exception cref="System.InvalidOperationException">Thrown if the collection is empty.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if the collection is empty.</exception>
         [Pure]
         public static T Last<T>(this ImmutableArray<T>.Builder builder)
         {


### PR DESCRIPTION
/cc @mairaw @Priya91 

In this case, since there isn't a `/ref` folder, we ran the tool on `/src`.  No changes were made other than simplifying crefs.