### PR TITLE
Don't allocate twice in IdnMapping.GetAscii on Unix

### DIFF
--- a/src/Common/src/System/Globalization/IdnMapping.Unix.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.Unix.cs
@@ -11,44 +11,38 @@ namespace System.Globalization
             uint flags = Flags;
             CheckInvalidIdnCharacters(unicode, count, flags, nameof(unicode));
 
-            const int StackAllocThreshold = 512;
-            if (count < StackAllocThreshold)
+            // Each unicode character is represented by 2 ASCII chars
+            // and a "xn--" prefix of length 4
+            int estimatedLength = count * 2 + 4;
+            int actualLength;
+            if (estimatedLength < StackallocThreshold)
             {
-                char* output = stackalloc char[count];
-                return GetAsciiCore(unicode, count, flags, output, count, reattempt: true);
+                char* outputSmall = stackalloc char[estimatedLength];
+                actualLength = Interop.GlobalizationNative.ToAscii(flags, unicode, count, outputSmall, estimatedLength);
+                if (actualLength == 0)
+                {
+                    throw new ArgumentException(SR.Argument_IdnIllegalName, nameof(unicode));
+                }
+                else if (actualLength <= estimatedLength)
+                {
+                    return new string(outputSmall, 0, actualLength);
+                }
             }
             else
             {
-                char[] output = new char[count];
-                fixed (char* pOutput = output)
+                actualLength = Interop.GlobalizationNative.ToAscii(flags, unicode, count, null, 0);
+            }
+
+            char[] outputLarge = new char[actualLength];
+            fixed (char* pOutputLarge = outputLarge)
+            {
+                actualLength = Interop.GlobalizationNative.ToAscii(flags, unicode, count, pOutputLarge, actualLength);
+                if (actualLength == 0 || actualLength > outputLarge.Length)
                 {
-                    return GetAsciiCore(unicode, count, flags, pOutput, count, reattempt: true);
+                    throw new ArgumentException(SR.Argument_IdnIllegalName, nameof(unicode));
                 }
+                return new string(pOutputLarge, 0, actualLength);
             }
-        }
-
-        private unsafe string GetAsciiCore(char* unicode, int count, uint flags, char* output, int outputLength, bool reattempt)
-        {
-            int realLen = Interop.GlobalizationNative.ToAscii(flags, unicode, count, output, outputLength);
-
-            if (realLen == 0)
-            {
-                throw new ArgumentException(SR.Argument_IdnIllegalName, nameof(unicode));
-            }
-            else if (realLen <= outputLength)
-            {
-                return new string(output, 0, realLen);
-            }
-            else if (reattempt)
-            {
-                char[] newOutput = new char[realLen];
-                fixed (char* pNewOutput = newOutput)
-                {
-                    return GetAsciiCore(unicode, count, flags, pNewOutput, realLen, reattempt: false);
-                }
-            }
-
-            throw new ArgumentException(SR.Argument_IdnIllegalName, nameof(unicode));
         }
 
         private unsafe string GetUnicodeCore(char* ascii, int count)

--- a/src/Common/src/System/Globalization/IdnMapping.Unix.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.Unix.cs
@@ -11,9 +11,9 @@ namespace System.Globalization
             uint flags = Flags;
             CheckInvalidIdnCharacters(unicode, count, flags, nameof(unicode));
 
-            // Each unicode character is represented by 2 ASCII chars
-            // and a "xn--" prefix of length 4
             const int StackallocThreshold = 512;
+            // Each unicode character is represented by 2 ASCII chars
+            // and the whole string is prefixed by "xn--" (length 4)
             int estimatedLength = (int)Math.Min(count * 2L + 4, StackallocThreshold);
             int actualLength;
             if (estimatedLength < StackallocThreshold)

--- a/src/Common/src/System/Globalization/IdnMapping.Unix.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.Unix.cs
@@ -12,7 +12,7 @@ namespace System.Globalization
             CheckInvalidIdnCharacters(unicode, count, flags, nameof(unicode));
 
             const int StackallocThreshold = 512;
-            // Each unicode character is represented by 2 ASCII chars
+            // Each unicode character is represented by up to 3 ASCII chars
             // and the whole string is prefixed by "xn--" (length 4)
             int estimatedLength = (int)Math.Min(count * 3L + 4, StackallocThreshold);
             int actualLength;

--- a/src/Common/src/System/Globalization/IdnMapping.Unix.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.Unix.cs
@@ -14,7 +14,7 @@ namespace System.Globalization
             const int StackallocThreshold = 512;
             // Each unicode character is represented by 2 ASCII chars
             // and the whole string is prefixed by "xn--" (length 4)
-            int estimatedLength = (int)Math.Min(count * 2L + 4, StackallocThreshold);
+            int estimatedLength = (int)Math.Min(count * 3L + 4, StackallocThreshold);
             int actualLength;
             if (estimatedLength < StackallocThreshold)
             {

--- a/src/Common/src/System/Globalization/IdnMapping.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.cs
@@ -36,6 +36,8 @@ namespace System.Globalization
 #endif
     sealed partial class IdnMapping
     {
+        private const int StackallocThreshold = 512;
+
         private bool _allowUnassigned;
         private bool _useStd3AsciiRules;
 

--- a/src/Common/src/System/Globalization/IdnMapping.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.cs
@@ -36,8 +36,6 @@ namespace System.Globalization
 #endif
     sealed partial class IdnMapping
     {
-        private const int StackallocThreshold = 512;
-
         private bool _allowUnassigned;
         private bool _useStd3AsciiRules;
 


### PR DESCRIPTION
Reasoning for example unicode string "\u0101"
- Before, we allocate a char array of count 1 as the output array for GlobalizationNative.ToAscii.
- However, the actual result is "xn--yda", which is greater length than the original input buffer.
- Therefore, we allocate !again! with the correct length

Instead, we can pass a null buffer to the interop function and get the required output length. Therefore, we get the correct length and allocate only once correclty.

/cc @ellismg @tarekgh 