### PR TITLE
Add DbEnumerator contract to System.Data.Common

### DIFF
--- a/src/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/System.Data.Common/ref/System.Data.Common.cs
@@ -394,6 +394,13 @@ namespace System.Data.Common
         public abstract int GetValues(object[] values);
         public abstract bool IsDBNull(int i);
     }
+    public partial class DbEnumerator : System.Collections.IEnumerator
+    {
+        public DbEnumerator(System.Data.Common.DbDataReader reader, bool closeReader) { }
+        public object Current { get; }
+        public bool MoveNext() { return default(bool); }
+        public void Reset() { }
+    }
     public abstract partial class DbException : System.Exception
     {
         protected DbException() { }


### PR DESCRIPTION
DbEnumerator's APIs are compatible with .NET 4.0, so this change doesn't require a contract version bump.