### PR TITLE
Adding Binary Serialization Programming Model

### DIFF
--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -1204,6 +1204,14 @@
         ]
     },
     {
+        "Name": "System.Runtime.Serialization.Formatters",
+        "Description": "Provides common types for libraries that support runtime serialization.",
+        "CommonTypes": [
+            "System.SerializableAttribute",
+            "System.Runtime.Serialization.ISerializable"
+        ]
+    },
+    {
         "Name": "System.Runtime.Serialization.Json",
         "Description": "Provides classes for serializing objects to the JavaScript Object Notation (JSON) and deserializing JSON data to objects.",
         "CommonTypes": [

--- a/src/System.Runtime.Serialization.Formatters/System.Runtime.Serialization.Formatters.sln
+++ b/src/System.Runtime.Serialization.Formatters/System.Runtime.Serialization.Formatters.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Serialization.Formatters", "src\System.Runtime.Serialization.Formatters.csproj", "{CA488507-3B6E-4494-B7BE-7B4EEEB2C4D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Serialization.Formatters.Tests", "tests\System.Runtime.Serialization.Formatters.Tests.csproj", "{7C70BB15-870B-4946-8098-625DACD645A6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CA488507-3B6E-4494-B7BE-7B4EEEB2C4D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA488507-3B6E-4494-B7BE-7B4EEEB2C4D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA488507-3B6E-4494-B7BE-7B4EEEB2C4D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA488507-3B6E-4494-B7BE-7B4EEEB2C4D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C70BB15-870B-4946-8098-625DACD645A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C70BB15-870B-4946-8098-625DACD645A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C70BB15-870B-4946-8098-625DACD645A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C70BB15-870B-4946-8098-625DACD645A6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/System.Runtime.Serialization.Formatters/pkg/System.Runtime.Serialization.Formatters.builds
+++ b/src/System.Runtime.Serialization.Formatters/pkg/System.Runtime.Serialization.Formatters.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Runtime.Serialization.Formatters.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Runtime.Serialization.Formatters/pkg/System.Runtime.Serialization.Formatters.pkgproj
+++ b/src/System.Runtime.Serialization.Formatters/pkg/System.Runtime.Serialization.Formatters.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>  
+    <ProjectReference Include="..\ref\System.Runtime.Serialization.Formatters.csproj">
+      <SupportedFramework>net46;netcore50;netcoreapp1.0</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Runtime.Serialization.Formatters.builds" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+    <InboxOnTargetFramework Include="xamarintvos10" />
+    <InboxOnTargetFramework Include="xamarinwatchos10" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Serialization.Formatters/ref/System.Runtime.Serialization.Formatters.cs
+++ b/src/System.Runtime.Serialization.Formatters/ref/System.Runtime.Serialization.Formatters.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace System
+{
+    [AttributeUsage(AttributeTargets.Field, Inherited=false)]
+    public sealed class NonSerializedAttribute : Attribute 
+    { 
+        public NonSerializedAttribute() { 
+        }
+    }
+    
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Delegate, Inherited = false)]
+    public sealed class SerializableAttribute : Attribute 
+    {
+        public SerializableAttribute() {
+        }
+    }
+}
+
+namespace System.Runtime.Serialization
+{
+    public interface ISerializable 
+    {
+        void GetObjectData(SerializationInfo info, StreamingContext context);           
+    }
+    
+    public interface IDeserializationCallback 
+    {
+        void OnDeserialization(object sender);  
+    }
+    
+    [AttributeUsage(AttributeTargets.Field, Inherited=false)]
+    public sealed class OptionalFieldAttribute : Attribute 
+    {     
+        public int VersionAdded  {
+            get { return default(int); }
+            set { }
+        }
+    }
+ 
+    [AttributeUsage(AttributeTargets.Method, Inherited=false)]
+    public sealed class OnSerializingAttribute : Attribute 
+    {
+    }
+ 
+    [AttributeUsage(AttributeTargets.Method, Inherited=false)]
+    public sealed class OnSerializedAttribute : Attribute 
+    {
+    }
+ 
+    [AttributeUsage(AttributeTargets.Method, Inherited=false)]
+    public sealed class OnDeserializingAttribute : Attribute 
+    {
+    }
+ 
+    [AttributeUsage(AttributeTargets.Method, Inherited=false)]
+    public sealed class OnDeserializedAttribute : Attribute 
+    {
+    }
+    
+    public sealed class SerializationInfo 
+    {
+    }
+        
+    [Serializable]
+    [Flags]
+    public enum StreamingContextStates 
+    {
+        All         =0xFF,
+    }
+}

--- a/src/System.Runtime.Serialization.Formatters/ref/System.Runtime.Serialization.Formatters.csproj
+++ b/src/System.Runtime.Serialization.Formatters/ref/System.Runtime.Serialization.Formatters.csproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>netstandard1.3</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="System.Runtime.Serialization.Formatters.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Serialization.Formatters/ref/project.json
+++ b/src/System.Runtime.Serialization.Formatters/ref/project.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.0.0",
+    "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24102-00"
+  },
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4"
+      ]
+    }
+  }
+}

--- a/src/System.Runtime.Serialization.Formatters/src/Resources/Strings.resx
+++ b/src/System.Runtime.Serialization.Formatters/src/Resources/Strings.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Serialization_OptionalFieldVersionValue" xml:space="preserve">
+    <value>Version value must be positive.</value>
+  </data>
+</root>

--- a/src/System.Runtime.Serialization.Formatters/src/System.Runtime.Serialization.Formatters.builds
+++ b/src/System.Runtime.Serialization.Formatters/src/System.Runtime.Serialization.Formatters.builds
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Runtime.Serialization.Formatters.csproj" />
+    <Project Include="System.Runtime.Serialization.Formatters.csproj">
+      <TargetGroup>net46</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Runtime.Serialization.Formatters/src/System.Runtime.Serialization.Formatters.csproj
+++ b/src/System.Runtime.Serialization.Formatters/src/System.Runtime.Serialization.Formatters.csproj
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{CA488507-3B6E-4494-B7BE-7B4EEEB2C4D1}</ProjectGuid>
+    <AssemblyName>System.Runtime.Serialization.Formatters</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <RootNamespace>System.Runtime.Serialization.Formatters</RootNamespace>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.4</PackageTargetFramework>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.4</NuGetTargetMoniker>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == ''">
+    <Compile Include="System\NonSerializedAttribute.cs" />
+    <Compile Include="System\SerializableAttribute.cs" />
+    <Compile Include="System\Runtime\Serialization\IDeserializationCallback.cs" />
+    <Compile Include="System\Runtime\Serialization\ISerializable.cs" />
+    <Compile Include="System\Runtime\Serialization\SerializationInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Serialization.Formatters/src/System/NonSerializedAttribute.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/NonSerializedAttribute.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System
+{
+    [AttributeUsage(AttributeTargets.Field, Inherited = false)]
+    public sealed class NonSerializedAttribute : Attribute
+    {
+        public NonSerializedAttribute()
+        {
+        }
+    }
+}

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/IDeserializationCallback.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/IDeserializationCallback.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.Runtime.Serialization
+{
+    public interface IDeserializationCallback
+    {
+        void OnDeserialization(object sender);
+    }
+}

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ISerializable.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ISerializable.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.Runtime.Serialization
+{
+    public interface ISerializable
+    {
+        void GetObjectData(SerializationInfo info, StreamingContext context);
+    }
+}

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/SerializationInfo.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/SerializationInfo.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.Runtime.Serialization
+{
+    public sealed class SerializationInfo
+    {
+    }
+}

--- a/src/System.Runtime.Serialization.Formatters/src/System/SerializableAttribute.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/SerializableAttribute.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Delegate, Inherited = false)]
+    public sealed class SerializableAttribute : Attribute
+    {
+        public SerializableAttribute()
+        {
+        }
+    }
+}

--- a/src/System.Runtime.Serialization.Formatters/src/project.json
+++ b/src/System.Runtime.Serialization.Formatters/src/project.json
@@ -1,0 +1,23 @@
+{
+  "frameworks": {
+    "netstandard1.4": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1-rc3-24102-00",
+        "System.Collections": "4.0.10",
+        "System.Diagnostics.Debug": "4.0.10",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Extensions": "4.0.10",
+        "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24102-00"
+      },
+      "imports": [
+        "dotnet5.5"
+      ]
+    },
+    "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+      }
+    }
+  }
+}

--- a/src/System.Runtime.Serialization.Formatters/tests/BasicTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BasicTests.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Runtime.Serialization.Formatters.Tests
+{
+    public class BinaryFormatterTests
+    {
+        [Fact]
+        public void Foo()
+        {
+            Assert.Equal(1, 1);
+        }
+    }
+
+    [Serializable]
+    internal class Serializable : ISerializable
+    {
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+        }
+    }
+}

--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.builds
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Runtime.Serialization.Formatters.Tests.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7C70BB15-870B-4946-8098-625DACD645A6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.Runtime.Serialization.Formatters.Tests</AssemblyName>
+    <RootNamespace>System.Runtime.Serialization.Formatters.Tests</RootNamespace>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="BasicTests.cs" /> 
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Runtime.Serialization.Formatters.csproj">
+      <Project>{ca488507-3b6e-4494-b7be-7b4eeeb2c4d1}</Project>
+      <Name>System.Runtime.Serialization.Formatters</Name>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Serialization.Formatters/tests/project.json
+++ b/src/System.Runtime.Serialization.Formatters/tests/project.json
@@ -1,0 +1,34 @@
+{
+  "dependencies": {
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0030",
+    "Microsoft.NETCore.Platforms": "1.0.1-rc3-24102-00",
+    "System.Collections": "4.0.11-rc3-24102-00",
+    "System.Diagnostics.Debug": "4.0.11-rc3-24102-00",
+    "System.ObjectModel": "4.0.12-rc3-24102-00",
+    "System.Reflection.TypeExtensions": "4.1.0-rc3-24102-00",
+    "System.Runtime": "4.1.0-rc3-24102-00",
+    "System.Runtime.Extensions": "4.1.0-rc3-24102-00",
+    "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24102-00",
+    "System.Text.RegularExpressions": "4.1.0-rc3-24102-00",
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
+    "test-runtime": {
+      "target": "project",
+      "exclude": "compile"
+    }
+  },
+  "frameworks": {
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
+  }
+}


### PR DESCRIPTION
We decided to add binary serialization programming model (ISerializable, etc.) as an out of band package.
This will allow existing code implementing the SPM to compile for .NET Core without changes.

This is the ferst in a series of commits to ease porting of code involving serialization.
In subsequent commits, we are planing to:
1. Fill in the details of SerializationInfo
2. Add Exception.set_StackTrace
3. Add FormatterServices.GetUninitializedObject
4. Add BinaryFormatter (the exact semantics TBD)