### PR TITLE
Fix intermittent X509 test failure and leaks.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/Cert.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/Cert.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace System.Security.Cryptography.X509Certificates.Tests
+{
+    //
+    // Helper class centralizes all loading of PFX's. Loading PFX's is a problem because of the key on disk that it creates and gets left behind
+    // if the certificate isn't properly disposed. Properly disposing PFX's imported into a X509Certificate2Collection is a pain because X509Certificate2Collection 
+    // doesn't implement IDisposable. To make this easier, we wrap these in an ImportedCollection class that does implement IDisposable.
+    //
+    internal static class Cert
+    {
+        //
+        // The Import() methods have an overload for each X509Certificate2Collection.Import() overload.
+        //
+
+        // Do not refactor this into a call to Import(byte[], string, X509KeyStorageFlags). The test meant to exercise
+        // the api that takes only one argument.
+        public static ImportedCollection Import(byte[] rawData)
+        {
+            X509Certificate2Collection collection = new X509Certificate2Collection();
+            collection.Import(rawData);
+            return new ImportedCollection(collection);
+        }
+
+        public static ImportedCollection Import(byte[] rawData, string password, X509KeyStorageFlags keyStorageFlags)
+        {
+            X509Certificate2Collection collection = new X509Certificate2Collection();
+            collection.Import(rawData, password, keyStorageFlags);
+            return new ImportedCollection(collection);
+        }
+
+        // Do not refactor this into a call to Import(string, string, X509KeyStorageFlags). The test meant to exercise
+        // the api that takes only one argument.
+        public static ImportedCollection Import(string fileName)
+        {
+            X509Certificate2Collection collection = new X509Certificate2Collection();
+            collection.Import(fileName);
+            return new ImportedCollection(collection);
+        }
+
+        public static ImportedCollection Import(string fileName, string password, X509KeyStorageFlags keyStorageFlags)
+        {
+            X509Certificate2Collection collection = new X509Certificate2Collection();
+            collection.Import(fileName, password, keyStorageFlags);
+            return new ImportedCollection(collection);
+        }
+    }
+
+    //
+    // Wraps an X509Certificate2Collection in an IDisposable for easier cleanup.
+    //
+    internal sealed class ImportedCollection : IDisposable
+    {
+        public ImportedCollection(X509Certificate2Collection collection)
+        {
+            // Make an independent copy of the certs to dispose (in case the test mutates the collection after we return.)
+            _certs = new X509Certificate2[collection.Count];
+            collection.CopyTo(_certs, 0);
+            Collection = collection;
+        }
+
+        public X509Certificate2Collection Collection { get; }
+
+        public void Dispose()
+        {
+            if (_certs != null)
+            {
+                foreach (X509Certificate2 cert in _certs)
+                {
+                    cert.Dispose();
+                }
+                _certs = null;
+            }
+        }
+
+        private X509Certificate2[] _certs;
+    }
+}
+

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -205,11 +205,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                 // Read it back as a collection, there should be only one cert, and it should
                 // be equal to the one we started with.
-                X509Certificate2Collection fromPfx = new X509Certificate2Collection();
-                fromPfx.Import(pkcs12Bytes);
+                using (ImportedCollection ic = Cert.Import(pkcs12Bytes))
+                {
+                    X509Certificate2Collection fromPfx = ic.Collection;
 
-                Assert.Equal(1, fromPfx.Count);
-                Assert.Equal(publicOnly, fromPfx[0]);
+                    Assert.Equal(1, fromPfx.Count);
+                    Assert.Equal(publicOnly, fromPfx[0]);
+                }
             }
         }
     }

--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -55,18 +55,20 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             using (var testCert = new X509Certificate2(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword))
             {
-                X509Certificate2Collection collection = new X509Certificate2Collection();
-                collection.Import(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword, X509KeyStorageFlags.DefaultKeySet);
+                using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword, X509KeyStorageFlags.DefaultKeySet))
+                {
+                    X509Certificate2Collection collection = ic.Collection;
 
-                X509Chain chain = new X509Chain();
-                chain.ChainPolicy.ExtraStore.AddRange(collection);
-                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                chain.ChainPolicy.VerificationTime = new DateTime(2015, 9, 22, 12, 25, 0);
+                    X509Chain chain = new X509Chain();
+                    chain.ChainPolicy.ExtraStore.AddRange(collection);
+                    chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                    chain.ChainPolicy.VerificationTime = new DateTime(2015, 9, 22, 12, 25, 0);
 
-                bool valid = chain.Build(testCert);
+                    bool valid = chain.Build(testCert);
 
-                Assert.False(valid);
-                Assert.Contains(chain.ChainStatus, s => s.Status == X509ChainStatusFlags.UntrustedRoot);
+                    Assert.False(valid);
+                    Assert.Contains(chain.ChainStatus, s => s.Status == X509ChainStatusFlags.UntrustedRoot);
+                }
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionImportTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionImportTests.cs
@@ -21,164 +21,182 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void ImportEmpty_Pkcs12()
         {
-            var collection = new X509Certificate2Collection();
-
-            collection.Import(TestData.EmptyPfx);
-
-            Assert.Equal(0, collection.Count);
+            using (ImportedCollection ic = Cert.Import(TestData.EmptyPfx))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(0, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportX509DerBytes()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(TestData.MsCertificate);
-
-            Assert.Equal(1, collection.Count);
+            using (ImportedCollection ic = Cert.Import(TestData.MsCertificate))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(1, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportX509PemBytes()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(TestData.MsCertificatePemBytes);
-
-            Assert.Equal(1, collection.Count);
+            using (ImportedCollection ic = Cert.Import(TestData.MsCertificatePemBytes))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(1, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportX509DerFile()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(Path.Combine("TestData", "MS.cer"));
-
-            Assert.Equal(1, collection.Count);
+            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "MS.cer")))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(1, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportX509PemFile()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(Path.Combine("TestData", "MS.pem"));
-
-            Assert.Equal(1, collection.Count);
+            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "MS.pem")))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(1, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportPkcs7DerBytes_Empty()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(TestData.Pkcs7EmptyDerBytes);
-
-            Assert.Equal(0, collection.Count);
+            using (ImportedCollection ic = Cert.Import(TestData.Pkcs7EmptyDerBytes))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(0, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportPkcs7PemBytes_Empty()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(TestData.Pkcs7EmptyPemBytes);
-
-            Assert.Equal(0, collection.Count);
+            using (ImportedCollection ic = Cert.Import(TestData.Pkcs7EmptyPemBytes))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(0, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportPkcs7DerFile_Empty()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(Path.Combine("TestData", "empty.p7b"));
-
-            Assert.Equal(0, collection.Count);
+            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "empty.p7b")))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(0, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportPkcs7PemFile_Empty()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(Path.Combine("TestData", "empty.p7c"));
-
-            Assert.Equal(0, collection.Count);
+            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "empty.p7c")))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(0, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportPkcs7DerBytes_Single()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(TestData.Pkcs7SingleDerBytes);
-
-            Assert.Equal(1, collection.Count);
+            using (ImportedCollection ic = Cert.Import(TestData.Pkcs7SingleDerBytes))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(1, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportPkcs7PemBytes_Single()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(TestData.Pkcs7SinglePemBytes);
-
-            Assert.Equal(1, collection.Count);
+            using (ImportedCollection ic = Cert.Import(TestData.Pkcs7SinglePemBytes))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(1, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportPkcs7DerFile_Single()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(Path.Combine("TestData", "singlecert.p7b"));
-
-            Assert.Equal(1, collection.Count);
+            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "singlecert.p7b")))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(1, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportPkcs7PemFile_Single()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(Path.Combine("TestData", "singlecert.p7c"));
-
-            Assert.Equal(1, collection.Count);
+            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "singlecert.p7c")))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(1, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportPkcs7DerBytes_Chain()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(TestData.Pkcs7ChainDerBytes);
-
-            Assert.Equal(3, collection.Count);
+            using (ImportedCollection ic = Cert.Import(TestData.Pkcs7ChainDerBytes))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(3, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportPkcs7PemBytes_Chain()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(TestData.Pkcs7ChainPemBytes);
-
-            Assert.Equal(3, collection.Count);
+            using (ImportedCollection ic = Cert.Import(TestData.Pkcs7ChainPemBytes))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(3, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportPkcs7DerFile_Chain()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(Path.Combine("TestData", "certchain.p7b"));
-
-            Assert.Equal(3, collection.Count);
+            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "certchain.p7b")))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(3, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportPkcs7PemFile_Chain()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(Path.Combine("TestData", "certchain.p7c"));
-
-            Assert.Equal(3, collection.Count);
+            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "certchain.p7c")))
+            {
+                X509Certificate2Collection collection = ic.Collection;
+                Assert.Equal(3, collection.Count);
+            }
         }
 
         [Fact]
         public static void ImportPkcs12Bytes_Single()
         {
-            X509Certificate2Collection cc2 = new X509Certificate2Collection();
-            cc2.Import(TestData.PfxData, TestData.PfxDataPassword, X509KeyStorageFlags.DefaultKeySet);
-            int count = cc2.Count;
-            Assert.Equal(1, count);
+            using (ImportedCollection ic = Cert.Import(TestData.PfxData, TestData.PfxDataPassword, X509KeyStorageFlags.DefaultKeySet))
+            {
+                X509Certificate2Collection cc2 = ic.Collection;
+                int count = cc2.Count;
+                Assert.Equal(1, count);
+            }
         }
 
         [Fact]
@@ -186,18 +204,20 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
             {
-                X509Certificate2Collection cc2 = new X509Certificate2Collection();
-                cc2.Import(TestData.PfxData, TestData.PfxDataPassword, X509KeyStorageFlags.DefaultKeySet);
-                int count = cc2.Count;
-                Assert.Equal(1, count);
-
-                using (X509Certificate2 c = cc2[0])
+                using (ImportedCollection ic = Cert.Import(TestData.PfxData, TestData.PfxDataPassword, X509KeyStorageFlags.DefaultKeySet))
                 {
-                    // pfxCer was loaded directly, cc2[0] was Imported, two distinct copies.
-                    Assert.NotSame(pfxCer, c);
+                    X509Certificate2Collection cc2 = ic.Collection;
+                    int count = cc2.Count;
+                    Assert.Equal(1, count);
 
-                    Assert.Equal(pfxCer, c);
-                    Assert.Equal(pfxCer.Thumbprint, c.Thumbprint);
+                    using (X509Certificate2 c = cc2[0])
+                    {
+                        // pfxCer was loaded directly, cc2[0] was Imported, two distinct copies.
+                        Assert.NotSame(pfxCer, c);
+
+                        Assert.Equal(pfxCer, c);
+                        Assert.Equal(pfxCer.Thumbprint, c.Thumbprint);
+                    }
                 }
             }
         }
@@ -205,65 +225,73 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void ImportPkcs12File_Single()
         {
-            X509Certificate2Collection cc2 = new X509Certificate2Collection();
-            cc2.Import(Path.Combine("TestData", "My.pfx"), TestData.PfxDataPassword, X509KeyStorageFlags.DefaultKeySet);
-            int count = cc2.Count;
-            Assert.Equal(1, count);
+            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "My.pfx"), TestData.PfxDataPassword, X509KeyStorageFlags.DefaultKeySet))
+            {
+                X509Certificate2Collection cc2 = ic.Collection;
+                int count = cc2.Count;
+                Assert.Equal(1, count);
+            }
         }
 
         [Fact]
         public static void ImportPkcs12Bytes_Chain()
         {
-            X509Certificate2Collection certs = new X509Certificate2Collection();
-            certs.Import(TestData.ChainPfxBytes, TestData.ChainPfxPassword, X509KeyStorageFlags.DefaultKeySet);
-            int count = certs.Count;
-            Assert.Equal(3, count);
+            using (ImportedCollection ic = Cert.Import(TestData.ChainPfxBytes, TestData.ChainPfxPassword, X509KeyStorageFlags.DefaultKeySet))
+            {
+                X509Certificate2Collection certs = ic.Collection;
+                int count = certs.Count;
+                Assert.Equal(3, count);
+            }
         }
 
         [Fact]
         public static void ImportPkcs12File_Chain()
         {
-            X509Certificate2Collection certs = new X509Certificate2Collection();
-            certs.Import(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword, X509KeyStorageFlags.DefaultKeySet);
-            int count = certs.Count;
-            Assert.Equal(3, count);
+            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword, X509KeyStorageFlags.DefaultKeySet))
+            {
+                X509Certificate2Collection certs = ic.Collection;
+                int count = certs.Count;
+                Assert.Equal(3, count);
+            }
         }
 
         [Fact]
         public static void ImportPkcs12File_Chain_VerifyContents()
         {
-            X509Certificate2Collection certs = new X509Certificate2Collection();
-            certs.Import(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword, X509KeyStorageFlags.DefaultKeySet);
-            int count = certs.Count;
-            Assert.Equal(3, count);
-
-            // Verify that the read ordering is consistent across the platforms
-            string[] expectedSubjects =
+            using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword, X509KeyStorageFlags.DefaultKeySet))
             {
+                X509Certificate2Collection certs = ic.Collection;
+                int count = certs.Count;
+                Assert.Equal(3, count);
+
+                // Verify that the read ordering is consistent across the platforms
+                string[] expectedSubjects =
+                {
                 "MS Passport Test Sub CA",
                 "MS Passport Test Root CA",
                 "test.local",
             };
 
-            string[] actualSubjects = certs.OfType<X509Certificate2>().
-                Select(cert => cert.GetNameInfo(X509NameType.SimpleName, false)).
-                ToArray();
+                string[] actualSubjects = certs.OfType<X509Certificate2>().
+                    Select(cert => cert.GetNameInfo(X509NameType.SimpleName, false)).
+                    ToArray();
 
-            Assert.Equal(expectedSubjects, actualSubjects);
+                Assert.Equal(expectedSubjects, actualSubjects);
 
-            // And verify that we have private keys when we expect them
-            bool[] expectedHasPrivateKeys =
-            {
+                // And verify that we have private keys when we expect them
+                bool[] expectedHasPrivateKeys =
+                {
                 false,
                 false,
                 true,
             };
 
-            bool[] actualHasPrivateKeys = certs.OfType<X509Certificate2>().
-                Select(cert => cert.HasPrivateKey).
-                ToArray();
+                bool[] actualHasPrivateKeys = certs.OfType<X509Certificate2>().
+                    Select(cert => cert.HasPrivateKey).
+                    ToArray();
 
-            Assert.Equal(expectedHasPrivateKeys, actualHasPrivateKeys);
+                Assert.Equal(expectedHasPrivateKeys, actualHasPrivateKeys);
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -477,18 +477,20 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
             {
-                X509Certificate2Collection cc2 = new X509Certificate2Collection();
-                cc2.Import(TestData.StoreSavedAsCerData);
-                int count = cc2.Count;
-                Assert.Equal(1, count);
-
-                using (X509Certificate2 c = cc2[0])
+                using (ImportedCollection ic = Cert.Import(TestData.StoreSavedAsCerData))
                 {
-                    // pfxCer was loaded directly, cc2[0] was Imported, two distinct copies.
-                    Assert.NotSame(pfxCer, c);
+                    X509Certificate2Collection cc2 = ic.Collection;
+                    int count = cc2.Count;
+                    Assert.Equal(1, count);
 
-                    Assert.Equal(pfxCer, c);
-                    Assert.Equal(pfxCer.Thumbprint, c.Thumbprint);
+                    using (X509Certificate2 c = cc2[0])
+                    {
+                        // pfxCer was loaded directly, cc2[0] was Imported, two distinct copies.
+                        Assert.NotSame(pfxCer, c);
+
+                        Assert.Equal(pfxCer, c);
+                        Assert.Equal(pfxCer.Thumbprint, c.Thumbprint);
+                    }
                 }
             }
         }
@@ -499,18 +501,20 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
             {
-                X509Certificate2Collection cc2 = new X509Certificate2Collection();
-                cc2.Import(TestData.StoreSavedAsSerializedCerData);
-                int count = cc2.Count;
-                Assert.Equal(1, count);
-
-                using (X509Certificate2 c = cc2[0])
+                using (ImportedCollection ic = Cert.Import(TestData.StoreSavedAsSerializedCerData))
                 {
-                    // pfxCer was loaded directly, cc2[0] was Imported, two distinct copies.
-                    Assert.NotSame(pfxCer, c);
+                    X509Certificate2Collection cc2 = ic.Collection;
+                    int count = cc2.Count;
+                    Assert.Equal(1, count);
 
-                    Assert.Equal(pfxCer, c);
-                    Assert.Equal(pfxCer.Thumbprint, c.Thumbprint);
+                    using (X509Certificate2 c = cc2[0])
+                    {
+                        // pfxCer was loaded directly, cc2[0] was Imported, two distinct copies.
+                        Assert.NotSame(pfxCer, c);
+
+                        Assert.Equal(pfxCer, c);
+                        Assert.Equal(pfxCer.Thumbprint, c.Thumbprint);
+                    }
                 }
             }
         }
@@ -530,10 +534,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             using (var msCer = new X509Certificate2(TestData.MsCertificate))
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
+            using (ImportedCollection ic = Cert.Import(TestData.StoreSavedAsSerializedStoreData))
             {
 
-                X509Certificate2Collection cc2 = new X509Certificate2Collection();
-                cc2.Import(TestData.StoreSavedAsSerializedStoreData);
+                X509Certificate2Collection cc2 = ic.Collection;
                 int count = cc2.Count;
                 Assert.Equal(2, count);
 
@@ -563,9 +567,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             using (var msCer = new X509Certificate2(TestData.MsCertificate))
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
+            using (ImportedCollection ic = Cert.Import(TestData.StoreSavedAsPfxData))
             {
-                X509Certificate2Collection cc2 = new X509Certificate2Collection();
-                cc2.Import(TestData.StoreSavedAsPfxData);
+                X509Certificate2Collection cc2 = ic.Collection;
                 int count = cc2.Count;
                 Assert.Equal(2, count);
 
@@ -592,18 +596,20 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
             {
-                X509Certificate2Collection cc2 = new X509Certificate2Collection();
-                cc2.Import(Path.Combine("TestData" ,"My.pfx"), TestData.PfxDataPassword, X509KeyStorageFlags.DefaultKeySet);
-                int count = cc2.Count;
-                Assert.Equal(1, count);
-
-                using (X509Certificate2 c = cc2[0])
+                using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "My.pfx"), TestData.PfxDataPassword, X509KeyStorageFlags.DefaultKeySet))
                 {
-                    // pfxCer was loaded directly, cc2[0] was Imported, two distinct copies.
-                    Assert.NotSame(pfxCer, c);
+                    X509Certificate2Collection cc2 = ic.Collection;
+                    int count = cc2.Count;
+                    Assert.Equal(1, count);
 
-                    Assert.Equal(pfxCer, c);
-                    Assert.Equal(pfxCer.Thumbprint, c.Thumbprint);
+                    using (X509Certificate2 c = cc2[0])
+                    {
+                        // pfxCer was loaded directly, cc2[0] was Imported, two distinct copies.
+                        Assert.NotSame(pfxCer, c);
+
+                        Assert.Equal(pfxCer, c);
+                        Assert.Equal(pfxCer.Thumbprint, c.Thumbprint);
+                    }
                 }
             }
         }
@@ -612,14 +618,16 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [ActiveIssue(2745, PlatformID.AnyUnix)]
         public static void ImportMultiplePrivateKeysPfx()
         {
-            var collection = new X509Certificate2Collection();
-            collection.Import(TestData.MultiPrivateKeyPfx);
-
-            Assert.Equal(2, collection.Count);
-
-            foreach (X509Certificate2 cert in collection)
+            using (ImportedCollection ic = Cert.Import(TestData.MultiPrivateKeyPfx))
             {
-                Assert.True(cert.HasPrivateKey, "cert.HasPrivateKey");
+                X509Certificate2Collection collection = ic.Collection;
+
+                Assert.Equal(2, collection.Count);
+
+                foreach (X509Certificate2 cert in collection)
+                {
+                    Assert.True(cert.HasPrivateKey, "cert.HasPrivateKey");
+                }
             }
         }
 
@@ -720,28 +728,30 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                 byte[] exported = collection.Export(X509ContentType.Pkcs12);
 
-                var importedCollection = new X509Certificate2Collection();
-                importedCollection.Import(exported);
-
-                // Verify that the two collections contain the same certificates,
-                // but the order isn't really a factor.
-                Assert.Equal(collection.Count, importedCollection.Count);
-
-                // Compare just the subject names first, because it's the easiest thing to read out of the failure message.
-                string[] subjects = new string[collection.Count];
-                string[] importedSubjects = new string[collection.Count];
-
-                for (int i = 0; i < collection.Count; i++)
+                using (ImportedCollection ic = Cert.Import(exported))
                 {
-                    subjects[i] = collection[i].GetNameInfo(X509NameType.SimpleName, false);
-                    importedSubjects[i] = importedCollection[i].GetNameInfo(X509NameType.SimpleName, false);
+                    X509Certificate2Collection importedCollection = ic.Collection;
+
+                    // Verify that the two collections contain the same certificates,
+                    // but the order isn't really a factor.
+                    Assert.Equal(collection.Count, importedCollection.Count);
+
+                    // Compare just the subject names first, because it's the easiest thing to read out of the failure message.
+                    string[] subjects = new string[collection.Count];
+                    string[] importedSubjects = new string[collection.Count];
+
+                    for (int i = 0; i < collection.Count; i++)
+                    {
+                        subjects[i] = collection[i].GetNameInfo(X509NameType.SimpleName, false);
+                        importedSubjects[i] = importedCollection[i].GetNameInfo(X509NameType.SimpleName, false);
+                    }
+
+                    Assert.Equal(subjects, importedSubjects);
+
+                    // But, really, the collections should be equivalent
+                    // (after being coerced to IEnumerable<X509Certificate2>)
+                    Assert.Equal(collection.OfType<X509Certificate2>(), importedCollection.OfType<X509Certificate2>());
                 }
-
-                Assert.Equal(subjects, importedSubjects);
-
-                // But, really, the collections should be equivalent
-                // (after being coerced to IEnumerable<X509Certificate2>)
-                Assert.Equal(collection.OfType<X509Certificate2>(), importedCollection.OfType<X509Certificate2>());
             }
         }
 
@@ -749,11 +759,19 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         public static void MultipleImport()
         {
             var collection = new X509Certificate2Collection();
-
-            collection.Import(Path.Combine("TestData", "DummyTcpServer.pfx"), null, default(X509KeyStorageFlags));
-            collection.Import(TestData.PfxData, TestData.PfxDataPassword, default(X509KeyStorageFlags));
-
-            Assert.Equal(3, collection.Count);
+            try
+            {
+                collection.Import(Path.Combine("TestData", "DummyTcpServer.pfx"), null, default(X509KeyStorageFlags));
+                collection.Import(TestData.PfxData, TestData.PfxDataPassword, default(X509KeyStorageFlags));
+                Assert.Equal(3, collection.Count);
+            }
+            finally
+            {
+                foreach (X509Certificate2 cert in collection)
+                {
+                    cert.Dispose();
+                }
+            }
         }
 
         [Fact]
@@ -763,47 +781,59 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         {
             var collection = new X509Certificate2Collection();
 
-            collection.Import(Path.Combine("TestData", "DummyTcpServer.pfx"), null, X509KeyStorageFlags.Exportable);
-            collection.Import(TestData.PfxData, TestData.PfxDataPassword, X509KeyStorageFlags.Exportable);
-
-            // Pre-condition, we have multiple private keys
-            int originalPrivateKeyCount = collection.OfType<X509Certificate2>().Count(c => c.HasPrivateKey);
-            Assert.Equal(2, originalPrivateKeyCount);
-
-            // Export, re-import.
-            byte[] exported;
-
             try
             {
-                exported = collection.Export(X509ContentType.Pkcs12);
-            }
-            catch (PlatformNotSupportedException)
-            {
-                // [ActiveIssue(2743, PlatformID.AnyUnix)]
-                // Our Unix builds can't export more than one private key in a single PFX, so this is
-                // their exit point.
-                //
-                // If Windows gets here, or any exception other than PlatformNotSupportedException is raised,
-                // let that fail the test.
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                collection.Import(Path.Combine("TestData", "DummyTcpServer.pfx"), null, X509KeyStorageFlags.Exportable);
+                collection.Import(TestData.PfxData, TestData.PfxDataPassword, X509KeyStorageFlags.Exportable);
+
+                // Pre-condition, we have multiple private keys
+                int originalPrivateKeyCount = collection.OfType<X509Certificate2>().Count(c => c.HasPrivateKey);
+                Assert.Equal(2, originalPrivateKeyCount);
+
+                // Export, re-import.
+                byte[] exported;
+
+                try
                 {
-                    throw;
+                    exported = collection.Export(X509ContentType.Pkcs12);
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    // [ActiveIssue(2743, PlatformID.AnyUnix)]
+                    // Our Unix builds can't export more than one private key in a single PFX, so this is
+                    // their exit point.
+                    //
+                    // If Windows gets here, or any exception other than PlatformNotSupportedException is raised,
+                    // let that fail the test.
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        throw;
+                    }
+
+                    return;
                 }
 
-                return;
+                // As the other half of issue 2743, if we make it this far we better be Windows (or remove the catch
+                // above)
+                Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "RuntimeInformation.IsOSPlatform(OSPlatform.Windows)");
+
+                using (ImportedCollection ic = Cert.Import(exported))
+                {
+                    X509Certificate2Collection importedCollection = ic.Collection;
+
+                    Assert.Equal(collection.Count, importedCollection.Count);
+
+                    int importedPrivateKeyCount = importedCollection.OfType<X509Certificate2>().Count(c => c.HasPrivateKey);
+                    Assert.Equal(originalPrivateKeyCount, importedPrivateKeyCount);
+                }
             }
-
-            // As the other half of issue 2743, if we make it this far we better be Windows (or remove the catch
-            // above)
-            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "RuntimeInformation.IsOSPlatform(OSPlatform.Windows)");
-
-            var importedCollection = new X509Certificate2Collection();
-            importedCollection.Import(exported);
-
-            Assert.Equal(collection.Count, importedCollection.Count);
-
-            int importedPrivateKeyCount = importedCollection.OfType<X509Certificate2>().Count(c => c.HasPrivateKey);
-            Assert.Equal(originalPrivateKeyCount, importedPrivateKeyCount);
+            finally
+            {
+                foreach (X509Certificate2 cert in collection)
+                {
+                    cert.Dispose();
+                }
+            }
         }
 
         [Fact]
@@ -1324,17 +1354,19 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                 Assert.Equal(ct, X509Certificate2.GetCertContentType(blob));
 
-                X509Certificate2Collection cc2 = new X509Certificate2Collection();
-                cc2.Import(blob);
-                int count = cc2.Count;
-                Assert.Equal(1, count);
-
-                using (X509Certificate2 c = cc2[0])
+                using (ImportedCollection ic = Cert.Import(blob))
                 {
-                    Assert.NotSame(msCer, c);
-                    Assert.NotSame(pfxCer, c);
+                    X509Certificate2Collection cc2 = ic.Collection;
+                    int count = cc2.Count;
+                    Assert.Equal(1, count);
 
-                    Assert.True(msCer.Equals(c) || pfxCer.Equals(c));
+                    using (X509Certificate2 c = cc2[0])
+                    {
+                        Assert.NotSame(msCer, c);
+                        Assert.NotSame(pfxCer, c);
+
+                        Assert.True(msCer.Equals(c) || pfxCer.Equals(c));
+                    }
                 }
             }
         }
@@ -1350,23 +1382,25 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                 Assert.Equal(ct, X509Certificate2.GetCertContentType(blob));
 
-                X509Certificate2Collection cc2 = new X509Certificate2Collection();
-                cc2.Import(blob);
-                int count = cc2.Count;
-                Assert.Equal(2, count);
-
-                X509Certificate2[] cs = cc2.ToArray().OrderBy(c => c.Subject).ToArray();
-
-                using (X509Certificate2 first = cs[0])
+                using (ImportedCollection ic = Cert.Import(blob))
                 {
-                    Assert.NotSame(msCer, first);
-                    Assert.Equal(msCer, first);
-                }
+                    X509Certificate2Collection cc2 = ic.Collection;
+                    int count = cc2.Count;
+                    Assert.Equal(2, count);
 
-                using (X509Certificate2 second = cs[1])
-                {
-                    Assert.NotSame(pfxCer, second);
-                    Assert.Equal(pfxCer, second);
+                    X509Certificate2[] cs = cc2.ToArray().OrderBy(c => c.Subject).ToArray();
+
+                    using (X509Certificate2 first = cs[0])
+                    {
+                        Assert.NotSame(msCer, first);
+                        Assert.Equal(msCer, first);
+                    }
+
+                    using (X509Certificate2 second = cs[1])
+                    {
+                        Assert.NotSame(pfxCer, second);
+                        Assert.Equal(pfxCer, second);
+                    }
                 }
             }
         }

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -24,6 +24,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Cert.cs" />
     <Compile Include="CertTests.cs" />
     <Compile Include="ChainTests.cs" />
     <Compile Include="CollectionImportTests.cs" />


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/2583

And fixes the one out of every four runs key leaks. The culprit was the tests calling X509Certificate2Collection.Import(), which is the other way to load PFX's. These were being finalized rather than disposed so that leaks happened depending on how savage the process shutdown is in interrupting finalizers.

The tests now synchronize all PFX loads and wrap imported collections in a IDisposable object for easier cleanup.