### PR TITLE
Fix a bug in SqlDataReader.InvokeRetryable where task exceptions aren't being propagated.

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
@@ -4391,9 +4391,7 @@ namespace System.Data.SqlClient
 
                 if (task.IsCompleted)
                 {
-                    // If we've completed sync, then don't bother handling the TaskCompletionSource - we'll just return the completed task
                     CompleteRetryable(task, source, objectToDispose);
-                    return task;
                 }
                 else
                 {


### PR DESCRIPTION
NextResultAsync calls InvokeRetryable, which calls the CompleteRetryable method to set a TaskCompletionSource's task info. The bug here is that when an exception was thrown by an internal task, the Source's task would have its exception set but the internal task would get returned instead. So the Source task's exception would get reported as unobserved during garbage collection.