### PR TITLE
Re-enable dictionary tests for EventSource

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
@@ -218,7 +218,6 @@ namespace BasicEventSourceTests
                 var dictInt = new Dictionary<string, int>() { { "elem1", 10 }, { "elem2", 20 } };
 
                 /*************************************************************************/
-#if false   // TODO: enable when dictionary events are working again. GitHub issue #4867.
                 tests.Add(new SubTest("Write/Dict/EventWithStringDict_C",
                     delegate()
                     {
@@ -297,7 +296,6 @@ namespace BasicEventSourceTests
 
                         Assert.Equal(evt.PayloadValue(2, "s"), "end");
                     }));
-#endif // false
                 /*************************************************************************/
                 /**************************** Empty Event TESTING ************************/
                 /*************************************************************************/


### PR DESCRIPTION
Dictionary tests were ifdefed out because they were not working, but at some point since #4867 was filed the issue was fixed, so it's time to turn the tests back on.