### PR TITLE
Fix XmlAttributes.Remove behavior difference

### DIFF
--- a/src/System.Xml.XmlSerializer/src/Resources/Strings.resx
+++ b/src/System.Xml.XmlSerializer/src/Resources/Strings.resx
@@ -693,4 +693,7 @@
   <data name="Xml_MissingSerializationCodeException" xml:space="preserve">
     <value>Type '{0}' cannot be serialized by XmlSerializer, serialization code for the type is missing. Consult the SDK documentation for adding it as a root serialization type. http://go.microsoft.com/fwlink/?LinkId=613136</value>
   </data>
+  <data name="Arg_RemoveArgNotFound" xml:space="preserve">
+    <value>Cannot remove the specified item because it was not found in the specified Collection.</value>
+  </data>
 </root>

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlAnyElementAttributes.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlAnyElementAttributes.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
 using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 
 
 namespace System.Xml.Serialization
@@ -17,7 +14,7 @@ namespace System.Xml.Serialization
     /// </devdoc>
     public class XmlAnyElementAttributes : IList
     {
-        private List<object> _list;
+        private List<XmlAnyElementAttribute> _list = new List<XmlAnyElementAttribute>();
 
         /// <include file='doc\XmlAnyElementAttributes.uex' path='docs/doc[@for="XmlAnyElementAttributes.this"]/*' />
         /// <devdoc>
@@ -25,53 +22,81 @@ namespace System.Xml.Serialization
         /// </devdoc>
         public XmlAnyElementAttribute this[int index]
         {
-            get { return (XmlAnyElementAttribute)List[index]; }
-            set { List[index] = value; }
+            get { return _list[index]; }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                _list[index] = value;
+            }
         }
 
         /// <include file='doc\XmlAnyElementAttributes.uex' path='docs/doc[@for="XmlAnyElementAttributes.Add"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public int Add(XmlAnyElementAttribute attribute)
+        public int Add(XmlAnyElementAttribute value)
         {
-            return List.Add(attribute);
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            int index = _list.Count;
+            _list.Add(value);
+            return index;
         }
 
         /// <include file='doc\XmlAnyElementAttributes.uex' path='docs/doc[@for="XmlAnyElementAttributes.Insert"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public void Insert(int index, XmlAnyElementAttribute attribute)
+        public void Insert(int index, XmlAnyElementAttribute value)
         {
-            List.Insert(index, attribute);
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            _list.Insert(index, value);
         }
 
         /// <include file='doc\XmlAnyElementAttributes.uex' path='docs/doc[@for="XmlAnyElementAttributes.IndexOf"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public int IndexOf(XmlAnyElementAttribute attribute)
+        public int IndexOf(XmlAnyElementAttribute value)
         {
-            return List.IndexOf(attribute);
+            return _list.IndexOf(value);
         }
 
         /// <include file='doc\XmlAnyElementAttributes.uex' path='docs/doc[@for="XmlAnyElementAttributes.Contains"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public bool Contains(XmlAnyElementAttribute attribute)
+        public bool Contains(XmlAnyElementAttribute value)
         {
-            return List.Contains(attribute);
+            return _list.Contains(value);
         }
 
         /// <include file='doc\XmlAnyElementAttributes.uex' path='docs/doc[@for="XmlAnyElementAttributes.Remove"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public void Remove(XmlAnyElementAttribute attribute)
+        public void Remove(XmlAnyElementAttribute value)
         {
-            List.Remove(attribute);
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (!_list.Remove(value))
+            {
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+            }
         }
 
         /// <include file='doc\XmlAnyElementAttributes.uex' path='docs/doc[@for="XmlAnyElementAttributes.CopyTo"]/*' />
@@ -80,21 +105,12 @@ namespace System.Xml.Serialization
         /// </devdoc>
         public void CopyTo(XmlAnyElementAttribute[] array, int index)
         {
-            List.CopyTo(array, index);
-        }
-        private List<object> InnerList
-        {
-            get
-            {
-                if (_list == null)
-                    _list = new List<object>();
-                return _list;
-            }
+            _list.CopyTo(array, index);
         }
 
         private IList List
         {
-            get { return InnerList; }
+            get { return _list; }
         }
 
         public int Count
@@ -107,32 +123,32 @@ namespace System.Xml.Serialization
 
         public void Clear()
         {
-            InnerList.Clear();
+            _list.Clear();
         }
 
         public void RemoveAt(int index)
         {
-            InnerList.RemoveAt(index);
+            _list.RemoveAt(index);
         }
 
         bool IList.IsReadOnly
         {
-            get { return false; }
+            get { return List.IsReadOnly; }
         }
 
         bool IList.IsFixedSize
         {
-            get { return false; }
+            get { return List.IsFixedSize; }
         }
 
         bool ICollection.IsSynchronized
         {
-            get { return false; }
+            get { return List.IsSynchronized; }
         }
 
         Object ICollection.SyncRoot
         {
-            get { throw new NotSupportedException(); }
+            get { return List.SyncRoot; }
         }
 
         void ICollection.CopyTo(Array array, int index)
@@ -144,43 +160,67 @@ namespace System.Xml.Serialization
         {
             get
             {
-                return InnerList[index];
+                return List[index];
             }
             set
             {
-                InnerList[index] = value;
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                List[index] = value;
             }
         }
 
         bool IList.Contains(Object value)
         {
-            return InnerList.Contains(value);
+            return List.Contains(value);
         }
 
         int IList.Add(Object value)
         {
+            if (value == null)
+            {
+                throw new ArgumentException(nameof(value));
+            }
+
             return List.Add(value);
         }
 
         void IList.Remove(Object value)
         {
-            int index = InnerList.IndexOf(value);
-            InnerList.RemoveAt(index);
+            if (value == null)
+            {
+                throw new ArgumentException(nameof(value));
+            }
+
+            var attribute = value as XmlAnyElementAttribute;
+            if (attribute == null)
+            {
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+            }
+            Remove(attribute);
         }
 
         int IList.IndexOf(Object value)
         {
-            return InnerList.IndexOf(value);
+            return List.IndexOf(value);
         }
 
         void IList.Insert(int index, Object value)
         {
-            InnerList.Insert(index, value);
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            List.Insert(index, value);
         }
 
         public IEnumerator GetEnumerator()
         {
-            return InnerList.GetEnumerator();
+            return List.GetEnumerator();
         }
     }
 }

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlArrayItemAttributes.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlArrayItemAttributes.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
 using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 
 
 namespace System.Xml.Serialization
@@ -17,7 +14,7 @@ namespace System.Xml.Serialization
     /// </devdoc>
     public class XmlArrayItemAttributes : IList
     {
-        private List<object> _list;
+        private List<XmlArrayItemAttribute> _list = new List<XmlArrayItemAttribute>();
 
         /// <include file='doc\XmlArrayItemAttributes.uex' path='docs/doc[@for="XmlArrayItemAttributes.this"]/*' />
         /// <devdoc>
@@ -25,53 +22,81 @@ namespace System.Xml.Serialization
         /// </devdoc>
         public XmlArrayItemAttribute this[int index]
         {
-            get { return (XmlArrayItemAttribute)List[index]; }
-            set { List[index] = value; }
+            get { return _list[index]; }
+            set
+            {
+                if (value  == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                _list[index] = value;
+            }
         }
 
         /// <include file='doc\XmlArrayItemAttributes.uex' path='docs/doc[@for="XmlArrayItemAttributes.Add"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public int Add(XmlArrayItemAttribute attribute)
+        public int Add(XmlArrayItemAttribute value)
         {
-            return List.Add(attribute);
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            int index = _list.Count;
+            _list.Add(value);
+            return index;
         }
 
         /// <include file='doc\XmlArrayItemAttributes.uex' path='docs/doc[@for="XmlArrayItemAttributes.Insert"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public void Insert(int index, XmlArrayItemAttribute attribute)
+        public void Insert(int index, XmlArrayItemAttribute value)
         {
-            List.Insert(index, attribute);
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            _list.Insert(index, value);
         }
 
         /// <include file='doc\XmlArrayItemAttributes.uex' path='docs/doc[@for="XmlArrayItemAttributes.IndexOf"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public int IndexOf(XmlArrayItemAttribute attribute)
+        public int IndexOf(XmlArrayItemAttribute value)
         {
-            return List.IndexOf(attribute);
+            return _list.IndexOf(value);
         }
 
         /// <include file='doc\XmlArrayItemAttributes.uex' path='docs/doc[@for="XmlArrayItemAttributes.Contains"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public bool Contains(XmlArrayItemAttribute attribute)
+        public bool Contains(XmlArrayItemAttribute value)
         {
-            return List.Contains(attribute);
+            return _list.Contains(value);
         }
 
         /// <include file='doc\XmlArrayItemAttributes.uex' path='docs/doc[@for="XmlArrayItemAttributes.Remove"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public void Remove(XmlArrayItemAttribute attribute)
+        public void Remove(XmlArrayItemAttribute value)
         {
-            List.Remove(attribute);
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (!_list.Remove(value))
+            {
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+            }
         }
 
         /// <include file='doc\XmlArrayItemAttributes.uex' path='docs/doc[@for="XmlArrayItemAttributes.CopyTo"]/*' />
@@ -80,21 +105,12 @@ namespace System.Xml.Serialization
         /// </devdoc>
         public void CopyTo(XmlArrayItemAttribute[] array, int index)
         {
-            List.CopyTo(array, index);
-        }
-        private List<object> InnerList
-        {
-            get
-            {
-                if (_list == null)
-                    _list = new List<object>();
-                return _list;
-            }
+            _list.CopyTo(array, index);
         }
 
         private IList List
         {
-            get { return InnerList; }
+            get { return _list; }
         }
 
         public int Count
@@ -107,32 +123,32 @@ namespace System.Xml.Serialization
 
         public void Clear()
         {
-            InnerList.Clear();
+            _list.Clear();
         }
 
         public void RemoveAt(int index)
         {
-            InnerList.RemoveAt(index);
+            _list.RemoveAt(index);
         }
 
         bool IList.IsReadOnly
         {
-            get { return false; }
+            get { return List.IsReadOnly; }
         }
 
         bool IList.IsFixedSize
         {
-            get { return false; }
+            get { return List.IsFixedSize; }
         }
 
         bool ICollection.IsSynchronized
         {
-            get { return false; }
+            get { return List.IsSynchronized; }
         }
 
         Object ICollection.SyncRoot
         {
-            get { throw new NotSupportedException(); }
+            get { return List.SyncRoot; }
         }
 
         void ICollection.CopyTo(Array array, int index)
@@ -144,43 +160,67 @@ namespace System.Xml.Serialization
         {
             get
             {
-                return InnerList[index];
+                return List[index];
             }
             set
             {
-                InnerList[index] = value;
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                List[index] = value;
             }
         }
 
         bool IList.Contains(Object value)
         {
-            return InnerList.Contains(value);
+            return List.Contains(value);
         }
 
         int IList.Add(Object value)
         {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
             return List.Add(value);
         }
 
         void IList.Remove(Object value)
         {
-            int index = InnerList.IndexOf(value);
-            InnerList.RemoveAt(index);
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            var attribute = value as XmlArrayItemAttribute;
+            if (attribute == null)
+            {
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+            }
+            Remove(attribute);
         }
 
         int IList.IndexOf(Object value)
         {
-            return InnerList.IndexOf(value);
+            return List.IndexOf(value);
         }
 
         void IList.Insert(int index, Object value)
         {
-            InnerList.Insert(index, value);
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            List.Insert(index, value);
         }
 
         public IEnumerator GetEnumerator()
         {
-            return InnerList.GetEnumerator();
+            return List.GetEnumerator();
         }
     }
 }

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlElementAttributes.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlElementAttributes.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
 using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 
 
 namespace System.Xml.Serialization
@@ -17,7 +14,7 @@ namespace System.Xml.Serialization
     /// </devdoc>
     public class XmlElementAttributes : IList
     {
-        private List<object> _list;
+        private List<XmlElementAttribute> _list = new List<XmlElementAttribute>();
 
         /// <include file='doc\XmlElementAttributes.uex' path='docs/doc[@for="XmlElementAttributes.this"]/*' />
         /// <devdoc>
@@ -25,53 +22,81 @@ namespace System.Xml.Serialization
         /// </devdoc>
         public XmlElementAttribute this[int index]
         {
-            get { return (XmlElementAttribute)List[index]; }
-            set { List[index] = value; }
+            get { return _list[index]; }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                _list[index] = value;
+            }
         }
 
         /// <include file='doc\XmlElementAttributes.uex' path='docs/doc[@for="XmlElementAttributes.Add"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public int Add(XmlElementAttribute attribute)
+        public int Add(XmlElementAttribute value)
         {
-            return List.Add(attribute);
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            int index = _list.Count;
+            _list.Add(value);
+            return index;
         }
 
         /// <include file='doc\XmlElementAttributes.uex' path='docs/doc[@for="XmlElementAttributes.Insert"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public void Insert(int index, XmlElementAttribute attribute)
+        public void Insert(int index, XmlElementAttribute value)
         {
-            List.Insert(index, attribute);
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            _list.Insert(index, value);
         }
 
         /// <include file='doc\XmlElementAttributes.uex' path='docs/doc[@for="XmlElementAttributes.IndexOf"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public int IndexOf(XmlElementAttribute attribute)
+        public int IndexOf(XmlElementAttribute value)
         {
-            return List.IndexOf(attribute);
+            return _list.IndexOf(value);
         }
 
         /// <include file='doc\XmlElementAttributes.uex' path='docs/doc[@for="XmlElementAttributes.Contains"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public bool Contains(XmlElementAttribute attribute)
+        public bool Contains(XmlElementAttribute value)
         {
-            return List.Contains(attribute);
+            return _list.Contains(value);
         }
 
         /// <include file='doc\XmlElementAttributes.uex' path='docs/doc[@for="XmlElementAttributes.Remove"]/*' />
         /// <devdoc>
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
-        public void Remove(XmlElementAttribute attribute)
+        public void Remove(XmlElementAttribute value)
         {
-            List.Remove(attribute);
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (!_list.Remove(value))
+            {
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+            }
         }
 
         /// <include file='doc\XmlElementAttributes.uex' path='docs/doc[@for="XmlElementAttributes.CopyTo"]/*' />
@@ -80,21 +105,12 @@ namespace System.Xml.Serialization
         /// </devdoc>
         public void CopyTo(XmlElementAttribute[] array, int index)
         {
-            List.CopyTo(array, index);
-        }
-        private List<object> InnerList
-        {
-            get
-            {
-                if (_list == null)
-                    _list = new List<object>();
-                return _list;
-            }
+            _list.CopyTo(array, index);
         }
 
         private IList List
         {
-            get { return InnerList; }
+            get { return _list; }
         }
 
         public int Count
@@ -107,32 +123,32 @@ namespace System.Xml.Serialization
 
         public void Clear()
         {
-            InnerList.Clear();
+            _list.Clear();
         }
 
         public void RemoveAt(int index)
         {
-            InnerList.RemoveAt(index);
+            _list.RemoveAt(index);
         }
 
         bool IList.IsReadOnly
         {
-            get { return false; }
+            get { return List.IsReadOnly; }
         }
 
         bool IList.IsFixedSize
         {
-            get { return false; }
+            get { return List.IsFixedSize; }
         }
 
         bool ICollection.IsSynchronized
         {
-            get { return false; }
+            get { return List.IsSynchronized; }
         }
 
         Object ICollection.SyncRoot
         {
-            get { throw new NotSupportedException(); }
+            get { return List.SyncRoot; }
         }
 
         void ICollection.CopyTo(Array array, int index)
@@ -144,43 +160,67 @@ namespace System.Xml.Serialization
         {
             get
             {
-                return InnerList[index];
+                return List[index];
             }
             set
             {
-                InnerList[index] = value;
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                List[index] = value;
             }
         }
 
         bool IList.Contains(Object value)
         {
-            return InnerList.Contains(value);
+            return List.Contains(value);
         }
 
         int IList.Add(Object value)
         {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
             return List.Add(value);
         }
 
         void IList.Remove(Object value)
         {
-            int index = InnerList.IndexOf(value);
-            InnerList.RemoveAt(index);
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            var attribute = value as XmlElementAttribute;
+            if (attribute == null)
+            {
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+            }
+            Remove(attribute);
         }
 
         int IList.IndexOf(Object value)
         {
-            return InnerList.IndexOf(value);
+            return List.IndexOf(value);
         }
 
         void IList.Insert(int index, Object value)
         {
-            InnerList.Insert(index, value);
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            List.Insert(index, value);
         }
 
         public IEnumerator GetEnumerator()
         {
-            return InnerList.GetEnumerator();
+            return List.GetEnumerator();
         }
     }
 }

--- a/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
+++ b/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
@@ -1681,6 +1681,102 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         }
     }
 
+    [Fact]
+    public static void Xml_XmlAttributes_RemoveXmlElementAttribute()
+    {
+        XmlAttributes attrs = new XmlAttributes();
+
+        XmlElementAttribute item = new XmlElementAttribute("elem1");
+        attrs.XmlElements.Add(item);
+        Assert.True(attrs.XmlElements.Contains(item));
+
+        attrs.XmlElements.Remove(item);
+        Assert.False(attrs.XmlElements.Contains(item));
+    }
+
+    [Fact]
+    public static void Xml_XmlAttributes_RemoveXmlElementAttribute_ThrowsOnMissingItem()
+    {
+        XmlAttributes attrs = new XmlAttributes();
+
+        XmlElementAttribute item1 = new XmlElementAttribute("elem1");
+        attrs.XmlElements.Add(item1);
+
+        XmlElementAttribute item2 = new XmlElementAttribute("elem2");
+        attrs.XmlElements.Add(item2);
+        Assert.True(attrs.XmlElements.Contains(item1));
+        Assert.True(attrs.XmlElements.Contains(item2));
+
+        attrs.XmlElements.Remove(item2);
+        Assert.False(attrs.XmlElements.Contains(item2));
+
+        Assert.Throws<ArgumentException>(() => { attrs.XmlElements.Remove(item2); });
+    }
+
+    [Fact]
+    public static void Xml_XmlAttributes_RemoveXmlArrayItemAttribute()
+    {
+        XmlAttributes attrs = new XmlAttributes();
+
+        XmlArrayItemAttribute item = new XmlArrayItemAttribute("item1");
+        attrs.XmlArrayItems.Add(item);
+        Assert.True(attrs.XmlArrayItems.Contains(item));
+
+        attrs.XmlArrayItems.Remove(item);
+        Assert.False(attrs.XmlArrayItems.Contains(item));
+    }
+
+    [Fact]
+    public static void Xml_XmlAttributes_RemoveXmlArrayItemAttribute_ThrowsOnMissingItem()
+    {
+        XmlAttributes attrs = new XmlAttributes();
+
+        XmlArrayItemAttribute item1 = new XmlArrayItemAttribute("item1");
+        attrs.XmlArrayItems.Add(item1);
+
+        XmlArrayItemAttribute item2 = new XmlArrayItemAttribute("item2");
+        attrs.XmlArrayItems.Add(item2);
+        Assert.True(attrs.XmlArrayItems.Contains(item1));
+        Assert.True(attrs.XmlArrayItems.Contains(item2));
+
+        attrs.XmlArrayItems.Remove(item2);
+        Assert.False(attrs.XmlArrayItems.Contains(item2));
+
+        Assert.Throws<ArgumentException>(() => { attrs.XmlArrayItems.Remove(item2); });
+    }
+
+    [Fact]
+    public static void Xml_XmlAttributes_RemoveXmlAnyElementAttribute()
+    {
+        XmlAttributes attrs = new XmlAttributes();
+
+        XmlAnyElementAttribute item = new XmlAnyElementAttribute("elem1");
+        attrs.XmlAnyElements.Add(item);
+        Assert.True(attrs.XmlAnyElements.Contains(item));
+
+        attrs.XmlAnyElements.Remove(item);
+        Assert.False(attrs.XmlAnyElements.Contains(item));
+    }
+
+    [Fact]
+    public static void Xml_XmlAttributes_RemoveXmlAnyElementAttributeThrowsOnMissingItem()
+    {
+        XmlAttributes attrs = new XmlAttributes();
+
+        XmlAnyElementAttribute item1 = new XmlAnyElementAttribute("elem1");
+        attrs.XmlAnyElements.Add(item1);
+
+        XmlAnyElementAttribute item2 = new XmlAnyElementAttribute("elem2");
+        attrs.XmlAnyElements.Add(item2);
+        Assert.True(attrs.XmlAnyElements.Contains(item1));
+        Assert.True(attrs.XmlAnyElements.Contains(item2));
+
+        attrs.XmlAnyElements.Remove(item2);
+        Assert.False(attrs.XmlAnyElements.Contains(item2));
+
+        Assert.Throws<ArgumentException>(() => { attrs.XmlAnyElements.Remove(item2); });
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, Func<XmlSerializer> serializerFactory = null,
         bool skipStringCompare = false, XmlSerializerNamespaces xns = null)
     {


### PR DESCRIPTION
- The issue is due to implementation difference XmlAttributes.Remove throws on Desktop if item is not found whereas there is no exception on CoreCLR. 
- Since we don't want to update XmlAttributes back to legacy type CollectionBase, I'm changing these XmlAttributes type to derive from generic List<> and override Remove() method to throw on missing item.
- Fix #5831 and also #7837

cc: @SGuyGe @zhenlan @shmao 