### PR TITLE
Import XML comments for System.Resources.Reader

### DIFF
--- a/src/System.Resources.Reader/ref/System.Resources.Reader.cs
+++ b/src/System.Resources.Reader/ref/System.Resources.Reader.cs
@@ -8,11 +8,40 @@
 
 namespace System.Resources
 {
+    /// <summary>
+    /// Enumerates the resources in a binary resources (.resources) file by reading sequential resource
+    /// name/value pairs.Security Note: Calling methods in this class with untrusted data is a security
+    /// risk. Call the methods in the class only with trusted data. For more information, see Untrusted Data
+    /// Security Risks.
+    /// </summary>
     public sealed partial class ResourceReader : System.IDisposable
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResourceReader" /> class for
+        /// the specified stream.
+        /// </summary>
+        /// <param name="stream">The input stream for reading resources.</param>
+        /// <exception cref="ArgumentException">The <paramref name="stream" /> parameter is not readable.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="stream" /> parameter is null.</exception>
+        /// <exception cref="IO.IOException">
+        /// An I/O error has occurred while accessing <paramref name="stream" />.
+        /// </exception>
         [System.Security.SecurityCriticalAttribute]
         public ResourceReader(System.IO.Stream stream) { }
+        /// <summary>
+        /// Releases all resources used by the current instance of the <see cref="ResourceReader" />
+        /// class.
+        /// </summary>
         public void Dispose() { }
+        /// <summary>
+        /// Returns an enumerator for this <see cref="ResourceReader" /> object.
+        /// </summary>
+        /// <returns>
+        /// An enumerator for this <see cref="ResourceReader" /> object.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The reader has been closed or disposed, and cannot be accessed.
+        /// </exception>
         public System.Collections.IDictionaryEnumerator GetEnumerator() { return default(System.Collections.IDictionaryEnumerator); }
     }
 }


### PR DESCRIPTION
/cc @cartermp @Priya91 

Notice that here the Simplifier simplified System.IO.IOException to IO.IOException because the ref source code doesn't have the using statements. Is that what we want?