### PR TITLE
[README.md] ASP.NET 5 -> Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,5 +79,5 @@ There are many .NET related projects on GitHub.
 
 - The [.NET home repo](https://github.com/Microsoft/dotnet) links to 100s of .NET projects, from Microsoft and the community.
 - The [.NET Core repo](https://github.com/dotnet/core) links to .NET Core related projects from Microsoft.
-- The [ASP.NET home repo](https://github.com/aspnet/home) is the best place to start learning about ASP.NET 5.
+- The [ASP.NET home repo](https://github.com/aspnet/home) is the best place to start learning about ASP.NET Core.
 - [dotnet.github.io](http://dotnet.github.io) is a good place to discover .NET Foundation projects.


### PR DESCRIPTION
Noticed that the README referenced ASP.NET 5 instead of ASP.NET Core, which is its new name. Here's a PR that changes it to Core.