### PR TITLE
Fix PLINQ partitioning test that misses data

### DIFF
--- a/src/System.Linq.Parallel/tests/Helpers/CustomPartitioners.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/CustomPartitioners.cs
@@ -99,7 +99,7 @@ namespace System.Linq.Parallel.Tests
         public override IList<IEnumerator<KeyValuePair<long, int>>> GetOrderablePartitions(int partitionCount)
         {
             IEnumerator<KeyValuePair<long, int>>[] partitions = new IEnumerator<KeyValuePair<long, int>>[partitionCount];
-            int partitionSize = Math.Max(1, _count / partitionCount);
+            int partitionSize = Math.Max(1, (int)Math.Ceiling(_count / (double)partitionCount));
             for (int i = 0; i < partitionCount; i++)
             {
                 int start = partitionSize * i;


### PR DESCRIPTION
When the number of elements wasn't evenly divisible by the number of partitions, some elements would end up not being included, which would cause the test to fail.  And since the number of partitions is by default based on Environment.ProcessorCount and the test is using 1024 elements, the test would pass on machines with a power-of-2 number of cores, but fail on machines with 6 or 12 cores.

Fixes https://github.com/dotnet/corefx/issues/8324
cc: @AlfredoMS, @MattGal 