### PR TITLE
Change output path of TinyAssembly.dll to fix execution on Helix

### DIFF
--- a/src/System.Reflection.TypeExtensions/tests/CoreCLR/System.Reflection.TypeExtensions.CoreCLR.Tests.csproj
+++ b/src/System.Reflection.TypeExtensions/tests/CoreCLR/System.Reflection.TypeExtensions.CoreCLR.Tests.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\..\Common\tests\Data\TinyAssembly.dll">
-      <Link>Module\TinyAssembly.dll</Link>
+      <Link>TinyAssembly.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
.NET Helix honors the output path, local execution "flattens" it..  leading to failure to load the DLL.

In my testing (CI for the PR will validate) this has no effect on local execution, and fixes the test for distributed runs.