### PR TITLE
Override CleanAllProjects instead of Clean in build.proj

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -138,8 +138,8 @@
   <!-- Override RestorePackages from dir.traversal.targets and do a batch restore -->
   <Target Name="RestorePackages" DependsOnTargets="BatchRestorePackages" />
 
-  <!-- Override clean from dir.traversal.targets and just remove the full BinDir -->
-  <Target Name="Clean">
+  <!-- Override CleanAllProjects from dir.traversal.targets and just remove the full BinDir -->
+  <Target Name="CleanAllProjects">
     <RemoveDir Directories="$(BinDir)" />
   </Target>
 


### PR DESCRIPTION
Prior to this change, build.proj overrode the Clean target
directly which did not honor TraversalCleanDependsOn.  This
meant other repo's could not customize the behavior of
a clean, either via Clean.cmd or 'build /t:clean'.

With this change, other repo's can add custom build targets
to TraversalCleanDependsOn to do pre- or post- clean handling.
WCF in particular requires this.