### PR TITLE
Fix GetAscii Test with "."

### DIFF
--- a/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingGetAsciiTests.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingGetAsciiTests.cs
@@ -15,6 +15,12 @@ namespace System.Globalization.Tests
             for (int i = 0x20; i < 0x7F; i++)
             {
                 char c = (char)i;
+                
+                // We test '.' separately
+                if (c == '.') 
+                {
+                    continue; 
+                }
                 string ascii = c.ToString();
                 // [ActiveIssue(8242, PlatformId.AnyUnix)]
                 if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -23,12 +29,12 @@ namespace System.Globalization.Tests
                     {
                         yield return new object[] { ascii, 0, 1, ascii.ToLower() };
                     }
-                    else if (c != '-' && (c != '.' || !RuntimeInformation.IsOSPlatform(OSPlatform.OSX)))
+                    else if (c != '-')
                     {
                         yield return new object[] { ascii, 0, 1, ascii };
                     }
                 }
-                else if (c != '.')
+                else
                 {
                     yield return new object[] { ascii, 0, 1, ascii };
                 }
@@ -77,6 +83,25 @@ namespace System.Globalization.Tests
                 Assert.Equal(expected, new IdnMapping().GetAscii(unicode, index));
             }
             Assert.Equal(expected, new IdnMapping().GetAscii(unicode, index, count));
+        }
+        
+        [Fact]
+        public void TestGetAsciiWithDot()
+        {
+            string result = "";
+            Exception ex = Record.Exception(()=> result = new IdnMapping().GetAscii("."));
+            
+            if (ex == null)
+            {
+                // Windows and OSX always throw exception. some versions of Linux succeed and others throw exception   
+                Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+                Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
+                Assert.Equal(result, ".");
+            }
+            else
+            {
+                Assert.True(ex is ArgumentException);
+            }
         }
 
         public static IEnumerable<object[]> GetAscii_Invalid_TestData()


### PR DESCRIPTION
Some Linux versions accept "." and process it and some doesn't
the change here is to make the test reliable when running on any platform