### PR TITLE
Make win8 ARM clrcompression pkg

### DIFF
--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
@@ -31,7 +31,7 @@
       <OSGroup>Windows_NT</OSGroup>
       <Platform>amd64</Platform>
     </Project>
-    <Project Include="win7\runtime.native.System.IO.Compression.pkgproj">
+    <Project Include="win8\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
       <Platform>arm</Platform>
     </Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
@@ -29,22 +29,22 @@
       <Platform>amd64</Platform>
     </ProjectReference>
     <ProjectReference Include="win7\runtime.native.System.IO.Compression.pkgproj">
-      <Platform>amd64</Platform>
-    </ProjectReference>
-    <ProjectReference Include="win7\runtime.native.System.IO.Compression.pkgproj">
-      <Platform>arm</Platform>
-    </ProjectReference>
-    <ProjectReference Include="win7\runtime.native.System.IO.Compression.pkgproj">
       <Platform>x86</Platform>
     </ProjectReference>
-    <ProjectReference Include="win10\runtime.native.System.IO.Compression.pkgproj">
+    <ProjectReference Include="win7\runtime.native.System.IO.Compression.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
-    <ProjectReference Include="win10\runtime.native.System.IO.Compression.pkgproj">
+    <ProjectReference Include="win8\runtime.native.System.IO.Compression.pkgproj">
       <Platform>arm</Platform>
     </ProjectReference>
     <ProjectReference Include="win10\runtime.native.System.IO.Compression.pkgproj">
       <Platform>x86</Platform>
+    </ProjectReference>
+    <ProjectReference Include="win10\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="win10\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>arm</Platform>
     </ProjectReference>
   </ItemGroup>
 

--- a/src/Native/pkg/runtime.native.System.IO.Compression/win8/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/win8/runtime.native.System.IO.Compression.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+    <PropertyGroup>
+        <Version>4.0.1</Version>
+        <PackageTargetRuntime>win8-$(PackagePlatform)</PackageTargetRuntime>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <File Include="$(WinNativePath)\clrcompression.dll">
+            <TargetPath>runtimes/win8-$(PackagePlatform)/native</TargetPath>
+        </File>
+    </ItemGroup>
+
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
win7-arm is not a valid RID. This commit removes that package and replaces it with an equivalent win8-arm package.

resolves #7436

@weshaggard @ericstj 