### PR TITLE
Add import workaround for Crypt.Algo tests

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/tests/project.json
+++ b/src/System.Security.Cryptography.Algorithms/tests/project.json
@@ -21,7 +21,7 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": "portable-net45+win8"
+      "imports": [ "netstandard1.6", "portable-net45+win8" ]
     }
   },
   "runtimes": {


### PR DESCRIPTION
Crypto.Algo is now ns1.6, but we are restoring as DNXCore50 which
doesn't support ns1.6 (since it's deprecated) and our CLI still doesn't
have the mapping for netcoreapp1.0 to ns1.6.  Until we switch TFMs to
NETCoreApp1.0 and update CLI we need this workaround.

This isn't necessary for the normal build, but needed for our test
builds which replace the project reference with a package reference.

/cc @chcosta @jhendrixMSFT 