### PR TITLE
Creating attribute to store tuple names

### DIFF
--- a/src/System.ValueTuple/src/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/src/System.ValueTuple.csproj
@@ -16,6 +16,7 @@
     <RootNamespace>System</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="System\Runtime\CompilerServices\TupleElementNamesAttribute.cs" />
     <Compile Include="System\ValueTuple\ValueTuple.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.ValueTuple/src/System/Runtime/CompilerServices/TupleElementNamesAttribute.cs
+++ b/src/System.ValueTuple/src/System/Runtime/CompilerServices/TupleElementNamesAttribute.cs
@@ -33,12 +33,12 @@ namespace System.Runtime.CompilerServices
         /// </remarks>
         public TupleElementNamesAttribute(string[] transformNames)
         {
-            if ((object)transformNames == null)
+            if (transformNames == null)
             {
                 throw new ArgumentNullException(nameof(transformNames));
             }
 
-            this._transformNames = transformNames;
+            _transformNames = transformNames;
         }
 
         /// <summary>
@@ -58,12 +58,6 @@ namespace System.Runtime.CompilerServices
         /// construction, which <see cref="System.ValueTuple"/> occurrences are meant to
         /// carry element names.
         /// </summary>
-        public IList<string> TransformNames
-        {
-            get
-            {
-                return _transformNames;
-            }
-        }
+        public IList<string> TransformNames => _transformNames;
     }
 }

--- a/src/System.ValueTuple/src/System/Runtime/CompilerServices/TupleElementNamesAttribute.cs
+++ b/src/System.ValueTuple/src/System/Runtime/CompilerServices/TupleElementNamesAttribute.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Indicates that the use of <see cref="System.ValueTuple"/> on a member is meant to be treated as a tuple with element names.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue | AttributeTargets.Class | AttributeTargets.Struct )]
+    public sealed class TupleElementNamesAttribute : Attribute
+    {
+        private readonly string[] _transformNames;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TupleElementNamesAttribute"/> class.
+        /// </summary>
+        /// <param name="transformNames">
+        /// Specifies, in a prefix traversal of a type's
+        /// construction, which <see cref="System.ValueType"/> occurrences are meant to 
+        /// carry element names.
+        /// </param>
+        /// <remarks>
+        /// This constructor is meant to be used on types that are built on an underlying
+        /// occurrence of <see cref="System.ValueType"/> that is meant to carry element names.
+        /// For instance, if <c>C</c> is a generic type with two type parameters, then a
+        /// use of the constructed type <c>C{<see cref="System.ValueTuple{T1, T2}"/>, <see cref="System.ValueTuple{T1, T2, T3}"/></c>
+        /// might be intended to treat the first type argument as a tuple with element names
+        /// and the second as a tuple without element names. In which case, the appropriate attribute
+        /// specification should use <c>transformNames</c> value of <c>{ "name1", "name2", null }</c>.
+        /// </remarks>
+        public TupleElementNamesAttribute(string[] transformNames)
+        {
+            if ((object)transformNames == null)
+            {
+                throw new ArgumentNullException(nameof(transformNames));
+            }
+
+            this._transformNames = transformNames;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TupleElementNamesAttribute"/> class.
+        /// </summary>
+        /// <remarks>
+        /// When <see cref="TupleElementNamesAttribute"/> is created with this constructor,
+        /// it can be omitted instead.
+        /// </remarks>
+        public TupleElementNamesAttribute()
+        {
+            _transformNames = new string[] { };
+        }
+
+        /// <summary>
+        /// Specifies, in a prefix traversal of a type's
+        /// construction, which <see cref="System.ValueTuple"/> occurrences are meant to
+        /// carry element names.
+        /// </summary>
+        public IList<string> TransformNames
+        {
+            get
+            {
+                return _transformNames;
+            }
+        }
+    }
+}

--- a/src/System.ValueTuple/tests/System.ValueTuple.Tests.csproj
+++ b/src/System.ValueTuple/tests/System.ValueTuple.Tests.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>System.ValueTuple.Tests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="TupleElementNamesAttribute\UnitTests.cs" />
     <Compile Include="ValueTuple\UnitTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.ValueTuple/tests/TupleElementNamesAttribute/UnitTests.cs
+++ b/src/System.ValueTuple/tests/TupleElementNamesAttribute/UnitTests.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class TupleElementNamesAttributeTests
+{
+    [Fact]
+    public static void DefaultConstructor()
+    {
+        var attribute = new TupleElementNamesAttribute();
+        Assert.NotNull(attribute.TransformNames);
+        Assert.Equal(0, attribute.TransformNames.Count);
+    }
+
+    [Fact]
+    public static void Constructor()
+    {
+        var attribute = new TupleElementNamesAttribute(new string[] { "name1", "name2" });
+        Assert.NotNull(attribute.TransformNames);
+        Assert.Equal(new string[] { "name1", "name2" }, attribute.TransformNames);
+
+        Assert.Throws<ArgumentNullException>(() => new TupleElementNamesAttribute(null));
+    }
+
+    [TupleElementNames]
+    public object appliedToField = null;
+
+    [TupleElementNames(new string[] { null, "name1", "name2" })]
+    public object appliedToField2 = null;
+
+    public static void AppliedToParameter([TupleElementNames] object parameter, [TupleElementNames(new string[] { "name1", null })] object parameter2) { }
+
+    [TupleElementNames]
+    public static object AppliedToProperty { get; set; }
+
+    [TupleElementNames(new string[] { null, "name1", "name2" })]
+    public static object AppliedToProperty2 { get; set; }
+
+    [return: TupleElementNames]
+    public static void AppliedToReturn()
+    {
+    }
+
+    [TupleElementNames]
+    public class AppliedToClass { }
+    
+    [TupleElementNames(new string[] { null, "name1", "name2" })]
+    public class AppliedToClass2 { }
+
+    [TupleElementNames]
+    public struct AppliedToStruct { }
+    
+    [TupleElementNames(new string[] { null, "name1", "name2" })]
+    public class AppliedToStruct2 { }
+}


### PR DESCRIPTION
This attribute is similar to [DynamicAttribute](https://github.com/dotnet/corefx/blob/d0dc5fc099946adc1035b34a8b1f6042eddb0c75/src/System.Dynamic.Runtime/src/System/Runtime/CompilerServices/DynamicAttribute.cs). The compiler will emit it to annotate `ValueTuple` with element names. 
I will update the doc comments when the remaining questions on the traversal of types and mapping of element names into the `string[]` are closed.

@AlekseyTs @VSadov for review before I get a code review from corefx team.