### PR TITLE
Add InvalidCredentialException to System.Net.Security contract

### DIFF
--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -119,6 +119,12 @@ namespace System.Security.Authentication
         public AuthenticationException(string message) { }
         public AuthenticationException(string message, System.Exception innerException) { }
     }
+    public partial class InvalidCredentialException : System.Security.Authentication.AuthenticationException
+    {
+        public InvalidCredentialException() { }
+        public InvalidCredentialException(string message) { }
+        public InvalidCredentialException(string message, System.Exception innerException) { }
+    }
 }
 namespace System.Security.Authentication.ExtendedProtection
 {


### PR DESCRIPTION
It looks like this exception type was inadvertently left out of the contract file.  It's a public type in the implementation and it's thrown in several places.

cc: @davidsh, @cipop