### PR TITLE
Add FileSystemWatcher.WaitForChanged methods 

### DIFF
--- a/src/System.IO.FileSystem.Watcher/ref/System.IO.FileSystem.Watcher.cs
+++ b/src/System.IO.FileSystem.Watcher/ref/System.IO.FileSystem.Watcher.cs
@@ -43,6 +43,8 @@ namespace System.IO
         protected void OnDeleted(System.IO.FileSystemEventArgs e) { }
         protected void OnError(System.IO.ErrorEventArgs e) { }
         protected void OnRenamed(System.IO.RenamedEventArgs e) { }
+        public System.IO.WaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType) { return default(System.IO.WaitForChangedResult); }
+        public System.IO.WaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType, int timeout) { return default(System.IO.WaitForChangedResult); }
     }
     [System.FlagsAttribute]
     public enum NotifyFilters
@@ -63,6 +65,13 @@ namespace System.IO
         public string OldName { get { return default(string); } }
     }
     public delegate void RenamedEventHandler(object sender, System.IO.RenamedEventArgs e);
+    public struct WaitForChangedResult
+    {
+        public System.IO.WatcherChangeTypes ChangeType { get { return default(System.IO.WatcherChangeTypes); } set { } }
+        public string Name { get { return default(string); } set { } }
+        public string OldName { get { return default(string); } set { } }
+        public bool TimedOut { get { return false; } set { } }
+    }
     [System.FlagsAttribute]
     public enum WatcherChangeTypes
     {

--- a/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
+++ b/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
@@ -39,6 +39,7 @@
     <Compile Include="System\IO\RenamedEventArgs.cs" />
     <Compile Include="System\IO\RenamedEventHandler.cs" />
     <Compile Include="System\IO\WatcherChangeTypes.cs" />
+    <Compile Include="System\IO\WaitForChangedResult.cs" />
     <Compile Include="$(CommonPath)\System\IO\PathInternal.cs">
       <Link>Common\System\IO\PathInternal.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
@@ -405,12 +405,8 @@ namespace System.IO
         /// <internalonly/>
         private void NotifyInternalBufferOverflowEvent()
         {
-            ErrorEventHandler handler = _onErrorHandler;
-            if (handler != null)
-            {
-                handler(this, new ErrorEventArgs(
+            _onErrorHandler?.Invoke(this, new ErrorEventArgs(
                     new InternalBufferOverflowException(SR.Format(SR.FSW_BufferOverflow, _directory))));
-            }
         }
 
         /// <devdoc>
@@ -463,11 +459,7 @@ namespace System.IO
         [SuppressMessage("Microsoft.Security", "CA2109:ReviewVisibleEventHandlers", MessageId = "0#", Justification = "Changing from protected to private would be a breaking change")]
         protected void OnChanged(FileSystemEventArgs e)
         {
-            FileSystemEventHandler changedHandler = _onChangedHandler;
-            if (changedHandler != null)
-            {
-                changedHandler(this, e);
-            }
+            _onChangedHandler?.Invoke(this, e);
         }
 
         /// <devdoc>
@@ -476,11 +468,7 @@ namespace System.IO
         [SuppressMessage("Microsoft.Security", "CA2109:ReviewVisibleEventHandlers", MessageId = "0#", Justification = "Changing from protected to private would be a breaking change")]
         protected void OnCreated(FileSystemEventArgs e)
         {
-            FileSystemEventHandler createdHandler = _onCreatedHandler;
-            if (createdHandler != null)
-            {
-                createdHandler(this, e);
-            }
+            _onCreatedHandler?.Invoke(this, e);
         }
 
         /// <devdoc>
@@ -489,11 +477,7 @@ namespace System.IO
         [SuppressMessage("Microsoft.Security", "CA2109:ReviewVisibleEventHandlers", MessageId = "0#", Justification = "Changing from protected to private would be a breaking change")]
         protected void OnDeleted(FileSystemEventArgs e)
         {
-            FileSystemEventHandler deletedHandler = _onDeletedHandler;
-            if (deletedHandler != null)
-            {
-                deletedHandler(this, e);
-            }
+            _onDeletedHandler?.Invoke(this, e);
         }
 
         /// <devdoc>
@@ -502,11 +486,7 @@ namespace System.IO
         [SuppressMessage("Microsoft.Security", "CA2109:ReviewVisibleEventHandlers", MessageId = "0#", Justification = "Changing from protected to private would be a breaking change")]
         protected void OnError(ErrorEventArgs e)
         {
-            ErrorEventHandler errorHandler = _onErrorHandler;
-            if (errorHandler != null)
-            {
-                errorHandler(this, e);
-            }
+            _onErrorHandler?.Invoke(this, e);
         }
 
         /// <devdoc>
@@ -515,11 +495,7 @@ namespace System.IO
         [SuppressMessage("Microsoft.Security", "CA2109:ReviewVisibleEventHandlers", MessageId = "0#", Justification = "Changing from protected to private would be a breaking change")]
         protected void OnRenamed(RenamedEventArgs e)
         {
-            RenamedEventHandler renamedHandler = _onRenamedHandler;
-            if (renamedHandler != null)
-            {
-                renamedHandler(this, e);
-            }
+            _onRenamedHandler?.Invoke(this, e);
         }
 
         /// <devdoc>

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/WaitForChangedResult.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/WaitForChangedResult.cs
@@ -14,7 +14,8 @@ namespace System.IO
             TimedOut = timedOut;
         }
 
-        internal static readonly WaitForChangedResult TimedOutResult = new WaitForChangedResult(0, null, null, true);
+        internal static readonly WaitForChangedResult TimedOutResult = 
+            new WaitForChangedResult(changeType: 0, name: null, oldName: null, timedOut: true);
 
         public WatcherChangeTypes ChangeType { get; set; }
         public string Name { get; set; }

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/WaitForChangedResult.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/WaitForChangedResult.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO
+{
+    public struct WaitForChangedResult
+    {
+        internal WaitForChangedResult(WatcherChangeTypes changeType, string name, string oldName, bool timedOut)
+        {
+            ChangeType = changeType;
+            Name = name;
+            OldName = oldName;
+            TimedOut = timedOut;
+        }
+
+        internal static readonly WaitForChangedResult TimedOutResult = new WaitForChangedResult(0, null, null, true);
+
+        public WatcherChangeTypes ChangeType { get; set; }
+        public string Name { get; set; }
+        public string OldName { get; set; }
+        public bool TimedOut { get; set; }
+    }
+}

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
@@ -1,0 +1,152 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public partial class WaitForChangedTests : FileSystemWatcherTest
+    {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ZeroTimeout_TimesOut(bool enabledBeforeWait)
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, GetTestFileName())))
+            using (var fsw = new FileSystemWatcher(testDirectory.Path))
+            {
+                if (enabledBeforeWait) fsw.EnableRaisingEvents = true;
+                AssertTimedOut(fsw.WaitForChanged(WatcherChangeTypes.All, 0));
+                Assert.Equal(enabledBeforeWait, fsw.EnableRaisingEvents);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void NonZeroTimeout_NoEvents_TimesOut(bool enabledBeforeWait)
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, GetTestFileName())))
+            using (var fsw = new FileSystemWatcher(testDirectory.Path))
+            {
+                if (enabledBeforeWait) fsw.EnableRaisingEvents = true;
+                AssertTimedOut(fsw.WaitForChanged(0, 1));
+                Assert.Equal(enabledBeforeWait, fsw.EnableRaisingEvents);
+            }
+        }
+
+        [Theory]
+        [InlineData(WatcherChangeTypes.Deleted, false)]
+        [InlineData(WatcherChangeTypes.Created, true)]
+        [InlineData(WatcherChangeTypes.Changed, false)]
+        [InlineData(WatcherChangeTypes.Renamed, true)]
+        [InlineData(WatcherChangeTypes.All, true)]
+        public void NonZeroTimeout_NoActivity_TimesOut(WatcherChangeTypes changeType, bool enabledBeforeWait)
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, GetTestFileName())))
+            using (var fsw = new FileSystemWatcher(testDirectory.Path))
+            {
+                if (enabledBeforeWait) fsw.EnableRaisingEvents = true;
+                AssertTimedOut(fsw.WaitForChanged(changeType, 1));
+                Assert.Equal(enabledBeforeWait, fsw.EnableRaisingEvents);
+            }
+        }
+
+        [Theory]
+        [InlineData(WatcherChangeTypes.Created)]
+        [InlineData(WatcherChangeTypes.Deleted)]
+        public void CreatedDeleted_Success(WatcherChangeTypes changeType)
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var fsw = new FileSystemWatcher(testDirectory.Path))
+            {
+                Task<WaitForChangedResult> t = Task.Run(() => fsw.WaitForChanged(changeType));
+                DateTimeOffset end = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+                while (!t.IsCompleted && DateTimeOffset.UtcNow < end)
+                {
+                    string name = Path.Combine(testDirectory.Path, Path.GetRandomFileName());
+                    File.Create(name).Dispose();
+                    File.Delete(name);
+                    Task.Delay(100).Wait();
+                }
+
+                Assert.True(t.IsCompleted, "WaitForChanged didn't complete");
+                Assert.Equal(TaskStatus.RanToCompletion, t.Status);
+                Assert.Equal(changeType, t.Result.ChangeType);
+                Assert.NotNull(t.Result.Name);
+                Assert.Null(t.Result.OldName);
+                Assert.False(t.Result.TimedOut);
+            }
+        }
+
+        [Fact]
+        public void Changed_Success()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var fsw = new FileSystemWatcher(testDirectory.Path))
+            {
+                string name = Path.Combine(testDirectory.Path, Path.GetRandomFileName());
+                File.Create(name).Dispose();
+
+                Task<WaitForChangedResult> t = Task.Run(() => fsw.WaitForChanged(WatcherChangeTypes.Changed));
+                DateTimeOffset end = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+
+                while (!t.IsCompleted && DateTimeOffset.UtcNow < end)
+                {
+                    File.AppendAllText(name, "text");
+                    Task.Delay(100).Wait();
+                }
+
+                Assert.True(t.IsCompleted, "WaitForChanged didn't complete");
+                Assert.Equal(TaskStatus.RanToCompletion, t.Status);
+                Assert.Equal(WatcherChangeTypes.Changed, t.Result.ChangeType);
+                Assert.NotNull(t.Result.Name);
+                Assert.Null(t.Result.OldName);
+                Assert.False(t.Result.TimedOut);
+            }
+        }
+
+        [Fact]
+        public void Renamed_Success()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var fsw = new FileSystemWatcher(testDirectory.Path))
+            {
+                Task<WaitForChangedResult> t = Task.Run(() => fsw.WaitForChanged(WatcherChangeTypes.Renamed));
+                DateTimeOffset end = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+
+                string name1 = Path.Combine(testDirectory.Path, Path.GetRandomFileName());
+                string name2 = Path.Combine(testDirectory.Path, Path.GetRandomFileName());
+                File.Create(name1).Dispose();
+
+                while (!t.IsCompleted && DateTimeOffset.UtcNow < end)
+                {
+                    File.Move(name1, name2);
+                    File.Move(name2, name1);
+                    Task.Delay(100).Wait();
+                }
+
+                Assert.True(t.IsCompleted, "WaitForChanged didn't complete");
+                Assert.Equal(TaskStatus.RanToCompletion, t.Status);
+                Assert.Equal(WatcherChangeTypes.Renamed, t.Result.ChangeType);
+                Assert.True(
+                    (t.Result.Name == Path.GetFileName(name1) && t.Result.OldName == Path.GetFileName(name2)) ||
+                    (t.Result.Name == Path.GetFileName(name2) && t.Result.OldName == Path.GetFileName(name1)));
+                Assert.False(t.Result.TimedOut);
+            }
+        }
+
+        private static void AssertTimedOut(WaitForChangedResult result)
+        {
+            Assert.Equal(0, (int)result.ChangeType);
+            Assert.Null(result.Name);
+            Assert.Null(result.OldName);
+            Assert.True(result.TimedOut);
+        }
+    }
+}

--- a/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
+++ b/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
@@ -26,6 +26,7 @@
     <Compile Include="FileSystemWatcher.IncludeSubDirectories.cs" />
     <Compile Include="FileSystemWatcher.InternalBufferSize.cs" />
     <Compile Include="FileSystemWatcher.NotifyFilter.cs" />
+    <Compile Include="FileSystemWatcher.WaitForChanged.cs" />
     <Compile Include="FileSystemWatcher.Renamed.cs" />
     <Compile Include="FileSystemWatcher.MoveFile.cs" />
     <Compile Include="Utility\TestFileSystemWatcher.cs" />


### PR DESCRIPTION
These were previously left out when ported to .NET Core.  This puts back an implementation of the WaitForChanged methods that mimics the behavior in the full framework.

cc: @ianhays, @ericstj, @weshaggard, @danmosemsft 