### PR TITLE
Fix build on NetBSD with LLVM-3.9

### DIFF
--- a/src/Native/System.Native/pal_console.cpp
+++ b/src/Native/System.Native/pal_console.cpp
@@ -463,7 +463,7 @@ static bool InitializeSignalHandling()
     int rv;
 
     // Hook up signal handlers for use with ctrl-C / ctrl-Break handling
-    newAction.sa_sigaction = &TransferSignalToHandlerLoop,
+    newAction.sa_sigaction = &TransferSignalToHandlerLoop;
     rv = sigaction(SIGINT, &newAction, &g_origSigIntHandler);
     assert(rv == 0);
     rv = sigaction(SIGQUIT, &newAction, &g_origSigQuitHandler);


### PR DESCRIPTION
```
/tmp/pkgsrc-tmp/wip/corefx-git/work/corefx/src/Native/System.Native/pal_console.cpp:466:58:
error: possible misuse of comma operator here [-Werror,-Wcomma]
    newAction.sa_sigaction = &TransferSignalToHandlerLoop,
                                                         ^
```