### PR TITLE
Add SSL support to LoopbackServer in HTTP tests

### DIFF
--- a/src/Common/tests/System/Net/CertificateConfiguration.cs
+++ b/src/Common/tests/System/Net/CertificateConfiguration.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+
+using Xunit;
+
+namespace System.Net.Tests
+{
+    internal static class CertificateConfiguration
+    {
+        private const string CertificatePassword = "testcertificate";
+        private const string TestDataFolder = "TestData";
+
+        public static X509Certificate2 GetServerCertificate() => GetCertWithPrivateKey(GetServerCertificateCollection());
+
+        public static X509Certificate2 GetClientCertificate() => GetCertWithPrivateKey(GetClientCertificateCollection());
+
+        public static X509Certificate2Collection GetServerCertificateCollection() => GetCertificateCollection("contoso.com.pfx");
+
+        public static X509Certificate2Collection GetClientCertificateCollection() => GetCertificateCollection("testclient1_at_contoso.com.pfx");
+
+        private static X509Certificate2Collection GetCertificateCollection(string certificateFileName)
+        {
+            var certCollection = new X509Certificate2Collection();
+            certCollection.Import(Path.Combine(TestDataFolder, certificateFileName), CertificatePassword, X509KeyStorageFlags.DefaultKeySet);
+            return certCollection;
+        }
+
+        private static X509Certificate2 GetCertWithPrivateKey(X509Certificate2Collection certCollection)
+        {
+            X509Certificate2 certificate = null;
+
+            foreach (X509Certificate2 c in certCollection)
+            {
+                if (certificate == null && c.HasPrivateKey)
+                {
+                    certificate = c;
+                }
+                else
+                {
+                    c.Dispose();
+                }
+            }
+
+            Assert.NotNull(certificate);
+            return certificate;
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Timeouts.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Timeouts.cs
@@ -65,36 +65,38 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task ConnectTimeout_TimesOut_Throws()
         {
-            await LoopbackServer.CreateClientAndServerAsync(async (handler, client, server, url) =>
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
-                const int NumBacklogSockets = 16; // must be larger than OS' queue length when using Listen(1).
-                var socketBacklog = new List<Socket>(NumBacklogSockets);
-                try
+                using (var handler = new HttpClientHandler() { ConnectTimeout = TimeSpan.FromMilliseconds(10) })
+                using (var client = new HttpClient(handler))
                 {
-                    handler.ConnectTimeout = TimeSpan.FromMilliseconds(10);
-
-                    // Listen's backlog is only advisory; the OS may actually allow a larger backlog than that.
-                    // As such, create a bunch of clients to connect to the endpoint so that our actual request
-                    // will timeout while trying to connect.
-                    for (int i = 0; i < NumBacklogSockets; i++)
+                    const int NumBacklogSockets = 16; // must be larger than OS' queue length when using Listen(1).
+                    var socketBacklog = new List<Socket>(NumBacklogSockets);
+                    try
                     {
-                        var tmpClient = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-                        var ignored = tmpClient.ConnectAsync(new IPEndPoint(IPAddress.Parse(url.Host), url.Port));
-                        socketBacklog.Add(tmpClient);
+                        // Listen's backlog is only advisory; the OS may actually allow a larger backlog than that.
+                        // As such, create a bunch of clients to connect to the endpoint so that our actual request
+                        // will timeout while trying to connect.
+                        for (int i = 0; i < NumBacklogSockets; i++)
+                        {
+                            var tmpClient = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                            var ignored = tmpClient.ConnectAsync(new IPEndPoint(IPAddress.Parse(url.Host), url.Port));
+                            socketBacklog.Add(tmpClient);
+                        }
+
+                        // Make the actual connection.  It should timeout in connect.
+                        var sw = Stopwatch.StartNew();
+                        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.GetAsync(url));
+                        sw.Stop();
+
+                        Assert.InRange(sw.ElapsedMilliseconds, 1, 10 * 1000); // allow a very wide range
                     }
-
-                    // Make the actual connection.  It should timeout in connect.
-                    var sw = Stopwatch.StartNew();
-                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.GetAsync(url));
-                    sw.Stop();
-
-                    Assert.InRange(sw.ElapsedMilliseconds, 1, 10 * 1000); // allow a very wide range
-                }
-                finally
-                {
-                    foreach (Socket c in socketBacklog)
+                    finally
                     {
-                        c.Dispose();
+                        foreach (Socket c in socketBacklog)
+                        {
+                            c.Dispose();
+                        }
                     }
                 }
             });

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -35,6 +35,9 @@
     <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
       <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\CertificateConfiguration.cs">
+      <Link>Common\System\Net\CertificateConfiguration.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
       <Link>Common\System\Net\HttpTestServers.cs</Link>
     </Compile>
@@ -90,6 +93,9 @@
       <Name>RemoteExecutorConsoleApp</Name>
       <OSGroup>$(InputOSGroup)</OSGroup>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <SupplementalTestData Include="$(PackagesDir)System.Net.TestData\1.0.0-prerelease\content\**\*.*" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.Http/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/unix/project.json
@@ -9,6 +9,7 @@
     "System.IO.FileSystem": "4.0.1-rc3-24109-00",
     "System.Linq.Expressions": "4.1.0-rc3-24109-00",
     "System.Net.Primitives": "4.0.11-rc3-24109-00",
+    "System.Net.Security": "4.0.0-rc3-24109-00",
     "System.Net.Sockets": "4.1.0-rc3-24109-00",
     "System.ObjectModel": "4.0.12-rc3-24109-00",
     "System.Runtime.Extensions": "4.1.0-rc3-24109-00",

--- a/src/System.Net.Http/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/win/project.json
@@ -9,6 +9,7 @@
     "System.IO.FileSystem": "4.0.1-rc3-24109-00",
     "System.Linq.Expressions": "4.1.0-rc3-24109-00",
     "System.Net.Primitives": "4.0.11-rc3-24109-00",
+    "System.Net.Security": "4.0.0-rc3-24109-00",
     "System.Net.Sockets": "4.1.0-rc3-24109-00",
     "System.ObjectModel": "4.0.12-rc3-24109-00",
     "System.Runtime.Extensions": "4.1.0-rc3-24109-00",

--- a/src/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
@@ -4,6 +4,7 @@
 
 using System.Net.Sockets;
 using System.Net.Test.Common;
+using System.Net.Tests;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
@@ -11,7 +12,7 @@ using Xunit;
 
 namespace System.Net.Security.Tests
 {
-    public class CertificateValidationClientServer
+    public class CertificateValidationClientServer : IDisposable
     {
         private readonly X509Certificate2 _clientCertificate;
         private readonly X509Certificate2Collection _clientCertificateCollection;
@@ -20,11 +21,19 @@ namespace System.Net.Security.Tests
 
         public CertificateValidationClientServer()
         {
-            _serverCertificateCollection = TestConfiguration.GetServerCertificateCollection();
-            _serverCertificate = TestConfiguration.GetServerCertificate();
+            _serverCertificateCollection = CertificateConfiguration.GetServerCertificateCollection();
+            _serverCertificate = CertificateConfiguration.GetServerCertificate();
 
-            _clientCertificateCollection = TestConfiguration.GetClientCertificateCollection();
-            _clientCertificate = TestConfiguration.GetClientCertificate();
+            _clientCertificateCollection = CertificateConfiguration.GetClientCertificateCollection();
+            _clientCertificate = CertificateConfiguration.GetClientCertificate();
+        }
+
+        public void Dispose()
+        {
+            _serverCertificate.Dispose();
+            _clientCertificate.Dispose();
+            foreach (X509Certificate2 cert in _serverCertificateCollection) cert.Dispose();
+            foreach (X509Certificate2 cert in _clientCertificateCollection) cert.Dispose();
         }
 
         [Theory]

--- a/src/System.Net.Security/tests/FunctionalTests/DummyTcpServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/DummyTcpServer.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Net.Sockets;
 using System.Net.Test.Common;
+using System.Net.Tests;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
@@ -147,19 +148,23 @@ namespace System.Net.Security.Tests
 
 
                     SslStream sslStream = null;
-                    X509Certificate2 certificate = TestConfiguration.GetServerCertificate();
+                    X509Certificate2 certificate = CertificateConfiguration.GetServerCertificate();
 
                     try
                     {
                         sslStream = (SslStream)state.Stream;
 
                         _log.WriteLine("Server: attempting to open SslStream.");
-                        sslStream.AuthenticateAsServerAsync(certificate, false, _sslProtocols, false).ContinueWith(t => OnAuthenticate(t, state), TaskScheduler.Default);
+                        sslStream.AuthenticateAsServerAsync(certificate, false, _sslProtocols, false).ContinueWith(t =>
+                        {
+                            certificate.Dispose();
+                            OnAuthenticate(t, state);
+                        }, TaskScheduler.Default);
                     }
                     catch (Exception ex)
                     {
                         _log.WriteLine("Server: Exception: {0}", ex);
-
+                        certificate.Dispose();
                         state.Dispose(); // close connection to client
                     }
                 }

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Net.Test.Common;
+using System.Net.Tests;
 using System.Runtime.ExceptionServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
@@ -15,7 +16,7 @@ using Xunit.Abstractions;
 
 namespace System.Net.Security.Tests
 {
-    public class ServerAsyncAuthenticateTest
+    public class ServerAsyncAuthenticateTest : IDisposable
     {
         private readonly ITestOutputHelper _log;
         private readonly ITestOutputHelper _logVerbose;
@@ -25,7 +26,12 @@ namespace System.Net.Security.Tests
         {
             _log = TestLogging.GetInstance();
             _logVerbose = VerboseTestLogging.GetInstance();
-            _serverCertificate = TestConfiguration.GetServerCertificate();
+            _serverCertificate = CertificateConfiguration.GetServerCertificate();
+        }
+
+        public void Dispose()
+        {
+            _serverCertificate.Dispose();
         }
 
         [Theory]

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Net.Sockets;
+using System.Net.Tests;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
@@ -16,9 +17,9 @@ namespace System.Net.Security.Tests
         [Fact]
         public async void SslStream_SendReceiveOverNetworkStream_Ok()
         {
-            X509Certificate2 serverCertificate = TestConfiguration.GetServerCertificate();
             TcpListener listener = new TcpListener(IPAddress.Any, 0);
 
+            using (X509Certificate2 serverCertificate = CertificateConfiguration.GetServerCertificate())
             using (TcpClient client = new TcpClient())
             {
                 listener.Start();

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -53,6 +53,9 @@
     <Compile Include="ServiceNameCollectionTest.cs" />
 
     <!-- Common test files -->
+    <Compile Include="$(CommonTestPath)\System\Net\CertificateConfiguration.cs">
+      <Link>Common\System\Net\CertificateConfiguration.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
       <Link>Common\System\Net\HttpTestServers.cs</Link>
     </Compile>

--- a/src/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -17,9 +17,6 @@ namespace System.Net.Security.Tests
         public const int PassingTestTimeoutMilliseconds = 1 * 60 * 1000;
         public const int FailingTestTimeoutMiliseconds = 250;
 
-        private const string CertificatePassword = "testcertificate";
-        private const string TestDataFolder = "TestData";
-
         public const string Realm = "TEST.COREFX.NET";
         public const string KerberosUser = "krb_user";
         public const string DefaultPassword = "password";
@@ -29,56 +26,6 @@ namespace System.Net.Security.Tests
         public const string NtlmUser = "ntlm_user";
         public const string NtlmPassword = "ntlm_password";
         public const string NtlmUserFilePath = "/var/tmp/ntlm_user_file";
-
-        public static X509Certificate2 GetServerCertificate()
-        {
-            X509Certificate2Collection certCollection = TestConfiguration.GetServerCertificateCollection();
-            return GetCertWithPrivateKey(certCollection);
-        }
-
-        public static X509Certificate2Collection GetServerCertificateCollection()
-        {
-            return GetCertificateCollection("contoso.com.pfx");
-        }
-
-        public static X509Certificate2 GetClientCertificate()
-        {
-            X509Certificate2Collection certCollection = TestConfiguration.GetClientCertificateCollection();
-            return GetCertWithPrivateKey(certCollection);
-        }
-
-        public static X509Certificate2Collection GetClientCertificateCollection()
-        {
-            return GetCertificateCollection("testclient1_at_contoso.com.pfx");
-        }
-
-        private static X509Certificate2Collection GetCertificateCollection(string certificateFileName)
-        {
-            var certCollection = new X509Certificate2Collection();
-            certCollection.Import(
-                Path.Combine(TestDataFolder, certificateFileName),
-                CertificatePassword,
-                X509KeyStorageFlags.DefaultKeySet);
-
-            return certCollection;
-        }
-
-        private static X509Certificate2 GetCertWithPrivateKey(X509Certificate2Collection certCollection)
-        {
-            X509Certificate2 certificate = null;
-
-            foreach (X509Certificate2 c in certCollection)
-            {
-                if (c.HasPrivateKey)
-                {
-                    certificate = c;
-                    break;
-                }
-            }
-
-            Assert.NotNull(certificate);
-            return certificate;
-        }
 
         public static bool SupportsNullEncryption { get { return s_supportsNullEncryption.Value; } }
 


### PR DESCRIPTION
We currently make a lot of calls off-box in our unit tests.  By adding SSL support to the loopback server, we should be able to convert many more tests to avoid needing to actually hit the network.  This adds such basic support, and converts a few tests to use it.

Per previous PR feedback, I also moved the client-related code out of the loopback server, moving it to the call sites.  Those call sites will be more easily reviewed with whitespace-diffing disabled, as the majority of the changes are indentation due to adding using blocks.

Also, since I was moving the certificate configuration code to a central location, I fixed an issue related to cleanup. Fixes https://github.com/dotnet/corefx/issues/8320

cc: @davidsh, @cipop, @bartonjs 