### PR TITLE
Add Stream.Begin/EndRead and Stream.Begin/EndWrite

### DIFF
--- a/src/System.IO/ref/System.IO.cs
+++ b/src/System.IO/ref/System.IO.cs
@@ -89,7 +89,11 @@ namespace System.IO
         public override bool CanWrite { get { return default(bool); } }
         public override long Length { get { return default(long); } }
         public override long Position { get { return default(long); } set { } }
+        public override System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
+        public override System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
         protected override void Dispose(bool disposing) { }
+        public override int EndRead(System.IAsyncResult asyncResult) { return 0; }
+        public override void EndWrite(System.IAsyncResult asyncResult) { return; }
         public override void Flush() { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }
         public override int Read(byte[] array, int offset, int count) { return default(int); }
@@ -128,8 +132,12 @@ namespace System.IO
         public virtual int Capacity { get { return default(int); } set { } }
         public override long Length { get { return default(long); } }
         public override long Position { get { return default(long); } set { } }
+        public override System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
+        public override System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
         public override System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }
         protected override void Dispose(bool disposing) { }
+        public override int EndRead(System.IAsyncResult asyncResult) { return 0; }
+        public override void EndWrite(System.IAsyncResult asyncResult) { return; }
         public override void Flush() { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }
         public override int Read(byte[] buffer, int offset, int count) { buffer = default(byte[]); return default(int); }
@@ -162,6 +170,8 @@ namespace System.IO
         public abstract long Position { get; set; }
         public virtual int ReadTimeout { get { return default(int); } set { } }
         public virtual int WriteTimeout { get { return default(int); } set { } }
+        public virtual System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
+        public virtual System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
         public void CopyTo(System.IO.Stream destination) { }
         public void CopyTo(System.IO.Stream destination, int bufferSize) { }
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination) { return default(System.Threading.Tasks.Task); }
@@ -169,6 +179,8 @@ namespace System.IO
         public virtual System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
+        public virtual int EndRead(System.IAsyncResult asyncResult) { return 0; }
+        public virtual void EndWrite(System.IAsyncResult asyncResult) { return; }
         public abstract void Flush();
         public System.Threading.Tasks.Task FlushAsync() { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }

--- a/src/System.IO/src/System.IO.csproj
+++ b/src/System.IO/src/System.IO.csproj
@@ -37,6 +37,9 @@
   <ItemGroup Condition="'$(TargetGroup)' != 'net462'">
     <Compile Include="System\IO\BufferedStream.cs" />
     <Compile Include="System\IO\InvalidDataException.cs" />
+    <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs">
+      <Link>Common\System\Threading\Tasks\TaskToApm.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcore50aot' or '$(TargetGroup)' == 'netstandard13aot'">
     <Compile Include="System\IO\BinaryReader.cs" />

--- a/src/System.IO/src/System/IO/BufferedStream.cs
+++ b/src/System.IO/src/System/IO/BufferedStream.cs
@@ -644,6 +644,12 @@ namespace System.IO
             }
         }
 
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
+            TaskToApm.Begin(ReadAsync(buffer, offset, count, CancellationToken.None), callback, state);
+
+        public override int EndRead(IAsyncResult asyncResult) =>
+            TaskToApm.End<int>(asyncResult);
+
         public override int ReadByte()
         {
             return _readPos != _readLen ?
@@ -998,6 +1004,12 @@ namespace System.IO
                 sem.Release();
             }
         }
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
+            TaskToApm.Begin(WriteAsync(buffer, offset, count, CancellationToken.None), callback, state);
+
+        public override void EndWrite(IAsyncResult asyncResult) =>
+            TaskToApm.End(asyncResult);
 
         public override void WriteByte(byte value)
         {

--- a/src/System.IO/src/System/IO/MemoryStream.cs
+++ b/src/System.IO/src/System/IO/MemoryStream.cs
@@ -448,6 +448,11 @@ namespace System.IO
         }
 #pragma warning restore 1998
 
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
+            TaskToApm.Begin(ReadAsync(buffer, offset, count, CancellationToken.None), callback, state);
+
+        public override int EndRead(IAsyncResult asyncResult) =>
+            TaskToApm.End<int>(asyncResult);
 
         public override int ReadByte()
         {
@@ -732,6 +737,12 @@ namespace System.IO
             Write(buffer, offset, count);
         }
 #pragma warning restore 1998
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
+            TaskToApm.Begin(WriteAsync(buffer, offset, count, CancellationToken.None), callback, state);
+
+        public override void EndWrite(IAsyncResult asyncResult) =>
+            TaskToApm.End(asyncResult);
 
         public override void WriteByte(byte value)
         {

--- a/src/System.IO/src/System/IO/Stream.cs
+++ b/src/System.IO/src/System/IO/Stream.cs
@@ -187,11 +187,22 @@ namespace System.IO
                 throw new NotSupportedException(SR.NotSupported_UnreadableStream);
             }
 
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled<int>(cancellationToken);
-            }
+            return cancellationToken.IsCancellationRequested ?
+                Task.FromCanceled<int>(cancellationToken) :
+                Task.Factory.FromAsync(
+                    (localBuffer, localOffset, localCount, callback, state) => ((Stream)state).BeginRead(localBuffer, localOffset, localCount, callback, state),
+                    iar => ((Stream)iar.AsyncState).EndRead(iar),
+                    buffer, offset, count, this, TaskCreationOptions.DenyChildAttach | TaskCreationOptions.HideScheduler);
+        }
 
+        public virtual IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
+            TaskToApm.Begin(ReadAsyncInternal(buffer, offset, count), callback, state);
+
+        public virtual int EndRead(IAsyncResult asyncResult) => 
+            TaskToApm.End<int>(asyncResult);
+
+        private Task<int> ReadAsyncInternal(Byte[] buffer, int offset, int count)
+        {
             // To avoid a race with a stream's position pointer & generating race 
             // conditions with internal buffer indexes in our own streams that 
             // don't natively support async IO operations when there are multiple 
@@ -223,11 +234,22 @@ namespace System.IO
                 throw new NotSupportedException(SR.NotSupported_UnwritableStream);
             }
 
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled(cancellationToken);
-            }
+            return cancellationToken.IsCancellationRequested ?
+                Task.FromCanceled<int>(cancellationToken) :
+                Task.Factory.FromAsync(
+                    (localBuffer, localOffset, localCount, callback, state) => ((Stream)state).BeginWrite(localBuffer, localOffset, localCount, callback, state),
+                    iar => ((Stream)iar.AsyncState).EndWrite(iar),
+                    buffer, offset, count, this, TaskCreationOptions.DenyChildAttach | TaskCreationOptions.HideScheduler);
+        }
 
+        public virtual IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
+            TaskToApm.Begin(WriteAsyncInternal(buffer, offset, count), callback, state);
+
+        public virtual void EndWrite(IAsyncResult asyncResult) => 
+            TaskToApm.End(asyncResult);
+
+        private Task WriteAsyncInternal(Byte[] buffer, int offset, int count)
+        {
             // To avoid a race with a stream's position pointer & generating race 
             // conditions with internal buffer indexes in our own streams that 
             // don't natively support async IO operations when there are multiple 
@@ -388,6 +410,12 @@ namespace System.IO
             }
 #pragma warning restore 1998
 
+            public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
+                TaskToApm.Begin(ReadAsync(buffer, offset, count, CancellationToken.None), callback, state);
+
+            public override int EndRead(IAsyncResult asyncResult) =>
+                TaskToApm.End<int>(asyncResult);
+
             public override int ReadByte()
             {
                 return -1;
@@ -403,6 +431,12 @@ namespace System.IO
                 cancellationToken.ThrowIfCancellationRequested();
             }
 #pragma warning restore 1998
+
+            public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
+                TaskToApm.Begin(WriteAsync(buffer, offset, count, CancellationToken.None), callback, state);
+
+            public override void EndWrite(IAsyncResult asyncResult) =>
+                TaskToApm.End(asyncResult);
 
             public override void WriteByte(byte value)
             {


### PR DESCRIPTION
While we want developers to implement and consume the ReadAsync/WriteAsync methods on Stream, not having the older Begin/End* methods causes portability problems for libraries (it also makes porting harder).

This commit adds back the virtual methods in the contract and provides an implementation for Stream in corert (coreclr already has implementations in mscorlib).  It also provides overrides on the streams defined in System.IO.dll.

Once a new package is published with this updated contract, I'll add overrides to the rest of our stream implementations in corefx as well as tests.

cc: @ianhays, @weshaggard, @danmosemsft, @KrzysztofCwalina, @jkotas 