### PR TITLE
Remove intermediary allocation from Path.GetFileNameWithoutExtension

### DIFF
--- a/src/Common/src/System/IO/PathInternal.Unix.cs
+++ b/src/Common/src/System/IO/PathInternal.Unix.cs
@@ -91,5 +91,18 @@ namespace System.IO
 
             return builder.ToString();
         }
+        
+        /// <summary>
+        /// Returns true if the character is a directory or volume separator.
+        /// </summary>
+        /// <param name="ch">The character to test.</param>
+        internal static bool IsDirectoryOrVolumeSeparator(char ch)
+        {
+            // The directory separator, volume separator, and the alternate directory
+            // separator should be the same on Unix, so we only need to check one.
+            Debug.Assert(Path.DirectorySeparatorChar == Path.AltDirectorySeparatorChar);
+            Debug.Assert(Path.DirectorySeparatorChar == Path.VolumeSeparatorChar);
+            return ch == Path.DirectorySeparatorChar;
+        }
     }
 }

--- a/src/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/Common/src/System/IO/PathInternal.Windows.cs
@@ -436,5 +436,14 @@ namespace System.IO
 
             return builder.ToString();
         }
+        
+        /// <summary>
+        /// Returns true if the character is a directory or volume separator.
+        /// </summary>
+        /// <param name="ch">The character to test.</param>
+        internal static bool IsDirectoryOrVolumeSeparator(char ch)
+        {
+            return PathInternal.IsDirectorySeparator(ch) || Path.VolumeSeparatorChar == ch;
+        }
     }
 }

--- a/src/Common/src/System/IO/PathInternal.cs
+++ b/src/Common/src/System/IO/PathInternal.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Text;
 
 namespace System.IO
@@ -80,6 +81,33 @@ namespace System.IO
 
             builder.Length = end + 1;
             return builder;
+        }
+        
+        /// <summary>
+        /// Returns the start index of the filename
+        /// in the given path, or 0 if no directory
+        /// or volume separator is found.
+        /// </summary>
+        /// <param name="path">The path in which to find the index of the filename.</param>
+        /// <remarks>
+        /// This method returns path.Length for
+        /// inputs like "/usr/foo/" on Unix. As such,
+        /// it is not safe for being used to index
+        /// the string without additional verification.
+        /// </remarks>
+        internal static int FindFileNameIndex(string path)
+        {
+            Debug.Assert(path != null);
+            PathInternal.CheckInvalidPathChars(path);
+            
+            for (int i = path.Length - 1; i >= 0; i--)
+            {
+                char ch = path[i];
+                if (IsDirectoryOrVolumeSeparator(ch))
+                    return i + 1;
+            }
+            
+            return 0; // the whole path is the filename
         }
     }
 }

--- a/src/Common/tests/Tests/System/IO/PathInternal.Windows.Tests.cs
+++ b/src/Common/tests/Tests/System/IO/PathInternal.Windows.Tests.cs
@@ -161,4 +161,19 @@ public class PathInternal_Windows_Tests
         if (string.Equals(path, expected, StringComparison.Ordinal))
             Assert.Same(path, result);
     }
+    
+    [Theory]
+    [InlineData(@"\", 1)]
+    [InlineData("", 0)]
+    [InlineData(":", 1)]
+    [InlineData(";", 0)]
+    [InlineData("/", 1)]
+    [InlineData(@"Foo\/\/\", 8)]
+    [InlineData("Foo:Bar", 4)]
+    [InlineData(@"C:\Users\Foobar\", 16)]
+    [PlatformSpecific(PlatformID.Windows)]
+    public void FindFileNameIndexTests(string path, int expected)
+    {
+        Assert.Equal(expected, PathInternal.FindFileNameIndex(path));
+    }
 }

--- a/src/Common/tests/Tests/System/IO/PathInternal_Unix_Tests.cs
+++ b/src/Common/tests/Tests/System/IO/PathInternal_Unix_Tests.cs
@@ -39,4 +39,20 @@ public class PathInternal_Unix_Tests
         if (string.Equals(path, expected, StringComparison.Ordinal))
             Assert.Same(path, result);
     }
+    
+    [Theory]
+    [InlineData(@"\", 0)]
+    [InlineData("", 0)]
+    [InlineData(":", 0)]
+    [InlineData(";", 0)]
+    [InlineData("/", 1)]
+    [InlineData(@"Foo\/\/\", 7)]
+    [InlineData("Foo:Bar", 0)]
+    [InlineData("/usr/foo/", 9)]
+    [InlineData("/home/bar", 6)]
+    [PlatformSpecific(PlatformID.AnyUnix)]
+    public void FindFileNameIndexTests(string path, int expected)
+    {
+        Assert.Equal(expected, PathInternal.FindFileNameIndex(path));
+    }
 }

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
@@ -21,14 +21,6 @@ namespace System.IO
         private static readonly int MaxPath = Interop.Sys.MaxPath;
         private static readonly int MaxLongPath = MaxPath;
 
-        private static bool IsDirectoryOrVolumeSeparator(char c)
-        {
-            // The directory separator is the same as the volume separator,
-            // so we only need to check one.
-            Debug.Assert(DirectorySeparatorChar == VolumeSeparatorChar);
-            return PathInternal.IsDirectorySeparator(c);
-        }
-
         // Expands the given path to a fully qualified path. 
         public static string GetFullPath(string path)
         {

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs
@@ -29,11 +29,6 @@ namespace System.IO
         internal static readonly int MaxPath = 260;
         internal static readonly int MaxLongPath = short.MaxValue;
 
-        private static bool IsDirectoryOrVolumeSeparator(char c)
-        {
-            return PathInternal.IsDirectorySeparator(c) || VolumeSeparatorChar == c;
-        }
-
         // Expands the given path to a fully qualified path. 
         public static string GetFullPath(string path)
         {


### PR DESCRIPTION
Instead of calling `GetFileName` and potentially creating another substring if it contains a dot, we can instead find the index where the filename starts and work with that in `GetFileNameWithoutExtension`.

cc @justinvp @hughbe 