### PR TITLE
Remove OfficialBuildId handling to clean up build.cmd/sh scripts

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -8,7 +8,6 @@ setlocal EnableDelayedExpansion
 
 :ReadArguments
 :: Read in the args to determine whether to run the native build, managed build, or both (default)
-set OfficialBuildIdArg=
 set "__args= %*"
 set processedArgs=
 set unprocessedBuildArgs=
@@ -25,17 +24,6 @@ if /I [%1]==[native] (
 if /I [%1] == [managed] (
     set __buildSpec=managed
     set processedArgs=!processedArgs! %1
-    goto Next
-)
-
-if /I [%1] == [/p:OfficialBuildId] (
-    if /I [%2]==[] (
-        echo Error: officialbuildid arg should have a value
-        exit /b 1
-    )
-    set processedArgs=!processedArgs! %1=%2
-    set OfficialBuildIdArg=/p:OfficialBuildId=%2
-    shift /1
     goto Next
 )
 
@@ -75,7 +63,9 @@ echo [%time%] Building Native Libraries...
 :: Generate Native versioning assets
 set __binDir=%~dp0bin
 set __versionLog=%~dp0version.log
-msbuild "%~dp0build.proj" /nologo /t:GenerateVersionHeader /p:NativeVersionHeaderFile="%__binDir%\obj\_version.h" /p:GenerateVersionHeader=true %OfficialBuildIdArg% > "%__versionLog%"
+if not exist "%__binDir%\obj\_version.h" (
+    msbuild "%~dp0build.proj" /nologo /t:GenerateVersionHeader /p:GenerateNativeVersionInfo=true > "%__versionLog%"
+)
 IF EXIST "%~dp0src\native\Windows\build-native.cmd" (
     call %~dp0src\native\Windows\build-native.cmd %__args% >nativebuild.log
     IF ERRORLEVEL 1 (
@@ -113,7 +103,7 @@ call :build %__args%
 goto :AfterBuild
 
 :build
-%_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /v:minimal /clp:Summary /nodeReuse:false /flp:v=normal;LogFile="%_buildlog%";Append "/l:BinClashLogger,%_binclashLoggerDll%;LogFile=%_binclashlog%" !unprocessedBuildArgs! %_buildpostfix% %OfficialBuildIdArg%
+%_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /v:minimal /clp:Summary /nodeReuse:false /flp:v=normal;LogFile="%_buildlog%";Append "/l:BinClashLogger,%_binclashLoggerDll%;LogFile=%_binclashlog%" !unprocessedBuildArgs! %_buildpostfix%
 set BUILDERRORLEVEL=%ERRORLEVEL%
 goto :eof
 

--- a/build.sh
+++ b/build.sh
@@ -87,8 +87,9 @@ prepare_native_build()
 
     # Generate version.c if specified, else have an empty one.
     __versionSourceFile=$__scriptpath/bin/obj/version.c
+    if [ -f "${__versionSourceFile}" ]; then __generateversionsource=false; fi
     if [ $__generateversionsource == true ]; then
-        $__scriptpath/Tools/corerun $__scriptpath/Tools/MSBuild.exe "$__scriptpath/build.proj" /t:GenerateVersionSourceFile /p:NativeVersionSourceFile=$__scriptpath/bin/obj/version.c /p:GenerateVersionSourceFile=true /v:minimal $__OfficialBuildIdArg
+        $__scriptpath/Tools/corerun $__scriptpath/Tools/MSBuild.exe "$__scriptpath/build.proj" /t:GenerateVersionSourceFile /p:NativeVersionSourceFile=$__scriptpath/bin/obj/version.c /p:GenerateVersionSourceFile=true /v:minimal
     else
         __versionSourceLine="static char sccsid[] __attribute__((used)) = \"@(#)No version information produced\";"
         echo $__versionSourceLine > $__versionSourceFile
@@ -167,7 +168,6 @@ __msbuildpath=$__packageroot/$__msbuildpackageid.$__msbuildpackageversion/lib/MS
 __buildmanaged=false
 __buildnative=false
 __TestNugetRuntimeId=win7-x64
-__OfficialBuildIdArg=
 
 # Use uname to determine what the CPU is.
 CPUName=$(uname -p)
@@ -363,11 +363,7 @@ while :; do
             __ServerGC=1
             ;;
         *)
-          if [[ $1 == "/p:OfficialBuildId="* ]]; then
-            __OfficialBuildIdArg=$1
-          else
             __UnprocessedBuildArgs="$__UnprocessedBuildArgs $1"
-          fi
     esac
 
     shift


### PR DESCRIPTION
The idea is that since `OfficialBuildId` will be passed in **ONLY** by official builds, then there is no point on having special script handling for this argument. Instead, Official builds will add a pre-built step, that will basically call build.cmd/build.sh with the right params to generate the right version files required for the build.

@jhendrixMSFT we will need to add this new steps to the build definitions. I can do that, but this is just an FYI.

cc: @weshaggard @jhendrixMSFT 

related: dotnet/coreclr#4395