### PR TITLE
Exposing members of StreamingContext

### DIFF
--- a/src/System.Runtime.Serialization.Primitives/ref/System.Runtime.Serialization.Primitives.cs
+++ b/src/System.Runtime.Serialization.Primitives/ref/System.Runtime.Serialization.Primitives.cs
@@ -12,53 +12,53 @@ namespace System.Runtime.Serialization
     public sealed partial class CollectionDataContractAttribute : System.Attribute
     {
         public CollectionDataContractAttribute() { }
-        public bool IsItemNameSetExplicitly { get { return default(bool); } }
-        public bool IsKeyNameSetExplicitly { get { return default(bool); } }
-        public bool IsNameSetExplicitly { get { return default(bool); } }
-        public bool IsNamespaceSetExplicitly { get { return default(bool); } }
-        public bool IsReference { get { return default(bool); } set { } }
-        public bool IsReferenceSetExplicitly { get { return default(bool); } }
-        public bool IsValueNameSetExplicitly { get { return default(bool); } }
-        public string ItemName { get { return default(string); } set { } }
-        public string KeyName { get { return default(string); } set { } }
-        public string Name { get { return default(string); } set { } }
-        public string Namespace { get { return default(string); } set { } }
-        public string ValueName { get { return default(string); } set { } }
+        public bool IsItemNameSetExplicitly { get { throw null; } }
+        public bool IsKeyNameSetExplicitly { get { throw null; } }
+        public bool IsNameSetExplicitly { get { throw null; } }
+        public bool IsNamespaceSetExplicitly { get { throw null; } }
+        public bool IsReference { get { throw null; } set { } }
+        public bool IsReferenceSetExplicitly { get { throw null; } }
+        public bool IsValueNameSetExplicitly { get { throw null; } }
+        public string ItemName { get { throw null; } set { } }
+        public string KeyName { get { throw null; } set { } }
+        public string Name { get { throw null; } set { } }
+        public string Namespace { get { throw null; } set { } }
+        public string ValueName { get { throw null; } set { } }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(3), Inherited = false, AllowMultiple = true)]
     public sealed partial class ContractNamespaceAttribute : System.Attribute
     {
         public ContractNamespaceAttribute(string contractNamespace) { }
-        public string ClrNamespace { get { return default(string); } set { } }
-        public string ContractNamespace { get { return default(string); } }
+        public string ClrNamespace { get { throw null; } set { } }
+        public string ContractNamespace { get { throw null; } }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(28), Inherited = false, AllowMultiple = false)]
     public sealed partial class DataContractAttribute : System.Attribute
     {
         public DataContractAttribute() { }
-        public bool IsNameSetExplicitly { get { return default(bool); } }
-        public bool IsNamespaceSetExplicitly { get { return default(bool); } }
-        public bool IsReference { get { return default(bool); } set { } }
-        public bool IsReferenceSetExplicitly { get { return default(bool); } }
-        public string Name { get { return default(string); } set { } }
-        public string Namespace { get { return default(string); } set { } }
+        public bool IsNameSetExplicitly { get { throw null; } }
+        public bool IsNamespaceSetExplicitly { get { throw null; } }
+        public bool IsReference { get { throw null; } set { } }
+        public bool IsReferenceSetExplicitly { get { throw null; } }
+        public string Name { get { throw null; } set { } }
+        public string Namespace { get { throw null; } set { } }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(384), Inherited = false, AllowMultiple = false)]
     public sealed partial class DataMemberAttribute : System.Attribute
     {
         public DataMemberAttribute() { }
-        public bool EmitDefaultValue { get { return default(bool); } set { } }
-        public bool IsNameSetExplicitly { get { return default(bool); } }
-        public bool IsRequired { get { return default(bool); } set { } }
-        public string Name { get { return default(string); } set { } }
-        public int Order { get { return default(int); } set { } }
+        public bool EmitDefaultValue { get { throw null; } set { } }
+        public bool IsNameSetExplicitly { get { throw null; } }
+        public bool IsRequired { get { throw null; } set { } }
+        public string Name { get { throw null; } set { } }
+        public int Order { get { throw null; } set { } }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(256), Inherited = false, AllowMultiple = false)]
     public sealed partial class EnumMemberAttribute : System.Attribute
     {
         public EnumMemberAttribute() { }
-        public bool IsValueSetExplicitly { get { return default(bool); } }
-        public string Value { get { return default(string); } set { } }
+        public bool IsValueSetExplicitly { get { throw null; } }
+        public string Value { get { throw null; } set { } }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(384), Inherited = false, AllowMultiple = false)]
     public sealed partial class IgnoreDataMemberAttribute : System.Attribute
@@ -82,8 +82,8 @@ namespace System.Runtime.Serialization
     {
         public KnownTypeAttribute(string methodName) { }
         public KnownTypeAttribute(System.Type type) { }
-        public string MethodName { get { return default(string); } }
-        public System.Type Type { get { return default(System.Type); } }
+        public string MethodName { get { throw null; } }
+        public System.Type Type { get { throw null; } }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited = false)]
     public sealed partial class OnDeserializedAttribute : System.Attribute
@@ -114,7 +114,27 @@ namespace System.Runtime.Serialization
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct StreamingContext
     {
-        public override bool Equals(object obj) { return default(bool); }
-        public override int GetHashCode() { return default(int); }
+        public StreamingContext(StreamingContextStates state) { }
+        public StreamingContext(StreamingContextStates state, Object additional) { }
+       
+        public Object Context { get { throw null; } }       
+        public StreamingContextStates State  { get { throw null; } }
+
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+    }
+    
+    [Flags]
+    public enum StreamingContextStates
+    {
+        //CrossProcess = 0x01,
+        //CrossMachine = 0x02,
+        //File = 0x04,
+        //Persistence = 0x08,
+        //Remoting = 0x10,
+        //Other = 0x20,
+        //Clone = 0x40,
+        //CrossAppDomain = 0x80,
+        All = 0xFF,
     }
 }

--- a/src/System.Runtime.Serialization.Primitives/src/System/Runtime/Serialization/StreamingContext.cs
+++ b/src/System.Runtime.Serialization.Primitives/src/System/Runtime/Serialization/StreamingContext.cs
@@ -18,43 +18,37 @@ namespace System.Runtime.Serialization
 {
     public struct StreamingContext
     {
-        internal Object m_additionalContext;
-        internal StreamingContextStates m_state;
+        internal readonly object _additionalContext;
+        internal readonly StreamingContextStates _state;
 
-        internal StreamingContext(StreamingContextStates state)
+        public StreamingContext(StreamingContextStates state)
             : this(state, null)
         {
         }
 
-        internal StreamingContext(StreamingContextStates state, Object additional)
+        public StreamingContext(StreamingContextStates state, object additional)
         {
-            m_state = state;
-            m_additionalContext = additional;
+            _state = state;
+            _additionalContext = additional;
         }
 
-        internal Object Context
-        {
-            get { return m_additionalContext; }
-        }
-
-        public override bool Equals(Object obj)
+        public object Context => _additionalContext;
+        
+        public StreamingContextStates State => _state;
+        
+        public override bool Equals(object obj)
         {
             if (!(obj is StreamingContext))
             {
                 return false;
             }
             StreamingContext ctx = (StreamingContext)obj;
-            return ctx.m_additionalContext == m_additionalContext && ctx.m_state == m_state;
+            return ctx._additionalContext == _additionalContext && ctx._state == _state;
         }
 
         public override int GetHashCode()
         {
-            return (int)m_state;
-        }
-
-        internal StreamingContextStates State
-        {
-            get { return m_state; }
+            return (int)_state;
         }
     }
 
@@ -62,16 +56,16 @@ namespace System.Runtime.Serialization
     // Keep these in sync with the version in vm\runtimehandles.h
     // **********************************************************
     [Flags]
-    internal enum StreamingContextStates
+    public enum StreamingContextStates
     {
-        CrossProcess = 0x01,
-        CrossMachine = 0x02,
-        File = 0x04,
-        Persistence = 0x08,
-        Remoting = 0x10,
-        Other = 0x20,
-        Clone = 0x40,
-        CrossAppDomain = 0x80,
+        //CrossProcess = 0x01,
+        //CrossMachine = 0x02,
+        //File = 0x04,
+        //Persistence = 0x08,
+        //Remoting = 0x10,
+        //Other = 0x20,
+        //Clone = 0x40,
+        //CrossAppDomain = 0x80,
         All = 0xFF,
     }
 }


### PR DESCRIPTION
These members are used in non trivial percentage of apps/scenarios.
Exposing only one member of StreamingContextStates as we currently don't have
plans to support remoting.

In addition, I changed the reference assembly to use throw null (as it is done in System.Runtime.Serialization.Formatters).