### PR TITLE
Better perf for Path.GetInvalidFileNameChars, GetInvalidPathChars

### DIFF
--- a/src/Common/src/System/IO/PathInternal.Unix.cs
+++ b/src/Common/src/System/IO/PathInternal.Unix.cs
@@ -12,9 +12,10 @@ namespace System.IO
     {
         // There is only one invalid path character in Unix
         private const char InvalidPathChar = '\0';
-        internal static readonly char[] InvalidPathChars = GetInvalidPathChars();
-
+        
         internal static readonly int MaxComponentLength = Interop.Sys.MaxName;
+        
+        internal static char[] GetInvalidPathChars() => new char[] { InvalidPathChar };
 
         /// <summary>Returns a value indicating if the given path contains invalid characters.</summary>
         internal static bool HasIllegalCharacters(string path)
@@ -22,8 +23,6 @@ namespace System.IO
             Debug.Assert(path != null);
             return path.IndexOf(InvalidPathChar) >= 0;
         }
-        
-        internal static char[] GetInvalidPathChars() => new char[] { InvalidPathChar };
 
         internal static int GetRootLength(string path)
         {

--- a/src/Common/src/System/IO/PathInternal.Unix.cs
+++ b/src/Common/src/System/IO/PathInternal.Unix.cs
@@ -12,10 +12,9 @@ namespace System.IO
     {
         // There is only one invalid path character in Unix
         private const char InvalidPathChar = '\0';
+        internal static char[] GetInvalidPathChars() => new char[] { InvalidPathChar };
         
         internal static readonly int MaxComponentLength = Interop.Sys.MaxName;
-        
-        internal static char[] GetInvalidPathChars() => new char[] { InvalidPathChar };
 
         /// <summary>Returns a value indicating if the given path contains invalid characters.</summary>
         internal static bool HasIllegalCharacters(string path)

--- a/src/Common/src/System/IO/PathInternal.Unix.cs
+++ b/src/Common/src/System/IO/PathInternal.Unix.cs
@@ -12,7 +12,7 @@ namespace System.IO
     {
         // There is only one invalid path character in Unix
         private const char InvalidPathChar = '\0';
-        internal static readonly char[] InvalidPathChars = { InvalidPathChar };
+        internal static readonly char[] InvalidPathChars = GetInvalidPathChars();
 
         internal static readonly int MaxComponentLength = Interop.Sys.MaxName;
 
@@ -22,6 +22,8 @@ namespace System.IO
             Debug.Assert(path != null);
             return path.IndexOf(InvalidPathChar) >= 0;
         }
+        
+        internal static char[] GetInvalidPathChars() => new char[] { InvalidPathChar };
 
         internal static int GetRootLength(string path)
         {

--- a/src/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/Common/src/System/IO/PathInternal.Windows.cs
@@ -51,7 +51,9 @@ namespace System.IO
         internal const int DevicePrefixLength = 4;
         internal static readonly int MaxComponentLength = 255;
 
-        internal static readonly char[] InvalidPathChars =
+        internal static readonly char[] InvalidPathChars = GetInvalidPathChars();
+        
+        internal static char[] GetInvalidPathChars() => new char[]
         {
             '\"', '<', '>', '|', '\0',
             (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10,

--- a/src/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/Common/src/System/IO/PathInternal.Windows.cs
@@ -51,8 +51,6 @@ namespace System.IO
         internal const int DevicePrefixLength = 4;
         internal static readonly int MaxComponentLength = 255;
 
-        internal static readonly char[] InvalidPathChars = GetInvalidPathChars();
-        
         internal static char[] GetInvalidPathChars() => new char[]
         {
             '\"', '<', '>', '|', '\0',

--- a/src/Common/src/System/IO/PathInternal.cs
+++ b/src/Common/src/System/IO/PathInternal.cs
@@ -9,6 +9,8 @@ namespace System.IO
     /// <summary>Contains internal path helpers that are shared between many projects.</summary>
     internal static partial class PathInternal
     {
+        internal static readonly char[] InvalidPathChars = GetInvalidPathChars();
+        
         /// <summary>
         /// Checks for invalid path characters in the given path.
         /// </summary>

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
@@ -16,8 +16,6 @@ namespace System.IO
 
         private const string DirectorySeparatorCharAsString = "/";
 
-        private static readonly char[] InvalidFileNameChars = { '\0', '/' };
-
         private static readonly int MaxPath = Interop.Sys.MaxPath;
         private static readonly int MaxLongPath = MaxPath;
 
@@ -62,6 +60,8 @@ namespace System.IO
 
             return result;
         }
+        
+        public static char[] GetInvalidFileNameChars() => new char[] { '\0', '/' };
 
         /// <summary>
         /// Try to remove relative segments from the given path (without combining with a root).

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
@@ -15,6 +15,8 @@ namespace System.IO
         public static readonly char PathSeparator = ':';
 
         private const string DirectorySeparatorCharAsString = "/";
+        
+        public static char[] GetInvalidFileNameChars() => new char[] { '\0', '/' };
 
         private static readonly int MaxPath = Interop.Sys.MaxPath;
         private static readonly int MaxLongPath = MaxPath;
@@ -60,8 +62,6 @@ namespace System.IO
 
             return result;
         }
-        
-        public static char[] GetInvalidFileNameChars() => new char[] { '\0', '/' };
 
         /// <summary>
         /// Try to remove relative segments from the given path (without combining with a root).

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs
@@ -14,6 +14,15 @@ namespace System.IO
         public static readonly char PathSeparator = ';';
 
         private const string DirectorySeparatorCharAsString = "\\";
+        
+        public static char[] GetInvalidFileNameChars() => new char[]
+        { 
+            '\"', '<', '>', '|', '\0', 
+            (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10, 
+            (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20, 
+            (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30, 
+            (char)31, ':', '*', '?', '\\', '/' 
+        };
 
         // The max total path is 260, and the max individual component length is 255. 
         // For example, D:\<256 char file name> isn't legal, even though it's under 260 chars.
@@ -84,15 +93,6 @@ namespace System.IO
 
             return fullPath;
         }
-        
-        public static char[] GetInvalidFileNameChars() => new char[]
-        { 
-            '\"', '<', '>', '|', '\0', 
-            (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10, 
-            (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20, 
-            (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30, 
-            (char)31, ':', '*', '?', '\\', '/' 
-        };
 
         public static string GetTempPath()
         {

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Windows.cs
@@ -15,15 +15,6 @@ namespace System.IO
 
         private const string DirectorySeparatorCharAsString = "\\";
 
-        private static readonly char[] InvalidFileNameChars = 
-        { 
-            '\"', '<', '>', '|', '\0', 
-            (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10, 
-            (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20, 
-            (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30, 
-            (char)31, ':', '*', '?', '\\', '/' 
-        };
-
         // The max total path is 260, and the max individual component length is 255. 
         // For example, D:\<256 char file name> isn't legal, even though it's under 260 chars.
         internal static readonly int MaxPath = 260;
@@ -93,6 +84,15 @@ namespace System.IO
 
             return fullPath;
         }
+        
+        public static char[] GetInvalidFileNameChars() => new char[]
+        { 
+            '\"', '<', '>', '|', '\0', 
+            (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10, 
+            (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20, 
+            (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30, 
+            (char)31, ':', '*', '?', '\\', '/' 
+        };
 
         public static string GetTempPath()
         {

--- a/src/System.Runtime.Extensions/src/System/IO/Path.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.cs
@@ -85,12 +85,18 @@ namespace System.IO
 
         public static char[] GetInvalidPathChars()
         {
-            return (char[])PathInternal.InvalidPathChars.Clone();
+            var src = PathInternal.InvalidPathChars;
+            var dest = new char[src.Length];
+            Buffer.BlockCopy(src, 0, dest, 0, src.Length * sizeof(char));
+            return dest;
         }
 
         public static char[] GetInvalidFileNameChars()
         {
-            return (char[])InvalidFileNameChars.Clone();
+            var src = InvalidFileNameChars;
+            var dest = new char[src.Length];
+            Buffer.BlockCopy(src, 0, dest, 0, src.Length * sizeof(char));
+            return dest;
         }
 
         // Returns the extension of the given path. The returned value includes the

--- a/src/System.Runtime.Extensions/src/System/IO/Path.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.cs
@@ -83,21 +83,7 @@ namespace System.IO
             return null;
         }
 
-        public static char[] GetInvalidPathChars()
-        {
-            var src = PathInternal.InvalidPathChars;
-            var dest = new char[src.Length];
-            Buffer.BlockCopy(src, 0, dest, 0, src.Length * sizeof(char));
-            return dest;
-        }
-
-        public static char[] GetInvalidFileNameChars()
-        {
-            var src = InvalidFileNameChars;
-            var dest = new char[src.Length];
-            Buffer.BlockCopy(src, 0, dest, 0, src.Length * sizeof(char));
-            return dest;
-        }
+        public static char[] GetInvalidPathChars() => PathInternal.GetInvalidPathChars();
 
         // Returns the extension of the given path. The returned value includes the
         // period (".") character of the extension except when you have a terminal period when you get string.Empty, such as ".exe" or


### PR DESCRIPTION
<s>Since `GetInvalidPathChars` and `GetInvalidFileNameChars` are an array of primitives, it's probably best to use `Buffer.BlockCopy` rather than `Clone` here, since the latter is slower and isn't type-safe.

Notes:

- I [recently submitted](https://github.com/dotnet/coreclr/pull/4807) a PR to coreclr that makes `Buffer.BlockCopy` somewhat faster for these types of cases (specifically, copying from different non-byte arrays of the same type)

- Here are perf results on my machine checking the difference between `Clone` and `BlockCopy`:

  - [Capacity of 50](https://gist.github.com/jamesqo/4521fc8c4e830aaf7109cc71fd4b23c9) (this is around the size of the array on Windows)
  - [Capacity of 1](https://gist.github.com/jamesqo/19099203dc56e1cc38946ad550621451) (Unix only has one or two invalid path chars)
  - [Test source code](https://gist.github.com/jamesqo/04f1eb6e0dca173800bf1ca0ca9c9fdf)</s>

Have `PathInternal.InvalidPathChars` call `GetInvalidPathChars`, instead of the other way around. Also removed unnecessary `InvalidFileNameChars` array allocation.