### PR TITLE
Produce symbol packages inside packages output directory

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -507,6 +507,7 @@
 
     <PackagesBasePath Condition="'$(PackagesBasePath)'==''">$(BinDir)$(OSPlatformConfig)</PackagesBasePath>
     <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(PackageOutputRoot)$(ConfigurationGroup)/</PackageOutputPath>
+    <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)'==''">$(PackageOutputPath)symbols/</SymbolPackageOutputPath>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Specify `SymbolPackageOutputPath` to be `PackageOutputPath\symbols`. The old default location was `bin\symbolpkg`, which didn't include Configuration and wasn't published by the publish-packages workflow scripts.

/cc @weshaggard @chcosta @jhendrixMSFT 