### PR TITLE
ReflectionBasedDCS: Fix 5 test failures, MemberInfo, DateTimeOffset, KeyValuePair

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionXmlFormatWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionXmlFormatWriter.cs
@@ -23,11 +23,20 @@ namespace System.Runtime.Serialization
         internal void ReflectionWriteClass(XmlWriterDelegator xmlWriter, object obj, XmlObjectSerializerWriteContext context, ClassDataContract classContract)
         {
             ReflectionInitArgs(xmlWriter, obj, context, classContract);
-            ReflectionWriteMembers(xmlWriter, obj, context, classContract, classContract);
+            ReflectionWriteMembers(xmlWriter, _arg1Object, _arg2Context, _arg3ClassDataContract, _arg3ClassDataContract);
         }
 
         private void ReflectionInitArgs(XmlWriterDelegator xmlWriter, object obj, XmlObjectSerializerWriteContext context, ClassDataContract classContract)
         {
+            if (obj.GetType() == typeof(DateTimeOffset))
+            {
+                obj = DateTimeOffsetAdapter.GetDateTimeOffsetAdapter((DateTimeOffset)obj);
+            }
+            else if (obj.GetType().GetTypeInfo().IsGenericType && obj.GetType().GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
+            {
+                obj = classContract.KeyValuePairAdapterConstructorInfo.Invoke(new object[] { obj });
+            }
+
             _arg0XmlWriter = xmlWriter;
             _arg1Object = obj;
             _arg2Context = context;
@@ -52,8 +61,7 @@ namespace System.Runtime.Serialization
                     context.StoreIsGetOnlyCollection();
                 }
                 bool writeXsiType = CheckIfMemberHasConflict(member, classContract, derivedMostClassContract);
-                MemberInfo[] memberInfos = classType.GetMember(member.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                MemberInfo memberInfo = memberInfos[0];
+                MemberInfo memberInfo = member.MemberInfo;
                 object memberValue = ReflectionGetMemberValue(obj, memberInfo);
                 if (writeXsiType || !ReflectionTryWritePrimitive(xmlWriter, context, memberType, memberValue, member.MemberInfo, null /*arrayItemIndex*/, ns, memberNames[i] /*nameLocal*/, i + _childElementIndex))
                 {

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -22,7 +22,6 @@ using Xunit;
 public static partial class DataContractSerializerTests
 {
     [Fact]
-    [ActiveIssue("ReflectionBasedDCS")]
     public static void DCS_DateTimeOffsetAsRoot()
     {
         // Assume that UTC offset doesn't change more often than once in the day 2013-01-02
@@ -809,7 +808,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("ReflectionBasedDCS")]
     public static void DCS_DataMemberAttribute()
     {
         SerializeAndDeserialize<DMA_1>(new DMA_1 { P1 = "abc", P2 = 12, P3 = true, P4 = 'a', P5 = 10, MyDataMemberInAnotherNamespace = new MyDataContractClass04_1() { MyDataMember = "Test" }, Order100 = true, OrderMaxValue = false }, @"<DMA_1 xmlns=""http://schemas.datacontract.org/2004/07/SerializationTypes"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><MyDataMemberInAnotherNamespace xmlns:a=""http://MyDataContractClass04_1.com/""><a:MyDataMember>Test</a:MyDataMember></MyDataMemberInAnotherNamespace><P1>abc</P1><P4>97</P4><P5>10</P5><xyz>12</xyz><P3>true</P3><Order100>true</Order100><OrderMaxValue>false</OrderMaxValue></DMA_1>");
@@ -1303,7 +1301,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("ReflectionBasedDCS")]
     public static void DCS_DuplicatedKnownTypesWithAdapterThroughConstructor()
     {
         //Constructor# 5  
@@ -1722,7 +1719,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("ReflectionBasedDCS")]
     public static void DCS_DuplicatedKeyDateTimeOffset()
     {
         DateTimeOffset value = new DateTimeOffset(new DateTime(2013, 1, 2, 3, 4, 5, 6, DateTimeKind.Utc).AddMinutes(7));
@@ -1903,7 +1899,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("ReflectionBasedDCS")]
     public static void DCS_MyPersonSurrogate()
     {
         DataContractSerializer dcs = new DataContractSerializer(typeof(Family));


### PR DESCRIPTION
Fix the following 5 tests:

DCS_DateTimeOffsetAsRoot
DCS_DataMemberAttribute
DCS_DuplicatedKnownTypesWithAdapterThroughConstructor
DCS_DuplicatedKeyDateTimeOffset
DCS_MyPersonSurrogate

cc: @SGuyGe @shmao @zhenlan 