### PR TITLE
Added diagnostics to sqlclient

### DIFF
--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
@@ -88,6 +88,7 @@
     <Compile Include="System\Data\SqlClient\SqlBulkCopyColumnMappingCollection.cs" />
     <Compile Include="System\Data\SqlClient\SqlBulkCopyOptions.cs" />
     <Compile Include="System\Data\SqlClient\SqlCachedBuffer.cs" />
+    <Compile Include="System\Data\SqlClient\SqlClientDiagnosticListenerExtensions.cs" />
     <Compile Include="System\Data\SqlClient\SqlClientFactory.cs" />
     <Compile Include="System\Data\SqlClient\SqlCommand.cs" />
     <Compile Include="System\Data\SqlClient\SqlConnection.cs" />

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Data.SqlClient
+{
+    /// <summary>
+    /// Extension methods on the DiagnosticListener class to log SqlCommand data
+    /// </summary>
+    internal static class SqlClientDiagnosticListenerExtensions
+    {
+        public const string DiagnosticListenerName = "SqlClientDiagnosticListener";
+
+        private const string SqlClientPrefix = "System.Data.SqlClient.";
+        public const string SqlBeforeExecuteCommand = SqlClientPrefix + nameof(WriteCommandBefore);
+        public const string SqlAfterExecuteCommand = SqlClientPrefix + nameof(WriteCommandAfter);
+        public const string SqlErrorExecuteCommand = SqlClientPrefix + nameof(WriteCommandError);
+
+        public static Guid WriteCommandBefore(this DiagnosticListener @this, SqlCommand sqlCommand, [CallerMemberName] string operation = "")
+        {
+            if (@this.IsEnabled(SqlBeforeExecuteCommand))
+            {
+                Guid operationId = Guid.NewGuid();
+
+                @this.Write(
+                    SqlBeforeExecuteCommand,
+                    new
+                    {
+                        OperationId = operationId,
+                        Operation = operation,
+                        Command = sqlCommand
+                    });
+
+                return operationId;
+            }
+            else
+                return Guid.Empty;
+        }
+
+        public static void WriteCommandAfter(this DiagnosticListener @this, Guid operationId, SqlCommand sqlCommand, [CallerMemberName] string operation = "")
+        {
+            if (@this.IsEnabled(SqlAfterExecuteCommand))
+            {
+                @this.Write(
+                    SqlAfterExecuteCommand,
+                    new
+                    {
+                        OperationId = operationId,
+                        Operation = operation,
+                        Command = sqlCommand,
+                        Statistics = sqlCommand.Statistics?.GetDictionary(),
+                        Timestamp = Stopwatch.GetTimestamp()
+                    });
+            }
+        }
+
+        public static void WriteCommandError(this DiagnosticListener @this, Guid operationId, SqlCommand sqlCommand, Exception ex, [CallerMemberName] string operation = "")
+        {
+            if (@this.IsEnabled(SqlErrorExecuteCommand))
+            {
+                @this.Write(
+                    SqlErrorExecuteCommand,
+                    new
+                    {
+                        OperationId = operationId,
+                        Operation = operation,
+                        Command = sqlCommand,
+                        Exception = ex,
+                        Timestamp = Stopwatch.GetTimestamp()
+                    });
+            }
+        }
+    }
+}

--- a/src/System.Data.SqlClient/src/project.json
+++ b/src/System.Data.SqlClient/src/project.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "frameworks": {
     "netstandard1.3": {
       "imports": "dotnet5.4",
@@ -9,6 +9,7 @@
         "System.Collections.Concurrent": "4.0.0",
         "System.Data.Common": "4.0.1-rc3-24112-00",
         "System.Diagnostics.Debug": "4.0.10",
+        "System.Diagnostics.DiagnosticSource": "4.0.0-rc3-24112-00",
         "System.Diagnostics.Tools": "4.0.0",
         "System.Globalization": "4.0.10",
         "System.IO": "4.0.10",
@@ -51,5 +52,6 @@
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }
     }
-  }
+  },
+  "dependencies": {}
 }

--- a/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
@@ -1,0 +1,490 @@
+﻿using Xunit;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections;
+using System.Xml;
+using Xunit.Abstractions;
+using System.Threading.Tasks;
+
+namespace System.Data.SqlClient.Tests
+{
+    public class DiagnosticTest
+    {
+        private string _connectionString = "server=tcp:server,1432;database=test;uid=admin;pwd=SQLDB;connect timeout=60;";
+        private readonly ITestOutputHelper _output;
+
+        public DiagnosticTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void ExecuteScalarTest()
+        {
+            CollectStatisticsDiagnostics(() =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select @@servername;";
+
+                    conn.Open();
+                    var output = cmd.ExecuteScalar();
+                }
+            });
+        }
+        [Fact]
+        public void ExecuteScalarErrorTest()
+        {
+            CollectStatisticsDiagnostics(() =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select 1 / 0;";
+
+                    conn.Open();
+
+                    try { var output = cmd.ExecuteScalar(); }
+                    catch { }
+                }
+            });
+        }
+        [Fact]
+        public void ExecuteNonQueryTest()
+        {
+            CollectStatisticsDiagnostics(() =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select @@servername;";
+
+                    conn.Open();
+                    var output = cmd.ExecuteNonQuery();
+                }
+            });
+        }
+        [Fact]
+        public void ExecuteNonQueryErrorTest()
+        {
+            CollectStatisticsDiagnostics(() =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select 1 / 0;";
+
+                    conn.Open();
+                    try { var output = cmd.ExecuteNonQuery(); }
+                    catch { }
+                }
+            });
+        }
+        [Fact]
+        public void ExecuteReaderTest()
+        {
+            CollectStatisticsDiagnostics(() =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select @@servername;";
+
+                    conn.Open();
+                    SqlDataReader reader = cmd.ExecuteReader();
+                    while (reader.Read()) { }
+                }
+            });
+        }
+        [Fact]
+        public void ExecuteReaderErrorTest()
+        {
+            CollectStatisticsDiagnostics(() =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select 1 / 0;";
+
+                    try
+                    {
+                        SqlDataReader reader = cmd.ExecuteReader();
+                        while (reader.Read()) { }
+                    }
+                    catch { }
+                }
+            });
+        }
+        [Fact]
+        public void ExecuteReaderWithCommandBehaviorTest()
+        {
+            CollectStatisticsDiagnostics(() =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select @@servername;";
+
+                    conn.Open();
+                    SqlDataReader reader = cmd.ExecuteReader(CommandBehavior.Default);
+                    while (reader.Read()) { }
+                }
+            });
+        }
+        [Fact]
+        public void ExecuteXmlReaderTest()
+        {
+            CollectStatisticsDiagnostics(() =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select * from sys.objects for xml auto, xmldata;";
+
+                    conn.Open();
+                    XmlReader reader = cmd.ExecuteXmlReader();
+                    while (reader.Read()) { }
+                }
+            });
+        }
+        [Fact]
+        public void ExecuteXmlReaderErrorTest()
+        {
+            CollectStatisticsDiagnostics(() =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select *, baddata = 1 / 0 from sys.objects for xml auto, xmldata;";
+
+                    try
+                    {
+                        XmlReader reader = cmd.ExecuteXmlReader();
+                        while (reader.Read()) { }
+                    }
+                    catch { }
+                }
+            });
+        }
+
+        [Fact]
+        public void ExecuteScalarAsyncTest()
+        {
+            CollectStatisticsDiagnosticsAsync(async () =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select @@servername;";
+
+                    conn.Open();
+                    var output = await cmd.ExecuteScalarAsync();
+                }
+            });
+        }
+        [Fact]
+        public void ExecuteScalarAsyncErrorTest()
+        {
+            CollectStatisticsDiagnosticsAsync(async () =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select 1 / 0;";
+
+                    conn.Open();
+
+                    try { var output = await cmd.ExecuteScalarAsync(); }
+                    catch { }
+                }
+            });
+        }
+        [Fact]
+        public void ExecuteNonQueryAsyncTest()
+        {
+            CollectStatisticsDiagnosticsAsync(async () =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select @@servername;";
+
+                    conn.Open();
+                    var output = await cmd.ExecuteNonQueryAsync();
+                }
+            });
+        }
+        [Fact]
+        public void ExecuteNonQueryAsyncErrorTest()
+        {
+            CollectStatisticsDiagnosticsAsync(async () =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select 1 / 0;";
+
+                    conn.Open();
+                    try { var output = await cmd.ExecuteNonQueryAsync(); }
+                    catch { }
+                }
+            });
+        }
+        [Fact]
+        public void ExecuteReaderAsyncTest()
+        {
+            CollectStatisticsDiagnosticsAsync(async () =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select @@servername;";
+
+                    conn.Open();
+                    SqlDataReader reader = await cmd.ExecuteReaderAsync();
+                    while (reader.Read()) { }
+                }
+            });
+        }
+        [Fact]
+        public void ExecuteReaderAsyncErrorTest()
+        {
+            CollectStatisticsDiagnosticsAsync(async () =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select 1 / 0;";
+
+                    try
+                    {
+                        SqlDataReader reader = await cmd.ExecuteReaderAsync();
+                        while (reader.Read()) { }
+                    }
+                    catch { }
+                }
+            });
+        }
+        [Fact]
+        public void ExecuteXmlReaderAsyncTest()
+        {
+            CollectStatisticsDiagnosticsAsync(async () =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select * from sys.objects for xml auto, xmldata;";
+
+                    conn.Open();
+                    XmlReader reader = await cmd.ExecuteXmlReaderAsync();
+                    while (reader.Read()) { }
+                }
+            });
+        }
+        [Fact]
+        public void ExecuteXmlReaderAsyncErrorTest()
+        {
+            CollectStatisticsDiagnosticsAsync(async () =>
+            {
+                using (SqlConnection conn = new SqlConnection(_connectionString))
+                using (SqlCommand cmd = new SqlCommand())
+                {
+                    cmd.Connection = conn;
+                    cmd.CommandText = "select *, baddata = 1 / 0 from sys.objects for xml auto, xmldata;";
+
+                    try
+                    {
+                        XmlReader reader = await cmd.ExecuteXmlReaderAsync();
+                        while (reader.Read()) { }
+                    }
+                    catch { }
+                }
+            });
+        }
+        
+        private void CollectStatisticsDiagnostics(Action sqlOperation)
+        {
+            bool statsLogged = false;
+            bool operationHasError = false;
+            Guid beginOperationId = Guid.Empty;
+            
+            FakeDiagnosticListenerObserver diagnosticListenerObserver = new FakeDiagnosticListenerObserver(kvp =>
+                {
+                    IDictionary statistics;
+
+                    if (kvp.Key.Equals("System.Data.SqlClient.WriteCommandBefore"))
+                    {
+                        Assert.NotNull(kvp.Value);
+
+                        Guid retrievedOperationId = GetPropertyValueFromType<Guid>(kvp.Value, "OperationId");
+                        Assert.NotEqual(retrievedOperationId, Guid.Empty);
+
+                        SqlCommand sqlCommand = GetPropertyValueFromType<SqlCommand>(kvp.Value, "Command");
+                        Assert.NotNull(sqlCommand);
+
+                        string operation = GetPropertyValueFromType<string>(kvp.Value, "Operation");
+                        Assert.False(string.IsNullOrWhiteSpace(operation));
+
+                        beginOperationId = retrievedOperationId;
+                                                                        
+                        statsLogged = true;
+                    }
+                    else if (kvp.Key.Equals("System.Data.SqlClient.WriteCommandAfter"))
+                    {
+                        Assert.NotNull(kvp.Value);
+
+                        Guid retrievedOperationId = GetPropertyValueFromType<Guid>(kvp.Value, "OperationId");
+                        Assert.NotEqual(retrievedOperationId, Guid.Empty);
+
+                        SqlCommand sqlCommand = GetPropertyValueFromType<SqlCommand>(kvp.Value, "Command");
+                        Assert.NotNull(sqlCommand);
+
+                        statistics = GetPropertyValueFromType<IDictionary>(kvp.Value, "Statistics");
+                        if (!operationHasError)
+                            Assert.NotNull(statistics);
+
+                        string operation = GetPropertyValueFromType<string>(kvp.Value, "Operation");
+                        Assert.False(string.IsNullOrWhiteSpace(operation));
+
+                        // if we get to this point, then statistics exist and this must be the "end" 
+                        // event, so we need to make sure the operation IDs match
+                        Assert.Equal(retrievedOperationId, beginOperationId);
+                        beginOperationId = Guid.Empty;
+
+                        statsLogged = true;
+                    }
+                    else if (kvp.Key.Equals("System.Data.SqlClient.WriteCommandError"))
+                    {
+                        operationHasError = true;
+                        Assert.NotNull(kvp.Value);
+
+                        SqlCommand sqlCommand = GetPropertyValueFromType<SqlCommand>(kvp.Value, "Command");
+                        Assert.NotNull(sqlCommand);
+
+                        Exception ex = GetPropertyValueFromType<Exception>(kvp.Value, "Exception");
+                        Assert.NotNull(ex);
+
+                        string operation = GetPropertyValueFromType<string>(kvp.Value, "Operation");
+                        Assert.False(string.IsNullOrWhiteSpace(operation));
+
+                        statsLogged = true;
+                    }
+                });
+
+            diagnosticListenerObserver.Enable();
+            using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
+            { 
+                sqlOperation();
+
+                Assert.True(statsLogged);
+
+                diagnosticListenerObserver.Disable();
+            }
+        }
+        private async void CollectStatisticsDiagnosticsAsync(Func<Task> sqlOperation)
+        {
+            bool statsLogged = false;
+            bool operationHasError = false;
+            Guid beginOperationId = Guid.Empty;
+
+            FakeDiagnosticListenerObserver diagnosticListenerObserver = new FakeDiagnosticListenerObserver(kvp =>
+            {
+                IDictionary statistics;
+
+                if (kvp.Key.Equals("System.Data.SqlClient.WriteCommandBefore"))
+                {
+                    Assert.NotNull(kvp.Value);
+
+                    Guid retrievedOperationId = GetPropertyValueFromType<Guid>(kvp.Value, "OperationId");
+                    Assert.NotEqual(retrievedOperationId, Guid.Empty);
+
+                    SqlCommand sqlCommand = GetPropertyValueFromType<SqlCommand>(kvp.Value, "Command");
+                    Assert.NotNull(sqlCommand);
+
+                    string operation = GetPropertyValueFromType<string>(kvp.Value, "Operation");
+                    Assert.False(string.IsNullOrWhiteSpace(operation));
+
+                    beginOperationId = retrievedOperationId;
+
+                    statsLogged = true;
+                }
+                else if (kvp.Key.Equals("System.Data.SqlClient.WriteCommandAfter"))
+                {
+                    Assert.NotNull(kvp.Value);
+
+                    Guid retrievedOperationId = GetPropertyValueFromType<Guid>(kvp.Value, "OperationId");
+                    Assert.NotEqual(retrievedOperationId, Guid.Empty);
+
+                    SqlCommand sqlCommand = GetPropertyValueFromType<SqlCommand>(kvp.Value, "Command");
+                    Assert.NotNull(sqlCommand);
+
+                    statistics = GetPropertyValueFromType<IDictionary>(kvp.Value, "Statistics");
+                    if (!operationHasError)
+                        Assert.NotNull(statistics);
+
+                    string operation = GetPropertyValueFromType<string>(kvp.Value, "Operation");
+                    Assert.False(string.IsNullOrWhiteSpace(operation));
+
+                    // if we get to this point, then statistics exist and this must be the "end" 
+                    // event, so we need to make sure the operation IDs match
+                    Assert.Equal(retrievedOperationId, beginOperationId);
+                    beginOperationId = Guid.Empty;
+
+                    statsLogged = true;
+                }
+                else if (kvp.Key.Equals("System.Data.SqlClient.WriteCommandError"))
+                {
+                    operationHasError = true;
+                    Assert.NotNull(kvp.Value);
+
+                    SqlCommand sqlCommand = GetPropertyValueFromType<SqlCommand>(kvp.Value, "Command");
+                    Assert.NotNull(sqlCommand);
+
+                    Exception ex = GetPropertyValueFromType<Exception>(kvp.Value, "Exception");
+                    Assert.NotNull(ex);
+
+                    string operation = GetPropertyValueFromType<string>(kvp.Value, "Operation");
+                    Assert.False(string.IsNullOrWhiteSpace(operation));
+
+                    statsLogged = true;
+                }
+            });
+
+            diagnosticListenerObserver.Enable();
+            using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
+            { 
+                await sqlOperation();
+
+                Assert.True(statsLogged);
+
+                diagnosticListenerObserver.Disable();
+            }
+        }
+        
+        private T GetPropertyValueFromType<T>(object obj, string propName)
+        {
+            Type type = obj.GetType();
+            PropertyInfo pi = type.GetRuntimeProperty(propName);
+
+            var propertyValue = pi.GetValue(obj);
+            return (T)propertyValue;
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/FunctionalTests/FakeDiagnosticListenerObserver.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/FakeDiagnosticListenerObserver.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Diagnostics;
+
+namespace System.Data.SqlClient.Tests
+{
+    public sealed class FakeDiagnosticListenerObserver : IObserver<DiagnosticListener>
+    {
+        private class FakeDiagnosticSourceWriteObserver : IObserver<KeyValuePair<string, object>>
+        {
+            private readonly Action<KeyValuePair<string, object>> _writeCallback;
+
+            public FakeDiagnosticSourceWriteObserver(Action<KeyValuePair<string, object>> writeCallback)
+            {
+                _writeCallback = writeCallback;
+            }
+
+            public void OnCompleted()
+            {
+            }
+
+            public void OnError(Exception error)
+            {
+            }
+
+            public void OnNext(KeyValuePair<string, object> value)
+            {
+                _writeCallback(value);
+            }
+        }
+
+        private readonly Action<KeyValuePair<string, object>> _writeCallback;
+        private bool _writeObserverEnabled;
+
+        public FakeDiagnosticListenerObserver(Action<KeyValuePair<string, object>> writeCallback)
+        {
+            _writeCallback = writeCallback;
+        }
+
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnNext(DiagnosticListener value)
+        {
+            if (value.Name.Equals("SqlClientDiagnosticListener"))
+            {
+                value.Subscribe(new FakeDiagnosticSourceWriteObserver(_writeCallback), IsEnabled);
+            }
+        }
+
+        public void Enable()
+        {
+            _writeObserverEnabled = true;
+        }
+        public void Disable()
+        {
+            _writeObserverEnabled = false;
+        }
+        private bool IsEnabled(string s)
+        {
+            return _writeObserverEnabled;
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -15,8 +15,12 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(EnableManualTests)' == 'true' ">
+    <Compile Include="DiagnosticTest.cs" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="ExceptionTest.cs" />
+    <Compile Include="FakeDiagnosticListenerObserver.cs" />
     <Compile Include="SqlBulkCopyColumnMappingCollectionTest.cs" />
     <Compile Include="SqlConnectionTest.RetrieveStatistics.cs" />
     <Compile Include="SqlErrorCollectionTest.cs" />

--- a/src/System.Data.SqlClient/tests/FunctionalTests/project.json
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/project.json
@@ -4,6 +4,10 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24112-00",
     "System.Data.Common": "4.0.1-rc3-24112-00",
     "System.Text.RegularExpressions": "4.1.0-rc3-24112-00",
+    "System.Collections": "4.0.11-rc3-24112-00",
+    "System.Collections.Concurrent": "4.0.12-rc3-24112-00",
+    "System.Diagnostics.DiagnosticSource": "4.0.0-rc3-24112-00",
+    "System.Xml.ReaderWriter": "4.0.11-rc3-24112-00",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00312-04",
     "test-runtime": {


### PR DESCRIPTION
This pull request includes changes to SqlClient in order to provide a mechanism for facilitating diagnostics collection in the library for all `Execute*()` operations (sync and async).

Tests have been created in order to test the functionality as well.

This functionality is proposed for merging as a facilitator of client-side diagnostics and logging to collect relevant data retrieval information for monitoring, baselining, and troubleshooting.