### PR TITLE
Switch SecureString to use CryptProtectMemory

### DIFF
--- a/src/Common/src/Interop/Windows/Crypt32/Interop.CryptProtectMemory.cs
+++ b/src/Common/src/Interop/Windows/Crypt32/Interop.CryptProtectMemory.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+internal partial class Interop
+{
+    internal partial class Crypt32
+    {
+        internal const uint CRYPTPROTECTMEMORY_BLOCK_SIZE = 16;
+        internal const uint CRYPTPROTECTMEMORY_SAME_PROCESS = 0;
+
+        [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern bool CryptProtectMemory(SafeBSTRHandle pData, uint cbData, uint dwFlags);
+
+        [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern bool CryptUnprotectMemory(SafeBSTRHandle pData, uint cbData, uint dwFlags);
+    }
+}

--- a/src/System.Security.SecureString/src/System.Security.SecureString.csproj
+++ b/src/System.Security.SecureString/src/System.Security.SecureString.csproj
@@ -37,17 +37,8 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptProtectData.cs">
-      <Link>Common\Interop\Windows\Interop.CryptProtectData.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptProtectDataFlags.cs">
-      <Link>Common\Interop\Windows\Interop.CryptProtectDataFlags.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptUnprotectData.cs">
-      <Link>Common\Interop\Windows\Interop.CryptUnprotectData.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.DATA_BLOB.cs">
-      <Link>Common\Interop\Windows\Interop.DATA_BLOB.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptProtectMemory.cs">
+      <Link>Common\Interop\Windows\Interop.CryptProtectMemory.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.FormatMessage.cs">
       <Link>Interop\Windows\Interop.FormatMessage.cs</Link>

--- a/src/System.Security.SecureString/src/System/Security/SafeBSTRHandle.cs
+++ b/src/System.Security.SecureString/src/System/Security/SafeBSTRHandle.cs
@@ -11,12 +11,10 @@ namespace System.Security
     {
         internal SafeBSTRHandle() : base(true) { }
 
-        internal static SafeBSTRHandle Allocate(uint lenInChars) => Allocate(IntPtr.Zero, lenInChars * sizeof(char));
-
-        internal static SafeBSTRHandle Allocate(IntPtr src, uint lenInBytes)
+        internal static SafeBSTRHandle Allocate(uint lenInChars)
         {
-            Debug.Assert(lenInBytes % sizeof(char) == 0);
-            SafeBSTRHandle bstr = Interop.OleAut32.SysAllocStringLen(src, lenInBytes / sizeof(char));
+            uint lenInBytes = lenInChars * sizeof(char);
+            SafeBSTRHandle bstr = Interop.OleAut32.SysAllocStringLen(IntPtr.Zero, lenInChars);
             if (bstr.IsInvalid) // SysAllocStringLen returns a NULL ptr when there's insufficient memory
             {
                 throw new OutOfMemoryException();
@@ -64,18 +62,18 @@ namespace System.Security
                 source.AcquirePointer(ref sourcePtr);
                 target.AcquirePointer(ref targetPtr);
 
-                Debug.Assert(Interop.OleAut32.SysStringLen((IntPtr)sourcePtr) * sizeof(char) >= bytesToCopy, "Source buffer is too small.");
-                Buffer.MemoryCopy(sourcePtr, targetPtr, Interop.OleAut32.SysStringLen((IntPtr)targetPtr) * sizeof(char), bytesToCopy);
+                Debug.Assert(source.ByteLength >= bytesToCopy, "Source buffer is too small.");
+                Buffer.MemoryCopy(sourcePtr, targetPtr, target.ByteLength, bytesToCopy);
             }
             finally
             {
-                if (sourcePtr != null)
-                {
-                    source.ReleasePointer();
-                }
                 if (targetPtr != null)
                 {
                     target.ReleasePointer();
+                }
+                if (sourcePtr != null)
+                {
+                    source.ReleasePointer();
                 }
             }
         }


### PR DESCRIPTION
Switch from CryptProtectData to CryptProtectMemory, per feedback and to enable these to be used without a logged-in user, matching the full framework.

Also added some more tests.

Fixes https://github.com/dotnet/corefx/issues/8379
cc: @bartonjs, @weshaggard 