### PR TITLE
Disable ConnectTimeoout test on Linux

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Timeouts.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Timeouts.cs
@@ -62,6 +62,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(8181, PlatformID.Linux)] // failing to timeout on Ubuntu 16.04 in CI
         [Fact]
         public async Task ConnectTimeout_TimesOut_Throws()
         {


### PR DESCRIPTION
It's failing on Ubuntu 16.04.  Something about the curl used in CI is likely wrong.

https://github.com/dotnet/corefx/issues/8181