### PR TITLE
Improve WinHttpHandler logic regarding default credentials

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
@@ -272,10 +272,18 @@ namespace System.Net.Http
             }
         }
 
-        public void ChangeDefaultCredentialsPolicy(SafeWinHttpHandle requestHandle, bool allowDefaultCredentials)
+        public void ChangeDefaultCredentialsPolicy(
+            SafeWinHttpHandle requestHandle,
+            uint authTarget,
+            bool allowDefaultCredentials)
         {
+            Debug.Assert(authTarget == Interop.WinHttp.WINHTTP_AUTH_TARGET_PROXY || 
+                         authTarget == Interop.WinHttp.WINHTTP_AUTH_TARGET_SERVER);
+
             uint optionData = allowDefaultCredentials ?
-                Interop.WinHttp.WINHTTP_AUTOLOGON_SECURITY_LEVEL_LOW :
+                (authTarget == Interop.WinHttp.WINHTTP_AUTH_TARGET_PROXY ?
+                    Interop.WinHttp.WINHTTP_AUTOLOGON_SECURITY_LEVEL_MEDIUM :
+                    Interop.WinHttp.WINHTTP_AUTOLOGON_SECURITY_LEVEL_LOW) :
                 Interop.WinHttp.WINHTTP_AUTOLOGON_SECURITY_LEVEL_HIGH;
 
             if (!Interop.WinHttp.WinHttpSetOption(
@@ -309,7 +317,7 @@ namespace System.Net.Http
             if (networkCredential == CredentialCache.DefaultNetworkCredentials)
             {
                 // Allow WinHTTP to transmit the default credentials.
-                ChangeDefaultCredentialsPolicy(requestHandle, allowDefaultCredentials:true);
+                ChangeDefaultCredentialsPolicy(requestHandle, authTarget, allowDefaultCredentials:true);
                 return;
             }
 

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -171,6 +171,8 @@ namespace System.Net.Http
             UseProxy = true;
             UseCookies = true;
             CookieContainer = new CookieContainer();
+            _winHttpHandler.DefaultProxyCredentials = null;
+            _winHttpHandler.ServerCredentials = null;
 
             // The existing .NET Desktop HttpClientHandler based on the HWR stack uses only WinINet registry
             // settings for the proxy.  This also includes supporting the "Automatic Detect a proxy" using

--- a/src/System.Net.Http/tests/FunctionalTests/DefaultCredentialsTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DefaultCredentialsTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Net.Test.Common;
 using System.Security.Principal;
 using System.Threading.Tasks;
 
@@ -32,7 +33,7 @@ namespace System.Net.Http.Functional.Tests
 
         [ConditionalTheory(nameof(HttpInternalTestsEnabled))]
         [InlineData(false)]
-        // TODO: Issue #8176 [InlineData(true)]
+        [InlineData(true)]
         public async Task UseDefaultCredentials_DefaultValue_Unauthorized(bool useProxy)
         {
             var handler = new HttpClientHandler();
@@ -99,7 +100,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalTheory(nameof(HttpInternalTestsEnabled))]
-        // TODO: Issue #8176 [InlineData(false)]
+        [InlineData(false)]
         [InlineData(true)]
         public async Task Credentials_SetToWrappedDefaultCredential_ConnectAsCurrentIdentity(bool useProxy)
         {
@@ -119,6 +120,50 @@ namespace System.Net.Http.Functional.Tests
                 WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent();
                 _output.WriteLine("currentIdentity={0}", currentIdentity.Name);
                 VerifyAuthentication(responseBody, true, currentIdentity.Name);
+            }
+        }
+
+        [ConditionalFact(nameof(HttpInternalTestsEnabled))]
+        public async Task Proxy_UseAuthenticatedProxyWithNoCredentials_ProxyAuthenticationRequired()
+        {
+            var handler = new HttpClientHandler();
+            handler.Proxy = new AuthenticatedProxy(null);
+
+            using (var client = new HttpClient(handler))
+            using (HttpResponseMessage response = await client.GetAsync(HttpTestServers.RemoteEchoServer))
+            {
+                Assert.Equal(HttpStatusCode.ProxyAuthenticationRequired, response.StatusCode);
+            }
+        }
+
+        [ConditionalFact(nameof(HttpInternalTestsEnabled))]
+        public async Task Proxy_UseAuthenticatedProxyWithDefaultCredentials_OK()
+        {
+            var handler = new HttpClientHandler();
+            handler.Proxy = new AuthenticatedProxy(CredentialCache.DefaultCredentials);
+
+            using (var client = new HttpClient(handler))
+            using (HttpResponseMessage response = await client.GetAsync(HttpTestServers.RemoteEchoServer))
+            {
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
+        }
+
+        [ConditionalFact(nameof(HttpInternalTestsEnabled))]
+        public async Task Proxy_UseAuthenticatedProxyWithWrappedDefaultCredentials_OK()
+        {
+            ICredentials wrappedCreds = new CredentialWrapper
+            {
+                InnerCredentials = CredentialCache.DefaultCredentials
+            };
+
+            var handler = new HttpClientHandler();
+            handler.Proxy = new AuthenticatedProxy(wrappedCreds);
+
+            using (var client = new HttpClient(handler))
+            using (HttpResponseMessage response = await client.GetAsync(HttpTestServers.RemoteEchoServer))
+            {
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }
         }
 
@@ -153,5 +198,50 @@ namespace System.Net.Http.Functional.Tests
             public NetworkCredential GetCredential(Uri uri, String authType) => 
                 InnerCredentials?.GetCredential(uri, authType);
         }
+
+        private class AuthenticatedProxy : IWebProxy
+        {
+            ICredentials _credentials;
+            Uri _proxyUri;
+
+            public AuthenticatedProxy(ICredentials credentials)
+            {
+                _credentials = credentials;
+
+                string host = Environment.GetEnvironmentVariable("HTTP_INTERNAL_PROXYSERVER");
+                Assert.False(string.IsNullOrEmpty(host), "HTTP_INTERNAL_PROXYSERVER must specify proxy hostname");
+
+                string portString = Environment.GetEnvironmentVariable("HTTP_INTERNAL_PROXYSERVER_PORT");
+                Assert.False(string.IsNullOrEmpty(portString), "HTTP_INTERNAL_PROXYSERVER_PORT must specify proxy port number");
+
+                int port;
+                Assert.True(int.TryParse(portString, out port), "HTTP_INTERNAL_PROXYSERVER_PORT must be a valid port number");
+
+                _proxyUri = new Uri(string.Format("http://{0}:{1}", host, port));
+            }
+
+            public ICredentials Credentials
+            {
+                get
+                {
+                    return _credentials;
+                }
+
+                set
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public Uri GetProxy(Uri destination)
+            {
+                return _proxyUri;
+            }
+
+            public bool IsBypassed(Uri host)
+            {
+                return false;
+            }
+        }        
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/DefaultCredentialsTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DefaultCredentialsTest.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 
 namespace System.Net.Http.Functional.Tests
 {
+    // TODO: #2383 - Consolidate the use of the environment variable settings to Common/tests.
     public class DefaultCredentialsTest
     {
         private static string HttpInternalTestServer => Environment.GetEnvironmentVariable("HTTP_INTERNAL_TESTSERVER");


### PR DESCRIPTION
In some cases, WinHttpHandler was not sending default credentials that were specified inside a custom ICredentials object. In other cases, default credentials would be sent even though CredentialCache.DefaultCredentials was not specified. The code was incorrectly comparing the proxy and server credential (ICredential interface) values against the DefaultCredentials object. Instead, the ICredentials.GetCredential() method should be called to compute the final NetworkCredential object. This takes into account the given uri and auth scheme.

This PR fixes the logic by delay the setting in WinHTTP for releasing default credentials. This ensures that default crdentials are released when requested.

Fixes #8176.