### PR TITLE
Disable two recently added tests

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
@@ -61,6 +61,7 @@ namespace System.IO.Tests
             }
         }
 
+        [ActiveIssue(8439, PlatformID.AnyUnix)]
         [Theory]
         [InlineData(WatcherChangeTypes.Created)]
         [InlineData(WatcherChangeTypes.Deleted)]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -74,6 +74,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(8444, PlatformID.AnyUnix)]
         [ConditionalTheory(nameof(BackendSupportsSslConfiguration))]
         [InlineData(SslProtocols.Tls)]
         [InlineData(SslProtocols.Tls11)]


### PR DESCRIPTION
These were both added in the last few days and have both failed in CI at least once.

cc: @ellismg 