### PR TITLE
Add a few System.IO tests for Stream.Begin/End

### DIFF
--- a/src/System.IO/tests/BufferedStream/BufferedStreamTests.cs
+++ b/src/System.IO/tests/BufferedStream/BufferedStreamTests.cs
@@ -17,8 +17,10 @@ namespace System.IO.Tests
             return new BufferedStream(new MemoryStream());
         }
 
-        [Fact]
-        public async Task ConcurrentOperationsAreSerialized()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ConcurrentOperationsAreSerialized(bool apm)
         {
             byte[] data = Enumerable.Range(0, 1000).Select(i => (byte)i).ToArray();
             var mcaos = new ManuallyReleaseAsyncOperationsStream();
@@ -27,7 +29,9 @@ namespace System.IO.Tests
             var tasks = new Task[4];
             for (int i = 0; i < 4; i++)
             {
-                tasks[i] = stream.WriteAsync(data, 250 * i, 250);
+                tasks[i] = apm ?
+                    Task.Factory.FromAsync(stream.BeginWrite, stream.EndWrite, data, 250 * i, 250, null) :
+                    stream.WriteAsync(data, 250 * i, 250);
             }
             Assert.False(tasks.All(t => t.IsCompleted));
 
@@ -49,6 +53,7 @@ namespace System.IO.Tests
             Assert.Equal(TaskStatus.Faulted, stream.ReadAsync(new byte[1], 0, 1).Status);
 
             Assert.Equal(TaskStatus.Faulted, stream.WriteAsync(new byte[10000], 0, 10000).Status);
+            Assert.Equal(TaskStatus.Faulted, Task.Factory.FromAsync(stream.BeginWrite, stream.EndWrite, new byte[10000], 0, 10000, null).Status);
 
             stream.WriteByte(1);
             Assert.Equal(TaskStatus.Faulted, stream.FlushAsync().Status);
@@ -216,9 +221,29 @@ namespace System.IO.Tests
             throw new InvalidOperationException("Exception from ReadAsync");
         }
 
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            throw new InvalidOperationException("Exception from BeginRead");
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            throw new InvalidOperationException("Exception from EndRead");
+        }
+
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             throw new InvalidOperationException("Exception from WriteAsync");
+        }
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            throw new InvalidOperationException("Exception from BeginWrite");
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+            throw new InvalidOperationException("Exception from EndWrite");
         }
 
         public override Task FlushAsync(CancellationToken cancellationToken)

--- a/src/System.IO/tests/Stream/Stream.Methods.cs
+++ b/src/System.IO/tests/Stream/Stream.Methods.cs
@@ -217,52 +217,69 @@ namespace System.IO.Tests
             stream.Seek(1, SeekOrigin.Current); // In the original test, success here would end the test
 
             //[] we will do some async tests here now
-            stream.Position = 0;
-
-            btArr = new byte[iLength];
-            for (int i = 0; i < iLength; i++)
-                btArr[i] = (byte)(i + 5);
-
-            await stream.WriteAsync(btArr, 0, btArr.Length);
-
-            stream.Position = 0;
-            for (int i = 0; i < iLength; i++)
+            for (int asyncMethod = 0; asyncMethod < 2; asyncMethod++) // 0 == apm, 1 == async
             {
-                Assert.Equal((byte)(i + 5), stream.ReadByte());
-            }
+                stream.Position = 0;
 
-            //we will read asynchronously
-            stream.Position = 0;
+                btArr = new byte[iLength];
+                for (int i = 0; i < iLength; i++)
+                    btArr[i] = (byte)(i + 5);
 
-            byte[] compArr = new byte[iLength];
+                await (asyncMethod == 0 ?
+                    Task.Factory.FromAsync(stream.BeginWrite, stream.EndWrite, btArr, 0, btArr.Length, null) :
+                    stream.WriteAsync(btArr, 0, btArr.Length));
 
-            iValue = await stream.ReadAsync(compArr, 0, compArr.Length);
+                stream.Position = 0;
+                for (int i = 0; i < iLength; i++)
+                {
+                    Assert.Equal((byte)(i + 5), stream.ReadByte());
+                }
 
-            Assert.Equal(btArr.Length, iValue);
+                //we will read asynchronously
+                stream.Position = 0;
 
-            for (int i = 0; i < iLength; i++)
-            {
-                Assert.Equal(compArr[i], btArr[i]);
+                byte[] compArr = new byte[iLength];
+
+                iValue = await (asyncMethod == 0 ?
+                    Task.Factory.FromAsync(stream.BeginRead, stream.EndRead, compArr, 0, compArr.Length, null) :
+                    stream.ReadAsync(compArr, 0, compArr.Length));
+
+                Assert.Equal(btArr.Length, iValue);
+
+                for (int i = 0; i < iLength; i++)
+                {
+                    Assert.Equal(compArr[i], btArr[i]);
+                }
             }
         }
 
-        [Fact]
-        public async Task FlushAsyncTest()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task FlushAsyncTest(bool apm)
         {
             byte[] data = Enumerable.Range(0, 8000).Select(i => (byte)i).ToArray();
             Stream stream = CreateStream();
 
             for (int i = 0; i < 4; i++)
             {
-                await stream.WriteAsync(data, 2000 * i, 2000);
+                await (apm ?
+                    Task.Factory.FromAsync(stream.BeginWrite, stream.EndWrite, data, 2000 * i, 2000, null) :
+                    stream.WriteAsync(data, 2000 * i, 2000));
                 await stream.FlushAsync();
             }
 
             stream.Position = 0;
             byte[] output = new byte[data.Length];
             int bytesRead, totalRead = 0;
-            while ((bytesRead = await stream.ReadAsync(output, totalRead, data.Length - totalRead)) > 0)
+            while (true)
+            {
+                Task<int> readTask = apm ?
+                    Task.Factory.FromAsync(stream.BeginRead, stream.EndRead, output, totalRead, data.Length - totalRead, null) :
+                    stream.ReadAsync(output, totalRead, data.Length - totalRead);
+                if ((bytesRead = await readTask) == 0) break;
                 totalRead += bytesRead;
+            }
             Assert.Equal(data, output);
         }
 

--- a/src/System.IO/tests/Stream/Stream.NullTests.cs
+++ b/src/System.IO/tests/Stream/Stream.NullTests.cs
@@ -119,6 +119,10 @@ namespace System.IO.Tests
             await source.WriteAsync(buffer, offset, count);
             Assert.Equal(copy, buffer);
             Assert.Equal(0, source.Position);
+
+            await Task.Factory.FromAsync(source.BeginWrite, source.EndWrite, buffer, offset, count, null);
+            Assert.Equal(copy, buffer);
+            Assert.Equal(0, source.Position);
         }
         
         [Fact]


### PR DESCRIPTION
Our existing set of System.IO tests around ReadAsync/WriteAsync aren't very extensive, but I modified the ones we do have to also test Begin/End.

cc: @ianhays 