### PR TITLE
Fix HttpClient test hanging on machines with a single core

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -505,7 +505,7 @@ namespace System.Net.Http.Functional.Tests
 
         private static async Task<T> WhenCanceled<T>(CancellationToken cancellationToken)
         {
-            await Task.Delay(-1, cancellationToken);
+            await Task.Delay(-1, cancellationToken).ConfigureAwait(false);
             return default(T);
         }
 


### PR DESCRIPTION
One of the HttpClient client tests hangs on a machine with a single core. xunit by default uses a SynchronizationContext that has N threads to do work, where N defaults to Environment.ProcessorCount.  Thus on a single core machine, there's only one thread available to run tests, and if that thread blocks waiting for an async operation that'll schedule work back to that context, it'll deadlock.

cc: @davidsh, @bartonjs 