### PR TITLE
Allow multi-part netlink messages in pal_networkchange.cpp

### DIFF
--- a/src/Common/src/Interop/Linux/System.Native/Interop.NetworkChange.cs
+++ b/src/Common/src/Interop/Linux/System.Native/Interop.NetworkChange.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
             LinkRemoved = 3
         }
 
-        public delegate void NetworkChangeEvent(NetworkChangeKind kind);
+        public delegate void NetworkChangeEvent(int socket, NetworkChangeKind kind);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateNetworkChangeListenerSocket")]
         public static extern Error CreateNetworkChangeListenerSocket(out int socket);
@@ -26,7 +26,7 @@ internal static partial class Interop
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CloseNetworkChangeListenerSocket")]
         public static extern Error CloseNetworkChangeListenerSocket(int socket);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadSingleEvent")]
-        public static extern NetworkChangeKind ReadSingleEvent(int socket);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadEvents")]
+        public static extern void ReadEvents(int socket, NetworkChangeEvent onNetworkChange);
     }
 }

--- a/src/Native/System.Native/pal_networkchange.h
+++ b/src/Native/System.Native/pal_networkchange.h
@@ -16,7 +16,7 @@ enum class NetworkChangeKind : int32_t
     LinkRemoved = 3
 };
 
-typedef void (*NetworkChangeEvent)(NetworkChangeKind notificationKind);
+typedef void (*NetworkChangeEvent)(int32_t sock, NetworkChangeKind notificationKind);
 
-extern "C" NetworkChangeKind SystemNative_ReadSingleEvent(int sock);
+extern "C" void SystemNative_ReadEvents(int32_t sock, NetworkChangeEvent onNetworkChange);
 NetworkChangeKind ReadNewLinkMessage(nlmsghdr* hdr);

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Linux.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Linux.cs
@@ -15,6 +15,7 @@ namespace System.Net.NetworkInformation
         private static NetworkAddressChangedEventHandler s_addressChangedSubscribers;
         private static volatile int s_socket = 0;
         private static readonly object s_lockObj = new object();
+        private static readonly Interop.Sys.NetworkChangeEvent s_networkChangeCallback = ProcessEvent;
 
         public static event NetworkAddressChangedEventHandler NetworkAddressChanged
         {
@@ -82,7 +83,7 @@ namespace System.Net.NetworkInformation
         {
             while (socket == s_socket)
             {
-                Interop.Sys.ReadEvents(socket, ProcessEvent);
+                Interop.Sys.ReadEvents(socket, s_networkChangeCallback);
             }
         }
         

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Linux.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Linux.cs
@@ -82,19 +82,19 @@ namespace System.Net.NetworkInformation
         {
             while (socket == s_socket)
             {
-                Interop.Sys.NetworkChangeKind kind = Interop.Sys.ReadSingleEvent(socket);
-                if (kind == Interop.Sys.NetworkChangeKind.None)
+                Interop.Sys.ReadEvents(socket, ProcessEvent);
+            }
+        }
+        
+        private static void ProcessEvent(int socket, Interop.Sys.NetworkChangeKind kind)
+        {
+            if (kind != Interop.Sys.NetworkChangeKind.None)
+            {
+                lock (s_lockObj)
                 {
-                    continue;
-                }
-                else
-                {
-                    lock (s_lockObj)
+                    if (socket == s_socket)
                     {
-                        if (socket == s_socket)
-                        {
-                            OnSocketEvent(kind);
-                        }
+                        OnSocketEvent(kind);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #5281 

* Previously, I made the assumption that there could only be single-part messages sent over the channel we are listening on. This doesn't seem to be guaranteed anywhere in the documentation, although it seems to be vanishingly rare to receive a multi-part message in our particular usage.
* To allow multiple messages to be received, I've used a callback mechanism. A single call to `SystemNative_ReadEvents` may result in multiple change events being propogated out by the PAL layer. The functionality should otherwise remain identical, and in the vast majority of cases, only a single event will be retrieved at a time.

The handling here is based off the example code in the manpage for netlink. According to those docs, you are always supposed to use the NL_* macros to interact with the nlmsghdr struct, and this seems to be the prescribed way to do it.

NOTE: This uses some previously-dead code, which might be confusing at first. The delegate declarations for `NetworkChangeEvent` (on both sides) were there, but weren't used for anything. I updated them slightly to carry the socket handle. This means that, when an event is propogated out by the PAL, it carries the original socket handle with it. If the managed side has invalidated or changed that handle (unsubscribe -> resubscribe), it will be ignored, as it was before.

The NetworkInformation functional tests don't really cover this code path, as it's hard to emulate this kind of network activity. I used the [manual testing program](https://github.com/mellinoe/NetworkInformationApp/blob/master/src/NetworkInformation.SampleUsage/Program.cs#L262) I had from when I originally wrote this code.

@stephentoub 