### PR TITLE
Add non generic IDictionary tests to ConcurrentDictionary

### DIFF
--- a/src/Common/tests/System/Collections/ICollection.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/ICollection.Generic.Tests.cs
@@ -34,11 +34,12 @@ namespace System.Collections.Tests
             return collection;
         }
 
-        protected virtual bool DuplicateValuesAllowed { get { return true; } }
-        protected virtual bool DefaultValueWhenNotAllowed_Throws { get { return true; } }
-        protected virtual bool IsReadOnly { get { return false; } }
-        protected virtual bool DefaultValueAllowed { get { return true; } }
-        protected virtual IEnumerable<T> InvalidValues { get { return Array.Empty<T>(); } }
+        protected virtual bool DuplicateValuesAllowed => true;
+        protected virtual bool DefaultValueWhenNotAllowed_Throws => true;
+        protected virtual bool IsReadOnly => false;
+        protected virtual bool DefaultValueAllowed => true;
+        protected virtual IEnumerable<T> InvalidValues => Array.Empty<T>();
+
         protected virtual void AddToCollection(ICollection<T> collection, int numberOfItemsToAdd)
         {
             int seed = 9600;

--- a/src/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
@@ -34,11 +34,12 @@ namespace System.Collections.Tests
             return collection;
         }
 
-        protected virtual bool DuplicateValuesAllowed { get { return true; } }
-        protected virtual bool IsReadOnly { get { return false; } }
-        protected virtual bool NullAllowed { get { return true; } }
-        protected virtual bool ExpectedIsSynchronized { get { return false; } }
-        protected virtual IEnumerable<object> InvalidValues { get { return new object[] { }; } }
+        protected virtual bool DuplicateValuesAllowed => true;
+        protected virtual bool IsReadOnly => false;
+        protected virtual bool NullAllowed => true;
+        protected virtual bool ExpectedIsSynchronized => false;
+        protected virtual IEnumerable<object> InvalidValues => new object[0];
+
         protected abstract void AddToCollection(ICollection collection, int numberOfItemsToAdd);
 
         /// <summary>
@@ -46,27 +47,27 @@ namespace System.Collections.Tests
         /// on an Array of Enum values. Some implementations special-case for this and throw an ArgumentException,
         /// while others just throw an InvalidCastExcepton.
         /// </summary>
-        protected virtual bool ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowsArgumentException { get { return false; } }
+        protected virtual Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(InvalidCastException);
 
         /// <summary>
         /// Used for the ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType test where we try to call CopyTo
         /// on an Array of different reference values. Some implementations special-case for this and throw an ArgumentException,
-        /// while others just throw an InvalidCastExcepton.
+        /// while others just throw an InvalidCastExcepton or an ArrayTypeMismatchException.
         /// </summary>
-        protected virtual bool ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType_ThrowsArgumentException { get { return true; } }
+        protected virtual Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType_ThrowType => typeof(ArgumentException);
 
         /// <summary>
         /// Used for the ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType test where we try to call CopyTo
         /// on an Array of different value values. Some implementations special-case for this and throw an ArgumentException,
         /// while others just throw an InvalidCastExcepton.
         /// </summary>
-        protected virtual bool ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowsArgumentException { get { return true; } }
+        protected virtual Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowType => typeof(ArgumentException);
 
         /// <summary>
         /// Used for ICollection_NonGeneric_SyncRoot tests. Some implementations (e.g. ConcurrentDictionary)
-        /// don't support the SyncRoot property of an ICollection and throw a NotSupportedException
+        /// don't support the SyncRoot property of an ICollection and throw a NotSupportedException.
         /// </summary>
-        public virtual bool ICollection_NonGeneric_SupportsSyncRoot => true;
+        protected virtual bool ICollection_NonGeneric_SupportsSyncRoot => true;
 
         #endregion
 
@@ -199,14 +200,7 @@ namespace System.Collections.Tests
                 ICollection collection = NonGenericICollectionFactory(count);
                 float[] array = new float[count * 3 / 2];
 
-                if (ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowsArgumentException)
-                {
-                    Assert.Throws<ArgumentException>(() => collection.CopyTo(array, 0));
-                }
-                else
-                {
-                    Assert.Throws<InvalidCastException>(() => collection.CopyTo(array, 0));
-                }
+                Assert.Throws(ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowType, () => collection.CopyTo(array, 0));
             }
         }
 
@@ -218,14 +212,7 @@ namespace System.Collections.Tests
             {
                 ICollection collection = NonGenericICollectionFactory(count);
                 StringBuilder[] array = new StringBuilder[count * 3 / 2];
-                if (ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType_ThrowsArgumentException)
-                {
-                    Assert.Throws<ArgumentException>(() => collection.CopyTo(array, 0));
-                }
-                else
-                {
-                    Assert.Throws<InvalidCastException>(() => collection.CopyTo(array, 0));
-                }
+                Assert.Throws(ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType_ThrowType, () => collection.CopyTo(array, 0));
             }
         }
 
@@ -237,10 +224,7 @@ namespace System.Collections.Tests
             if (count > 0 && count < enumArr.Length)
             {
                 ICollection collection = NonGenericICollectionFactory(count);
-                if (ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowsArgumentException)
-                    Assert.Throws<ArgumentException>(() => collection.CopyTo(enumArr, 0));
-                else
-                    Assert.Throws<InvalidCastException>(() => collection.CopyTo(enumArr, 0));
+                Assert.Throws(ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType, () => collection.CopyTo(enumArr, 0));
             }
         }
 

--- a/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.cs
@@ -683,14 +683,38 @@ namespace System.Collections.Tests
         public void IDictionary_NonGeneric_IDictionaryEnumerator_Current_FromStartToFinish(int count)
         {
             IDictionaryEnumerator enumerator = NonGenericIDictionaryFactory(count).GetEnumerator();
-            object current, key, value, entry;
-            while (enumerator.MoveNext())
+            for (int i = 0; i < 2; i++)
             {
-                current = enumerator.Current;
-                key = enumerator.Key;
-                value = enumerator.Value;
-                entry = enumerator.Entry;
+                int counter = 0;
+                while (enumerator.MoveNext())
+                {
+                    object current = enumerator.Current;
+                    object key = enumerator.Key;
+                    object value = enumerator.Value;
+                    DictionaryEntry entry = enumerator.Entry;
+                    Assert.Equal(current, entry);
+                    Assert.Equal(key, entry.Key);
+                    Assert.Equal(value, entry.Value);
+                    counter++;
+                }
+                Assert.Equal(count, counter);
+                if (!ResetImplemented)
+                {
+                    break;
+                }
+                enumerator.Reset();
             }
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void IDictionary_NonGeneric_IDictionaryEnumerator_Reset_BeforeIteration_Support(int count)
+        {
+            IDictionaryEnumerator enumerator = NonGenericIDictionaryFactory(count).GetEnumerator();
+            if (ResetImplemented)
+                enumerator.Reset();
+            else
+                Assert.Throws<NotSupportedException>(() => enumerator.Reset());
         }
 
         [Theory]

--- a/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Xunit;
 
@@ -81,6 +79,22 @@ namespace System.Collections.Tests
             return missingKey;
         }
 
+        /// <summary>
+        /// Used in IDictionary_NonGeneric_Values_ModifyingTheDictionaryUpdatesTheCollection and 
+        /// IDictionary_NonGeneric_Keys_ModifyingTheDictionaryUpdatesTheCollection.
+        /// Some collections (e.g ConcurrentDictionary) use iterators in the Keys and Values properties,
+        /// and do not respond to updates in the base collection.
+        /// </summary>
+        protected virtual bool IDictionary_NonGeneric_Keys_Values_ModifyingTheDictionaryUpdatesTheCollection => true;
+
+        /// <summary>
+        /// Used in IDictionary_NonGeneric_Values_Enumeration_ParentDictionaryModifiedInvalidatesEnumerator and 
+        /// IDictionary_NonGeneric_Keys_Enumeration_ParentDictionaryModifiedInvalidatesEnumerator.
+        /// Some collections (e.g. ConcurrentDictionary) do not throw an InvalidOperationException
+        /// when enumerating the Keys or Values property and the parent is modified.
+        /// </summary>
+        protected virtual bool IDictionary_NonGeneric_Keys_Values_ParentDictionaryModifiedInvalidates => true;
+
         #endregion
 
         #region ICollection Helper Methods
@@ -90,10 +104,11 @@ namespace System.Collections.Tests
             return NonGenericIDictionaryFactory();
         }
 
-        protected override bool DuplicateValuesAllowed { get { return false; } }
-        protected override bool NullAllowed { get { return false; } }
-        protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
-        protected override bool ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowsArgumentException { get { return true; } }
+        protected override bool DuplicateValuesAllowed => false;
+        protected override bool NullAllowed => false;
+        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(ArgumentException);
+
         protected override void AddToCollection(ICollection collection, int numberOfItemsToAdd)
         {
             Assert.False(IsReadOnly);
@@ -148,6 +163,13 @@ namespace System.Collections.Tests
                 };
             }
         }
+
+        /// <summary>
+        /// Used in IDictionary_NonGeneric_Keys_Enumeration_Reset and IDictionary_NonGeneric_Values_Enumeration_Reset.
+        /// Typically, the support for Reset in enumerators for the Keys and Values depend on the support for it
+        /// in the parent dictionary. However, some collections (e.g. ConcurrentDictionary) don't.
+        /// </summary>
+        protected virtual bool IDictionary_NonGeneric_Keys_Values_Enumeration_ResetImplemented => ResetImplemented;
 
         #endregion
 
@@ -306,8 +328,16 @@ namespace System.Collections.Tests
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
             ICollection keys = dictionary.Keys;
+            int previousCount = keys.Count;
             dictionary.Clear();
-            Assert.Empty(keys);
+            if (IDictionary_NonGeneric_Keys_Values_ModifyingTheDictionaryUpdatesTheCollection)
+            {
+                Assert.Empty(keys);
+            }
+            else
+            {
+                Assert.Equal(previousCount, keys.Count);
+            }
         }
 
         [Theory]
@@ -318,9 +348,20 @@ namespace System.Collections.Tests
             ICollection keys = dictionary.Keys;
             IEnumerator keysEnum = keys.GetEnumerator();
             dictionary.Add(GetNewKey(dictionary), CreateTValue(3432));
-            Assert.Throws<InvalidOperationException>(() => keysEnum.MoveNext());
-            Assert.Throws<InvalidOperationException>(() => keysEnum.Reset());
-            Assert.Throws<InvalidOperationException>(() => keysEnum.Current);
+            if (IDictionary_NonGeneric_Keys_Values_ParentDictionaryModifiedInvalidates)
+            {
+                Assert.Throws<InvalidOperationException>(() => keysEnum.MoveNext());
+                Assert.Throws<InvalidOperationException>(() => keysEnum.Reset());
+            }
+            else
+            {
+                keysEnum.MoveNext();
+                if (count > 0)
+                {
+                    var cur = keysEnum.Current;
+                }
+                keysEnum.Reset();
+            }
         }
 
         [Theory]
@@ -328,7 +369,7 @@ namespace System.Collections.Tests
         public void IDictionary_NonGeneric_Keys_Enumeration_Reset(int count)
         {
             IEnumerator enumerator = NonGenericIDictionaryFactory(count).Keys.GetEnumerator();
-            if (ResetImplemented)
+            if (IDictionary_NonGeneric_Keys_Values_Enumeration_ResetImplemented)
                 enumerator.Reset();
             else
                 Assert.Throws<NotSupportedException>(() => enumerator.Reset());
@@ -373,8 +414,16 @@ namespace System.Collections.Tests
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
             ICollection values = dictionary.Values;
+            int previousCount = values.Count;
             dictionary.Clear();
-            Assert.Empty(values);
+            if (IDictionary_NonGeneric_Keys_Values_ModifyingTheDictionaryUpdatesTheCollection)
+            {
+                Assert.Empty(values);
+            }
+            else
+            {
+                Assert.Equal(previousCount, values.Count);
+            }
         }
 
         [Theory]
@@ -385,9 +434,21 @@ namespace System.Collections.Tests
             ICollection values = dictionary.Values;
             IEnumerator valuesEnum = values.GetEnumerator();
             dictionary.Add(GetNewKey(dictionary), CreateTValue(3432));
-            Assert.Throws<InvalidOperationException>(() => valuesEnum.MoveNext());
-            Assert.Throws<InvalidOperationException>(() => valuesEnum.Reset());
-            Assert.Throws<InvalidOperationException>(() => valuesEnum.Current);
+            if (IDictionary_NonGeneric_Keys_Values_ParentDictionaryModifiedInvalidates)
+            {
+                Assert.Throws<InvalidOperationException>(() => valuesEnum.MoveNext());
+                Assert.Throws<InvalidOperationException>(() => valuesEnum.Reset());
+                Assert.Throws<InvalidOperationException>(() => valuesEnum.Current);
+            }
+            else
+            {
+                valuesEnum.MoveNext();
+                if (count > 0)
+                {
+                    var cur = valuesEnum.Current;
+                }
+                valuesEnum.Reset();
+            }
         }
 
         [Theory]
@@ -395,7 +456,7 @@ namespace System.Collections.Tests
         public void IDictionary_NonGeneric_Values_Enumeration_Reset(int count)
         {
             IEnumerator enumerator = NonGenericIDictionaryFactory(count).Values.GetEnumerator();
-            if (ResetImplemented)
+            if (IDictionary_NonGeneric_Keys_Values_Enumeration_ResetImplemented)
                 enumerator.Reset();
             else
                 Assert.Throws<NotSupportedException>(() => enumerator.Reset());

--- a/src/System.Collections.Concurrent/tests/ConcurrentDicionary/ConcurrentDictionary.Generic.Tests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentDicionary/ConcurrentDictionary.Generic.Tests.cs
@@ -44,7 +44,7 @@ namespace System.Collections.Concurrent.Tests
     }
 
     /// <summary>
-    /// Contains tests that ensure the correctness of the Dictionary class.
+    /// Contains tests that ensure the correctness of the ConcurrentDictionary class.
     /// </summary>
     public abstract class ConcurrentDictionary_Generic_Tests<TKey, TValue> : IDictionary_Generic_Tests<TKey, TValue>
     {
@@ -64,7 +64,7 @@ namespace System.Collections.Concurrent.Tests
         protected override bool IDictionary_Generic_Keys_Values_ModifyingTheDictionaryUpdatesTheCollection => false;
 
         protected override bool ResetImplemented => false;
-        protected override bool IDictionary_Generic_Keys_Values_ResetImplemented => true;
+        protected override bool IDictionary_Generic_Keys_Values_Enumeration_ResetImplemented => true;
 
         protected override EnumerableOrder Order => EnumerableOrder.Unspecified;
 

--- a/src/System.Collections.Concurrent/tests/ConcurrentDicionary/ConcurrentDictionary.NonGeneric.Tests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentDicionary/ConcurrentDictionary.NonGeneric.Tests.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Tests;
+using System.Collections.Generic;
+
+namespace System.Collections.Concurrent.Tests
+{
+    public class ConcurrentDictionary_NonGeneric_Tests : IDictionary_NonGeneric_Tests
+    {
+        #region IDictionary<TKey, TValue Helper Methods
+
+        protected override IDictionary NonGenericIDictionaryFactory()
+        {
+            return new ConcurrentDictionary<string, string>();
+        }
+
+        /// <summary>
+        /// Creates an object that is dependent on the seed given. The object may be either
+        /// a value type or a reference type, chosen based on the value of the seed.
+        /// </summary>
+        protected override object CreateTKey(int seed)
+        {
+            int stringLength = seed % 10 + 5;
+            Random rand = new Random(seed);
+            byte[] bytes = new byte[stringLength];
+            rand.NextBytes(bytes);
+            return Convert.ToBase64String(bytes);
+        }
+
+        /// <summary>
+        /// Creates an object that is dependent on the seed given. The object may be either
+        /// a value type or a reference type, chosen based on the value of the seed.
+        /// </summary>
+        protected override object CreateTValue(int seed) => CreateTKey(seed);
+
+        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
+
+        protected override bool Enumerator_Current_UndefinedOperation_Throws => false;
+
+        protected override bool IDictionary_NonGeneric_Keys_Values_ModifyingTheDictionaryUpdatesTheCollection => false;
+
+        protected override bool ICollection_NonGeneric_SupportsSyncRoot => false;
+
+        protected override bool IDictionary_NonGeneric_Keys_Values_ParentDictionaryModifiedInvalidates => false;
+
+        protected override bool ResetImplemented => false;
+
+        protected override bool IDictionary_NonGeneric_Keys_Values_Enumeration_ResetImplemented => true;
+
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType_ThrowType => typeof(ArrayTypeMismatchException);
+
+        #endregion
+    }
+}

--- a/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
+++ b/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="BlockingCollectionCancellationTests.cs" />
     <Compile Include="BlockingCollectionTests.cs" />
     <Compile Include="ConcurrentBagTests.cs" />
+    <Compile Include="ConcurrentDicionary\ConcurrentDictionary.NonGeneric.Tests.cs" />
     <Compile Include="ConcurrentDicionary\ConcurrentDictionary.Generic.Tests.cs" />
     <Compile Include="ConcurrentDicionary\ConcurrentDictionaryTests.cs" />
     <Compile Include="ConcurrentQueueTests.cs" />

--- a/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionaryTests.cs
+++ b/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionaryTests.cs
@@ -18,9 +18,9 @@ namespace System.Collections.Specialized.Tests
 
     public abstract class HybridDictionaryTestBase : IDictionary_NonGeneric_Tests
     {
-        protected override bool ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowsArgumentException => false;
-        protected override bool ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType_ThrowsArgumentException => false;
-        protected override bool ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowsArgumentException => false;
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(InvalidCastException);
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType_ThrowType => typeof(InvalidCastException);
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowType => typeof(InvalidCastException);
 
         protected override object CreateTKey(int seed)
         {

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Keys.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Keys.cs
@@ -62,7 +62,7 @@ namespace System.Collections.Tests
         protected override bool DuplicateValuesAllowed { get { return false; } }
         protected override bool IsReadOnly { get { return true; } }
         protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
-        protected override bool ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowsArgumentException { get { return true; } }
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(ArgumentException);
 
         protected override ICollection NonGenericICollectionFactory()
         {

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Values.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Values.cs
@@ -63,7 +63,7 @@ namespace System.Collections.Tests
         protected override bool DuplicateValuesAllowed { get { return true; } }
         protected override bool IsReadOnly { get { return true; } }
         protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
-        protected override bool ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowsArgumentException { get { return true; } }
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(ArgumentException);
         protected override IEnumerable<ModifyEnumerable> ModifyEnumerables { get { return new List<ModifyEnumerable>(); } }
         protected override ICollection NonGenericICollectionFactory()
         {

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.AsNonGenericICollection.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.AsNonGenericICollection.cs
@@ -9,7 +9,8 @@ namespace System.Collections.Tests
 {
     public class LinkedList_ICollection_NonGeneric_Tests : ICollection_NonGeneric_Tests
     {
-        protected override bool ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowsArgumentException { get { return true; } }
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(ArgumentException);
+
         protected override void AddToCollection(ICollection collection, int numberOfItemsToAdd)
         {
             int seed = numberOfItemsToAdd * 34;

--- a/src/System.Collections/tests/Generic/Queue/Queue.Tests.cs
+++ b/src/System.Collections/tests/Generic/Queue/Queue.Tests.cs
@@ -13,7 +13,8 @@ namespace System.Collections.Tests
     {
         #region ICollection Helper Methods
 
-        protected override bool ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowsArgumentException { get { return true; } }
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(ArgumentException);
+
         protected override void AddToCollection(ICollection collection, int numberOfItemsToAdd)
         {
             int seed = numberOfItemsToAdd * 34;

--- a/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.Keys.cs
+++ b/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.Keys.cs
@@ -59,7 +59,7 @@ namespace System.Collections.Tests
         protected override bool DuplicateValuesAllowed { get { return false; } }
         protected override bool IsReadOnly { get { return true; } }
         protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
-        protected override bool ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowsArgumentException { get { return true; } }
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(ArgumentException);
 
         protected override ICollection NonGenericICollectionFactory()
         {

--- a/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.Values.cs
+++ b/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.Values.cs
@@ -58,7 +58,7 @@ namespace System.Collections.Tests
         protected override bool DuplicateValuesAllowed { get { return true; } }
         protected override bool IsReadOnly { get { return true; } }
         protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
-        protected override bool ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowsArgumentException { get { return true; } }
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(ArgumentException);
 
         protected override ICollection NonGenericICollectionFactory()
         {

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Tests.cs
@@ -8,7 +8,7 @@ namespace System.Collections.Tests
 {
     public class SortedSet_ICollection_NonGeneric_Tests : ICollection_NonGeneric_Tests
     {
-        protected override bool ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowsArgumentException { get { return true; } }
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(ArgumentException);
         protected override bool Enumerator_Current_UndefinedOperation_Throws { get { return true; } }
 
         protected override void AddToCollection(ICollection collection, int numberOfItemsToAdd)

--- a/src/System.Collections/tests/Generic/Stack/Stack.Tests.cs
+++ b/src/System.Collections/tests/Generic/Stack/Stack.Tests.cs
@@ -10,7 +10,8 @@ namespace System.Collections.Tests
     {
         #region ICollection Helper Methods
 
-        protected override bool ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowsArgumentException { get { return true; } }
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(ArgumentException);
+
         protected override void AddToCollection(ICollection collection, int numberOfItemsToAdd)
         {
             int seed = numberOfItemsToAdd * 34;


### PR DESCRIPTION
Natural followup to #8433

- Changes some customization points for some ICollection non generic throw types as some implementations don't throw either an InvalidCastException or an ArgumentException, but an ArrayTypeMismatchException

- Adds some customziation points for the IDictionary.NonGeneric that duplicate the behaviour of the IDictionary.Generic additions in  #8433

- Adds some more tests for IDictionaryEnumerator.Reset

/cc @ianhays @stephentoub (for a 2nd look)