### PR TITLE
Fix handling of ScopeIDs with IPAddresses in NetworkInformation

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixNetworkInterface.cs
@@ -80,6 +80,7 @@ namespace System.Net.NetworkInformation
         protected unsafe void ProcessIpv6Address(Interop.Sys.IpAddressInfo* addressInfo, uint scopeId)
         {
             IPAddress address = IPAddressUtil.GetIPAddressFromNativeInfo(addressInfo);
+            address.ScopeId = scopeId;
             AddAddress(address);
             _ipv6ScopeId = scopeId;
         }


### PR DESCRIPTION
We had the scopeId, we just weren't storing it into the IPAddress.

(As with other aspects of NetworkInformation, this is hard to add a test for, but I'm going to add a test to the HttpClient suite that tries to use a link-local Uri with a loopback server, and that will implicitly provide some verification here, as that will only succeed if the scope ID is correct.)

Fixes https://github.com/dotnet/corefx/issues/8458
cc: @mellinoe, @ericeil, @mikeharder 
