### PR TITLE
Address remaining TODO's in SSC.Csp.

### DIFF
--- a/src/System.Security.Cryptography.Csp/System.Security.Cryptography.Csp.sln
+++ b/src/System.Security.Cryptography.Csp/System.Security.Cryptography.Csp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.Cryptography.Csp", "src\System.Security.Cryptography.Csp.csproj", "{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}"
 EndProject
@@ -9,18 +9,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security.Cryptograph
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Windows_NT_Debug|Any CPU = Windows_NT_Debug|Any CPU
+		Windows_NT_Release|Any CPU = Windows_NT_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
-		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
-		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}.Windows_NT_Debug|Any CPU.ActiveCfg = Windows_NT_Debug|Any CPU
+		{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}.Windows_NT_Debug|Any CPU.Build.0 = Windows_NT_Debug|Any CPU
+		{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}.Windows_NT_Release|Any CPU.ActiveCfg = Windows_NT_Release|Any CPU
+		{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}.Windows_NT_Release|Any CPU.Build.0 = Windows_NT_Release|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Windows_NT_Debug|Any CPU.ActiveCfg = Windows_NT_Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Windows_NT_Debug|Any CPU.Build.0 = Windows_NT_Debug|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Windows_NT_Release|Any CPU.ActiveCfg = Windows_NT_Release|Any CPU
+		{A05C2EF2-A986-448C-9C63-735CC17409AA}.Windows_NT_Release|Any CPU.Build.0 = Windows_NT_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
+++ b/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">Windows_NT_Debug</Configuration>
     <ProjectGuid>{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}</ProjectGuid>
     <AssemblyName>System.Security.Cryptography.Csp</AssemblyName>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
@@ -13,10 +14,8 @@
     <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)' != 'net46' AND '$(TargetsWindows)' == 'true'">
     <Compile Include="System\Security\Cryptography\CspProviderFlags.cs" />
     <Compile Include="System\Security\Cryptography\ICspAsymmetricAlgorithm.cs" />

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
@@ -567,11 +567,6 @@ namespace Internal.NativeCrypto
             {
                 case Constants.CLR_KEYLEN:
                     {
-                        //ToDO : Check if we should use silent flag here as this might not run
-                        //downlevel so we might want to use silent flag
-
-                        // Some Csp's may pop up a UI here since we don't use CRYPT_SILENT flag
-                        // which is not supported in downlevel platforms
                         if (!Interop.CryptGetKeyParam(safeKeyHandle, (int)CryptGetKeyParamQueryType.KP_KEYLEN, null, ref cb, 0))
                         {
                             throw new CryptographicException(SR.Format(SR.CryptGetKeyParam_Failed, Convert.ToString(GetErrorCode())));
@@ -682,22 +677,6 @@ namespace Internal.NativeCrypto
                     throw new ArgumentException(SR.Format(SR.Argument_InvalidValue, Convert.ToString(flags)));
                 }
             }
-
-            //TODO : I don't think we need following commented code. Leaving it now for confirming the same 
-            // during code review. Reviewers please let me kn know?
-
-            // make sure we are allowed to display the key protection UI if a user protected key is requested.
-            //if ((flags & CspProviderFlags.UseUserProtectedKey) != 0)
-            //{
-            //    // UI only allowed in interactive session.
-            //    if (!System.Environment.UserInteractive)
-            //    {
-            //        throw new InvalidOperationException(("Cryptography_NotInteractive"));
-            //    }
-            //    // we need to demand UI permission here.
-            //    UIPermission uiPermission = new UIPermission(UIPermissionWindow.SafeTopLevelWindows);
-            //    uiPermission.Demand();
-            //}
         }
 
         /// <summary>
@@ -804,7 +783,7 @@ namespace Internal.NativeCrypto
             }
             byte[] dataTobeDecrypted = new byte[encryptedDataLength];
             Buffer.BlockCopy(encryptedData, 0, dataTobeDecrypted, 0, encryptedDataLength);
-            Array.Reverse(dataTobeDecrypted); //ToDO: Check is this is really needed? To be confirmed with tests
+            Array.Reverse(dataTobeDecrypted);
 
             int dwFlags = fOAEP ? (int)CryptDecryptFlags.CRYPT_OAEP : 0;
             int decryptedDataLength = encryptedDataLength;

--- a/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
+++ b/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
+    <Configuration Condition="'$(Configuration)'==''">Windows_NT_Debug</Configuration>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -12,8 +12,8 @@
     <RootNamespace>System.Security.Cryptography.Csp.Tests</RootNamespace>
   </PropertyGroup>
     <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Release|AnyCPU'" />
   <ItemGroup>
     <ProjectReference Include="..\src\System.Security.Cryptography.Csp.csproj">
       <Project>{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}</Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/6373

<b>Address remaining TODO's in SSC.Csp.</b>

Ok, I'm addressing them. As well as fixing up the .sln and Configuration values as I seem
to have to do in every new assembly I touch. <b>Configuration=Windows_NT_Debug</b> is what pkg build passes so that's I'm using.


<a href="https://github.com/dotnet/corefx/blob/master/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs#L570">//ToDO : Check if we should use silent flag here </a>

No idea what this comment is referring to. CryptGetKeyParam() does not take a CRYPT_SILENT flag. Nor any other flag for that matter.

<a href="https://github.com/dotnet/corefx/blob/master/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs#L686">// make sure we are allowed to display the key protection UI if a user protected key is requested.</a>

Partial trust and CAS are thing of the unlamented past. There is a potential breakage if we're in a process window station that doesn't permit UI (we're supposed to throw InvalidOp), but since we have neither the <b>Environment.UserInteractive</b> property nor the blessing of P/Invoke gatekeepers to use the underlying native apis, it can't be helped.


<a href="https://github.com/dotnet/corefx/blob/master/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs#L807">Array.Reverse(dataTobeDecrypted); //ToDO: Check is this is really needed? To be confirmed with tests</a>

Yes, we need it. RSACsp byte-reverses on encryption (and thus on decryption) because... reasons. There's a method header comment already that explains this (<a href="https://github.com/dotnet/corefx/blob/master/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs#L787">Comment</a>) , and code coverage confirms we do exercise this path in tests.