### PR TITLE
Rewrite OpenSSL references on OSX to use @rpath

### DIFF
--- a/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
@@ -51,6 +51,22 @@ target_link_libraries(System.Security.Cryptography.Native
   ${OPENSSL_SSL_LIBRARY}
 )
 
+# On OS X every library emits the manner in which it should be referenced.
+# All of our libraries are referenced via @rpath, which is similar to how Linux and Windows
+# libraries are loaded. The homebrew installation of OpenSSL (libcrypto, libssl) uses the
+# full path to the library installation. This means that this library is not flexible to
+# users installing newer libcrypto in the working directory, or to systems which do not
+# install to the same path as homebrew does.
+#
+# So, after compiling, rewrite the references to libcrypto to be more flexible.
+if (APPLE)
+    add_custom_command(TARGET System.Security.Cryptography.Native POST_BUILD
+        COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib @rpath/libcrypto.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native>
+        COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libssl.1.0.0.dylib @rpath/libssl.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native>
+        COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath @loader_path $<TARGET_FILE:System.Security.Cryptography.Native>
+        )
+endif()
+
 include(configure.cmake)
 
 install (TARGETS System.Security.Cryptography.Native DESTINATION .)


### PR DESCRIPTION
Use install_name_tool to post-link rewrite the references from the homebrew install_name
to @rpath/libcrypto.1.0.0.dylib.  Additionally, register @loader_path as an rpath so that
new builds of OpenSSL can be copied into the same directory as System.Security.Cryptography.Native
and win out over the system-installed locations.

clean El Capitan machine with recent build: fails to load
brew install openssl: fails to load
brew link --force openssl: succeeds in loading
brew unlink openssl: fails to load
cp /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib where/S.S.C.Native.dylib_is/: succeeds in loading

Fixes #8124.
cc: @ellismg @janvorli @gkhanna79