### PR TITLE
Add HttpClient test with IPv6 Uris

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -162,6 +162,33 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [Theory]
+        [MemberData(nameof(GetAsync_IPv6Uri_Success_MemberData))]
+        public async Task GetAsync_IPv6Uri_Success(IPAddress address)
+        {
+            using (var client = new HttpClient())
+            {
+                var options = new LoopbackServer.Options { Address = address };
+                await LoopbackServer.CreateServerAsync(async (server, url) =>
+                {
+                    await TestHelper.WhenAllCompletedOrAnyFailed(
+                        LoopbackServer.ReadRequestAndSendResponseAsync(server, options: options),
+                        client.GetAsync(url));
+                }, options);
+            }
+        }
+
+        public static IEnumerable<object[]> GetAsync_IPv6Uri_Success_MemberData()
+        {
+            yield return new object[] { IPAddress.IPv6Loopback };
+
+            IPAddress addr = LoopbackServer.GetIPv6LinkLocalAddress();
+            if (addr != null)
+            {
+                yield return new object[] { addr };
+            }
+        }
+
         [Fact]
         public async Task SendAsync_MultipleRequestsReusingSameClient_Success()
         {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -163,8 +163,8 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [MemberData(nameof(GetAsync_IPv6Uri_Success_MemberData))]
-        public async Task GetAsync_IPv6Uri_Success(IPAddress address)
+        [MemberData(nameof(GetAsync_IPBasedUri_Success_MemberData))]
+        public async Task GetAsync_IPBasedUri_Success(IPAddress address)
         {
             using (var client = new HttpClient())
             {
@@ -178,14 +178,14 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        public static IEnumerable<object[]> GetAsync_IPv6Uri_Success_MemberData()
+        public static IEnumerable<object[]> GetAsync_IPBasedUri_Success_MemberData()
         {
-            yield return new object[] { IPAddress.IPv6Loopback };
-
-            IPAddress addr = LoopbackServer.GetIPv6LinkLocalAddress();
-            if (addr != null)
+            foreach (var addr in new[] { IPAddress.Loopback, IPAddress.IPv6Loopback, LoopbackServer.GetIPv6LinkLocalAddress() })
             {
-                yield return new object[] { addr };
+                if (addr != null)
+                {
+                    yield return new object[] { addr };
+                }
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
@@ -5,7 +5,8 @@
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
-
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Net.Http.Functional.Tests
@@ -78,6 +79,24 @@ namespace System.Net.Http.Functional.Tests
             {
                 return md5.ComputeHash(data);
             }        
+        }
+
+        public static Task WhenAllCompletedOrAnyFailed(params Task[] tasks)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+
+            int remaining = tasks.Length;
+            foreach (var task in tasks)
+            {
+                task.ContinueWith(t =>
+                {
+                    if (t.IsFaulted) tcs.SetException(t.Exception.InnerExceptions);
+                    else if (t.IsCanceled) tcs.SetCanceled();
+                    else if (Interlocked.Decrement(ref remaining) == 0) tcs.SetResult(true);
+                }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+            }
+
+            return tcs.Task;
         }
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
@@ -90,9 +90,18 @@ namespace System.Net.Http.Functional.Tests
             {
                 task.ContinueWith(t =>
                 {
-                    if (t.IsFaulted) tcs.SetException(t.Exception.InnerExceptions);
-                    else if (t.IsCanceled) tcs.SetCanceled();
-                    else if (Interlocked.Decrement(ref remaining) == 0) tcs.SetResult(true);
+                    if (t.IsFaulted)
+                    {
+                        tcs.SetException(t.Exception.InnerExceptions);
+                    }
+                    else if (t.IsCanceled)
+                    {
+                        tcs.SetCanceled();
+                    }
+                    else if (Interlocked.Decrement(ref remaining) == 0)
+                    {
+                        tcs.SetResult(true);
+                    }
                 }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/unix/project.json
@@ -8,6 +8,7 @@
     "System.IO": "4.1.0-rc3-24112-00",
     "System.IO.FileSystem": "4.0.1-rc3-24112-00",
     "System.Linq.Expressions": "4.1.0-rc3-24112-00",
+    "System.Net.NetworkInformation": "4.1.0-rc3-24112-00",
     "System.Net.Primitives": "4.0.11-rc3-24112-00",
     "System.Net.Security": "4.0.0-rc3-24112-00",
     "System.Net.Sockets": "4.1.0-rc3-24112-00",

--- a/src/System.Net.Http/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/win/project.json
@@ -8,6 +8,7 @@
     "System.IO": "4.1.0-rc3-24112-00",
     "System.IO.FileSystem": "4.0.1-rc3-24112-00",
     "System.Linq.Expressions": "4.1.0-rc3-24112-00",
+    "System.Net.NetworkInformation": "4.1.0-rc3-24112-00",
     "System.Net.Primitives": "4.0.11-rc3-24112-00",
     "System.Net.Security": "4.0.0-rc3-24112-00",
     "System.Net.Sockets": "4.1.0-rc3-24112-00",


### PR DESCRIPTION
Adds support to the loopback server for binding to IPv6 local addresses, then adds a test that uses both ::1 and a link-local address for the current machine.

cc: @davidsh, @ericeil, @mellinoe, @mikeharder 
(Relies on https://github.com/dotnet/corefx/pull/8462; won't pass on Unix until that's merged.)