### PR TITLE
Fix race condition issue in data contract serializers

### DIFF
--- a/src/System.Private.DataContractSerialization/src/netcore50aot/project.json
+++ b/src/System.Private.DataContractSerialization/src/netcore50aot/project.json
@@ -5,6 +5,7 @@
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-24111-00",
         "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-24111-00",
         "System.Collections": "4.0.10",
+        "System.Collections.Concurrent": "4.0.10",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
         "System.Globalization": "4.0.10",

--- a/src/System.Private.DataContractSerialization/src/project.json
+++ b/src/System.Private.DataContractSerialization/src/project.json
@@ -4,6 +4,7 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-24111-00",
         "System.Collections": "4.0.10",
+        "System.Collections.Concurrent": "4.0.10",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
         "System.Globalization": "4.0.10",


### PR DESCRIPTION
Use ConcurrentDictionary instead of Dictionary. 
I ran perf tests a few times to get the comparison before and after the change. Although there are noises in the results no consistent trend of regression is identified.

Fix https://github.com/dotnet/corefx/issues/8422
cc: @shmao @SGuyGe @zhenlan 