### PR TITLE
Dispose of the inner HttpClient in HttpWebRequest

### DIFF
--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -359,83 +359,84 @@ namespace System.Net
                 throw new InvalidOperationException(SR.net_reqsubmitted);
             }
 
-            var handler = new HttpClientHandler();
-            var client = new HttpClient(handler);
-            var request = new HttpRequestMessage(new HttpMethod(_originVerb), _requestUri);
-
-            if (_requestStream != null)
+            using (var handler = new HttpClientHandler())
+            using (var client = new HttpClient(handler))
+            using (var request = new HttpRequestMessage(new HttpMethod(_originVerb), _requestUri))
             {
-                ArraySegment<byte> bytes = _requestStream.GetBuffer();
-                request.Content = new ByteArrayContent(bytes.Array, bytes.Offset, bytes.Count);
-            }
-
-            // Set to match original defaults of HttpWebRequest.
-            // HttpClientHandler.AutomaticDecompression defaults to true; set it to false to match the desktop behavior 
-            handler.AutomaticDecompression = DecompressionMethods.None;
-            handler.Credentials = _credentials;
-
-            if (_cookieContainer != null)
-            {
-                handler.CookieContainer = _cookieContainer;
-                Debug.Assert(handler.UseCookies); // Default of handler.UseCookies is true.
-            }
-            else
-            {
-                handler.UseCookies = false;
-            }
-
-            Debug.Assert(handler.UseProxy); // Default of handler.UseProxy is true.
-            Debug.Assert(handler.Proxy == null); // Default of handler.Proxy is null.
-            if (_proxy == null)
-            {
-                handler.UseProxy = false;
-            }
-            else
-            {
-                handler.Proxy = _proxy;
-            }
-
-            // Copy the HttpWebRequest request headers from the WebHeaderCollection into HttpRequestMessage.Headers and
-            // HttpRequestMessage.Content.Headers.
-            foreach (string headerName in _webHeaderCollection)
-            {
-                // The System.Net.Http APIs require HttpRequestMessage headers to be properly divided between the request headers
-                // collection and the request content headers collection for all well-known header names.  And custom headers
-                // are only allowed in the request headers collection and not in the request content headers collection.
-                if (IsWellKnownContentHeader(headerName))
+                if (_requestStream != null)
                 {
-                    if (request.Content == null)
-                    {
-                        // Create empty content so that we can send the entity-body header.
-                        request.Content = new ByteArrayContent(Array.Empty<byte>());
-                    }
+                    ArraySegment<byte> bytes = _requestStream.GetBuffer();
+                    request.Content = new ByteArrayContent(bytes.Array, bytes.Offset, bytes.Count);
+                }
 
-                    request.Content.Headers.TryAddWithoutValidation(headerName, _webHeaderCollection[headerName]);
+                // Set to match original defaults of HttpWebRequest.
+                // HttpClientHandler.AutomaticDecompression defaults to true; set it to false to match the desktop behavior 
+                handler.AutomaticDecompression = DecompressionMethods.None;
+                handler.Credentials = _credentials;
+
+                if (_cookieContainer != null)
+                {
+                    handler.CookieContainer = _cookieContainer;
+                    Debug.Assert(handler.UseCookies); // Default of handler.UseCookies is true.
                 }
                 else
                 {
-                    request.Headers.TryAddWithoutValidation(headerName, _webHeaderCollection[headerName]);
+                    handler.UseCookies = false;
                 }
+
+                Debug.Assert(handler.UseProxy); // Default of handler.UseProxy is true.
+                Debug.Assert(handler.Proxy == null); // Default of handler.Proxy is null.
+                if (_proxy == null)
+                {
+                    handler.UseProxy = false;
+                }
+                else
+                {
+                    handler.Proxy = _proxy;
+                }
+
+                // Copy the HttpWebRequest request headers from the WebHeaderCollection into HttpRequestMessage.Headers and
+                // HttpRequestMessage.Content.Headers.
+                foreach (string headerName in _webHeaderCollection)
+                {
+                    // The System.Net.Http APIs require HttpRequestMessage headers to be properly divided between the request headers
+                    // collection and the request content headers collection for all well-known header names.  And custom headers
+                    // are only allowed in the request headers collection and not in the request content headers collection.
+                    if (IsWellKnownContentHeader(headerName))
+                    {
+                        if (request.Content == null)
+                        {
+                            // Create empty content so that we can send the entity-body header.
+                            request.Content = new ByteArrayContent(Array.Empty<byte>());
+                        }
+
+                        request.Content.Headers.TryAddWithoutValidation(headerName, _webHeaderCollection[headerName]);
+                    }
+                    else
+                    {
+                        request.Headers.TryAddWithoutValidation(headerName, _webHeaderCollection[headerName]);
+                    }
+                }
+
+                _sendRequestTask = client.SendAsync(
+                    request,
+                    _allowReadStreamBuffering ? HttpCompletionOption.ResponseContentRead : HttpCompletionOption.ResponseHeadersRead,
+                    _sendRequestCts.Token);
+                HttpResponseMessage responseMessage = await _sendRequestTask.ConfigureAwait(false);
+
+                HttpWebResponse response = new HttpWebResponse(responseMessage, _requestUri, _cookieContainer);
+
+                if (!responseMessage.IsSuccessStatusCode)
+                {
+                    throw new WebException(
+                        SR.Format(SR.net_servererror, (int)response.StatusCode, response.StatusDescription),
+                        null,
+                        WebExceptionStatus.ProtocolError,
+                        response);
+                }
+
+                return response;
             }
-
-            _sendRequestTask = client.SendAsync(
-                request,
-                _allowReadStreamBuffering ? HttpCompletionOption.ResponseContentRead : HttpCompletionOption.ResponseHeadersRead,
-                _sendRequestCts.Token);
-            HttpResponseMessage responseMessage = await _sendRequestTask.ConfigureAwait(false);
-
-            HttpWebResponse response = new HttpWebResponse(responseMessage, _requestUri, _cookieContainer);
-
-            if (!responseMessage.IsSuccessStatusCode)
-            {
-                throw new WebException(
-                    SR.Format(SR.net_servererror, (int)response.StatusCode, response.StatusDescription),
-                    null,
-                    WebExceptionStatus.ProtocolError,
-                    response);
-            }
-
-            return response;
         }
 
         public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -359,9 +359,10 @@ namespace System.Net
                 throw new InvalidOperationException(SR.net_reqsubmitted);
             }
 
-            using (var handler = new HttpClientHandler())
+            var handler = new HttpClientHandler();
+            var request = new HttpRequestMessage(new HttpMethod(_originVerb), _requestUri);
+            
             using (var client = new HttpClient(handler))
-            using (var request = new HttpRequestMessage(new HttpMethod(_originVerb), _requestUri))
             {
                 if (_requestStream != null)
                 {


### PR DESCRIPTION
While browsing through the code recently, I noticed that `HttpWebRequest` uses an `HttpClient` internally, which it does not dispose of afterwards. I made a quick fix to use `using` where the variables were initialized; since they're not saved to fields or anything I'm assuming I don't have to touch the finalizer/Dispose methods of this class. (Also assuming that since `client.SendAsync` is awaited immediately after it is invoked, we don't have to worry about the client being disposed before it finishes sending or anything.)

Changes:

- Added `using` statements
- Indented the code (hence why the diff is so big, try adding ?w=1 to the end of the GitHub URL to unsee whitespace changes)

cc @davidsh @stephentoub 