### PR TITLE
Add configurable test settings for Http and WebSocket tests

### DIFF
--- a/src/Common/tests/System/Net/HttpTestServers.cs
+++ b/src/Common/tests/System/Net/HttpTestServers.cs
@@ -6,8 +6,9 @@ namespace System.Net.Test.Common
 {
     internal class HttpTestServers
     {
-        public const string Host = "corefx-net.cloudapp.net";
-        public const string Http2Host = "http2.akamai.com";
+        public readonly static string Host = TestSettings.Http.Host;
+        public readonly static string SecureHost = TestSettings.Http.SecureHost;
+        public readonly static string Http2Host = TestSettings.Http.Http2Host;
 
         public const string SSLv2RemoteServer = "https://www.ssllabs.com:10200/";
         public const string SSLv3RemoteServer = "https://www.ssllabs.com:10300/";
@@ -32,10 +33,10 @@ namespace System.Net.Test.Common
         private const string GZipHandler = "GZip.ashx";
 
         public readonly static Uri RemoteEchoServer = new Uri("http://" + Host + "/" + EchoHandler);
-        public readonly static Uri SecureRemoteEchoServer = new Uri("https://" + Host + "/" + EchoHandler);
+        public readonly static Uri SecureRemoteEchoServer = new Uri("https://" + SecureHost + "/" + EchoHandler);
 
         public readonly static Uri RemoteVerifyUploadServer = new Uri("http://" + Host + "/" + VerifyUploadHandler);
-        public readonly static Uri SecureRemoteVerifyUploadServer = new Uri("https://" + Host + "/" + VerifyUploadHandler);
+        public readonly static Uri SecureRemoteVerifyUploadServer = new Uri("https://" + SecureHost + "/" + VerifyUploadHandler);
 
         public readonly static Uri RemoteEmptyContentServer = new Uri("http://" + Host + "/" + EmptyContentHandler);
         public readonly static Uri RemoteDeflateServer = new Uri("http://" + Host + "/" + DeflateHandler);

--- a/src/Common/tests/System/Net/TestSettings.cs
+++ b/src/Common/tests/System/Net/TestSettings.cs
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Test.Common
+{
+    internal static class TestSettings
+    {
+        public static class Http
+        {
+            public static string Host
+            {
+                get
+                {
+                    string server = Environment.GetEnvironmentVariable("COREFX_HTTPHOST");
+                    if (string.IsNullOrEmpty(server))
+                    {
+                        return "corefx-net.cloudapp.net";
+                    }
+                    else
+                    {
+                        return server;
+                    }
+                }
+            }
+
+            public static string SecureHost
+            {
+                get
+                {
+                    string server = Environment.GetEnvironmentVariable("COREFX_SECUREHTTPHOST");
+                    if (string.IsNullOrEmpty(server))
+                    {
+                        return "corefx-net.cloudapp.net";
+                    }
+                    else
+                    {
+                        return server;
+                    }
+                }
+            }
+
+            public static string Http2Host
+            {
+                get
+                {
+                    string server = Environment.GetEnvironmentVariable("COREFX_HTTP2HOST");
+                    if (string.IsNullOrEmpty(server))
+                    {
+                        return "http2.akamai.com";
+                    }
+                    else
+                    {
+                        return server;
+                    }
+                }
+            }
+
+            public static string DomainJoinedHttpHost => Environment.GetEnvironmentVariable("COREFX_DOMAINJOINED_HTTPHOST");
+            public static string DomainJoinedProxyHost => Environment.GetEnvironmentVariable("COREFX_DOMAINJOINED_PROXYHOST");
+            public static string DomainJoinedProxyPort => Environment.GetEnvironmentVariable("COREFX_DOMAINJOINED_PROXYPORT");
+
+            public static bool StressEnabled => Environment.GetEnvironmentVariable("COREFX_STRESS_HTTP") == "1";
+        }
+
+        public static class WebSocket
+        {
+            public static string Host
+            {
+                get
+                {
+                    string server = Environment.GetEnvironmentVariable("COREFX_WEBSOCKETHOST");
+                    if (string.IsNullOrEmpty(server))
+                    {
+                        return "corefx-net.cloudapp.net";
+                    }
+                    else
+                    {
+                        return server;
+                    }
+                }
+            }
+
+            public static string SecureHost
+            {
+                get
+                {
+                    string server = Environment.GetEnvironmentVariable("COREFX_SECUREWEBSOCKETHOST");
+                    if (string.IsNullOrEmpty(server))
+                    {
+                        return "corefx-net.cloudapp.net";
+                    }
+                    else
+                    {
+                        return server;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Common/tests/System/Net/WebSocketTestServers.cs
+++ b/src/Common/tests/System/Net/WebSocketTestServers.cs
@@ -6,16 +6,17 @@ namespace System.Net.Test.Common
 {
     internal class WebSocketTestServers
     {
-        public const string Host = "corefx-net.cloudapp.net";
+        public readonly static string Host = TestSettings.WebSocket.Host;
+        public readonly static string SecureHost = TestSettings.WebSocket.SecureHost;
 
         private const string EchoHandler = "WebSocket/EchoWebSocket.ashx";
         private const string EchoHeadersHandler = "WebSocket/EchoWebSocketHeaders.ashx";
 
         public readonly static Uri RemoteEchoServer = new Uri("ws://" + Host + "/" + EchoHandler);
-        public readonly static Uri SecureRemoteEchoServer = new Uri("wss://" + Host + "/" + EchoHandler);
+        public readonly static Uri SecureRemoteEchoServer = new Uri("wss://" + SecureHost + "/" + EchoHandler);
 
         public readonly static Uri RemoteEchoHeadersServer = new Uri("ws://" + Host + "/" + EchoHeadersHandler);
-        public readonly static Uri SecureRemoteEchoHeadersServer = new Uri("wss://" + Host + "/" + EchoHeadersHandler);
+        public readonly static Uri SecureRemoteEchoHeadersServer = new Uri("wss://" + SecureHost + "/" + EchoHeadersHandler);
         
         public readonly static object[][] EchoServers = { new object[] { RemoteEchoServer }, new object[] { SecureRemoteEchoServer } };
         public readonly static object[][] EchoHeadersServers = { new object[] { RemoteEchoHeadersServer }, new object[] { SecureRemoteEchoHeadersServer } };

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
@@ -17,6 +17,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
       <Link>Common\System\Net\HttpTestServers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\TestSettings.cs">
+      <Link>Common\System\Net\TestSettings.cs</Link>
+    </Compile>
     <Compile Include="ServerCertificateTest.cs" />
     <Compile Include="WinHttpHandlerTest.cs" />
     <Compile Include="XunitTestAssemblyAtrributes.cs" />

--- a/src/System.Net.Http/tests/FunctionalTests/DefaultCredentialsTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DefaultCredentialsTest.cs
@@ -14,13 +14,13 @@ namespace System.Net.Http.Functional.Tests
     // TODO: #2383 - Consolidate the use of the environment variable settings to Common/tests.
     public class DefaultCredentialsTest
     {
-        private static string HttpInternalTestServer => Environment.GetEnvironmentVariable("HTTP_INTERNAL_TESTSERVER");
-        private static bool HttpInternalTestsEnabled => !string.IsNullOrEmpty(HttpInternalTestServer);
+        private static string DomainJoinedTestServer => TestSettings.Http.DomainJoinedHttpHost;
+        private static bool DomainJoinedTestsEnabled => !string.IsNullOrEmpty(DomainJoinedTestServer);
         private static string SpecificUserName = "test";
         private static string SpecificPassword = "Password1";
-        private static string SpecificDomain = HttpInternalTestServer;
+        private static string SpecificDomain = DomainJoinedTestServer;
         private static Uri AuthenticatedServer =
-            new Uri($"http://{HttpInternalTestServer}/test/auth/negotiate/showidentity.ashx");
+            new Uri($"http://{DomainJoinedTestServer}/test/auth/negotiate/showidentity.ashx");
 
         private readonly ITestOutputHelper _output;
         private readonly NetworkCredential _specificCredential =
@@ -32,7 +32,7 @@ namespace System.Net.Http.Functional.Tests
             _output.WriteLine(AuthenticatedServer.ToString());
         }
 
-        [ConditionalTheory(nameof(HttpInternalTestsEnabled))]
+        [ConditionalTheory(nameof(DomainJoinedTestsEnabled))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task UseDefaultCredentials_DefaultValue_Unauthorized(bool useProxy)
@@ -47,7 +47,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalTheory(nameof(HttpInternalTestsEnabled))]
+        [ConditionalTheory(nameof(DomainJoinedTestsEnabled))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task UseDefaultCredentials_SetFalse_Unauthorized(bool useProxy)
@@ -61,7 +61,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalTheory(nameof(HttpInternalTestsEnabled))]
+        [ConditionalTheory(nameof(DomainJoinedTestsEnabled))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task UseDefaultCredentials_SetTrue_ConnectAsCurrentIdentity(bool useProxy)
@@ -80,7 +80,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalTheory(nameof(HttpInternalTestsEnabled))]
+        [ConditionalTheory(nameof(DomainJoinedTestsEnabled))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task Credentials_SetToSpecificCredential_ConnectAsSpecificIdentity(bool useProxy)
@@ -100,7 +100,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalTheory(nameof(HttpInternalTestsEnabled))]
+        [ConditionalTheory(nameof(DomainJoinedTestsEnabled))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task Credentials_SetToWrappedDefaultCredential_ConnectAsCurrentIdentity(bool useProxy)
@@ -124,7 +124,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalFact(nameof(HttpInternalTestsEnabled))]
+        [ConditionalFact(nameof(DomainJoinedTestsEnabled))]
         public async Task Proxy_UseAuthenticatedProxyWithNoCredentials_ProxyAuthenticationRequired()
         {
             var handler = new HttpClientHandler();
@@ -137,7 +137,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalFact(nameof(HttpInternalTestsEnabled))]
+        [ConditionalFact(nameof(DomainJoinedTestsEnabled))]
         public async Task Proxy_UseAuthenticatedProxyWithDefaultCredentials_OK()
         {
             var handler = new HttpClientHandler();
@@ -150,7 +150,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalFact(nameof(HttpInternalTestsEnabled))]
+        [ConditionalFact(nameof(DomainJoinedTestsEnabled))]
         public async Task Proxy_UseAuthenticatedProxyWithWrappedDefaultCredentials_OK()
         {
             ICredentials wrappedCreds = new CredentialWrapper
@@ -209,14 +209,14 @@ namespace System.Net.Http.Functional.Tests
             {
                 _credentials = credentials;
 
-                string host = Environment.GetEnvironmentVariable("HTTP_INTERNAL_PROXYSERVER");
-                Assert.False(string.IsNullOrEmpty(host), "HTTP_INTERNAL_PROXYSERVER must specify proxy hostname");
+                string host = TestSettings.Http.DomainJoinedProxyHost;
+                Assert.False(string.IsNullOrEmpty(host), "TestSettings.Http.DomainJoinedProxyHost must specify proxy hostname");
 
-                string portString = Environment.GetEnvironmentVariable("HTTP_INTERNAL_PROXYSERVER_PORT");
-                Assert.False(string.IsNullOrEmpty(portString), "HTTP_INTERNAL_PROXYSERVER_PORT must specify proxy port number");
+                string portString = TestSettings.Http.DomainJoinedProxyPort;
+                Assert.False(string.IsNullOrEmpty(portString), "TestSettings.Http.DomainJoinedProxyPort must specify proxy port number");
 
                 int port;
-                Assert.True(int.TryParse(portString, out port), "HTTP_INTERNAL_PROXYSERVER_PORT must be a valid port number");
+                Assert.True(int.TryParse(portString, out port), "TestSettings.Http.DomainJoinedProxyPort must be a valid port number");
 
                 _proxyUri = new Uri(string.Format("http://{0}:{1}", host, port));
             }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Sockets;
+using System.Net.Test.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -13,7 +14,7 @@ namespace System.Net.Http.Functional.Tests
 {
     public class HttpClientMiniStress
     {
-        private static bool HttpStressEnabled => Environment.GetEnvironmentVariable("HTTP_STRESS") == "1";
+        private static bool HttpStressEnabled => TestSettings.Http.StressEnabled;
 
         [ConditionalTheory(nameof(HttpStressEnabled))]
         [MemberData(nameof(GetStressOptions))]

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -41,6 +41,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
       <Link>Common\System\Net\HttpTestServers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\TestSettings.cs">
+      <Link>Common\System\Net\TestSettings.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\TestWebProxies.cs">
       <Link>Common\System\Net\TestWebProxies.cs</Link>
     </Compile>

--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -70,7 +70,7 @@ namespace System.Net.NameResolution.PalTests
         [Fact]
         public void GetHostByName_HostName_GetHostByAddr()
         {
-            IPHostEntry hostEntry1 = NameResolutionPal.GetHostByName(HttpTestServers.Http2Host);
+            IPHostEntry hostEntry1 = NameResolutionPal.GetHostByName(TestSettings.Http.Http2Host);
             Assert.NotNull(hostEntry1);
 
             IPAddress[] list1 = hostEntry1.AddressList;

--- a/src/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
+++ b/src/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
@@ -47,8 +47,8 @@
       <Link>Common\System\Net\IPEndPointStatics.cs</Link>
     </Compile>
 
-    <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
-      <Link>Common\System\Net\HttpTestServers.cs</Link>
+    <Compile Include="$(CommonTestPath)\System\Net\TestSettings.cs">
+      <Link>Common\System\Net\TestSettings.cs</Link>
     </Compile>
   </ItemGroup>
 

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -27,6 +27,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
       <Link>Common\System\Net\HttpTestServers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\TestSettings.cs">
+      <Link>Common\System\Net\TestSettings.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -18,11 +18,11 @@ namespace System.Net.Security.Tests
         {
             using (var client = new TcpClient(AddressFamily.InterNetwork))
             {
-                await client.ConnectAsync(HttpTestServers.Host, 443);
+                await client.ConnectAsync(TestSettings.Http.SecureHost, 443);
 
                 using (SslStream sslStream = new SslStream(client.GetStream(), false, RemoteHttpsCertValidation, null))
                 {
-                    await sslStream.AuthenticateAsClientAsync(HttpTestServers.Host);
+                    await sslStream.AuthenticateAsClientAsync(TestSettings.Http.SecureHost);
                 }
             }
         }

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -56,9 +56,6 @@
     <Compile Include="$(CommonTestPath)\System\Net\CertificateConfiguration.cs">
       <Link>Common\System\Net\CertificateConfiguration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
-      <Link>Common\System\Net\HttpTestServers.cs</Link>
-    </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.cs">
       <Link>Common\System\Net\Capability.Security.cs</Link>
     </Compile>
@@ -67,6 +64,9 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\TestLogging.cs">
       <Link>Common\System\Net\TestLogging.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\TestSettings.cs">
+      <Link>Common\System\Net\TestSettings.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\VerboseTestLogging.cs">
       <Link>Common\System\Net\VerboseTestLogging.cs</Link>

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -61,11 +61,11 @@
       <Link>SocketCommon\SocketImplementationType.cs</Link>
     </Compile>
     <!-- Common test files -->
-    <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
-      <Link>Common\System\Net\HttpTestServers.cs</Link>
-    </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\TestLogging.cs">
       <Link>Common\System\Net\TestLogging.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\TestSettings.cs">
+      <Link>Common\System\Net\TestSettings.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\VerboseTestLogging.cs">
       <Link>Common\System\Net\VerboseTestLogging.cs</Link>

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -30,7 +30,7 @@ namespace System.Net.Sockets.Tests
             {
                 Assert.False(client.Connected);
 
-                string host = HttpTestServers.Host;
+                string host = TestSettings.Http.Host;
                 const int port = 80;
 
                 if (mode == 0)
@@ -162,7 +162,7 @@ namespace System.Net.Sockets.Tests
                 client.ReceiveTimeout = 42;
                 client.SendTimeout = 84;
 
-                await client.ConnectAsync(HttpTestServers.Host, 80);
+                await client.ConnectAsync(TestSettings.Http.Host, 80);
 
                 // Verify their values remain as were set before connecting
                 Assert.True(client.LingerState.Enabled);

--- a/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -23,6 +23,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
       <Link>Common\System\Net\HttpTestServers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\TestSettings.cs">
+      <Link>Common\System\Net\TestSettings.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\WebSocketTestServers.cs">
       <Link>Common\System\Net\WebSocketTestServers.cs</Link>
     </Compile>


### PR DESCRIPTION
Building on the current use of environment variables for passing in test settings, added a common test helper class to allow the http and websocket tests to access alternate test servers. This will help with load balancing and network latency issues which are causing occasional timeouts in CI tests. This will also allow developers to run their own version of the Azure test endpoints. Consolidated the current environment variables used and standardized on a naming format.

Fixes #2383.