### PR TITLE
Don't cancel all requests when HttpClient disposed on Unix

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
@@ -124,7 +124,6 @@ namespace System.Net.Http.Functional.Tests
                     while (!string.IsNullOrEmpty(reader.ReadLine())) ;
 
                     writer.Write(responseText);
-                    writer.Flush();
                     s.Shutdown(SocketShutdown.Send);
 
                     return Task.CompletedTask;
@@ -146,7 +145,6 @@ namespace System.Net.Http.Functional.Tests
                     while (!string.IsNullOrEmpty(await reader.ReadLineAsync().ConfigureAwait(false))) ;
 
                     await writer.WriteAsync(responseText).ConfigureAwait(false);
-                    await writer.FlushAsync().ConfigureAwait(false);
                     s.Shutdown(SocketShutdown.Send);
                 });
 
@@ -175,7 +173,6 @@ namespace System.Net.Http.Functional.Tests
                     for (int i = 0; i < numBytes; i++) Assert.NotEqual(-1, reader.Read());
 
                     await writer.WriteAsync(responseText).ConfigureAwait(false);
-                    await writer.FlushAsync().ConfigureAwait(false);
                     s.Shutdown(SocketShutdown.Send);
                 });
 
@@ -197,7 +194,6 @@ namespace System.Net.Http.Functional.Tests
                     {
                         while (!string.IsNullOrEmpty(await reader.ReadLineAsync())) ;
                         await writer.WriteAsync(CreateResponse(new string('a', 32 * 1024)));
-                        await writer.FlushAsync();
 
                         WeakReference wr = wrt.GetAwaiter().GetResult();
                         Assert.True(SpinWait.SpinUntil(() =>

--- a/src/System.Net.Http/tests/FunctionalTests/LoopbackServer.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/LoopbackServer.cs
@@ -79,7 +79,6 @@ namespace System.Net.Http.Functional.Tests
             {
                 while (!string.IsNullOrEmpty(await reader.ReadLineAsync().ConfigureAwait(false))) ;
                 await writer.WriteAsync(response ?? DefaultHttpResponse).ConfigureAwait(false);
-                await writer.FlushAsync().ConfigureAwait(false);
                 s.Shutdown(SocketShutdown.Send);
             }, options);
         }
@@ -105,7 +104,7 @@ namespace System.Net.Http.Functional.Tests
                 }
 
                 using (var reader = new StreamReader(stream, Encoding.ASCII))
-                using (var writer = new StreamWriter(stream, Encoding.ASCII))
+                using (var writer = new StreamWriter(stream, Encoding.ASCII) { AutoFlush = true })
                 {
                     await funcAsync(s, stream, reader, writer).ConfigureAwait(false);
                 }
@@ -179,7 +178,6 @@ namespace System.Net.Http.Functional.Tests
                 {
                     await writer.WriteAsync($"{content}\r\n").ConfigureAwait(false);
                 }
-                await writer.FlushAsync().ConfigureAwait(false);
 
                 client.Shutdown(SocketShutdown.Both);
             }), out localEndPoint);


### PR DESCRIPTION
On Unix when an HttpClientHandler is disposed, we cancel all outstanding operations associated with that handler.  It turns out this isn't the desired behavior (aka the behavior of WinHttpHandler), which is that we should cancel all outstanding operations that haven't yet published its HttpResponseMessage, but for requests where the HttpResponseMessage has been published, it should remain valid.

This commit tweaks the behavior accordingly and adds a test for it.

cc: @ericeil, @davidsh, @cipop