### PR TITLE
Revert Stream.Begin/End contract changes

### DIFF
--- a/src/System.IO/ref/System.IO.cs
+++ b/src/System.IO/ref/System.IO.cs
@@ -89,11 +89,7 @@ namespace System.IO
         public override bool CanWrite { get { return default(bool); } }
         public override long Length { get { return default(long); } }
         public override long Position { get { return default(long); } set { } }
-        public override System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
-        public override System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
         protected override void Dispose(bool disposing) { }
-        public override int EndRead(System.IAsyncResult asyncResult) { return 0; }
-        public override void EndWrite(System.IAsyncResult asyncResult) { return; }
         public override void Flush() { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }
         public override int Read(byte[] array, int offset, int count) { return default(int); }
@@ -132,12 +128,8 @@ namespace System.IO
         public virtual int Capacity { get { return default(int); } set { } }
         public override long Length { get { return default(long); } }
         public override long Position { get { return default(long); } set { } }
-        public override System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
-        public override System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
         public override System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }
         protected override void Dispose(bool disposing) { }
-        public override int EndRead(System.IAsyncResult asyncResult) { return 0; }
-        public override void EndWrite(System.IAsyncResult asyncResult) { return; }
         public override void Flush() { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }
         public override int Read(byte[] buffer, int offset, int count) { buffer = default(byte[]); return default(int); }
@@ -170,8 +162,6 @@ namespace System.IO
         public abstract long Position { get; set; }
         public virtual int ReadTimeout { get { return default(int); } set { } }
         public virtual int WriteTimeout { get { return default(int); } set { } }
-        public virtual System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
-        public virtual System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { return default(System.IAsyncResult); }
         public void CopyTo(System.IO.Stream destination) { }
         public void CopyTo(System.IO.Stream destination, int bufferSize) { }
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination) { return default(System.Threading.Tasks.Task); }
@@ -179,8 +169,6 @@ namespace System.IO
         public virtual System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        public virtual int EndRead(System.IAsyncResult asyncResult) { return 0; }
-        public virtual void EndWrite(System.IAsyncResult asyncResult) { return; }
         public abstract void Flush();
         public System.Threading.Tasks.Task FlushAsync() { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { return default(System.Threading.Tasks.Task); }

--- a/src/System.IO/src/System.IO.csproj
+++ b/src/System.IO/src/System.IO.csproj
@@ -37,9 +37,6 @@
   <ItemGroup Condition="'$(TargetGroup)' != 'net462'">
     <Compile Include="System\IO\BufferedStream.cs" />
     <Compile Include="System\IO\InvalidDataException.cs" />
-    <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs">
-      <Link>Common\System\Threading\Tasks\TaskToApm.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcore50aot' or '$(TargetGroup)' == 'netstandard13aot'">
     <Compile Include="System\IO\BinaryReader.cs" />

--- a/src/System.IO/src/System/IO/BufferedStream.cs
+++ b/src/System.IO/src/System/IO/BufferedStream.cs
@@ -644,12 +644,6 @@ namespace System.IO
             }
         }
 
-        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
-            TaskToApm.Begin(ReadAsync(buffer, offset, count, CancellationToken.None), callback, state);
-
-        public override int EndRead(IAsyncResult asyncResult) =>
-            TaskToApm.End<int>(asyncResult);
-
         public override int ReadByte()
         {
             return _readPos != _readLen ?
@@ -1004,12 +998,6 @@ namespace System.IO
                 sem.Release();
             }
         }
-
-        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
-            TaskToApm.Begin(WriteAsync(buffer, offset, count, CancellationToken.None), callback, state);
-
-        public override void EndWrite(IAsyncResult asyncResult) =>
-            TaskToApm.End(asyncResult);
 
         public override void WriteByte(byte value)
         {

--- a/src/System.IO/src/System/IO/MemoryStream.cs
+++ b/src/System.IO/src/System/IO/MemoryStream.cs
@@ -448,11 +448,6 @@ namespace System.IO
         }
 #pragma warning restore 1998
 
-        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
-            TaskToApm.Begin(ReadAsync(buffer, offset, count, CancellationToken.None), callback, state);
-
-        public override int EndRead(IAsyncResult asyncResult) =>
-            TaskToApm.End<int>(asyncResult);
 
         public override int ReadByte()
         {
@@ -737,12 +732,6 @@ namespace System.IO
             Write(buffer, offset, count);
         }
 #pragma warning restore 1998
-
-        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
-            TaskToApm.Begin(WriteAsync(buffer, offset, count, CancellationToken.None), callback, state);
-
-        public override void EndWrite(IAsyncResult asyncResult) =>
-            TaskToApm.End(asyncResult);
 
         public override void WriteByte(byte value)
         {

--- a/src/System.IO/src/System/IO/Stream.cs
+++ b/src/System.IO/src/System/IO/Stream.cs
@@ -187,22 +187,11 @@ namespace System.IO
                 throw new NotSupportedException(SR.NotSupported_UnreadableStream);
             }
 
-            return cancellationToken.IsCancellationRequested ?
-                Task.FromCanceled<int>(cancellationToken) :
-                Task.Factory.FromAsync(
-                    (localBuffer, localOffset, localCount, callback, state) => ((Stream)state).BeginRead(localBuffer, localOffset, localCount, callback, state),
-                    iar => ((Stream)iar.AsyncState).EndRead(iar),
-                    buffer, offset, count, this, TaskCreationOptions.DenyChildAttach | TaskCreationOptions.HideScheduler);
-        }
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<int>(cancellationToken);
+            }
 
-        public virtual IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
-            TaskToApm.Begin(ReadAsyncInternal(buffer, offset, count), callback, state);
-
-        public virtual int EndRead(IAsyncResult asyncResult) => 
-            TaskToApm.End<int>(asyncResult);
-
-        private Task<int> ReadAsyncInternal(Byte[] buffer, int offset, int count)
-        {
             // To avoid a race with a stream's position pointer & generating race 
             // conditions with internal buffer indexes in our own streams that 
             // don't natively support async IO operations when there are multiple 
@@ -234,22 +223,11 @@ namespace System.IO
                 throw new NotSupportedException(SR.NotSupported_UnwritableStream);
             }
 
-            return cancellationToken.IsCancellationRequested ?
-                Task.FromCanceled<int>(cancellationToken) :
-                Task.Factory.FromAsync(
-                    (localBuffer, localOffset, localCount, callback, state) => ((Stream)state).BeginWrite(localBuffer, localOffset, localCount, callback, state),
-                    iar => ((Stream)iar.AsyncState).EndWrite(iar),
-                    buffer, offset, count, this, TaskCreationOptions.DenyChildAttach | TaskCreationOptions.HideScheduler);
-        }
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled(cancellationToken);
+            }
 
-        public virtual IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
-            TaskToApm.Begin(WriteAsyncInternal(buffer, offset, count), callback, state);
-
-        public virtual void EndWrite(IAsyncResult asyncResult) => 
-            TaskToApm.End(asyncResult);
-
-        private Task WriteAsyncInternal(Byte[] buffer, int offset, int count)
-        {
             // To avoid a race with a stream's position pointer & generating race 
             // conditions with internal buffer indexes in our own streams that 
             // don't natively support async IO operations when there are multiple 
@@ -410,12 +388,6 @@ namespace System.IO
             }
 #pragma warning restore 1998
 
-            public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
-                TaskToApm.Begin(ReadAsync(buffer, offset, count, CancellationToken.None), callback, state);
-
-            public override int EndRead(IAsyncResult asyncResult) =>
-                TaskToApm.End<int>(asyncResult);
-
             public override int ReadByte()
             {
                 return -1;
@@ -431,12 +403,6 @@ namespace System.IO
                 cancellationToken.ThrowIfCancellationRequested();
             }
 #pragma warning restore 1998
-
-            public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
-                TaskToApm.Begin(WriteAsync(buffer, offset, count, CancellationToken.None), callback, state);
-
-            public override void EndWrite(IAsyncResult asyncResult) =>
-                TaskToApm.End(asyncResult);
 
             public override void WriteByte(byte value)
             {

--- a/src/System.IO/tests/Stream/Stream.NullTests.cs
+++ b/src/System.IO/tests/Stream/Stream.NullTests.cs
@@ -119,10 +119,6 @@ namespace System.IO.Tests
             await source.WriteAsync(buffer, offset, count);
             Assert.Equal(copy, buffer);
             Assert.Equal(0, source.Position);
-
-            await Task.Factory.FromAsync(source.BeginWrite, source.EndWrite, buffer, offset, count, null);
-            Assert.Equal(copy, buffer);
-            Assert.Equal(0, source.Position);
         }
         
         [Fact]


### PR DESCRIPTION
Unfortunatley I'm reverting the changes to add Stream.BeginRead/EndRead and Stream.BeginWrite/EndWrite to the System.IO contract I made a few days ago, at least for now.

The plan here was to add them to the contract and then override them in all of our implementations.  But it turns out we can't override them in almost all of our implementations as they need to target earlier versions of the contract (that don't have these methods) in order to run on the variety of platforms that need be supported.

As called out in https://github.com/dotnet/coreclr/issues/4908, we could change the base implementation in mscorlib, but that would then introduce a difference in behavior between .NET Core and the full framework, Mono, etc., and even if we port the change to those platforms, it would only be for the most recent version at that time, and even then under a quirk.

For now, the least bad solution seems to be to stick without these methods for 1.0, and look to instead address the issue post-1.0 in a more holistic manner.  Streams that need to override Begin/End because they need to run in the full framework will need to continue to compile with two different builds, one that includes them and one that doesn't.

cc: @ericstj, @ianhays, @danmosemsft, @KrzysztofCwalina, @weshaggard, @davidfowl 