### PR TITLE
If we fail to register a socket file descriptor with kqueue/epoll, throw a more appropriate exception

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -469,8 +469,14 @@ namespace System.Net.Sockets
                 Interop.Error errorCode;
                 if (!_asyncEngineToken.TryRegister(_socket, _registeredEvents, events, out errorCode))
                 {
-                    // TODO (#7850): throw an appropriate exception
-                    throw new Exception(string.Format("SocketAsyncContext.Register: {0}", errorCode));
+                    if (errorCode == Interop.Error.ENOMEM || errorCode == Interop.Error.ENOSPC)
+                    {
+                        throw new OutOfMemoryException();
+                    }
+                    else
+                    {
+                        throw new InternalException();                        
+                    }
                 }
 
                 _registeredEvents = events;


### PR DESCRIPTION
As it turns out, the only circumstance under which these should fail is resource exhaustion, so we can just throw OutOfMemoryException, with InternalException as a fallback in case something unexpected happens.

Fixes #7850 

@stephentoub