### PR TITLE
Baseline tests against dotnet/coreclr#2051

### DIFF
--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1023,6 +1023,7 @@ namespace System.Tests
         }
 
         [Theory]
+        [ActiveIssue("dotnet/coreclr#2051", Xunit.PlatformID.AnyUnix)]
         [InlineData("He\0lo", "He\0lo", 0)]
         [InlineData("He\0lo", "He\0", 0)]
         [InlineData("He\0lo", "\0", 2)]
@@ -1470,6 +1471,7 @@ namespace System.Tests
         }
 
         [Theory]
+        [ActiveIssue("dotnet/coreclr#2051", Xunit.PlatformID.AnyUnix)]
         [InlineData("He\0lo", "He\0lo", 0)]
         [InlineData("He\0lo", "He\0", 0)]
         [InlineData("He\0lo", "\0", 2)]


### PR DESCRIPTION
This "regressed" due to Tarek's recent change which pushes us to ICU more often.  It's interesting that the StartsWith and EndsWith tests also did not start failing.  I will investigate that as part of closing out the above issue.