### PR TITLE
Flow OSGroup to Project Reference

### DIFF
--- a/src/System.Security.SecureString/tests/System.Security.SecureString.Tests.csproj
+++ b/src/System.Security.SecureString/tests/System.Security.SecureString.Tests.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\src\System.Security.SecureString.csproj">
       <Project>{A958BBDD-3238-4E58-AB7F-390AB6D88233}</Project>
       <Name>System.Security.SecureString</Name>
+      <OSGroup>$(InputOSGroup)</OSGroup>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
You have to do this dance when an OS Agnostic project references an
OS Specific project or bad things happen with regards to the target OS.

Fixes #8425