### PR TITLE
Deterministically dispose CngKey.Handle values.

### DIFF
--- a/src/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
@@ -54,30 +54,32 @@ namespace System.Security.Cryptography
 
             unsafe
             {
-                SafeNCryptKeyHandle keyHandle = GetKeyHandle();
-                switch (padding.Mode)
+                using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
                 {
-                    case RSAEncryptionPaddingMode.Pkcs1:
-                        return EncryptOrDecrypt(keyHandle, data, AsymmetricPaddingMode.NCRYPT_PAD_PKCS1_FLAG, null, encryptOrDecrypt);
+                    switch (padding.Mode)
+                    {
+                        case RSAEncryptionPaddingMode.Pkcs1:
+                            return EncryptOrDecrypt(keyHandle, data, AsymmetricPaddingMode.NCRYPT_PAD_PKCS1_FLAG, null, encryptOrDecrypt);
 
-                    case RSAEncryptionPaddingMode.Oaep:
-                        {
-                            using (SafeUnicodeStringHandle safeHashAlgorithmName = new SafeUnicodeStringHandle(padding.OaepHashAlgorithm.Name))
+                        case RSAEncryptionPaddingMode.Oaep:
                             {
-                                BCRYPT_OAEP_PADDING_INFO paddingInfo = new BCRYPT_OAEP_PADDING_INFO()
+                                using (SafeUnicodeStringHandle safeHashAlgorithmName = new SafeUnicodeStringHandle(padding.OaepHashAlgorithm.Name))
                                 {
-                                    pszAlgId = safeHashAlgorithmName.DangerousGetHandle(),
+                                    BCRYPT_OAEP_PADDING_INFO paddingInfo = new BCRYPT_OAEP_PADDING_INFO()
+                                    {
+                                        pszAlgId = safeHashAlgorithmName.DangerousGetHandle(),
 
-                                    // It would nice to put randomized data here but RSAEncryptionPadding does not at this point provide support for this.
-                                    pbLabel = IntPtr.Zero,
-                                    cbLabel = 0,
-                                };
-                                return EncryptOrDecrypt(keyHandle, data, AsymmetricPaddingMode.NCRYPT_PAD_OAEP_FLAG, &paddingInfo, encryptOrDecrypt);
+                                        // It would nice to put randomized data here but RSAEncryptionPadding does not at this point provide support for this.
+                                        pbLabel = IntPtr.Zero,
+                                        cbLabel = 0,
+                                    };
+                                    return EncryptOrDecrypt(keyHandle, data, AsymmetricPaddingMode.NCRYPT_PAD_OAEP_FLAG, &paddingInfo, encryptOrDecrypt);
+                                }
                             }
-                        }
 
-                    default:
-                        throw new CryptographicException(SR.Cryptography_UnsupportedPaddingMode);
+                        default:
+                            throw new CryptographicException(SR.Cryptography_UnsupportedPaddingMode);
+                    }
                 }
             }
         }

--- a/src/Common/src/System/Security/Cryptography/RSACng.SignVerify.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.SignVerify.cs
@@ -37,7 +37,10 @@ namespace System.Security.Cryptography
                     delegate (AsymmetricPaddingMode paddingMode, void* pPaddingInfo)
                     {
                         int estimatedSize = KeySize / 8;
-                        signature = GetKeyHandle().SignHash(hash, paddingMode, pPaddingInfo, estimatedSize);
+                        using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
+                        {
+                            signature = keyHandle.SignHash(hash, paddingMode, pPaddingInfo, estimatedSize);
+                        }
                     }
                 );
                 return signature;
@@ -60,7 +63,10 @@ namespace System.Security.Cryptography
                 SignOrVerify(padding, hashAlgorithm, hash,
                     delegate (AsymmetricPaddingMode paddingMode, void* pPaddingInfo)
                     {
-                        verified = GetKeyHandle().VerifyHash(hash, signature, paddingMode, pPaddingInfo);
+                        using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
+                        {
+                            verified = keyHandle.VerifyHash(hash, signature, paddingMode, pPaddingInfo);
+                        }
                     }
                 );
                 return verified;

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSACng.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSACng.cs
@@ -23,7 +23,7 @@ namespace System.Security.Cryptography
             private SafeNCryptKeyHandle _keyHandle;
             private int _lastKeySize;
 
-            private SafeNCryptKeyHandle GetKeyHandle()
+            private SafeNCryptKeyHandle GetDuplicatedKeyHandle()
             {
                 int keySize = KeySize;
 
@@ -40,7 +40,7 @@ namespace System.Security.Cryptography
                     _lastKeySize = keySize;
                 }
 
-                return _keyHandle;
+                return new DuplicateSafeNCryptKeyHandle(_keyHandle);
             }
 
             private byte[] ExportKeyBlob(bool includePrivateParameters)
@@ -49,9 +49,10 @@ namespace System.Security.Cryptography
                     Interop.BCrypt.KeyBlobType.BCRYPT_RSAFULLPRIVATE_BLOB :
                     Interop.BCrypt.KeyBlobType.BCRYPT_PUBLIC_KEY_BLOB;
 
-                SafeNCryptKeyHandle keyHandle = GetKeyHandle();
-
-                return CngKeyLite.ExportKeyBlob(keyHandle, blobType);
+                using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
+                {
+                    return CngKeyLite.ExportKeyBlob(keyHandle, blobType);
+                }
             }
 
             private void ImportKeyBlob(byte[] rsaBlob, bool includePrivate)

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/BasicSymmetricCipherNCrypt.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/BasicSymmetricCipherNCrypt.cs
@@ -62,13 +62,16 @@ namespace Internal.Cryptography
                 {
                     int numBytesWritten;
                     ErrorCode errorCode;
-                    if (_encrypting)
+                    using (SafeNCryptKeyHandle keyHandle = _cngKey.Handle)
                     {
-                        errorCode = Interop.NCrypt.NCryptEncrypt(_cngKey.Handle, pInput + inputOffset, count, null, pOutput + outputOffset, count, out numBytesWritten, AsymmetricPaddingMode.None);
-                    }
-                    else
-                    {
-                        errorCode = Interop.NCrypt.NCryptDecrypt(_cngKey.Handle, pInput + inputOffset, count, null, pOutput + outputOffset, count, out numBytesWritten, AsymmetricPaddingMode.None);
+                        if (_encrypting)
+                        {
+                            errorCode = Interop.NCrypt.NCryptEncrypt(keyHandle, pInput + inputOffset, count, null, pOutput + outputOffset, count, out numBytesWritten, AsymmetricPaddingMode.None);
+                        }
+                        else
+                        {
+                            errorCode = Interop.NCrypt.NCryptDecrypt(keyHandle, pInput + inputOffset, count, null, pOutput + outputOffset, count, out numBytesWritten, AsymmetricPaddingMode.None);
+                        }
                     }
                     if (errorCode != ErrorCode.ERROR_SUCCESS)
                         throw errorCode.ToCryptographicException();

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngAlgorithmCore.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngAlgorithmCore.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using System.Security.Cryptography;
+using Microsoft.Win32.SafeHandles;
 
 namespace Internal.Cryptography
 {
@@ -15,7 +16,10 @@ namespace Internal.Cryptography
     {
         public static CngKey Duplicate(CngKey key)
         {
-            return CngKey.Open(key.Handle, key.IsEphemeral ? CngKeyHandleOpenOptions.EphemeralKey : CngKeyHandleOpenOptions.None);
+            using (SafeNCryptKeyHandle keyHandle = key.Handle)
+            {
+                return CngKey.Open(keyHandle, key.IsEphemeral ? CngKeyHandleOpenOptions.EphemeralKey : CngKeyHandleOpenOptions.None);
+            }
         }
 
         public CngKey GetOrGenerateKey(int keySize, CngAlgorithm algorithm)

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.SignVerify.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.SignVerify.cs
@@ -39,8 +39,11 @@ namespace System.Security.Cryptography
 
             unsafe
             {
-                byte[] signature = Key.Handle.SignHash(hash, AsymmetricPaddingMode.None, null, estimatedSize);
-                return signature;
+                using (SafeNCryptKeyHandle keyHandle = Key.Handle)
+                {
+                    byte[] signature = keyHandle.SignHash(hash, AsymmetricPaddingMode.None, null, estimatedSize);
+                    return signature;
+                }
             }
         }
 
@@ -56,8 +59,11 @@ namespace System.Security.Cryptography
 
             unsafe
             {
-                bool verified = Key.Handle.VerifyHash(hash, signature, AsymmetricPaddingMode.None, null);
-                return verified;
+                using (SafeNCryptKeyHandle keyHandle = Key.Handle)
+                {
+                    bool verified = keyHandle.VerifyHash(hash, signature, AsymmetricPaddingMode.None, null);
+                    return verified;
+                }
             }
         }
     }

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.Key.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.Key.cs
@@ -52,7 +52,7 @@ namespace System.Security.Cryptography
             }
         }
 
-        private SafeNCryptKeyHandle GetKeyHandle()
+        private SafeNCryptKeyHandle GetDuplicatedKeyHandle()
         {
             return Key.Handle;
         }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/6010

Dispose all the handles we're pulling out of CngKey (which
means the similarly named helper in Algorithms has to
duplicate the safehandle too since they feed the same
set of source-linked files. So we have to add a light-weight
DuplicateSafeNcryptKeyHandle to go with our light-weight
SafeNcryptKeyHandle.

Latching the key handle independently of the key is fragile
and tricky, especially with the key management split between
RSA, RSACng and CngAlgorithmCore. It also opens us
up to the "You forgot that the GC can claim objects
and their fields while one of their instance methods are executing"
bugs. (In fact, we probably had some of those bugs lurking
now that this commit fixes.) Not worth it given that we're doing
expensive crypto algorithms in between.