### PR TITLE
Remove WinHttpHandler.ConnectTimeout property

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.cs
@@ -29,7 +29,6 @@ namespace System.Net.Http
         public bool CheckCertificateRevocationList { get { return default(bool); } set { } }
         public System.Net.Http.ClientCertificateOption ClientCertificateOption { get { return default(System.Net.Http.ClientCertificateOption); } set { } }
         public System.Security.Cryptography.X509Certificates.X509Certificate2Collection ClientCertificates { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate2Collection); } }
-        public System.TimeSpan ConnectTimeout { get { return default(System.TimeSpan); } set { } }
         public System.Net.CookieContainer CookieContainer { get { return default(System.Net.CookieContainer); } set { } }
         public System.Net.Http.CookieUsePolicy CookieUsePolicy { get { return default(System.Net.Http.CookieUsePolicy); } set { } }
         public System.Net.ICredentials DefaultProxyCredentials { get { return default(System.Net.ICredentials); } set { } }

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -73,7 +73,6 @@ namespace System.Net.Http
         private ICredentials _defaultProxyCredentials = CredentialCache.DefaultCredentials;
         private IWebProxy _proxy = null;
         private int _maxConnectionsPerServer = int.MaxValue;
-        private TimeSpan _connectTimeout = TimeSpan.FromSeconds(60);
         private TimeSpan _sendTimeout = TimeSpan.FromSeconds(30);
         private TimeSpan _receiveHeadersTimeout = TimeSpan.FromSeconds(30);
         private TimeSpan _receiveDataTimeout = TimeSpan.FromSeconds(30);
@@ -355,25 +354,6 @@ namespace System.Net.Http
 
                 CheckDisposedOrStarted();
                 _maxConnectionsPerServer = value;
-            }
-        }
-
-        public TimeSpan ConnectTimeout
-        {
-            get
-            {
-                return _connectTimeout;
-            }
-
-            set
-            {
-                if (value != Timeout.InfiniteTimeSpan && (value <= TimeSpan.Zero || value > s_maxTimeout))
-                {
-                    throw new ArgumentOutOfRangeException(nameof(value));
-                }
-
-                CheckDisposedOrStarted();
-                _connectTimeout = value;
             }
         }
 
@@ -944,7 +924,7 @@ namespace System.Net.Http
             if (!Interop.WinHttp.WinHttpSetTimeouts(
                 sessionHandle,
                 0,
-                (int)_connectTimeout.TotalMilliseconds,
+                0,
                 (int)_sendTimeout.TotalMilliseconds,
                 (int)_receiveHeadersTimeout.TotalMilliseconds))
             {

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/APICallHistory.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/APICallHistory.cs
@@ -65,8 +65,6 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
 
         public static uint? WinHttpOptionRedirectPolicy { get; set; }
 
-        public static int? WinHttpOptionConnectTimeout { get; set; }
-
         public static int? WinHttpOptionSendTimeout { get; set; }
 
         public static int? WinHttpOptionReceiveTimeout { get; set; }
@@ -94,7 +92,6 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             WinHttpOptionSecurityFlags = null;
             WinHttpOptionMaxHttpAutomaticRedirects = null;
             WinHttpOptionRedirectPolicy = null;
-            WinHttpOptionConnectTimeout = null;
             WinHttpOptionSendTimeout = null;
             WinHttpOptionReceiveTimeout = null;
             winHttpOptionClientCertContextList.Clear();

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
@@ -55,7 +55,6 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Assert.Equal(CredentialCache.DefaultCredentials, handler.DefaultProxyCredentials);
             Assert.Equal(null, handler.Proxy);
             Assert.Equal(Int32.MaxValue, handler.MaxConnectionsPerServer);
-            Assert.Equal(TimeSpan.FromSeconds(60), handler.ConnectTimeout);
             Assert.Equal(TimeSpan.FromSeconds(30), handler.SendTimeout);
             Assert.Equal(TimeSpan.FromSeconds(30), handler.ReceiveHeadersTimeout);
             Assert.Equal(TimeSpan.FromSeconds(30), handler.ReceiveDataTimeout);
@@ -118,39 +117,6 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             SendRequestHelper.Send(handler, delegate { handler.CheckCertificateRevocationList = false; });
 
             Assert.Equal(false, APICallHistory.WinHttpOptionEnableSslRevocation.HasValue);
-        }
-
-        [Fact]
-        public void ConnectTimeout_SetNegativeValue_ThrowsArgumentOutOfRangeException()
-        {
-            var handler = new WinHttpHandler();
-
-            Assert.Throws<ArgumentOutOfRangeException>(() => { handler.ConnectTimeout = TimeSpan.FromMinutes(-10); });
-        }
-
-        [Fact]
-        public void ConnectTimeout_SetTooLargeValue_ThrowsArgumentOutOfRangeException()
-        {
-            var handler = new WinHttpHandler();
-
-            Assert.Throws<ArgumentOutOfRangeException>(
-                () => { handler.ConnectTimeout = TimeSpan.FromMilliseconds(int.MaxValue + 1.0); });
-        }
-
-        [Fact]
-        public void ConnectTimeout_SetZeroValue_ThrowsArgumentOutOfRangeException()
-        {
-            var handler = new WinHttpHandler();
-
-            Assert.Throws<ArgumentOutOfRangeException>(() => { handler.ConnectTimeout = TimeSpan.FromSeconds(0); });
-        }
-
-        [Fact]
-        public void ConnectTimeout_SetInfiniteValue_NoExceptionThrown()
-        {
-            var handler = new WinHttpHandler();
-
-            handler.ConnectTimeout = Timeout.InfiniteTimeSpan;
         }
 
         [Fact]
@@ -438,7 +404,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             var handler = new WinHttpHandler();
 
-            handler.ConnectTimeout = Timeout.InfiniteTimeSpan;
+            handler.ReceiveHeadersTimeout = Timeout.InfiniteTimeSpan;
         }
 
         [Theory]

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -182,7 +182,6 @@ namespace System.Net.Http
             
             // Since the granular WinHttpHandler timeout properties are not exposed via the HttpClientHandler API,
             // we need to set them to infinite and allow the HttpClient.Timeout property to have precedence.
-            _winHttpHandler.ConnectTimeout = Timeout.InfiniteTimeSpan;
             _winHttpHandler.ReceiveHeadersTimeout = Timeout.InfiniteTimeSpan;
             _winHttpHandler.ReceiveDataTimeout = Timeout.InfiniteTimeSpan;
             _winHttpHandler.SendTimeout = Timeout.InfiniteTimeSpan;


### PR DESCRIPTION
It turns out that setting the WinHTTP 'Connect' timeout does nothing. We discovered this because we still got ERROR_WINHTTP_TIMEOUT errors after about 20 seconds even after setting the 'Connect' timeout to INFINITE. We discussed this with the WinHTTP team and they told us that this timeout is essentially deprecated due to performance enhancements in the TCP stack.

For the technically curious, here is the explanation. Underneath the 'Connect' timeout is really a set of TCP timeouts related to setting up the socket via the 3-leg SYN/ACK exchange. The TCP timeout is about retransmits with backoff and how many is tried by the winsock stack. The default of these initial packet exchanges is 21 seconds with 2 retransmits (3 overall SYNs) and initial RTO of 3 (3 + 6 + 12). So that explained the timeouts we saw during periods of high network congestion.

There is no API exposed in WinHTTP to control those low-level TCP timeouts. And thus it doesn't make any sense to have a 'ConnectTimeout' on the WinHttpHandler class.