### PR TITLE
Disable parts of the test build from projectreference->package dependency conversion.

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -10,6 +10,7 @@
     <ProjectGuid>{C85CF035-7804-41FF-9557-48B7C948B58D}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Net.Http.Functional.Tests</AssemblyName>
+    <KeepAllProjectReferences>true</KeepAllProjectReferences>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetsWindows)' == 'true' and '$(ProjectJson)' == '' ">

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -9,6 +9,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <KeepAllProjectReferences>true</KeepAllProjectReferences>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Disables System.net.http.functional.tests and system.net.security.functional.tests from the projectreference -> package dependency conversion during the test build.  These test libraries have build breaks when targeting Linux using packages due to differing surface area.  Further investigation will be required to understand the failures and produce a fix.  Opting out of conversion for now unblock our build pipeline.

Tracking issue - https://github.com/dotnet/corefx/issues/8482
I'll flesh out the tracking issue with more info soon...

/cc @weshaggard @jhendrixMSFT 