### PR TITLE
Change CurlHandler.SslProtocols default

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
@@ -95,7 +95,7 @@ namespace System.Net.Http
             private static void SetSslVersion(EasyRequest easy, IntPtr sslCtx = default(IntPtr))
             {
                 // Get the requested protocols.
-                System.Security.Authentication.SslProtocols protocols = easy._handler.SslProtocols;
+                System.Security.Authentication.SslProtocols protocols = easy._handler.ActualSslProtocols;
 
                 // We explicitly disallow choosing SSL2/3. Make sure they were filtered out.
                 Debug.Assert((protocols & ~SecurityProtocol.AllowedSecurityProtocols) == 0, 
@@ -143,7 +143,7 @@ namespace System.Net.Http
                 {
                     return CURLcode.CURLE_ABORTED_BY_CALLBACK;
                 }
-                Interop.Ssl.SetProtocolOptions(sslCtx, easy._handler.SslProtocols);
+                Interop.Ssl.SetProtocolOptions(sslCtx, easy._handler.ActualSslProtocols);
 
                 // Configure the SSL server certificate verification callback.
                 Interop.Ssl.SslCtxSetCertVerifyCallback(sslCtx, s_sslVerifyCallback, curl);

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -150,7 +150,7 @@ namespace System.Net.Http
         private X509Certificate2Collection _clientCertificates;
         private Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> _serverCertificateValidationCallback;
         private bool _checkCertificateRevocationList;
-        private SslProtocols _sslProtocols = SecurityProtocol.DefaultSecurityProtocols;
+        private SslProtocols _sslProtocols = SslProtocols.None; // use default
 
         private object LockObject { get { return _agent; } }
 
@@ -268,11 +268,13 @@ namespace System.Net.Http
             get { return _sslProtocols; }
             set
             {
-                SecurityProtocol.ThrowOnNotAllowed(value, allowNone: false);
+                SecurityProtocol.ThrowOnNotAllowed(value, allowNone: true);
                 CheckDisposedOrStarted();
                 _sslProtocols = value;
             }
         }
+
+        private SslProtocols ActualSslProtocols => this.SslProtocols != SslProtocols.None ? this.SslProtocols : SecurityProtocol.DefaultSecurityProtocols;
 
         internal bool SupportsAutomaticDecompression => s_supportsAutomaticDecompression;
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -19,12 +19,12 @@ namespace System.Net.Http.Functional.Tests
         {
             using (var handler = new HttpClientHandler())
             {
-                const SslProtocols expectedDefault = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
-                Assert.Equal(expectedDefault, handler.SslProtocols);
+                Assert.Equal(SslProtocols.None, handler.SslProtocols);
             }
         }
 
         [Theory]
+        [InlineData(SslProtocols.None)]
         [InlineData(SslProtocols.Tls)]
         [InlineData(SslProtocols.Tls11)]
         [InlineData(SslProtocols.Tls12)]
@@ -42,7 +42,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalFact(nameof(BackendSupportsSslConfiguration))]
-        public async Task SetProtcols_AfterRequest_ThrowsException()
+        public async Task SetProtocols_AfterRequest_ThrowsException()
         {
             using (var handler = new HttpClientHandler() { ServerCertificateCustomValidationCallback = LoopbackServer.AllowAllCertificates })
             using (var client = new HttpClient(handler))
@@ -58,7 +58,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [InlineData(SslProtocols.None)]
         [InlineData(~SslProtocols.None)]
 #pragma warning disable 0618 // obsolete warning
         [InlineData(SslProtocols.Ssl2)]


### PR DESCRIPTION
Same change as https://github.com/dotnet/corefx/pull/8518, but for CurlHandler.

cc: @davidsh, @ericeil