### PR TITLE
Update the System.AppContext library to call out that it supports 4.6.3

### DIFF
--- a/src/System.AppContext/pkg/System.AppContext.pkgproj
+++ b/src/System.AppContext/pkg/System.AppContext.pkgproj
@@ -11,7 +11,7 @@
       <SupportedFramework>net46;netcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.AppContext.csproj">
-      <SupportedFramework>net462;netcoreapp1.0</SupportedFramework>
+      <SupportedFramework>net463;netcoreapp1.0</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.AppContext.builds"/>
   </ItemGroup>

--- a/src/System.AppContext/ref/System.AppContext.csproj
+++ b/src/System.AppContext/ref/System.AppContext.csproj
@@ -4,8 +4,8 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>netstandard1.5</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
+    <PackageTargetFramework>netstandard1.6</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.AppContext.cs" />

--- a/src/System.AppContext/src/System.AppContext.builds
+++ b/src/System.AppContext/src/System.AppContext.builds
@@ -7,7 +7,7 @@
       <TargetGroup>net46</TargetGroup>
     </Project>
     <Project Include="System.AppContext.csproj">
-      <TargetGroup>net462</TargetGroup>
+      <TargetGroup>net463</TargetGroup>
     </Project>
     <Project Include="System.AppContext.csproj">
       <TargetGroup>netcore50</TargetGroup>

--- a/src/System.AppContext/src/System.AppContext.csproj
+++ b/src/System.AppContext/src/System.AppContext.csproj
@@ -9,11 +9,11 @@
     <AssemblyVersion Condition="'$(TargetGroup)'=='netcore50' OR '$(TargetGroup)'=='netcore50aot'">4.0.0.0</AssemblyVersion>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'!='netcore50aot'">true</IsPartialFacadeAssembly>
     <ContractProject Condition="'$(TargetGroup)'=='netcore50'">..\ref\4.0.0\System.AppContext.depproj</ContractProject>
-    <!-- The following line needs to be removed once we have a targeting pack for 4.6.2 -->
-    <TargetingPackNugetPackageId Condition="'$(TargetGroup)'=='net462'">Microsoft.TargetingPack.NETFramework.v4.6</TargetingPackNugetPackageId>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.5</PackageTargetFramework>
+    <!-- The following line needs to be removed once we have a targeting pack for 4.6.3 -->
+    <TargetingPackNugetPackageId Condition="'$(TargetGroup)'=='net463'">Microsoft.TargetingPack.NETFramework.v4.6.2</TargetingPackNugetPackageId>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.6</PackageTargetFramework>
     <ExcludeResourcesImport Condition="'$(IsPartialFacadeAssembly)'=='true'">true</ExcludeResourcesImport>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.5</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.6</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -22,8 +22,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
 
   <ItemGroup Condition="'$(TargetGroup)'=='netcore50aot'">
     <TargetingPackReference Include="Windows" />

--- a/src/System.AppContext/src/project.json
+++ b/src/System.AppContext/src/project.json
@@ -13,9 +13,9 @@
         "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-24112-00"
       }
     },
-    "net462": {
+    "net463": {
       "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+        "Microsoft.TargetingPack.NETFramework.v4.6.2": "1.0.1"
       }
     }
   }


### PR DESCRIPTION
(And not 4.6.2).

The entire surface area for AppContext will only be supported by Desktop in 4.6.3.