### PR TITLE
Fail gracefully if IPAddress.Parse is given an IPv6 address beginning with a single ':'

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/IPAddressPal.Unix.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddressPal.Unix.cs
@@ -89,8 +89,7 @@ namespace System.Net
 
                 if (input[i] == ':')
                 {
-                    Debug.Assert(i >= 1);
-                    if (input[i - 1] == ']')
+                    if (i >= 1 && input[i - 1] == ']')
                     {
                         trailingBracketIndex = i - 1;
                         portSeparatorIndex = i;


### PR DESCRIPTION
(This is one of the commits from #8522.  I will have to submit the test changes separately, after this change to System.Net.Primitives propagates such that it can be used from the System.Private.Uri tests.)

This is to match the Unix behavior with the existing Windows behavior.  On Windows (both CLR and CoreFx), `IPAddress.Parse(":1")` throws `FormatException`.  On Unix, we were failing an assert (or throwing `IndexOutOfRangeException`, in release builds).

Fixes #8356.

@stephentoub, @CIPop 