### PR TITLE
Remove the calls to CryptoNative_GetStreamSizes

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -104,9 +104,6 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetPeerCertChain")]
         internal static extern SafeSharedX509StackHandle SslGetPeerCertChain(SafeSslHandle ssl);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetStreamSizes")]
-        internal static extern void GetStreamSizes(out int header, out int trailer, out int maximumMessage);
-
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetPeerFinished")]
         internal static extern int SslGetPeerFinished(SafeSslHandle ssl, IntPtr buf, int count);
 

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -534,6 +534,8 @@ extern "C" void CryptoNative_SslCtxSetClientCertCallback(SSL_CTX* ctx, SslClient
 
 extern "C" void CryptoNative_GetStreamSizes(int32_t* header, int32_t* trailer, int32_t* maximumMessage)
 {
+    // This function is kept for compatibility with RC2 builds on a jagged upgrade path.
+    // Removal is tracked via issue #8504.
     if (header)
     {
         *header = SSL3_RT_HEADER_LENGTH;
@@ -541,11 +543,6 @@ extern "C" void CryptoNative_GetStreamSizes(int32_t* header, int32_t* trailer, i
 
     if (trailer)
     {
-        // TODO (Issue #4223) : Trailer size requirement is changing based on protocol
-        //       SSL3/TLS1.0 - 68, TLS1.1 - 37 and TLS1.2 - 24
-        //       Current usage is only to compute max input buffer size for
-        //       encryption and so setting to the max
-
         *trailer = 68;
     }
 

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.h
@@ -369,11 +369,6 @@ Shims the SSL_CTX_set_client_cert_cb method
 extern "C" void CryptoNative_SslCtxSetClientCertCallback(SSL_CTX* ctx, SslClientCertCallback callback);
 
 /*
-Gets the SSL stream sizes to use.
-*/
-extern "C" void CryptoNative_GetStreamSizes(int32_t* header, int32_t* trailer, int32_t* maximumMessage);
-
-/*
 Shims the SSL_get_finished method.
 */
 extern "C" int32_t CryptoNative_SslGetFinished(SSL* ssl, void* buf, int32_t count);


### PR DESCRIPTION
The StreamSizes concept is really around doing manual message framing with
Windows SChannel. Since OpenSSL libssl does all of the framing within the
library it's entirely opaque to us.

So, populate the structure with fixed values, and eliminate the call into the shim.

If there's a need for something fancier in the future, it'll require a different
function (which takes the SSL* as input to make the relevant fancy decisions).

Fixes #4223.
Created #8504 to track fully deleting the function in the future (I left it in place to handle complex
SxS scenarios for RC2 and RTM)

This scenario is covered by System.Net.Security.Tests.SslStreamStreamToStreamTest.SslStream_StreamToStream_LargeWrites_Sync_Success

cc: @stephentoub @terlochan @ericeil 