### PR TITLE
Use stackalloc in WebUtility + avoid some branching

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -620,7 +620,7 @@ namespace System.Net
             return IsIntBetween(h, '0', '9') ?
                 h - '0' :
                 IsIntBetween(h | '\u0020', 'a', 'f') ?
-                h - 'A' - (h & '\u0020') + 10 :
+                (h & ~'\u0020') - 'A' + 10 :
                 -1;
         }
 

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -710,7 +710,6 @@ namespace System.Net
         // Returns whether a given int is between two others (inclusive).
         // It takes advantage of unsigned integer wrapping to avoid
         // unnecessarily creating a branch.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsIntBetween(int value, int lowerBound, int upperBound)
         {
             Debug.Assert(upperBound >= lowerBound);

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -617,10 +617,10 @@ namespace System.Net
 
         private static int HexToInt(char h)
         {
-            return (h >= '0' && h <= '9') ? h - '0' :
-            (h >= 'a' && h <= 'f') ? h - 'a' + 10 :
-            (h >= 'A' && h <= 'F') ? h - 'A' + 10 :
-            -1;
+            return IsIntBetween(h, '0', '9') ? h - '0' :
+                IsIntBetween(h, 'a', 'f') ? h - 'a' + 10 :
+                IsIntBetween(h, 'A', 'F') ? h - 'A' + 10 :
+                -1;
         }
 
         private static char IntToHex(int n)
@@ -659,7 +659,7 @@ namespace System.Net
 
             int code = (int)ch;
 
-            const int safeSpecialCharMask = 0x03FF0000 | // 0..9
+            const int SafeSpecialCharMask = 0x03FF0000 | // 0..9
                 1 << ((int)'!' - 0x20) | // 0x21
                 1 << ((int)'(' - 0x20) | // 0x28
                 1 << ((int)')' - 0x20) | // 0x29
@@ -667,9 +667,9 @@ namespace System.Net
                 1 << ((int)'-' - 0x20) | // 0x2D
                 1 << ((int)'.' - 0x20); // 0x2E
 
-            return ((uint)(code - 'a') <= (uint)('z' - 'a')) ||
-                   ((uint)(code - 'A') <= (uint)('Z' - 'A')) ||
-                   ((uint)(code - 0x20) <= (uint)('9' - 0x20) && ((1 << (code - 0x20)) & safeSpecialCharMask) != 0) ||
+            return IsIntBetween(code, 'a', 'z') ||
+                   IsIntBetween(code, 'A', 'Z') ||
+                   (IsIntBetween(code, 0x20, '9') && ((1 << (code - 0x20)) & SafeSpecialCharMask) != 0) ||
                    (code == (int)'_');
         }
 
@@ -705,6 +705,16 @@ namespace System.Net
                 }
             }
             return false;
+        }
+        
+        // Returns whether a given int is between two others (inclusive).
+        // It takes advantage of unsigned integer wrapping to avoid
+        // unnecessarily creating a branch.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsIntBetween(int value, int lowerBound, int upperBound)
+        {
+            Debug.Assert(upperBound >= lowerBound);
+            return (uint)(value - lowerBound) <= (uint)(upperBound - lowerBound);
         }
 
 #endregion

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -96,7 +96,7 @@ namespace System.Net
                         int valueToEncode = -1; // set to >= 0 if needs to be encoded
 
 #if ENTITY_ENCODE_HIGH_ASCII_CHARS
-                        if (ch >= 160 && ch < 256)
+                        if (IsIntBetween(ch, 160, 255))
                         {
                             // The seemingly arbitrary 160 comes from RFC
                             valueToEncode = ch;
@@ -266,7 +266,7 @@ namespace System.Net
                         }
                     }
 #if ENTITY_ENCODE_HIGH_ASCII_CHARS
-                    else if (ch >= 160 && ch < 256)
+                    else if (IsIntBetween(ch, 160, 255))
                     {
                         return s.Length - cch;
                     }

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -620,7 +620,7 @@ namespace System.Net
             return IsIntBetween(h, '0', '9') ?
                 h - '0' :
                 IsIntBetween(h | '\u0020', 'a', 'f') ?
-                (h & ~'\u0020') - 'A' + 10 :
+                (h | '\u0020') - 'a' + 10 :
                 -1;
         }
 

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -285,21 +285,35 @@ namespace System.Net
 
         #region UrlEncode implementation
         
-        private static void GetEncodedBytes(byte[] originalBytes, int offset, int count, byte[] expandedBytes)
+        private unsafe static void GetEncodedBytes(byte[] originalBytes, int offset, int count, byte[] expandedBytes)
         {
-            int pos = 0;
-            int end = offset + count;
-            Debug.Assert(offset < end && end <= originalBytes.Length);
-            for (int i = offset; i < end; i++)
+            Debug.Assert(originalBytes != null);
+            Debug.Assert(expandedBytes != null);
+            Debug.Assert(originalBytes.Length > 0);
+            Debug.Assert(offset + count <= originalBytes.Length);
+            Debug.Assert(expandedBytes.Length >= originalBytes.Length);
+            
+            fixed (byte* pOriginalBytes = originalBytes)
+            fixed (byte* pExpandedBytes = expandedBytes)
             {
-#if DEBUG
+                bool sameBuffer = originalBytes == expandedBytes;
+                GetEncodedBytes(pOriginalBytes + offset, count, pExpandedBytes, expandedBytes.Length, sameBuffer);
+            }
+        }
+        
+        private unsafe static void GetEncodedBytes(byte* originalBytes, int originalCount, byte* expandedBytes, int expandedCount, bool sameBuffer)
+        {
+            Debug.Assert(originalBytes != null);
+            Debug.Assert(expandedBytes != null);
+            Debug.Assert(originalCount > 0);
+            Debug.Assert(expandedCount >= originalCount); // Protect against buffer overflows
+            
+            int pos = 0;
+            for (int i = 0; i < originalCount; i++)
+            {
                 // Make sure we never overwrite any bytes if originalBytes and
-                // expandedBytes refer to the same array
-                if (originalBytes == expandedBytes)
-                {
-                    Debug.Assert(i >= pos);
-                }
-#endif
+                // expandedBytes refer to the same buffer
+                Debug.Assert(!sameBuffer || (originalBytes + i >= expandedBytes + pos));
 
                 byte b = originalBytes[i];
                 char ch = (char)b;
@@ -325,7 +339,7 @@ namespace System.Net
 #region UrlEncode public methods
 
         [SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "Already shipped public API; code moved here as part of API consolidation")]
-        public static string UrlEncode(string value)
+        public unsafe static string UrlEncode(string value)
         {
             if (string.IsNullOrEmpty(value))
                 return value;
@@ -361,6 +375,8 @@ namespace System.Net
             int byteCount = Encoding.UTF8.GetByteCount(value);
             int unsafeByteCount = byteCount - unexpandedCount;
             int byteIndex = unsafeByteCount * 2;
+            
+            Debug.Assert(unsafeByteCount > 0);
 
             // Instead of allocating one array of length `byteCount` to store
             // the UTF-8 encoded bytes, and then a second array of length 
@@ -369,11 +385,26 @@ namespace System.Net
             // the latter and encode the data in place, saving the first allocation.
             // We store the UTF-8 bytes to the end of this array, and then URL encode to the
             // beginning of the array.
-            byte[] newBytes = new byte[byteCount + byteIndex];
-            Encoding.UTF8.GetBytes(value, 0, value.Length, newBytes, byteIndex);
+            const int StackAllocThreshold = 1024; // Arbitrary limit for how big the stackalloc can be
             
-            GetEncodedBytes(newBytes, byteIndex, byteCount, newBytes);
-            return Encoding.UTF8.GetString(newBytes);
+            int newByteCount = byteCount + byteIndex;
+            if (newByteCount <= StackAllocThreshold)
+            {
+                byte* pNewBytes = stackalloc byte[newByteCount];
+                fixed (char* pValue = value)
+                {
+                    Encoding.UTF8.GetBytes(pValue, value.Length, pNewBytes + byteIndex, byteCount);
+                }
+                GetEncodedBytes(pNewBytes + byteIndex, byteCount, pNewBytes, newByteCount, sameBuffer: true);
+                return Encoding.UTF8.GetString(pNewBytes, newByteCount);
+            }
+            else
+            {
+                byte[] newBytes = new byte[newByteCount];
+                Encoding.UTF8.GetBytes(value, 0, value.Length, newBytes, byteIndex);
+                GetEncodedBytes(newBytes, byteIndex, byteCount, newBytes);
+                return Encoding.UTF8.GetString(newBytes);
+            }
         }
 
         public static byte[] UrlEncodeToBytes(byte[] value, int offset, int count)

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -617,9 +617,10 @@ namespace System.Net
 
         private static int HexToInt(char h)
         {
-            return IsIntBetween(h, '0', '9') ? h - '0' :
-                IsIntBetween(h, 'a', 'f') ? h - 'a' + 10 :
-                IsIntBetween(h, 'A', 'F') ? h - 'A' + 10 :
+            return IsIntBetween(h, '0', '9') ?
+                h - '0' :
+                IsIntBetween(h | '\u0020', 'a', 'f') ?
+                h - 'A' - (h & '\u0020') + 10 :
                 -1;
         }
 
@@ -667,8 +668,7 @@ namespace System.Net
                 1 << ((int)'-' - 0x20) | // 0x2D
                 1 << ((int)'.' - 0x20); // 0x2E
 
-            return IsIntBetween(code, 'a', 'z') ||
-                   IsIntBetween(code, 'A', 'Z') ||
+            return IsIntBetween(code | '\u0020', 'a', 'z') ||
                    (IsIntBetween(code, 0x20, '9') && ((1 << (code - 0x20)) & SafeSpecialCharMask) != 0) ||
                    (code == (int)'_');
         }

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -339,7 +339,7 @@ namespace System.Net
 #region UrlEncode public methods
 
         [SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "Already shipped public API; code moved here as part of API consolidation")]
-        public unsafe static string UrlEncode(string value)
+        public static string UrlEncode(string value)
         {
             if (string.IsNullOrEmpty(value))
                 return value;
@@ -390,13 +390,16 @@ namespace System.Net
             int newByteCount = byteCount + byteIndex;
             if (newByteCount <= StackAllocThreshold)
             {
-                byte* pNewBytes = stackalloc byte[newByteCount];
-                fixed (char* pValue = value)
+                unsafe
                 {
-                    Encoding.UTF8.GetBytes(pValue, value.Length, pNewBytes + byteIndex, byteCount);
+                    byte* pNewBytes = stackalloc byte[newByteCount];
+                    fixed (char* pValue = value)
+                    {
+                        Encoding.UTF8.GetBytes(pValue, value.Length, pNewBytes + byteIndex, byteCount);
+                    }
+                    GetEncodedBytes(pNewBytes + byteIndex, byteCount, pNewBytes, newByteCount, sameBuffer: true);
+                    return Encoding.UTF8.GetString(pNewBytes, newByteCount);
                 }
-                GetEncodedBytes(pNewBytes + byteIndex, byteCount, pNewBytes, newByteCount, sameBuffer: true);
-                return Encoding.UTF8.GetString(pNewBytes, newByteCount);
             }
             else
             {


### PR DESCRIPTION
Changes:

- Refactor `UrlEncode` to use `stackalloc` if the UTF-8 representation of the input is <= 1024 bytes
  - Refactored the core of `GetEncodedBytes` to use pointers
  - Refactored the array-based overload of `GetEncodedBytes` to forward everything to the new pointer-based one
  - Added plenty of debug asserts to prevent buffer overflows/UB by `fixed` when the input array is null or empty
- Avoided branches in `HexToInt` and `IsUrlSafeChar` methods
  - Added `IsIntBetween` helper method to check whether a given int is between 2 others, without branching
    - Used it in `IsUrlSafeChar`, `HexToInt`, and some of the `Html*` methods
  - Another trick: since the difference between `a` (97) and `A` (65) is 32, which is a power of 2, you can use this fact to avoid a branch when checking if a char is a letter (recently found this out in dotnet/coreclr#4881)
    - [Related StackOverflow question](http://stackoverflow.com/q/37179678/4077294)
  - Renamed `safeSpecialCharMask` to use Pascal casing as it is const

Will post perf measurements as soon as I get the chance, but I wanted to submit a PR for code review/feedback first.

cc @hughbe @stephentoub 