### PR TITLE
System.Net.Http 4.1 contract implementation

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.cs
@@ -37,6 +37,7 @@ namespace System.Net.Http
         public int MaxResponseDrainSize { get { return default(int); } set { } }
         public int MaxResponseHeadersLength { get { return default(int); } set { } }
         public bool PreAuthenticate { get { return default(bool); } set { } }
+        public System.Collections.Generic.IDictionary<string, object> Properties { get { return default(System.Collections.Generic.IDictionary<string, object>); } }
         public System.Net.IWebProxy Proxy { get { return default(System.Net.IWebProxy); } set { } }
         public System.TimeSpan ReceiveDataTimeout { get { return default(System.TimeSpan); } set { } }
         public System.TimeSpan ReceiveHeadersTimeout { get { return default(System.TimeSpan); } set { } }

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -70,7 +71,7 @@ namespace System.Net.Http
         private ICredentials _serverCredentials = null;
         private bool _preAuthenticate = false;
         private WindowsProxyUsePolicy _windowsProxyUsePolicy = WindowsProxyUsePolicy.UseWinHttpProxy;
-        private ICredentials _defaultProxyCredentials = CredentialCache.DefaultCredentials;
+        private ICredentials _defaultProxyCredentials = null;
         private IWebProxy _proxy = null;
         private int _maxConnectionsPerServer = int.MaxValue;
         private TimeSpan _sendTimeout = TimeSpan.FromSeconds(30);
@@ -78,6 +79,7 @@ namespace System.Net.Http
         private TimeSpan _receiveDataTimeout = TimeSpan.FromSeconds(30);
         private int _maxResponseHeadersLength = 64 * 1024;
         private int _maxResponseDrainSize = 64 * 1024;
+        private IDictionary<String, Object> _properties; // Only create dictionary when required.
         private volatile bool _operationStarted;
         private volatile bool _disposed;
         private SafeWinHttpHandle _sessionHandle;
@@ -455,6 +457,19 @@ namespace System.Net.Http
 
                 CheckDisposedOrStarted();
                 _maxResponseDrainSize = value;
+            }
+        }
+
+        public IDictionary<string, object> Properties
+        {
+            get
+            {
+                if (_properties == null)
+                {
+                    _properties = new Dictionary<String, object>();
+                }
+
+                return _properties;
             }
         }
         #endregion

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
@@ -235,6 +235,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             var handler = new WinHttpHandler();
             IDictionary<String, object> dict = handler.Properties;
+            Assert.Same(dict, handler.Properties);
 
             var item = new Object();
             dict.Add("item", item);

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
@@ -52,7 +53,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Assert.Equal(false, handler.PreAuthenticate);
             Assert.Equal(null, handler.ServerCredentials);
             Assert.Equal(WindowsProxyUsePolicy.UseWinHttpProxy, handler.WindowsProxyUsePolicy);
-            Assert.Equal(CredentialCache.DefaultCredentials, handler.DefaultProxyCredentials);
+            Assert.Equal(null, handler.DefaultProxyCredentials);
             Assert.Equal(null, handler.Proxy);
             Assert.Equal(Int32.MaxValue, handler.MaxConnectionsPerServer);
             Assert.Equal(TimeSpan.FromSeconds(30), handler.SendTimeout);
@@ -60,6 +61,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Assert.Equal(TimeSpan.FromSeconds(30), handler.ReceiveDataTimeout);
             Assert.Equal(64 * 1024, handler.MaxResponseHeadersLength);
             Assert.Equal(64 * 1024, handler.MaxResponseDrainSize);
+            Assert.NotNull(handler.Properties);
         }
 
         [Fact]
@@ -218,6 +220,28 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
                 });
 
             Assert.Equal(true, APICallHistory.WinHttpOptionDisableCookies.HasValue);
+        }
+
+        [Fact]
+        public void Properties_Get_CountIsZero()
+        {
+            var handler = new WinHttpHandler();
+            IDictionary<String, object> dict = handler.Properties;
+            Assert.Equal(0, dict.Count);
+        }
+
+        [Fact]
+        public void Properties_AddItemToDictionary_ItemPresent()
+        {
+            var handler = new WinHttpHandler();
+            IDictionary<String, object> dict = handler.Properties;
+
+            var item = new Object();
+            dict.Add("item", item);
+
+            object value;
+            Assert.True(dict.TryGetValue("item", out value));
+            Assert.Equal(item, value);
         }
 
         [Fact]

--- a/src/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/System.Net.Http/ref/System.Net.Http.cs
@@ -85,11 +85,16 @@ namespace System.Net.Http
         public System.Security.Cryptography.X509Certificates.X509CertificateCollection ClientCertificates { get { return default(System.Security.Cryptography.X509Certificates.X509CertificateCollection); } }
         public System.Net.CookieContainer CookieContainer { get { return default(System.Net.CookieContainer); } set { } }
         public System.Net.ICredentials Credentials { get { return default(System.Net.ICredentials); } set { } }
+        public System.Net.ICredentials DefaultProxyCredentials { get { return default(System.Net.ICredentials); } set { } }
         public int MaxAutomaticRedirections { get { return default(int); } set { } }
+        public int MaxConnectionsPerServer { get { return default(int); } set { } }
         public long MaxRequestContentBufferSize { get { return default(long); } set { } }
+        public int MaxResponseHeadersLength { get { return default(int); } set { } }
         public bool PreAuthenticate { get { return default(bool); } set { } }
+        public System.Collections.Generic.IDictionary<string, object> Properties { get { return default(System.Collections.Generic.IDictionary<string, object>); } }
         public System.Net.IWebProxy Proxy { get { return default(System.Net.IWebProxy); } set { } }
         public System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool> ServerCertificateCustomValidationCallback { get { return default(System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool>); } set { } }
+        public System.Security.Authentication.SslProtocols SslProtocols { get { return default(System.Security.Authentication.SslProtocols); } set { } }
         public virtual bool SupportsAutomaticDecompression { get { return default(bool); } }
         public virtual bool SupportsProxy { get { return default(bool); } }
         public virtual bool SupportsRedirectConfiguration { get { return default(bool); } }

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
@@ -131,6 +132,10 @@ namespace System.Net.Http
             set { _curlHandler.MaxResponseHeadersLength = value; }
         }
 
+        public IDictionary<String, object> Properties
+        {
+            get { return _curlHandler.Properties; }
+        }
         #endregion Properties
 
         #region De/Constructors

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Net.Http.Headers;
 using System.Net.Security;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -69,6 +70,12 @@ namespace System.Net.Http
             set { _winHttpHandler.Proxy = value; }
         }
 
+        public ICredentials DefaultProxyCredentials
+        {
+            get { return _winHttpHandler.DefaultProxyCredentials; }
+            set { _winHttpHandler.DefaultProxyCredentials = value; }
+        }
+
         public bool PreAuthenticate
         {
             get { return _winHttpHandler.PreAuthenticate; }
@@ -79,6 +86,8 @@ namespace System.Net.Http
         {
             // WinHttpHandler doesn't have a separate UseDefaultCredentials property.  There
             // is just a ServerCredentials property.  So, we need to map the behavior.
+            //
+            // This property only affect .ServerCredentials and not .DefaultProxyCredentials.
 
             get { return (_winHttpHandler.ServerCredentials == CredentialCache.DefaultCredentials); }
 
@@ -86,13 +95,10 @@ namespace System.Net.Http
             {
                 if (value)
                 {
-                    _winHttpHandler.DefaultProxyCredentials = CredentialCache.DefaultCredentials;
                     _winHttpHandler.ServerCredentials = CredentialCache.DefaultCredentials;
                 }
                 else
                 {
-                    _winHttpHandler.DefaultProxyCredentials = null;
-
                     if (_winHttpHandler.ServerCredentials == CredentialCache.DefaultCredentials)
                     {
                         // Only clear out the ServerCredentials property if it was a DefaultCredentials.
@@ -126,6 +132,12 @@ namespace System.Net.Http
             set { _winHttpHandler.MaxAutomaticRedirections = value; }
         }
 
+        public int MaxConnectionsPerServer
+        {
+            get { return _winHttpHandler.MaxConnectionsPerServer; }
+            set { _winHttpHandler.MaxConnectionsPerServer = value; }
+        }
+
         public long MaxRequestContentBufferSize
         {
             // This property has been deprecated. In the .NET Desktop it was only used when the handler needed to 
@@ -139,6 +151,12 @@ namespace System.Net.Http
             // TODO (#7879): Add message/link to exception explaining the deprecation. 
             // Update corresponding exception in HttpClientHandler.Unix.cs if/when this is updated.
             set { throw new PlatformNotSupportedException(); }
+        }
+
+        public int MaxResponseHeadersLength
+        {
+            get { return _winHttpHandler.MaxResponseHeadersLength; }
+            set { _winHttpHandler.MaxResponseHeadersLength = value; }
         }
 
         public X509CertificateCollection ClientCertificates
@@ -156,6 +174,17 @@ namespace System.Net.Http
         {
             get { return _winHttpHandler.CheckCertificateRevocationList; }
             set { _winHttpHandler.CheckCertificateRevocationList = value; }
+        }
+
+        public SslProtocols SslProtocols
+        {
+            get { return _winHttpHandler.SslProtocols; }
+            set { _winHttpHandler.SslProtocols = value; }
+        }
+
+        public IDictionary<String, object> Properties
+        {
+            get { return _winHttpHandler.Properties; }
         }
 
         #endregion Properties

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -135,7 +135,7 @@ namespace System.Net.Http
         private IWebProxy _proxy = null;
         private ICredentials _serverCredentials = null;
         private bool _useProxy = HttpHandlerDefaults.DefaultUseProxy;
-        private ICredentials _defaultProxyCredentials = CredentialCache.DefaultCredentials;
+        private ICredentials _defaultProxyCredentials = null;
         private DecompressionMethods _automaticDecompression = HttpHandlerDefaults.DefaultAutomaticDecompression;
         private bool _preAuthenticate = HttpHandlerDefaults.DefaultPreAuthenticate;
         private CredentialCache _credentialCache = null; // protected by LockObject
@@ -151,6 +151,7 @@ namespace System.Net.Http
         private Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> _serverCertificateValidationCallback;
         private bool _checkCertificateRevocationList;
         private SslProtocols _sslProtocols = SslProtocols.None; // use default
+        private IDictionary<String, Object> _properties; // Only create dictionary when required.
 
         private object LockObject { get { return _agent; } }
 
@@ -387,6 +388,19 @@ namespace System.Net.Http
         {
             get { return false; }
             set { }
+        }
+
+        public IDictionary<string, object> Properties
+        {
+            get
+            {
+                if (_properties == null)
+                {
+                    _properties = new Dictionary<String, object>();
+                }
+
+                return _properties;
+            }
         }
         #endregion
 

--- a/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
@@ -321,7 +321,7 @@ namespace System.Net.Http
 
         public int MaxResponseHeadersLength
         {
-            get { return 0; } // TODO: Return default value used in Wininet.
+            get { return 0; } // TODO: Issue #8541 - return default value used in Wininet.
             set
             {
                 throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,

--- a/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
@@ -10,6 +10,7 @@ using System.Net.Http.Headers;
 using System.Net.Security;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -46,6 +47,7 @@ namespace System.Net.Http
         private DecompressionMethods automaticDecompression;
         private IWebProxy proxy;
         private X509Certificate2Collection clientCertificates;
+        private IDictionary<String, Object> properties; // Only create dictionary when required.
 
         #endregion Fields
 
@@ -226,6 +228,45 @@ namespace System.Net.Http
             }
         }
 
+        public ICredentials DefaultProxyCredentials
+        {
+            get
+            {
+                RTPasswordCredential rtCreds = rtFilter.ProxyCredential;
+                if (rtCreds == null)
+                {
+                    return null;
+                }
+
+                NetworkCredential creds = new NetworkCredential(rtCreds.UserName, rtCreds.Password);
+                return creds;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    CheckDisposedOrStarted();
+                    rtFilter.ProxyCredential = null;
+                }
+                else if (value == CredentialCache.DefaultCredentials)
+                {
+                    CheckDisposedOrStarted();
+                    // System managed
+                    rtFilter.ProxyCredential = null;
+                }
+                else if (value is NetworkCredential)
+                {
+                    CheckDisposedOrStarted();
+                    rtFilter.ProxyCredential = RTPasswordCredentialFromNetworkCredential((NetworkCredential)value);
+                }
+                else
+                {
+                    throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,
+                        SR.net_http_value_not_supported, value, nameof(DefaultProxyCredentials)));
+                }
+            }
+        }
+
         public bool AllowAutoRedirect
         {
             get { return rtFilter.AllowAutoRedirect; }
@@ -251,6 +292,16 @@ namespace System.Net.Http
             }
         }
 
+        public int MaxConnectionsPerServer
+        {
+            get { return (int)rtFilter.MaxConnectionsPerServer; }
+            set
+            {
+                CheckDisposedOrStarted();
+                rtFilter.MaxConnectionsPerServer = (uint)value;
+            }
+        }
+        
         public long MaxRequestContentBufferSize
         {
             get { return HttpContent.MaxBufferSize; }
@@ -265,6 +316,16 @@ namespace System.Net.Http
                         SR.net_http_value_not_supported, value, nameof(MaxRequestContentBufferSize)));
                 }
                 CheckDisposedOrStarted();
+            }
+        }
+
+        public int MaxResponseHeadersLength
+        {
+            get { return 0; } // TODO: Return default value used in Wininet.
+            set
+            {
+                throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,
+                    SR.net_http_value_not_supported, value, nameof(MaxResponseHeadersLength)));
             }
         }
 
@@ -319,6 +380,33 @@ namespace System.Net.Http
                     throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,
                         SR.net_http_value_not_supported, value, nameof(CheckCertificateRevocationList)));
                 }
+            }
+        }
+
+        public SslProtocols SslProtocols
+        {
+            get { return SslProtocols.None; }
+            set
+            {
+                CheckDisposedOrStarted();
+                if (value != SslProtocols.None)
+                {
+                    throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,
+                        SR.net_http_value_not_supported, value, nameof(SslProtocols)));
+                }
+            }
+        }
+
+        public IDictionary<String, Object> Properties
+        {
+            get
+            {
+                if (properties == null)
+                {
+                    properties = new Dictionary<String, object>();
+                }
+
+                return properties;
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -17,7 +17,7 @@ namespace System.Net.Http.Functional.Tests
         {
             using (var handler = new HttpClientHandler())
             {
-                Assert.Same(null, handler.DefaultProxyCredentials);
+                Assert.Null(handler.DefaultProxyCredentials);
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -13,11 +13,11 @@ namespace System.Net.Http.Functional.Tests
     public class HttpClientHandler_DefaultProxyCredentials_Test : RemoteExecutorTestBase
     {
         [Fact]
-        public void Default_CredentialCacheDefaultCredentials_Same()
+        public void Default_Get_Null()
         {
             using (var handler = new HttpClientHandler())
             {
-                Assert.Same(CredentialCache.DefaultCredentials, handler.DefaultProxyCredentials);
+                Assert.Same(null, handler.DefaultProxyCredentials);
             }
         }
 
@@ -65,7 +65,7 @@ namespace System.Net.Http.Functional.Tests
 
         [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)] // proxies set via the http_proxy environment variable are specific to Unix
-        public void ProxySetViaEnvironmentVariable_DefaultCredentialsUsed()
+        public void ProxySetViaEnvironmentVariable_DefaultProxyCredentialsUsed()
         {
             int port;
             Task<LoopbackGetRequestHttpProxy.ProxyResult> proxyTask = LoopbackGetRequestHttpProxy.StartAsync(out port, requireAuth: true, expectCreds: true);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -113,6 +113,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(8538, PlatformID.Windows)]
         [Fact]
         public async Task GetAsync_DisallowTls10_AllowTls11_AllowTls12()
         {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -150,6 +150,7 @@ namespace System.Net.Http.Functional.Tests
         {
             var handler = new HttpClientHandler();
             IDictionary<String, object> dict = handler.Properties;
+            Assert.Same(dict, handler.Properties);
             Assert.Equal(0, dict.Count);
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -104,6 +104,7 @@ namespace System.Net.Http.Functional.Tests
                 // Changes from .NET Framework (Desktop).
                 Assert.Equal(DecompressionMethods.GZip | DecompressionMethods.Deflate, handler.AutomaticDecompression);
                 Assert.Equal(0, handler.MaxRequestContentBufferSize);
+                Assert.NotNull(handler.Properties);
             }
         }
 
@@ -142,6 +143,28 @@ namespace System.Net.Http.Functional.Tests
                     Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
                 }
             }
+        }
+
+        [Fact]
+        public void Properties_Get_CountIsZero()
+        {
+            var handler = new HttpClientHandler();
+            IDictionary<String, object> dict = handler.Properties;
+            Assert.Equal(0, dict.Count);
+        }
+
+        [Fact]
+        public void Properties_AddItemToDictionary_ItemPresent()
+        {
+            var handler = new HttpClientHandler();
+            IDictionary<String, object> dict = handler.Properties;
+
+            var item = new Object();
+            dict.Add("item", item);
+
+            object value;
+            Assert.True(dict.TryGetValue("item", out value));
+            Assert.Equal(item, value);
         }
 
         [Theory, MemberData(nameof(EchoServers))]

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -55,7 +55,11 @@
     <Compile Include="FakeDiagnosticSourceListenerObserver.cs" />
     <Compile Include="FormUrlEncodedContentTest.cs" />
     <Compile Include="HttpClientHandlerTest.cs" />
+    <Compile Include="HttpClientHandlerTest.DefaultProxyCredentials.cs" />
+    <Compile Include="HttpClientHandlerTest.MaxConnectionsPerServer.cs" />
+    <Compile Include="HttpClientHandlerTest.MaxResponseHeadersLength.cs" />
     <Compile Include="HttpClientHandlerTest.ServerCertificates.cs" />
+    <Compile Include="HttpClientHandlerTest.SslProtocols.cs" />
     <Compile Include="HttpClientTest.cs" />
     <Compile Include="HttpClientMiniStressTest.cs" />
     <Compile Include="HttpContentTest.cs" />
@@ -79,12 +83,6 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <Compile Include="DefaultCredentialsTest.cs" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
-    <Compile Include="HttpClientHandlerTest.DefaultProxyCredentials.cs" />
-    <Compile Include="HttpClientHandlerTest.MaxConnectionsPerServer.cs" />
-    <Compile Include="HttpClientHandlerTest.MaxResponseHeadersLength.cs" />
-    <Compile Include="HttpClientHandlerTest.SslProtocols.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Net.Http.csproj">


### PR DESCRIPTION
As per approved #7623, add remaining properties to HttpClientHandler for
all platforms.

Move pre-existing Unix-only Http tests to run for all platforms.

Ensure that "credentials" related properties are secure by default and have
an initial (default) value of null.