### PR TITLE
Add tests for Regex collections throwing IndexOutOfRangeExceptions in their CopyTo implementations

### DIFF
--- a/src/System.Text.RegularExpressions/tests/CaptureCollectionTests.cs
+++ b/src/System.Text.RegularExpressions/tests/CaptureCollectionTests.cs
@@ -91,12 +91,27 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Fact]
-        public void ICollection_CopyTo_NullArray_ThrowsArgumentNullException()
+        public void ICollection_CopyTo_Invalid()
         {
-            Regex regex = new Regex("e");
+            Regex regex = new Regex(@"(?<A1>a*)(?<A2>b*)(?<A3>c*)");
             ICollection collection = regex.Match("aaabbccccccccccaaaabc").Captures;
 
+            // Array is null
             Assert.Throws<ArgumentNullException>("array", () => collection.CopyTo(null, 0));
+
+            // Array is multidimensional
+            Assert.Throws<ArgumentException>(null, () => collection.CopyTo(new object[10, 10], 0));
+
+            // Array has a non-zero lower bound
+            Array o = Array.CreateInstance(typeof(object), new int[] { 10 }, new int[] { 10 });
+            Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(o, 0));
+
+            // Index < 0
+            Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(new object[collection.Count], -1));
+
+            // Invalid index + length
+            Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(new object[collection.Count], 1));
+            Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(new object[collection.Count + 1], 2));
         }
     }
 }

--- a/src/System.Text.RegularExpressions/tests/GroupCollectionTests.cs
+++ b/src/System.Text.RegularExpressions/tests/GroupCollectionTests.cs
@@ -96,12 +96,27 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Fact]
-        public void ICollection_CopyTo_NullArray_ThrowsArgumentNullException()
+        public void ICollection_CopyTo_Invalid()
         {
             Regex regex = new Regex("e");
             ICollection collection = regex.Match("aaabbccccccccccaaaabc").Groups;
 
+            // Array is null
             Assert.Throws<ArgumentNullException>("array", () => collection.CopyTo(null, 0));
+
+            // Array is multidimensional
+            Assert.Throws<ArgumentException>(null, () => collection.CopyTo(new object[10, 10], 0));
+
+            // Array has a non-zero lower bound
+            Array o = Array.CreateInstance(typeof(object), new int[] { 10 }, new int[] { 10 });
+            Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(o, 0));
+
+            // Index < 0
+            Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(new object[collection.Count], -1));
+
+            // Invalid index + length
+            Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(new object[collection.Count], 1));
+            Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(new object[collection.Count + 1], 2));
         }
     }
 }

--- a/src/System.Text.RegularExpressions/tests/MatchCollectionTests.cs
+++ b/src/System.Text.RegularExpressions/tests/MatchCollectionTests.cs
@@ -95,9 +95,22 @@ namespace System.Text.RegularExpressions.Tests
             Regex regex = new Regex("e");
             ICollection collection = regex.Matches("dotnet");
 
+            // Array is null
             Assert.Throws<ArgumentNullException>("dest", () => collection.CopyTo(null, 0));
-            Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => collection.CopyTo(new Match[collection.Count], -1));
-            Assert.Throws<ArgumentException>(string.Empty, () => collection.CopyTo(new Match[collection.Count], collection.Count));
+
+            // Array is multidimensional
+            Assert.Throws<ArgumentException>(null, () => collection.CopyTo(new object[10, 10], 0));
+
+            // Array has a non-zero lower bound
+            Array o = Array.CreateInstance(typeof(object), new int[] { 10 }, new int[] { 10 });
+            Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => collection.CopyTo(o, 0));
+
+            // Index < 0
+            Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => collection.CopyTo(new object[collection.Count], -1));
+
+            // Invalid index + length
+            Assert.Throws<ArgumentException>("", () => collection.CopyTo(new object[collection.Count], 1));
+            Assert.Throws<ArgumentException>("", () => collection.CopyTo(new object[collection.Count + 1], 2));
         }
     }
 }


### PR DESCRIPTION
- We don't support non-zero lower bounds
- We don't support multidimensional arrays
- We don't support invalid index

/cc @Priya91 @stephentoub 