### PR TITLE
Add test verifying HttpClient negotiates Tls12 when None specified

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/LoopbackServer.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/LoopbackServer.cs
@@ -75,12 +75,14 @@ namespace System.Net.Http.Functional.Tests
 
         public static Task ReadRequestAndSendResponseAsync(Socket server, string response = null, Options options = null)
         {
-            return AcceptSocketAsync(server, async (s, stream, reader, writer) =>
-            {
-                while (!string.IsNullOrEmpty(await reader.ReadLineAsync().ConfigureAwait(false))) ;
-                await writer.WriteAsync(response ?? DefaultHttpResponse).ConfigureAwait(false);
-                s.Shutdown(SocketShutdown.Send);
-            }, options);
+            return AcceptSocketAsync(server, (s, stream, reader, writer) => ReadWriteAcceptedAsync(s, reader, writer, response), options);
+        }
+
+        public static async Task ReadWriteAcceptedAsync(Socket s, StreamReader reader, StreamWriter writer, string response = null)
+        {
+            while (!string.IsNullOrEmpty(await reader.ReadLineAsync().ConfigureAwait(false))) ;
+            await writer.WriteAsync(response ?? DefaultHttpResponse).ConfigureAwait(false);
+            s.Shutdown(SocketShutdown.Send);
         }
 
         public static async Task AcceptSocketAsync(Socket server, Func<Socket, Stream, StreamReader, StreamWriter, Task> funcAsync, Options options = null)

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -27,6 +27,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorTestBase.cs">
       <Link>Common\System\Diagnostics\RemoteExecutorTestBase.cs</Link>
     </Compile>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/8523
cc: @davidsh, @cipop