### PR TITLE
Add tests for CopyTo throwing IndexOutOfRangeException in System.Security.*

### DIFF
--- a/src/System.Security.Cryptography.Encoding/tests/AsnEncodedDataCollectionTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/AsnEncodedDataCollectionTests.cs
@@ -123,6 +123,11 @@ namespace System.Security.Cryptography.Encoding.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => c.CopyTo(a, -1));
             Assert.Throws<ArgumentOutOfRangeException>(() => c.CopyTo(a, 3));
             Assert.Throws<ArgumentException>(() => c.CopyTo(a, 1));
+
+            // Array has non-zero lower bound
+            ICollection ic = c;
+            Array array = Array.CreateInstance(typeof(object), new int[] { 10 }, new int[] { 10 });
+            Assert.Throws<IndexOutOfRangeException>(() => ic.CopyTo(array, 0));
         }
 
 

--- a/src/System.Security.Cryptography.Encoding/tests/OidCollectionTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/OidCollectionTests.cs
@@ -128,6 +128,15 @@ namespace System.Security.Cryptography.Encoding.Tests
         }
 
         [Fact]
+        public void CopyTo_NonZeroLowerBound_ThrowsIndexOutOfRangeException()
+        {
+            Oid item = new Oid(Sha1Oid, Sha1Name);
+            ICollection ic = new OidCollection { item };
+            Array array = Array.CreateInstance(typeof(object), new int[] { 10 }, new int[] { 10 });
+            Assert.Throws<IndexOutOfRangeException>(() => ic.CopyTo(array, 0));
+        }
+
+        [Fact]
         public void GetEnumerator_Success()
         {
             ValidateEnumerator(c => c.GetEnumerator(), e => e.Current);

--- a/src/System.Security.Cryptography.Pkcs/tests/CmsRecipientCollectionTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/CmsRecipientCollectionTests.cs
@@ -169,6 +169,10 @@ namespace System.Security.Cryptography.Pkcs.Tests
             Assert.Throws<ArgumentException>(() => ic.CopyTo(a, 1));
             Assert.Throws<ArgumentException>(() => ic.CopyTo(new CmsRecipient[2, 2], 1));
             Assert.Throws<InvalidCastException>(() => ic.CopyTo(new int[10], 1));
+
+            // Array has non-zero lower bound
+            Array array = Array.CreateInstance(typeof(object), new int[] { 10 }, new int[] { 10 });
+            Assert.Throws<IndexOutOfRangeException>(() => ic.CopyTo(array, 0));
         }
 
 

--- a/src/System.Security.Cryptography.Pkcs/tests/CryptographicAttributeObjectCollectionTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/CryptographicAttributeObjectCollectionTests.cs
@@ -161,6 +161,10 @@ namespace System.Security.Cryptography.Pkcs.Tests
             Assert.Throws<ArgumentException>(() => ic.CopyTo(a, 1));
             Assert.Throws<ArgumentException>(() => ic.CopyTo(new CryptographicAttributeObject[2, 2], 0));
             Assert.Throws<InvalidCastException>(() => ic.CopyTo(new int[10], 0));
+
+            // Array has non-zero lower bound
+            Array array = Array.CreateInstance(typeof(object), new int[] { 10 }, new int[] { 10 });
+            Assert.Throws<IndexOutOfRangeException>(() => ic.CopyTo(array, 0));
         }
 
         private static void AssertEquals(CryptographicAttributeObjectCollection c, IList<CryptographicAttributeObject> expected)

--- a/src/System.Security.Cryptography.Pkcs/tests/RecipientInfoCollectionTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/RecipientInfoCollectionTests.cs
@@ -139,6 +139,10 @@ namespace System.Security.Cryptography.Pkcs.Tests
             Assert.Throws<ArgumentException>(() => col.CopyTo(recipients, 4));
             Assert.Throws<ArgumentOutOfRangeException>(() => col.CopyTo(recipients, -1));
             Assert.Throws<ArgumentOutOfRangeException>(() => col.CopyTo(recipients, 6));
+
+            // Array has non-zero lower bound
+            Array array = Array.CreateInstance(typeof(object), new int[] { 10 }, new int[] { 10 });
+            Assert.Throws<IndexOutOfRangeException>(() => col.CopyTo(array, 0));
         }
 
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -861,6 +861,30 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        public static void X509ChainElementCollection_CopyTo_NonZeroLowerBound_ThrowsIndexOutOfRangeException()
+        {
+            using (X509Certificate2 microsoftDotCom = new X509Certificate2(TestData.MicrosoftDotComSslCertBytes))
+            using (X509Chain chain = new X509Chain())
+            {
+                chain.Build(microsoftDotCom);
+                ICollection collection = chain.ChainElements;
+                Array array = Array.CreateInstance(typeof(object), new int[] { 10 }, new int[] { 10 });
+                Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(array, 0));
+            }
+        }
+
+        [Fact]
+        public static void X509ExtensionCollection_CopyTo_NonZeroLowerBound_ThrowsIndexOutOfRangeException()
+        {
+            using (X509Certificate2 cert = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
+            {
+                ICollection collection = cert.Extensions;
+                Array array = Array.CreateInstance(typeof(object), new int[] { 10 }, new int[] { 10 });
+                Assert.Throws<IndexOutOfRangeException>(() => collection.CopyTo(array, 0));
+            }
+        }
+
+        [Fact]
         public static void X509CertificateCollectionIndexOf()
         {
             using (X509Certificate2 c1 = new X509Certificate2())


### PR DESCRIPTION
Calling CopyTo on these ICollections with an array that had a non-zero lower bound currently throws an IndexOutOfRangeException. This is a bug in the implementation: we do not reject these arrays, however, due to backcompat issues
/cc @bartonjs @AtsushiKan