### PR TITLE
Don't fallback to earlier ubuntu versions

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -293,31 +293,31 @@
         },
 
         "ubuntu.14.10": {
-            "#import": [ "ubuntu.14.04" ]
+            "#import": [ "ubuntu" ]
         },
         "ubuntu.14.10-x64": {
-            "#import": [ "ubuntu.14.10", "ubuntu.14.04-x64" ]
+            "#import": [ "ubuntu.14.10", "ubuntu-x64" ]
         },
 
         "ubuntu.15.04": {
-            "#import": [ "ubuntu.14.10" ]
+            "#import": [ "ubuntu" ]
         },
         "ubuntu.15.04-x64": {
-            "#import": [ "ubuntu.15.04", "ubuntu.14.10-x64" ]
+            "#import": [ "ubuntu.15.04", "ubuntu-x64" ]
         },
 
         "ubuntu.15.10": {
-            "#import": [ "ubuntu.15.04" ]
+            "#import": [ "ubuntu" ]
         },
         "ubuntu.15.10-x64": {
-            "#import": [ "ubuntu.15.10", "ubuntu.15.04-x64" ]
+            "#import": [ "ubuntu.15.10", "ubuntu-x64" ]
         },
 
         "ubuntu.16.04": {
-            "#import": [ "ubuntu.15.10" ]
+            "#import": [ "ubuntu" ]
         },
         "ubuntu.16.04-x64": {
-            "#import": [ "ubuntu.16.04", "ubuntu.15.10-x64" ]
+            "#import": [ "ubuntu.16.04", "ubuntu-x64" ]
         },
         
         "linuxmint.17": {


### PR DESCRIPTION
We should keep the different releases of Ubuntu segmented from one
another the RID graph as in general it is unlikely that packages that
apply to one version of ubuntu will apply to a different one.

This mimics the fact that third party packages are built for each of the
different distros and it's uncommon to take 14.04 packages and install
them on 14.10 (for example).