### PR TITLE
Fix WinHttpHandler default cred auth when server offers multiple schemes

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
@@ -304,7 +304,6 @@ namespace System.Net.Http
         {
             string userName;
             string password;
-            string domain;
 
             Debug.Assert(credentials != null);
             Debug.Assert(authScheme != 0);
@@ -329,7 +328,7 @@ namespace System.Net.Http
             {
                 userName = networkCredential.UserName;
                 password = networkCredential.Password;
-                domain = networkCredential.Domain;
+                string domain = networkCredential.Domain;
 
                 // WinHTTP does not support a blank username.  So, we will throw an exception.
                 if (string.IsNullOrEmpty(userName))

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
@@ -302,6 +302,10 @@ namespace System.Net.Http
             uint authScheme,
             uint authTarget)
         {
+            string userName;
+            string password;
+            string domain;
+
             Debug.Assert(credentials != null);
             Debug.Assert(authScheme != 0);
             Debug.Assert(authTarget == Interop.WinHttp.WINHTTP_AUTH_TARGET_PROXY || 
@@ -318,22 +322,25 @@ namespace System.Net.Http
             {
                 // Allow WinHTTP to transmit the default credentials.
                 ChangeDefaultCredentialsPolicy(requestHandle, authTarget, allowDefaultCredentials:true);
-                return;
+                userName = null;
+                password = null;
             }
-
-            string userName = networkCredential.UserName;
-            string password = networkCredential.Password;
-            string domain = networkCredential.Domain;
-
-            // WinHTTP does not support a blank username.  So, we will throw an exception.
-            if (string.IsNullOrEmpty(userName))
+            else
             {
-                throw new InvalidOperationException(SR.net_http_username_empty_string);
-            }
+                userName = networkCredential.UserName;
+                password = networkCredential.Password;
+                domain = networkCredential.Domain;
 
-            if (!string.IsNullOrEmpty(domain))
-            {
-                userName = domain + "\\" + userName;
+                // WinHTTP does not support a blank username.  So, we will throw an exception.
+                if (string.IsNullOrEmpty(userName))
+                {
+                    throw new InvalidOperationException(SR.net_http_username_empty_string);
+                }
+
+                if (!string.IsNullOrEmpty(domain))
+                {
+                    userName = domain + "\\" + userName;
+                }
             }
 
             if (!Interop.WinHttp.WinHttpSetCredentials(

--- a/src/System.Net.Http/tests/FunctionalTests/prerequisites/BasicAuthModule.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/prerequisites/BasicAuthModule.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Web;
+
+public class BasicAuthModule : IHttpModule
+{
+    public void Dispose()
+    {
+    }
+
+    public void Init(HttpApplication context)
+    {
+        context.EndRequest += Context_EndRequest; ;
+    }
+
+    private void Context_EndRequest(object sender, EventArgs e)
+    {
+        var context = (HttpApplication)sender;
+
+        var response = context.Response;
+        if (response.StatusCode != 401)
+        {
+            return;
+        }
+
+        response.AddHeader("WWW-Authenticate", "Basic");
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/prerequisites/Web.config
+++ b/src/System.Net.Http/tests/FunctionalTests/prerequisites/Web.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  http://go.microsoft.com/fwlink/?LinkId=169433
+  -->
+<configuration>
+  <system.webServer>
+    <modules>
+      <add name="WebApplication1" type="BasicAuthModule"/>
+    </modules>
+  </system.webServer>
+  <system.web>
+    <customErrors mode="Off" />
+  </system.web>
+</configuration>

--- a/src/System.Net.Http/tests/FunctionalTests/prerequisites/readme.txt
+++ b/src/System.Net.Http/tests/FunctionalTests/prerequisites/readme.txt
@@ -3,7 +3,14 @@
 
 Some Windows tests require an Active Directory domain. Both the client machine running the tests and the server endpoint need to be on the same domain.
 
-Set up IIS and ASP.NET on the test server. Create an application directory with the necessary path (see DefaultCredentialsTest.cs).
-The directory should only have Integrated Windows authentication access enabled. Disable Anonymous access.
+Set up IIS and ASP.NET on the test server. Create two application directories with the following paths:
+
+/test/auth/negotiate
+/test/auth/multipleschemes
+
+Set authentication on both application directories to use integrated Windows authentication. Disable Anonymous access.
+
+In the 'mutlipleschemes' application, you'll use the BasicAuthModule.cs and web.config files in a compiled ASP.NET project. This allows Basic auth to
+be offered as well but ensures that it is listed first in the response headers.
 
 Create an additional local user account on the test machine with a specific username and password (see DefaultCredentialsTest.cs).

--- a/src/System.Net.Http/tests/FunctionalTests/prerequisites/readme.txt
+++ b/src/System.Net.Http/tests/FunctionalTests/prerequisites/readme.txt
@@ -10,7 +10,7 @@ Set up IIS and ASP.NET on the test server. Create two application directories wi
 
 Set authentication on both application directories to use integrated Windows authentication. Disable Anonymous access.
 
-In the 'mutlipleschemes' application, you'll use the BasicAuthModule.cs and web.config files in a compiled ASP.NET project. This allows Basic auth to
+In the 'multipleschemes' application, you'll use the BasicAuthModule.cs and web.config files in a compiled ASP.NET project. This allows Basic auth to
 be offered as well but ensures that it is listed first in the response headers.
 
 Create an additional local user account on the test machine with a specific username and password (see DefaultCredentialsTest.cs).


### PR DESCRIPTION
When a server offers multiple auth schemes, WinHttpHandler is supposed
to select the more secure scheme regardless of the order of the
authentication headers. So, despite a server offering Basic and
Negotitate (in that order), Negotiate would be selected.

When using default credentials, however, it was not calling
WinHttpSetCredentials(null, null). This resulted in the first scheme
offered by the server (Basic) to be attempted. But there were no
credentials set and so a 401 resulted.

Fix WinHttpHandler so that it will always call WinHttpSetCredentials
even with default credentials. This ensures that the selected auth
scheme (in this case Negotiate) is used correctly.

Revised test configuration instructions. An IHttpModule is used for the
test server endpoint to ensure that IIS will put 'Basic' first in the
response headers.