### PR TITLE
Some fixes to the build instructions for Windows

### DIFF
--- a/Documentation/building/windows-instructions.md
+++ b/Documentation/building/windows-instructions.md
@@ -29,13 +29,13 @@ the Visual Studio IDE.
 ### Building individual DLLs of the CoreFX
 
 Under the src directory is a set of directories, each of which represents a particular assembly in CoreFX.  
-For example the src\System.Diagnostics.DiagnosticSource directory holds the source code for the System.Diagnostics.DiagnosticSource.dll assembly.   Each of these directories has a .sln solution 
+For example the src\System.Diagnostics.DiagnosticSource directory holds the source code for the System.Diagnostics.DiagnosticSource.dll assembly. Each of these directories has a .sln solution 
 file that typically includes two projects, one for the DLL being built and one for the tests.   Thus
-you can build both the DLL and Tests for System.Diagnostics.DiagnosticSource.dll by going to 
+you can build both the DLL and tests for System.Diagnostics.DiagnosticSource.dll by going to 
 src\System.Diagnostics.DiagnosticSource and typing `msbuild`. You can build just the System.Diagnostics.DiagnosticSource.dll (without the tests) by going to the src\System.Diagnostics.DiagnosticsSource\src directory and again typing `msbuild`. The DLL ends up as  bin\AnyOS.AnyCPU.Debug\System.Diagnostics.DiagnosticSource\System.DiagnosticSource.dll.
 
-There is also a pkg directory, and if you go into it and type `msbuild`, it will build the DLL (if needed)
-and then also build the Nuget package for it.   The Nuget package ends up in the bin\pkg directory.  
+There is also a pkg directory for each project, and if you go into it and type `msbuild`, it will build the DLL (if needed)
+and then also build the NuGet package for it. The NuGet package ends up in the bin\packages directory.  
 
 ### Building other OSes
 


### PR DESCRIPTION
Clarified that going into a particular project's `pkg` subdirectory (and not the top level one) will build its packages. Also changed the output path from `bin\pkg` -> `bin\packages`, since that's where they actually end up.

Other changes: some whitespace/capitalization fixes.