### PR TITLE
Fixed a build error on ARM

### DIFF
--- a/src/Native/System.Native/pal_networkchange.cpp
+++ b/src/Native/System.Native/pal_networkchange.cpp
@@ -60,7 +60,7 @@ extern "C" void SystemNative_ReadEvents(int32_t sock, NetworkChangeEvent onNetwo
         return;
     }
 
-    for (nlmsghdr* hdr = reinterpret_cast<nlmsghdr*>(buffer); NLMSG_OK(hdr, len); NLMSG_NEXT(hdr, len))
+    for (nlmsghdr* hdr = reinterpret_cast<nlmsghdr*>(buffer); NLMSG_OK(hdr, UnsignedCast(len)); NLMSG_NEXT(hdr, len))
     {
         switch (hdr->nlmsg_type)
         {


### PR DESCRIPTION
Fix #8557

The (len) variable need explicit type conversion to unsigned value.
The original type is ssize_t(signed size_t).

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>