### PR TITLE
Cross compilers for target are also required to cross build corefx on Linux

### DIFF
--- a/Documentation/building/cross-building.md
+++ b/Documentation/building/cross-building.md
@@ -17,7 +17,7 @@ In addition, to cross compile CoreFX, binutils, gcc and g++ for the target are r
 
 and for arm64 you need:
 
-    lgs@ubuntu ~/git/corefx/ $ sudo apt-get install binutils-aarch64-linux-gnu gcc-arm-linux-gnu g++-arm-linux-gnu
+    lgs@ubuntu ~/git/corefx/ $ sudo apt-get install binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
 
 Generating the rootfs

--- a/Documentation/building/cross-building.md
+++ b/Documentation/building/cross-building.md
@@ -35,7 +35,7 @@ For example, to generate an arm rootfs:
 
 and if you wanted to generate the rootfs elsewhere:
 
-    lgs@ubuntu ~/git/corefx/ $ sudo ROOTFS_DIR=/home/lgs/corefx-cross/arm ./build-rootfs.sh arm
+    lgs@ubuntu ~/git/corefx/ $ sudo ROOTFS_DIR=/home/lgs/corefx-cross/arm ./cross/build-rootfs.sh arm
 
 
 Cross compiling for native CoreFX

--- a/Documentation/building/cross-building.md
+++ b/Documentation/building/cross-building.md
@@ -11,13 +11,13 @@ You need a Debian based host, and the following packages need to be installed:
 
     lgs@ubuntu ~/git/corefx/ $ sudo apt-get install qemu qemu-user-static binfmt-support debootstrap
 
-In addition, to cross compile CoreFX, the binutils for the target are required. So for arm you need:
+In addition, to cross compile CoreFX, binutils, gcc and g++ for the target are required. So for arm you need:
 
-    lgs@ubuntu ~/git/corefx/ $ sudo apt-get install binutils-arm-linux-gnueabihf
+    lgs@ubuntu ~/git/corefx/ $ sudo apt-get install binutils-arm-linux-gnueabihf gcc-arm-linux-gnueabihf  g++-arm-linux-gnueabihf
 
 and for arm64 you need:
 
-    lgs@ubuntu ~/git/corefx/ $ sudo apt-get install binutils-aarch64-linux-gnu
+    lgs@ubuntu ~/git/corefx/ $ sudo apt-get install binutils-aarch64-linux-gnu gcc-arm-linux-gnu g++-arm-linux-gnu
 
 
 Generating the rootfs


### PR DESCRIPTION
Cross compilers for target are also required to cross build corefx on Linux.

Fix #8561