### PR TITLE
Add protected fields back to AsymmetricAlgorithm

### DIFF
--- a/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
+++ b/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
@@ -15,6 +15,8 @@ namespace System.Security.Cryptography
         public virtual System.Security.Cryptography.KeySizes[] LegalKeySizes { get { return default(System.Security.Cryptography.KeySizes[]); } }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
+        protected int KeySizeValue;
+        protected KeySizes[] LegalKeySizesValue;
     }
     public enum CipherMode
     {

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/AsymmetricAlgorithm.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/AsymmetricAlgorithm.cs
@@ -9,6 +9,9 @@ namespace System.Security.Cryptography
 {
     public abstract class AsymmetricAlgorithm : IDisposable
     {
+        protected int KeySizeValue;
+        protected KeySizes[] LegalKeySizesValue;
+
         protected AsymmetricAlgorithm()
         {
         }
@@ -17,14 +20,14 @@ namespace System.Security.Cryptography
         {
             get
             {
-                return _keySize;
+                return KeySizeValue;
             }
 
             set
             {
                 if (!value.IsLegalSize(this.LegalKeySizes))
                     throw new CryptographicException(SR.Cryptography_InvalidKeySize);
-                _keySize = value;
+                KeySizeValue = value;
                 return;
             }
         }
@@ -33,9 +36,8 @@ namespace System.Security.Cryptography
         {
             get
             {
-                // Desktop compat: Unless derived classes set the protected field "LegalKeySizesValue" to a non-null value, a NullReferenceException is what you get.
-                // In the Win8P profile, the "LegalKeySizesValue" field has been removed. So derived classes must override this property for the class to be any of any use.
-                throw new NullReferenceException();
+                // Desktop compat: No null check is performed
+                return (KeySizes[])LegalKeySizesValue.Clone();
             }
         }
 
@@ -49,6 +51,5 @@ namespace System.Security.Cryptography
         {
             return;
         }
-        private int _keySize;
     }
 }


### PR DESCRIPTION
Add back
protected int KeySizeValue;
protected KeySizes[] LegalKeySizesValue;

for desktop compatibility.

This also enables things like setting KeySizeValue to something outside the LegalKeySizes bounds, for example, when an RSA implementation can read a short key, but won't generate it.

Fixes #8490.
cc: @AtsushiKan @stephentoub 