### PR TITLE
Add protected fields back to SymmetricAlgorithm

### DIFF
--- a/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
+++ b/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
@@ -142,5 +142,13 @@ namespace System.Security.Cryptography
         protected virtual void Dispose(bool disposing) { }
         public abstract void GenerateIV();
         public abstract void GenerateKey();
+        protected CipherMode ModeValue;
+        protected PaddingMode PaddingValue;
+        protected byte[] KeyValue;
+        protected byte[] IVValue;
+        protected int BlockSizeValue;
+        protected int KeySizeValue;
+        protected KeySizes[] LegalBlockSizesValue;
+        protected KeySizes[] LegalKeySizesValue;
     }
 }

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/SymmetricAlgorithm.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/SymmetricAlgorithm.cs
@@ -11,15 +11,15 @@ namespace System.Security.Cryptography
     {
         protected SymmetricAlgorithm()
         {
-            _cipherMode = CipherMode.CBC;
-            _paddingMode = PaddingMode.PKCS7;
+            ModeValue = CipherMode.CBC;
+            PaddingValue = PaddingMode.PKCS7;
         }
 
         public virtual int BlockSize
         {
             get
             {
-                return _blockSize;
+                return BlockSizeValue;
             }
 
             set
@@ -28,11 +28,11 @@ namespace System.Security.Cryptography
                 if (!value.IsLegalSize(this.LegalBlockSizes, out validatedByZeroSkipSizeKeySizes))
                     throw new CryptographicException(SR.Cryptography_InvalidBlockSize);
 
-                if (_blockSize == value && !validatedByZeroSkipSizeKeySizes) // The !validatedByZeroSkipSizeKeySizes check preserves a very obscure back-compat behavior.
+                if (BlockSizeValue == value && !validatedByZeroSkipSizeKeySizes) // The !validatedByZeroSkipSizeKeySizes check preserves a very obscure back-compat behavior.
                     return;
 
-                _blockSize = value;
-                _iv = null;
+                BlockSizeValue = value;
+                IVValue = null;
                 return;
             }
         }
@@ -41,9 +41,9 @@ namespace System.Security.Cryptography
         {
             get
             {
-                if (_iv == null)
+                if (IVValue == null)
                     GenerateIV();
-                return _iv.CloneByteArray();
+                return IVValue.CloneByteArray();
             }
 
             set
@@ -53,7 +53,7 @@ namespace System.Security.Cryptography
                 if (value.Length != this.BlockSize / 8)
                     throw new CryptographicException(SR.Cryptography_InvalidIVSize);
 
-                _iv = value.CloneByteArray();
+                IVValue = value.CloneByteArray();
             }
         }
 
@@ -61,9 +61,9 @@ namespace System.Security.Cryptography
         {
             get
             {
-                if (_key == null)
+                if (KeyValue == null)
                     GenerateKey();
-                return _key.CloneByteArray();
+                return KeyValue.CloneByteArray();
             }
 
             set
@@ -77,7 +77,7 @@ namespace System.Security.Cryptography
 
                 // must convert bytes to bits
                 this.KeySize = (int)bitLength;
-                _key = value.CloneByteArray();
+                KeyValue = value.CloneByteArray();
             }
         }
 
@@ -85,7 +85,7 @@ namespace System.Security.Cryptography
         {
             get
             {
-                return _keySize;
+                return KeySizeValue;
             }
 
             set
@@ -93,8 +93,8 @@ namespace System.Security.Cryptography
                 if (!ValidKeySize(value))
                     throw new CryptographicException(SR.Cryptography_InvalidKeySize);
 
-                _keySize = value;
-                _key = null;
+                KeySizeValue = value;
+                KeyValue = null;
             }
         }
 
@@ -102,9 +102,8 @@ namespace System.Security.Cryptography
         {
             get
             {
-                // Desktop compat: Unless derived classes set the protected field "LegalBlockSizesValue" to a non-null value, a NullReferenceException is what you get.
-                // In the Win8P profile, the "LegalBlockSizesValue" field has been removed. So derived classes must override this property for the class to be any of any use.
-                throw new NullReferenceException();
+                // Desktop compat: No null check is performed.
+                return (KeySizes[])LegalBlockSizesValue.Clone();
             }
         }
 
@@ -112,9 +111,8 @@ namespace System.Security.Cryptography
         {
             get
             {
-                // Desktop compat: Unless derived classes set the protected field "LegalKeySizesValue" to a non-null value, a NullReferenceException is what you get.
-                // In the Win8P profile, the "LegalKeySizesValue" field has been removed. So derived classes must override this property for the class to be any of any use.
-                throw new NullReferenceException();
+                // Desktop compat: No null check is performed.
+                return (KeySizes[])LegalKeySizesValue.Clone();
             }
         }
 
@@ -122,7 +120,7 @@ namespace System.Security.Cryptography
         {
             get
             {
-                return _cipherMode;
+                return ModeValue;
             }
 
             set
@@ -130,7 +128,7 @@ namespace System.Security.Cryptography
                 if (!(value == CipherMode.CBC || value == CipherMode.ECB))
                     throw new CryptographicException(SR.Cryptography_InvalidCipherMode);
 
-                _cipherMode = value;
+                ModeValue = value;
             }
         }
 
@@ -138,20 +136,20 @@ namespace System.Security.Cryptography
         {
             get
             {
-                return _paddingMode;
+                return PaddingValue;
             }
 
             set
             {
                 if (!(value == PaddingMode.None || value == PaddingMode.PKCS7 || value == PaddingMode.Zeros))
                     throw new CryptographicException(SR.Cryptography_InvalidPaddingMode);
-                _paddingMode = value;
+                PaddingValue = value;
             }
         }
 
         public virtual ICryptoTransform CreateDecryptor()
         {
-            return CreateDecryptor(this.Key, this.IV);
+            return CreateDecryptor(Key, IV);
         }
 
         public abstract ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV);
@@ -173,15 +171,15 @@ namespace System.Security.Cryptography
         {
             if (disposing)
             {
-                if (_key != null)
+                if (KeyValue != null)
                 {
-                    Array.Clear(_key, 0, _key.Length);
-                    _key = null;
+                    Array.Clear(KeyValue, 0, KeyValue.Length);
+                    KeyValue = null;
                 }
-                if (_iv != null)
+                if (IVValue != null)
                 {
-                    Array.Clear(_iv, 0, _iv.Length);
-                    _iv = null;
+                    Array.Clear(IVValue, 0, IVValue.Length);
+                    IVValue = null;
                 }
             }
         }
@@ -197,13 +195,14 @@ namespace System.Security.Cryptography
                 return false;
             return bitLength.IsLegalSize(validSizes);
         }
-
-
-        private CipherMode _cipherMode;
-        private PaddingMode _paddingMode;
-        private byte[] _key;
-        private byte[] _iv;
-        private int _blockSize;
-        private int _keySize;
+        
+        protected CipherMode ModeValue;
+        protected PaddingMode PaddingValue;
+        protected byte[] KeyValue;
+        protected byte[] IVValue;
+        protected int BlockSizeValue;
+        protected int KeySizeValue;
+        protected KeySizes[] LegalBlockSizesValue;
+        protected KeySizes[] LegalKeySizesValue;
     }
 }

--- a/src/System.Security.Cryptography.Primitives/tests/SymmetricAlgorithm/Trivial.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/SymmetricAlgorithm/Trivial.cs
@@ -3,14 +3,23 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
-using System.Reflection;
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Security.Cryptography.Encryption.Tests.Symmetric
 {
     public static class TrivialTests
     {
+        [Fact]
+        public static void TestAutomaticKey()
+        {
+            using (Trivial t = new Trivial())
+            {
+                byte[] generatedKey = t.Key;
+                Assert.Equal(generatedKey, Trivial.GeneratedKey);
+                Assert.NotSame(generatedKey, Trivial.GeneratedKey);
+            }
+        }
+
         [Fact]
         public static void TestKey()
         {
@@ -19,15 +28,6 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
                 Assert.Equal(0, s.KeySize);
 
                 Assert.Throws<ArgumentNullException>(() => s.Key = null);
-
-                {
-                    // Testing automatic generation of Key.
-
-                    Trivial t = new Trivial();
-                    byte[] generatedKey = t.Key;
-                    Assert.Equal(generatedKey, Trivial.GeneratedKey);
-                    Assert.False(Object.ReferenceEquals(generatedKey, Trivial.GeneratedKey));
-                }
 
                 // Testing KeySize and Key setter.
                 int[] validKeySizes = { 40, 104, 152, 808, 816, 824, 832 };
@@ -49,10 +49,12 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
                         byte[] key = GenerateRandom(keySizeInBytes);
                         if (validKeySizes.Contains(keySizeInBytes * 8))
                         {
+                            s.SetKeySize(-1);
                             s.Key = key;
                             byte[] copyOfKey = s.Key;
                             Assert.Equal(key, copyOfKey);
-                            Assert.False(Object.ReferenceEquals(key, copyOfKey));
+                            Assert.Equal(key.Length * 8, s.KeySize);
+                            Assert.NotSame(key, copyOfKey);
                         }
                         else
                         {
@@ -72,21 +74,53 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
         }
 
         [Fact]
+        public static void KeySize_Key_LooseCoupling()
+        {
+            using (Trivial t = new Trivial())
+            {
+                t.GenerateKey();
+
+                // Set the KeySizeValue field, then confirm that get_Key doesn't check it at all.
+                const int UnusualKeySize = 51;
+                t.SetKeySize(UnusualKeySize);
+                Assert.Equal(UnusualKeySize, t.KeySize);
+
+                byte[] key = t.Key;
+                // It doesn't equal it in bytes
+                Assert.NotEqual(UnusualKeySize, key.Length);
+                // It doesn't equal it in bits
+                Assert.NotEqual(UnusualKeySize, key.Length * 8);
+            }
+        }
+
+        [Fact]
+        public static void KeySize_CurrentValue_NotGrandfathered()
+        {
+            using (Trivial t = new Trivial())
+            {
+                t.SetKeySize(525600);
+                Assert.Throws<CryptographicException>(() => t.KeySize = t.KeySize);
+            }
+        }
+
+        [Fact]
+        public static void TestAutomaticIv()
+        {
+            using (Trivial t = new Trivial())
+            {
+                t.BlockSize = 5 * 8;
+                byte[] generatedIv = t.IV;
+                Assert.Equal(generatedIv, Trivial.GeneratedIV);
+                Assert.NotSame(generatedIv, Trivial.GeneratedIV);
+            }
+        }
+
+        [Fact]
         public static void TestIv()
         {
             using (Trivial s = new Trivial())
             {
                 Assert.Throws<ArgumentNullException>(() => s.IV = null);
-
-                {
-                    // Testing automatic generation of Iv.
-
-                    Trivial t = new Trivial();
-                    t.BlockSize = 5 * 8;
-                    byte[] generatedIv = t.IV;
-                    Assert.Equal(generatedIv, Trivial.GeneratedIV);
-                    Assert.False(Object.ReferenceEquals(generatedIv, Trivial.GeneratedIV));
-                }
 
                 // Testing IV property setter
                 {
@@ -105,7 +139,6 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
                     }
                 }
             }
-            return;
         }
 
         [Fact]
@@ -133,6 +166,80 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
             return;
         }
 
+        [Fact]
+        public static void GetCipherMode_NoValidation()
+        {
+            using (Trivial t = new Trivial())
+            {
+                t.SetCipherMode(24601);
+                Assert.Equal(24601, (int)t.Mode);
+            }
+        }
+
+        [Fact]
+        public static void GetPaddingMode_NoValidation()
+        {
+            using (Trivial t = new Trivial())
+            {
+                t.SetPaddingMode(24601);
+                Assert.Equal(24601, (int)t.Padding);
+            }
+        }
+
+        [Fact]
+        public static void LegalBlockSizes_CopiesData()
+        {
+            using (Trivial t = new Trivial())
+            {
+                KeySizes[] a = t.LegalBlockSizes;
+                KeySizes[] b = t.LegalBlockSizes;
+
+                Assert.NotSame(a, b);
+            }
+        }
+
+        [Fact]
+        public static void LegalKeySizes_CopiesData()
+        {
+            using (Trivial t = new Trivial())
+            {
+                KeySizes[] a = t.LegalKeySizes;
+                KeySizes[] b = t.LegalKeySizes;
+
+                Assert.NotSame(a, b);
+            }
+        }
+
+        [Fact]
+        public static void SetKey_Uses_LegalKeySizesProperty()
+        {
+            using (SymmetricAlgorithm s = new DoesNotSetKeySizesFields())
+            {
+                Assert.Throws<CryptographicException>(() => s.Key = Array.Empty<byte>());
+                s.Key = new byte[16];
+            }
+        }
+
+        [Fact]
+        public static void SetKeySize_Uses_LegalKeySizesProperty()
+        {
+            using (SymmetricAlgorithm s = new DoesNotSetKeySizesFields())
+            {
+                Assert.Throws<CryptographicException>(() => s.KeySize = 0);
+                s.KeySize = 128;
+            }
+        }
+
+        [Fact]
+        public static void SetBlockSize_Uses_LegalBlockSizesProperty()
+        {
+            using (SymmetricAlgorithm s = new DoesNotSetKeySizesFields())
+            {
+                Assert.Throws<CryptographicException>(() => s.BlockSize = 0);
+                s.BlockSize = 8;
+            }
+        }
+        
         private static byte[] GenerateRandom(int size)
         {
             byte[] data = new byte[size];
@@ -148,20 +255,26 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
         {
             public Trivial()
             {
-                //
-                // Although the desktop CLR allows overriding the LegalKeySizes property, 
-                // the BlockSize setter does not invoke the overriding method when validating
-                // the blockSize. Instead, it accesses the underlying field (LegalKeySizesValue) directly.
-                //
-                // We've since removed this field from the public surface area (and fixed the BlockSize property
-                // to call LegalKeySizes rather than the underlying field.) To make this test also run on the desktop, however,
-                // we will also set the LegalKeySizesValue field if present.
-                //
-                FieldInfo legalBlockSizesValue = typeof(SymmetricAlgorithm).GetTypeInfo().GetDeclaredField("LegalBlockSizesValue");
-                if (legalBlockSizesValue != null && legalBlockSizesValue.IsFamily)
-                {
-                    legalBlockSizesValue.SetValue(this, LegalBlockSizes);
-                }
+                // Desktop's SymmetricAlgorithm reads from the field overly aggressively,
+                // but in Core it always reads from the property. By setting the field
+                // we're still happy on Desktop tests, and we can validate the default
+                // behavior of the LegalBlockSizes property.
+                LegalBlockSizesValue = new KeySizes[]
+                    {
+                        new KeySizes(5*8, -99*8, 0*8),
+                        new KeySizes(13*8, 22*8, 6*8),
+                        new KeySizes(101*8, 104*8, 1*8),
+                    };
+
+                // Desktop's SymmetricAlgorithm reads from the property correctly, but
+                // we'll set the field here, anyways, to validate the default behavior
+                // of the LegalKeySizes property.
+                LegalKeySizesValue = new KeySizes[]
+                    {
+                        new KeySizes(5*8, -99*8, 0*8),
+                        new KeySizes(13*8, 22*8, 6*8),
+                        new KeySizes(101*8, 104*8, 1*8),
+                    };
             }
 
             public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
@@ -184,34 +297,74 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
                 Key = GeneratedKey;
             }
 
-            public override KeySizes[] LegalBlockSizes
+            public void SetBlockSize(int blockSize)
             {
-                get
-                {
-                    return new KeySizes[]
-                    {
-                        new KeySizes(5*8, -99*8, 0*8),
-                        new KeySizes(13*8, 22*8, 6*8),
-                        new KeySizes(101*8, 104*8, 1*8),
-                    };
-                }
+                BlockSizeValue = blockSize;
             }
 
-            public override KeySizes[] LegalKeySizes
+            public void SetKeySize(int keySize)
             {
-                get
-                {
-                    return new KeySizes[]
-                    {
-                        new KeySizes(5*8, -99*8, 0*8),
-                        new KeySizes(13*8, 22*8, 6*8),
-                        new KeySizes(101*8, 104*8, 1*8),
-                    };
-                }
+                KeySizeValue = keySize;
+            }
+
+            public void SetCipherMode(int anyValue)
+            {
+                ModeValue = (CipherMode)anyValue;
+            }
+
+            public void SetPaddingMode(int anyValue)
+            {
+                PaddingValue = (PaddingMode)anyValue;
             }
 
             public static readonly byte[] GeneratedKey = GenerateRandom(13);
             public static readonly byte[] GeneratedIV = GenerateRandom(5);
+        }
+
+        private class DoesNotSetKeySizesFields : SymmetricAlgorithm
+        {
+            public DoesNotSetKeySizesFields()
+            {
+                // Ensure the default values for the fields.
+                Assert.Null(KeyValue);
+                Assert.Null(IVValue);
+                Assert.Null(LegalKeySizesValue);
+                Assert.Null(LegalBlockSizesValue);
+                Assert.Equal(0, KeySizeValue);
+                Assert.Equal(0, BlockSizeValue);
+                Assert.Equal(CipherMode.CBC, ModeValue);
+                Assert.Equal(PaddingMode.PKCS7, PaddingValue);
+            }
+
+            public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new CreateDecryptorNotImplementedException();
+            }
+
+            public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new CreateEncryptorNotImplementedException();
+            }
+
+            public override void GenerateIV()
+            {
+                throw new GenerateIvNotImplementedException();
+            }
+
+            public override void GenerateKey()
+            {
+                throw new GenerateKeyNotImplementedException();
+            }
+
+            public override KeySizes[] LegalBlockSizes
+            {
+                get { return new[] { new KeySizes(8, 64, 8) }; }
+            }
+
+            public override KeySizes[] LegalKeySizes
+            {
+                get { return new[] { new KeySizes(64, 128, 8) }; }
+            }
         }
 
         private class GenerateIvNotImplementedException : Exception { }


### PR DESCRIPTION
Add back
protected int BlockSizeValue;
protected byte[] IVValue;
protected byte[] KeyValue;
protected KeySizes[] LegalBlockSizesValue;
protected KeySizes[] LegalKeySizesValue;
protected int KeySizeValue;
protected CipherMode ModeValue;
protected PaddingMode PaddingValue;

for desktop compatibility.

This leaves out the FeedbackSizeValue field, since the FeedbackSize property doesn't exist (and therefore the presence of the field might suggest a convenient in-built int for aux storage).

Fixes #8489.
cc: @AtsushiKan @stephentoub 