### PR TITLE
Update netcore50 MaxResponseHeadersLength property

### DIFF
--- a/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
@@ -322,8 +322,8 @@ namespace System.Net.Http
         public int MaxResponseHeadersLength
         {
             // Windows.Web.Http is built on WinINet. There is no maximum limit (except for out of memory)
-            // for received response headers. So, returning 0 (indicating no limit) is appropriate.
-            get { return 0; }
+            // for received response headers. So, returning -1 (indicating no limit) is appropriate.
+            get { return -1; }
 
             set
             {

--- a/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpClientHandler.cs
@@ -321,7 +321,10 @@ namespace System.Net.Http
 
         public int MaxResponseHeadersLength
         {
-            get { return 0; } // TODO: Issue #8541 - return default value used in Wininet.
+            // Windows.Web.Http is built on WinINet. There is no maximum limit (except for out of memory)
+            // for received response headers. So, returning 0 (indicating no limit) is appropriate.
+            get { return 0; }
+
             set
             {
                 throw new PlatformNotSupportedException(String.Format(CultureInfo.InvariantCulture,


### PR DESCRIPTION
Windows.Web.Http is built on WinINet. There is no maximum limit (except
for out of memory) for received response headers. So, returning 0
(indicating no limit) is appropriate.

Fixes #8541.