### PR TITLE
Avoid unnecessary allocations in Path.GetRandomFileName

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.RAND.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.RAND.cs
@@ -2,14 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
     internal static partial class Crypto
     {
+        internal static unsafe bool GetRandomBytes(byte[] buf, int num)
+        {
+            Debug.Assert(buf != null);
+            Debug.Assert(num >= 0 && num <= buf.Length);
+
+            fixed (byte* pBuf = buf)
+            {
+                return GetRandomBytes(pBuf, num);
+            }
+        }
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetRandomBytes")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool GetRandomBytes(byte[] buf, int num);
+        internal static unsafe extern bool GetRandomBytes(byte* buf, int num);
     }
 }

--- a/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptGenRandom.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptGenRandom.cs
@@ -10,10 +10,21 @@ internal partial class Interop
 {
     internal partial class BCrypt
     {
-        internal static NTSTATUS BCryptGenRandom(byte[] pbBuffer, int cbBuffer)
+        internal static unsafe NTSTATUS BCryptGenRandom(byte[] pbBuffer, int cbBuffer)
         {
             Debug.Assert(pbBuffer != null);
             Debug.Assert(cbBuffer >= 0 && cbBuffer <= pbBuffer.Length);
+
+            fixed (byte* pb = pbBuffer)
+            {
+                return BCryptGenRandom(pb, cbBuffer);
+            }
+        }
+
+        internal static unsafe NTSTATUS BCryptGenRandom(byte* pbBuffer, int cbBuffer)
+        {
+            Debug.Assert(pbBuffer != null);
+            Debug.Assert(cbBuffer >= 0);
 
             return BCryptGenRandom(IntPtr.Zero, pbBuffer, cbBuffer, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
         }
@@ -21,6 +32,6 @@ internal partial class Interop
         private const int BCRYPT_USE_SYSTEM_PREFERRED_RNG = 0x00000002;
 
         [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        private static extern NTSTATUS BCryptGenRandom(IntPtr hAlgorithm, [In, Out] byte[] pbBuffer, int cbBuffer, int dwFlags);
+        private static unsafe extern NTSTATUS BCryptGenRandom(IntPtr hAlgorithm, byte* pbBuffer, int cbBuffer, int dwFlags);
     }
 }

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
@@ -212,14 +212,15 @@ namespace System.IO
             return IsPathRooted(path) ? DirectorySeparatorCharAsString : String.Empty;
         }
 
-        private static byte[] CreateCryptoRandomByteArray(int byteLength)
+        private static unsafe void GetCryptoRandomBytes(byte* bytes, int byteCount)
         {
-            var arr = new byte[byteLength];
-            if (!Interop.Crypto.GetRandomBytes(arr, arr.Length))
+            Debug.Assert(bytes != null);
+            Debug.Assert(byteCount >= 0);
+
+            if (!Interop.Crypto.GetRandomBytes(bytes, byteCount))
             {
                 throw new InvalidOperationException(SR.InvalidOperation_Cryptography);
             }
-            return arr;
         }
     }
 }

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Win32.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Win32.cs
@@ -8,17 +8,19 @@ namespace System.IO
 {
     public static partial class Path
     {
-        private static byte[] CreateCryptoRandomByteArray(int byteLength)
+        private static unsafe void GetCryptoRandomBytes(byte* bytes, int byteCount)
         {
             // We need to fill a byte array with cryptographically-strong random bytes, but we can't reference
             // System.Security.Cryptography.RandomNumberGenerator.dll due to layering.  Instead, we just
             // call to BCryptGenRandom directly, which is all that RandomNumberGenerator does.
 
-            var arr = new byte[byteLength];
-            Interop.BCrypt.NTSTATUS status = Interop.BCrypt.BCryptGenRandom(arr, arr.Length);
+            Debug.Assert(bytes != null);
+            Debug.Assert(byteCount >= 0);
+
+            Interop.BCrypt.NTSTATUS status = Interop.BCrypt.BCryptGenRandom(bytes, byteCount);
             if (status == Interop.BCrypt.NTSTATUS.STATUS_SUCCESS)
             {
-                return arr;
+                return;
             }
             else if (status == Interop.BCrypt.NTSTATUS.STATUS_NO_MEMORY)
             {

--- a/src/System.Runtime.Extensions/src/System/IO/Path.WinRT.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.WinRT.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 using Windows.Storage.Streams;
 using Windows.Security.Cryptography;
@@ -11,12 +13,18 @@ namespace System.IO
 {
     public static partial class Path
     {
-        private static byte[] CreateCryptoRandomByteArray(int byteLength)
+        private static unsafe void GetCryptoRandomBytes(byte* bytes, int byteCount)
         {
+            Debug.Assert(bytes != null);
+            Debug.Assert(byteCount >= 0);
+
             byte[] arr;
-            IBuffer buffer = CryptographicBuffer.GenerateRandom((uint)byteLength);
+            IBuffer buffer = CryptographicBuffer.GenerateRandom((uint)byteCount);
             CryptographicBuffer.CopyToByteArray(buffer, out arr);
-            return arr;
+
+            Debug.Assert(arr.Length == byteCount);
+
+            Marshal.Copy(arr, 0, new IntPtr(bytes), byteCount);
         }
     }
 }

--- a/src/System.Runtime.Extensions/src/System/IO/Path.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.cs
@@ -157,17 +157,18 @@ namespace System.IO
 
         // Returns a cryptographically strong random 8.3 string that can be 
         // used as either a folder name or a file name.
-        public static string GetRandomFileName()
+        public static unsafe string GetRandomFileName()
         {
-            // 5 bytes == 40 bits == 40/5 == 8 chars in our encoding.
-            // So 10 bytes provides 16 chars, of which we need 11
-            // for the 8.3 name.
-            byte[] key = CreateCryptoRandomByteArray(10);
+            // 9 random bytes provides 12 chars in our encoding for the 8.3 name.
+            const int KeyLength = 9;
+            byte* pKey = stackalloc byte[KeyLength];
+            GetCryptoRandomBytes(pKey, KeyLength);
 
-            // rndCharArray is expected to be 16 chars
-            char[] rndCharArray = ToBase32StringSuitableForDirName(key).ToCharArray();
-            rndCharArray[8] = '.';
-            return new string(rndCharArray, 0, 12);
+            const int RandomFileNameLength = 12;
+            char* pRandomFileName = stackalloc char[RandomFileNameLength];
+            GetBase32CharsSuitableForDirName(pKey, KeyLength, pRandomFileName, RandomFileNameLength);
+            pRandomFileName[8] = '.';
+            return new string(pRandomFileName, 0, RandomFileNameLength);
         }
 
         // Tests if a path includes a file extension. The result is
@@ -356,58 +357,58 @@ namespace System.IO
                 'q', 'r', 's', 't', 'u', 'v', 'w', 'x',
                 'y', 'z', '0', '1', '2', '3', '4', '5'};
 
-        private static string ToBase32StringSuitableForDirName(byte[] buff)
+        private static unsafe void GetBase32CharsSuitableForDirName(byte* bytes, int byteCount, char* chars, int charCount)
         {
-            // This routine is optimised to be used with buffs of length 20
-            Debug.Assert(((buff.Length % 5) == 0), "Unexpected hash length");
+            Debug.Assert(bytes != null);
+            Debug.Assert(chars != null);
+
+            // This routine is optimized to be used with bytes of length 9 and chars of length 12.
+            Debug.Assert(byteCount == 9, $"Unexpected {nameof(byteCount)}");
+            Debug.Assert(charCount == 12, $"Unexpected {nameof(charCount)}");
 
             // For every 5 bytes, 8 characters are appended.
-            StringBuilder sb = StringBuilderCache.Acquire();
-
-            // Create l char for each of the last 5 bits of each byte.  
+            // Create l char for each of the last 5 bits of each byte.
             // Consume 3 MSB bits 5 bytes at a time.
-            int len = buff.Length;
-            int i = 0;
-            do
-            {
-                byte b0 = (i < len) ? buff[i++] : (byte)0;
-                byte b1 = (i < len) ? buff[i++] : (byte)0;
-                byte b2 = (i < len) ? buff[i++] : (byte)0;
-                byte b3 = (i < len) ? buff[i++] : (byte)0;
-                byte b4 = (i < len) ? buff[i++] : (byte)0;
 
-                // Consume the 5 Least significant bits of each byte
-                sb.Append(s_Base32Char[b0 & 0x1F]);
-                sb.Append(s_Base32Char[b1 & 0x1F]);
-                sb.Append(s_Base32Char[b2 & 0x1F]);
-                sb.Append(s_Base32Char[b3 & 0x1F]);
-                sb.Append(s_Base32Char[b4 & 0x1F]);
+            byte b0 = bytes[0];
+            byte b1 = bytes[1];
+            byte b2 = bytes[2];
+            byte b3 = bytes[3];
+            byte b4 = bytes[4];
 
-                // Consume 3 MSB of b0, b1, MSB bits 6, 7 of b3, b4
-                sb.Append(s_Base32Char[(
-                        ((b0 & 0xE0) >> 5) |
-                        ((b3 & 0x60) >> 2))]);
+            // Consume the 5 Least significant bits of the first 5 bytes
+            chars[0] = s_Base32Char[b0 & 0x1F];
+            chars[1] = s_Base32Char[b1 & 0x1F];
+            chars[2] = s_Base32Char[b2 & 0x1F];
+            chars[3] = s_Base32Char[b3 & 0x1F];
+            chars[4] = s_Base32Char[b4 & 0x1F];
 
-                sb.Append(s_Base32Char[(
-                        ((b1 & 0xE0) >> 5) |
-                        ((b4 & 0x60) >> 2))]);
+            // Consume 3 MSB of b0, b1, MSB bits 6, 7 of b3, b4
+            chars[5] = s_Base32Char[(
+                    ((b0 & 0xE0) >> 5) |
+                    ((b3 & 0x60) >> 2))];
 
-                // Consume 3 MSB bits of b2, 1 MSB bit of b3, b4
+            chars[6] = s_Base32Char[(
+                    ((b1 & 0xE0) >> 5) |
+                    ((b4 & 0x60) >> 2))];
 
-                b2 >>= 5;
+            // Consume 3 MSB bits of b2, 1 MSB bit of b3, b4
+            b2 >>= 5;
 
-                Debug.Assert(((b2 & 0xF8) == 0), "Unexpected set bits");
+            Debug.Assert(((b2 & 0xF8) == 0), "Unexpected set bits");
 
-                if ((b3 & 0x80) != 0)
-                    b2 |= 0x08;
-                if ((b4 & 0x80) != 0)
-                    b2 |= 0x10;
+            if ((b3 & 0x80) != 0)
+                b2 |= 0x08;
+            if ((b4 & 0x80) != 0)
+                b2 |= 0x10;
 
-                sb.Append(s_Base32Char[b2]);
+            chars[7] = s_Base32Char[b2];
 
-            } while (i < len);
-
-            return StringBuilderCache.GetStringAndRelease(sb);
+            // Consume the 5 Least significant bits of the remaining 4 bytes
+            chars[8] = s_Base32Char[(bytes[5] & 0x1F)];
+            chars[9] = s_Base32Char[(bytes[6] & 0x1F)];
+            chars[10] = s_Base32Char[(bytes[7] & 0x1F)];
+            chars[11] = s_Base32Char[(bytes[8] & 0x1F)];
         }
     }
 }


### PR DESCRIPTION
Avoid unnecessary `byte[]`, `char[]`, and `string` allocations in `Path.GetRandomFileName`. A 10,000,000 iteration microbenchmark repeatedly calling `Path.GetRandomFileName()` shows a 3.8x reduction in gen0 GCs with a 55% speed improvement.

cc: @stephentoub, @bartonjs, @JeremyKuhne