### PR TITLE
Implement NetworkInterface.Id and .Description on Linux and OSX

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
@@ -91,10 +91,6 @@ namespace System.Net.NetworkInformation
 
         public override OperationalStatus OperationalStatus { get { return _operationalStatus; } }
 
-        public override string Id { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
-
-        public override string Description { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
-
         public override long Speed
         {
             get

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxNetworkInterface.cs
@@ -93,8 +93,6 @@ namespace System.Net.NetworkInformation
 
         public override long Speed { get { return _speed; } }
 
-        public override string Description { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
-
         public override bool SupportsMulticast { get { return _ipProperties.MulticastAddresses.Count > 0; } }
 
         public override bool IsReceiveOnly { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixNetworkInterface.cs
@@ -25,7 +25,11 @@ namespace System.Net.NetworkInformation
             _name = name;
         }
 
+        public override string Id { get { return _name; } }
+
         public sealed override string Name { get { return _name; } }
+
+        public override string Description { get { return _name; } }
 
         public sealed override NetworkInterfaceType NetworkInterfaceType { get { return _networkInterfaceType; } }
 
@@ -34,8 +38,6 @@ namespace System.Net.NetworkInformation
             Debug.Assert(_physicalAddress != null, "_physicalAddress was never initialized. This means no address with type AF_PACKET was discovered.");
             return _physicalAddress;
         }
-
-        public override string Id { get { return _index.ToString(); } }
 
         public override bool Supports(NetworkInterfaceComponent networkInterfaceComponent)
         {

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixNetworkInterface.cs
@@ -18,7 +18,6 @@ namespace System.Net.NetworkInformation
         protected Dictionary<IPAddress, IPAddress> _netMasks = new Dictionary<IPAddress, IPAddress>();
         // If this is an ipv6 device, contains the Scope ID.
         protected uint? _ipv6ScopeId = null;
-        private string _id;
 
         protected UnixNetworkInterface(string name)
         {
@@ -97,7 +96,6 @@ namespace System.Net.NetworkInformation
             PhysicalAddress physicalAddress = new PhysicalAddress(macAddress);
 
             _index = llAddr->InterfaceIndex;
-            _id = _index.ToString();
             _physicalAddress = physicalAddress;
             _networkInterfaceType = (NetworkInterfaceType)llAddr->HardwareType;
         }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixNetworkInterface.cs
@@ -24,11 +24,11 @@ namespace System.Net.NetworkInformation
             _name = name;
         }
 
-        public override string Id { get { return _name; } }
+        public sealed override string Id { get { return _name; } }
 
         public sealed override string Name { get { return _name; } }
 
-        public override string Description { get { return _name; } }
+        public sealed override string Description { get { return _name; } }
 
         public sealed override NetworkInterfaceType NetworkInterfaceType { get { return _networkInterfaceType; } }
 

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -58,8 +58,8 @@ namespace System.Net.NetworkInformation.Tests
             {
                 _log.WriteLine("- NetworkInterface -");
                 _log.WriteLine("Name: " + nic.Name);
-                Assert.Throws<PlatformNotSupportedException>(() => nic.Description);
-                Assert.Throws<PlatformNotSupportedException>(() => nic.Id);
+                _log.WriteLine("Description: " + nic.Description);
+                _log.WriteLine("ID: " + nic.Id);
                 Assert.Throws<PlatformNotSupportedException>(() => nic.IsReceiveOnly);
                 _log.WriteLine("Type: " + nic.NetworkInterfaceType);
                 _log.WriteLine("Status: " + nic.OperationalStatus);
@@ -88,7 +88,7 @@ namespace System.Net.NetworkInformation.Tests
             {
                 _log.WriteLine("- NetworkInterface -");
                 _log.WriteLine("Name: " + nic.Name);
-                Assert.Throws<PlatformNotSupportedException>(() => nic.Description);
+                _log.WriteLine("Description: " + nic.Description);
                 _log.WriteLine("ID: " + nic.Id);
                 Assert.Throws<PlatformNotSupportedException>(() => nic.IsReceiveOnly);
                 _log.WriteLine("Type: " + nic.NetworkInterfaceType);

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -58,8 +58,12 @@ namespace System.Net.NetworkInformation.Tests
             {
                 _log.WriteLine("- NetworkInterface -");
                 _log.WriteLine("Name: " + nic.Name);
-                _log.WriteLine("Description: " + nic.Description);
-                _log.WriteLine("ID: " + nic.Id);
+                string description = nic.Description;
+                Assert.False(string.IsNullOrEmpty(description), "NetworkInterface.Description should not be null or empty.");
+                _log.WriteLine("Description: " + description);
+                string id = nic.Id;
+                Assert.False(string.IsNullOrEmpty(id), "NetworkInterface.Id should not be null or empty.");
+                _log.WriteLine("ID: " + id);
                 Assert.Throws<PlatformNotSupportedException>(() => nic.IsReceiveOnly);
                 _log.WriteLine("Type: " + nic.NetworkInterfaceType);
                 _log.WriteLine("Status: " + nic.OperationalStatus);
@@ -88,8 +92,12 @@ namespace System.Net.NetworkInformation.Tests
             {
                 _log.WriteLine("- NetworkInterface -");
                 _log.WriteLine("Name: " + nic.Name);
-                _log.WriteLine("Description: " + nic.Description);
-                _log.WriteLine("ID: " + nic.Id);
+                string description = nic.Description;
+                Assert.False(string.IsNullOrEmpty(description), "NetworkInterface.Description should not be null or empty.");
+                _log.WriteLine("Description: " + description);
+                string id = nic.Id;
+                Assert.False(string.IsNullOrEmpty(id), "NetworkInterface.Id should not be null or empty.");
+                _log.WriteLine("ID: " + id);
                 Assert.Throws<PlatformNotSupportedException>(() => nic.IsReceiveOnly);
                 _log.WriteLine("Type: " + nic.NetworkInterfaceType);
                 _log.WriteLine("Status: " + nic.OperationalStatus);


### PR DESCRIPTION
These now return the same value as "Name" on these platforms, but this value is more useful than simply throwing a `PlatformNotSupportedException`. Previously, `OSXNetworkInterface.Id` was returning the system index of the network interface. This was not particularly useful.

Technically, these are implemented via `UnixNetworkInterface`, so future subclasses will also inherit the behavior.

@tmds , @CIPop 

Fixes https://github.com/dotnet/corefx/issues/8297