### PR TITLE
Making sure that build-tests.cmd will first restore the version files to avoid race conditions

### DIFF
--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -232,6 +232,7 @@
     </TraversalRestorePackagesDependsOn>
   </PropertyGroup>
 
+  <Import Project="$(ToolsDir)versioning.targets" Condition="Exists('$(ToolsDir)versioning.targets')" />
   <Target Name="Build" DependsOnTargets="$(TraversalBuildDependsOn)" />
 
   <Target Name="Clean" DependsOnTargets="$(TraversalCleanDependsOn)" />

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -12,6 +12,7 @@
     </TraversalBuildDependsOn>
   </PropertyGroup>
 
+  <Import Project="$(ToolsDir)versioning.targets" Condition="Exists('$(ToolsDir)versioning.targets')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="*\tests\**\*.builds">

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -11,8 +11,7 @@
       $(TraversalBuildDependsOn)
     </TraversalBuildDependsOn>
   </PropertyGroup>
-
-  <Import Project="$(ToolsDir)versioning.targets" Condition="Exists('$(ToolsDir)versioning.targets')" />
+  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="*\tests\**\*.builds">

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -5,6 +5,13 @@
     <_OriginalOSGroup>$(OSGroup)</_OriginalOSGroup>
   </PropertyGroup>
   
+  <PropertyGroup>
+    <TraversalBuildDependsOn>
+      CreateOrUpdateCurrentVersionFile;
+      $(TraversalBuildDependsOn)
+    </TraversalBuildDependsOn>
+  </PropertyGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="*\tests\**\*.builds">


### PR DESCRIPTION
Fixing build-test race conditions

cc: @chcosta 