### PR TITLE
Remove System.ComponentModel.Primitives in project.json

### DIFF
--- a/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -370,7 +370,7 @@ namespace System.ComponentModel
         protected virtual void OnValueChanged(object component, System.EventArgs e) { }
         public virtual void RemoveValueChanged(object component, System.EventHandler handler) { }
         public abstract void ResetValue(object component);
-        public System.ComponentModel.DesignerSerializationVisibility SerializationVisibility { get { return default(System.ComponentModel.DesignerSerializationVisibility); } }
+        // public System.ComponentModel.DesignerSerializationVisibility SerializationVisibility { get { return default(System.ComponentModel.DesignerSerializationVisibility); } }
         public abstract void SetValue(object component, object value);
         public abstract bool ShouldSerializeValue(object component);
     }

--- a/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.csproj
+++ b/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.csproj
@@ -10,11 +10,6 @@
   <ItemGroup>
     <Compile Include="System.ComponentModel.TypeConverter.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'==''">
-    <ProjectReference Include="..\..\System.ComponentModel.Primitives\src\System.ComponentModel.Primitives.csproj">
-      <Name>System.ComponentModel.TypeConverter.Primitives</Name>
-    </ProjectReference>
-  </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>


### PR DESCRIPTION
The S.CM.TypeDescriptor assembly now depends on the updated S.CM.Primitives which is not available yet via MyGet. This comments out the need for the dependency to fix some build breaks.