### PR TITLE
Disable TypeConverter contract usage of S.CM.Primitives

### DIFF
--- a/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -280,7 +280,7 @@ namespace System.ComponentModel
     }
     public partial interface ITypeDescriptorContext : System.IServiceProvider
     {
-        System.ComponentModel.IContainer Container { get; }
+        //System.ComponentModel.IContainer Container { get; }
         object Instance { get; }
         System.ComponentModel.PropertyDescriptor PropertyDescriptor { get; }
         void OnComponentChanged();
@@ -370,7 +370,7 @@ namespace System.ComponentModel
         protected virtual void OnValueChanged(object component, System.EventArgs e) { }
         public virtual void RemoveValueChanged(object component, System.EventHandler handler) { }
         public abstract void ResetValue(object component);
-        public System.ComponentModel.DesignerSerializationVisibility SerializationVisibility { get { return default(System.ComponentModel.DesignerSerializationVisibility); } }
+        //public System.ComponentModel.DesignerSerializationVisibility SerializationVisibility { get { return default(System.ComponentModel.DesignerSerializationVisibility); } }
         public abstract void SetValue(object component, object value);
         public abstract bool ShouldSerializeValue(object component);
     }


### PR DESCRIPTION
The build break appears to be an issue with the TypeConverter ref project's reference to System.ComponentModel.Primitives. As a temporary workaround, this comments out usage of Primitives types from the TypeConverter contract.