### PR TITLE
Add IDictionary tests for ListDictionary

### DIFF
--- a/src/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
@@ -69,6 +69,13 @@ namespace System.Collections.Tests
         /// </summary>
         protected virtual bool ICollection_NonGeneric_SupportsSyncRoot => true;
 
+        /// <summary>
+        /// Used for the ICollection_NonGeneric_SyncRootType_MatchesExcepted test. Most SyncRoots are created
+        /// using System.Threading.Interlocked.CompareExchange(ref _syncRoot, new Object(), null)
+        /// so we should test that the SyncRoot is the type we expect.
+        /// </summary>
+        protected virtual Type ICollection_NonGeneric_SyncRootType => typeof(object);
+
         #endregion
 
         #region IEnumerable Helper Methods
@@ -143,7 +150,30 @@ namespace System.Collections.Tests
                 Assert.NotSame(collection1.SyncRoot, collection2.SyncRoot);
             }
         }
-        
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void ICollection_NonGeneric_SyncRoot_MatchesExpectedType(int count)
+        {
+            if (ICollection_NonGeneric_SupportsSyncRoot)
+            {
+                ICollection collection = NonGenericICollectionFactory(count);
+                
+                Assert.IsType(ICollection_NonGeneric_SyncRootType, collection.SyncRoot);
+
+                if (ICollection_NonGeneric_SyncRootType == collection.GetType())
+                {
+                    // If we expect the SyncRoot to be the same type as the collection, 
+                    // the SyncRoot should be the same as the collection (e.g. HybridDictionary)
+                    Assert.Same(collection, collection.SyncRoot);
+                }
+                else
+                {
+                    Assert.NotSame(collection, collection.SyncRoot);
+                }
+            }
+        }
+
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
         public void ICollection_NonGeneric_SyncRoot_ThrowsNotSupportedException(int count)

--- a/src/Common/tests/System/Collections/IEnumerable.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/IEnumerable.Generic.Tests.cs
@@ -43,7 +43,7 @@ namespace System.Collections.Tests
         /// 
         /// If Reset is not implemented, this property must return False. The default value is true.
         /// </summary>
-        protected virtual bool ResetImplemented { get { return true; } }
+        protected virtual bool ResetImplemented => true;
 
         /// <summary>
         /// When calling Current of the enumerator before the first MoveNext, after the end of the collection,
@@ -55,13 +55,13 @@ namespace System.Collections.Tests
         /// If this property is set to true, the tests ensure that the exception is thrown. The default value is
         /// false.
         /// </summary>
-        protected virtual bool Enumerator_Current_UndefinedOperation_Throws { get { return false; } }
+        protected virtual bool Enumerator_Current_UndefinedOperation_Throws => false;
 
         /// <summary>
         /// The behavior of MoveNext at the end of the enumerable after modification is undefined for the generic
         /// IEnumerable. It may either throw an InvalidOperationException or do nothing.
         /// </summary>
-        protected bool MoveNextAtEndThrowsOnModifiedCollection { get { return true; } }
+        protected bool MoveNextAtEndThrowsOnModifiedCollection => true;
 
         /// <summary>
         /// Used in IEnumerable_Generic_Enumerator_Current.
@@ -72,7 +72,7 @@ namespace System.Collections.Tests
         /// <summary>
         /// Specifies whether this IEnumerable follows some sort of ordering pattern.
         /// </summary>
-        protected virtual EnumerableOrder Order { get { return EnumerableOrder.Sequential; } }
+        protected virtual EnumerableOrder Order => EnumerableOrder.Sequential;
 
         /// <summary>
         /// An enum to allow specification of the order of the Enumerable. Used in validation for enumerables.

--- a/src/Common/tests/System/Collections/IEnumerable.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IEnumerable.NonGeneric.Tests.cs
@@ -43,7 +43,7 @@ namespace System.Collections.Tests
         /// 
         /// If Reset is not implemented, this property must return False. The default value is true.
         /// </summary>
-        protected virtual bool ResetImplemented { get { return true; } }
+        protected virtual bool ResetImplemented => true;
 
         /// <summary>
         /// When calling Current of the enumerator before the first MoveNext, after the end of the collection,
@@ -55,7 +55,7 @@ namespace System.Collections.Tests
         /// If this property is set to true, the tests ensure that the exception is thrown. The default value is
         /// false.
         /// </summary>
-        protected virtual bool Enumerator_Current_UndefinedOperation_Throws { get { return false; } }
+        protected virtual bool Enumerator_Current_UndefinedOperation_Throws => false;
 
         #endregion
 

--- a/src/Common/tests/System/Collections/IEnumerableTest.cs
+++ b/src/Common/tests/System/Collections/IEnumerableTest.cs
@@ -18,20 +18,11 @@ namespace Tests.Collections
     {
         private const int EnumerableSize = 16;
 
-        protected T DefaultValue
-        {
-            get { return default(T); }
-        }
+        protected T DefaultValue => default(T);
 
-        protected bool MoveNextAtEndThrowsOnModifiedCollection
-        {
-            get { return true; }
-        }
+        protected bool MoveNextAtEndThrowsOnModifiedCollection => true;
 
-        protected virtual CollectionOrder CollectionOrder
-        {
-            get { return CollectionOrder.Sequential; }
-        }
+        protected virtual CollectionOrder CollectionOrder => CollectionOrder.Sequential;
 
         protected abstract bool IsResetNotSupported { get; }
         protected abstract bool IsGenericCompatibility { get; }
@@ -59,8 +50,7 @@ namespace Tests.Collections
         /// </summary>
         /// <param name="enumerable">The <see cref="IEnumerable" /> to invalidate enumerators for.</param>
         /// <returns>The new set of items in the <see cref="IEnumerable" /></returns>
-        protected abstract object[] InvalidateEnumerator(
-            IEnumerable enumerable);
+        protected abstract object[] InvalidateEnumerator(IEnumerable enumerable);
 
         private void RepeatTest(
             Action<IEnumerator, object[], int> testCode,

--- a/src/Common/tests/System/Collections/IList.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/IList.Generic.Tests.cs
@@ -98,17 +98,11 @@ namespace System.Collections.Tests
 
         #region ICollection<T> Helper Methods
 
-        protected override bool DefaultValueWhenNotAllowed_Throws { get { return false; } }
+        protected override bool DefaultValueWhenNotAllowed_Throws => false;
 
-        protected override ICollection<T> GenericICollectionFactory()
-        {
-            return GenericIListFactory();
-        }
+        protected override ICollection<T> GenericICollectionFactory() => GenericIListFactory();
 
-        protected override ICollection<T> GenericICollectionFactory(int count)
-        {
-            return GenericIListFactory(count);
-        }
+        protected override ICollection<T> GenericICollectionFactory(int count) => GenericIListFactory(count);
 
         #endregion
 

--- a/src/Common/tests/System/Collections/IList.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IList.NonGeneric.Tests.cs
@@ -69,21 +69,15 @@ namespace System.Collections.Tests
             }
         }
 
-        protected virtual bool ExpectedFixedSize { get { return false; } }
+        protected virtual bool ExpectedFixedSize => false;
 
         #endregion
 
         #region ICollection Helper Methods
 
-        protected override ICollection NonGenericICollectionFactory()
-        {
-            return NonGenericIListFactory();
-        }
+        protected override ICollection NonGenericICollectionFactory() => NonGenericIListFactory();
 
-        protected override ICollection NonGenericICollectionFactory(int count)
-        {
-            return NonGenericIListFactory(count);
-        }
+        protected override ICollection NonGenericICollectionFactory(int count) => NonGenericIListFactory(count);
 
         /// <summary>
         /// Returns a set of ModifyEnumerable delegates that modify the enumerable passed to them.

--- a/src/Common/tests/System/Collections/ISet.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/ISet.Generic.Tests.cs
@@ -54,24 +54,18 @@ namespace System.Collections.Tests
             }
         }
 
-        protected virtual int ISet_Large_Capacity { get { return 4000; } }
+        protected virtual int ISet_Large_Capacity => 4000;
 
         #endregion
 
         #region ICollection<T> Helper Methods
 
-        protected override ICollection<T> GenericICollectionFactory()
-        {
-            return GenericISetFactory();
-        }
+        protected override ICollection<T> GenericICollectionFactory() => GenericISetFactory();
 
-        protected override ICollection<T> GenericICollectionFactory(int count)
-        {
-            return GenericISetFactory(count);
-        }
+        protected override ICollection<T> GenericICollectionFactory(int count) => GenericISetFactory(count);
 
-        protected override bool DuplicateValuesAllowed { get { return false; } }
-        protected override bool DefaultValueWhenNotAllowed_Throws { get { return false; } }
+        protected override bool DuplicateValuesAllowed => false;
+        protected override bool DefaultValueWhenNotAllowed_Throws => false;
 
         #endregion
 

--- a/src/Common/tests/System/Collections/TestBase.Generic.cs
+++ b/src/Common/tests/System/Collections/TestBase.Generic.cs
@@ -27,18 +27,12 @@ namespace System.Collections.Tests
         /// The EqualityComparer that can be used in the overriding class when creating test enumerables
         /// or test collections. Default if not overridden is the default comparator.
         /// </summary>
-        protected virtual IEqualityComparer<T> GetIEqualityComparer()
-        {
-            return EqualityComparer<T>.Default;
-        }
+        protected virtual IEqualityComparer<T> GetIEqualityComparer() => EqualityComparer<T>.Default;
 
         /// <summary>
         /// The Comparer that can be used in the overriding class when creating test enumerables
         /// or test collections. Default if not overridden is the default comparator.
-        protected virtual IComparer<T> GetIComparer()
-        {
-            return Comparer<T>.Default;
-        }
+        protected virtual IComparer<T> GetIComparer() => Comparer<T>.Default;
 
         /// <summary>
         /// MemberData to be passed to tests that take an IEnumerable{T}. This method returns every permutation of

--- a/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionaryTests.cs
+++ b/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionaryTests.cs
@@ -22,6 +22,8 @@ namespace System.Collections.Specialized.Tests
         protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType_ThrowType => typeof(InvalidCastException);
         protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowType => typeof(InvalidCastException);
 
+        protected override Type ICollection_NonGeneric_SyncRootType => typeof(HybridDictionary);
+
         protected override object CreateTKey(int seed)
         {
             int stringLength = seed % 10 + 5;

--- a/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.IDictionary.Tests.cs
+++ b/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.IDictionary.Tests.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Tests;
+
+namespace System.Collections.Specialized.Tests
+{
+    public class ListDictionary_NoComparer_Tests : ListDictionaryTestBase
+    {
+        protected override IDictionary NonGenericIDictionaryFactory() => new ListDictionary();
+    }
+
+    public class ListDictionary_CustomComparer_Tests : ListDictionaryTestBase
+    {
+        protected override IDictionary NonGenericIDictionaryFactory() => new ListDictionary(StringComparer.Ordinal);
+    }
+
+    public abstract class ListDictionaryTestBase : IDictionary_NonGeneric_Tests
+    {
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(InvalidCastException);
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType_ThrowType => typeof(InvalidCastException);
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowType => typeof(InvalidCastException);
+
+        protected override object CreateTKey(int seed)
+        {
+            int stringLength = seed % 10 + 5;
+            Random rand = new Random(seed);
+            byte[] bytes = new byte[stringLength];
+            rand.NextBytes(bytes);
+            return Convert.ToBase64String(bytes);
+        }
+
+        protected override object CreateTValue(int seed) => CreateTKey(seed);
+    }
+}

--- a/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.Keys.Tests.cs
+++ b/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.Keys.Tests.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Tests;
+using System.Diagnostics;
+
+namespace System.Collections.Specialized.Tests
+{
+    public class ListDictionaryKeysTests : ICollection_NonGeneric_Tests
+    {
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(InvalidCastException);
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType_ThrowType => typeof(InvalidCastException);
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowType => typeof(InvalidCastException);
+
+        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
+
+        protected override bool IsReadOnly => true;
+
+        protected override ICollection NonGenericICollectionFactory() => new ListDictionary().Keys;
+
+        protected override ICollection NonGenericICollectionFactory(int count)
+        {
+            ListDictionary list = new ListDictionary();
+            int seed = 13453;
+            for (int i = 0; i < count; i++)
+                list.Add(CreateT(seed++), CreateT(seed++));
+            return list.Keys;
+        }
+
+        private string CreateT(int seed)
+        {
+            int stringLength = seed % 10 + 5;
+            Random rand = new Random(seed);
+            byte[] bytes = new byte[stringLength];
+            rand.NextBytes(bytes);
+            return Convert.ToBase64String(bytes);
+        }
+
+        protected override void AddToCollection(ICollection collection, int numberOfItemsToAdd) => Debug.Assert(false);
+
+        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
+    }
+}

--- a/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.Values.Tests.cs
+++ b/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.Values.Tests.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Tests;
+using System.Diagnostics;
+
+namespace System.Collections.Specialized.Tests
+{
+    public class ListDictionaryValuesTests : ICollection_NonGeneric_Tests
+    {
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(InvalidCastException);
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType_ThrowType => typeof(InvalidCastException);
+        protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowType => typeof(InvalidCastException);
+
+        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
+
+        protected override bool IsReadOnly => true;
+
+        protected override ICollection NonGenericICollectionFactory() => new ListDictionary().Values;
+
+        protected override ICollection NonGenericICollectionFactory(int count)
+        {
+            ListDictionary list = new ListDictionary();
+            int seed = 13453;
+            for (int i = 0; i < count; i++)
+                list.Add(CreateT(seed++), CreateT(seed++));
+            return list.Keys;
+        }
+
+        private string CreateT(int seed)
+        {
+            int stringLength = seed % 10 + 5;
+            Random rand = new Random(seed);
+            byte[] bytes = new byte[stringLength];
+            rand.NextBytes(bytes);
+            return Convert.ToBase64String(bytes);
+        }
+
+        protected override void AddToCollection(ICollection collection, int numberOfItemsToAdd) => Debug.Assert(false);
+
+        protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
+    }
+}

--- a/src/System.Collections.Specialized/tests/ListDictionaryTests.cs
+++ b/src/System.Collections.Specialized/tests/ListDictionaryTests.cs
@@ -5,25 +5,12 @@
 using System.Collections.Generic;
 using System.Collections.Tests;
 using System.Linq;
-
 using Xunit;
 
 namespace System.Collections.Specialized.Tests
 {
     public static class ListDictionaryTests
     {
-        /// <summary>
-        /// Construct ListDictionaries, empty..
-        /// </summary>
-        /// Format is:
-        ///  1. Dictionary
-        /// <returns>Row of data</returns>
-        public static IEnumerable<object[]> ListDictionary_Empty_Data()
-        {
-            yield return new object[] { new ListDictionary() };
-            yield return new object[] { new ListDictionary(StringComparer.Ordinal) };
-        }
-
         /// <summary>
         /// Data used for testing with a set of collections.
         /// </summary>
@@ -58,19 +45,6 @@ namespace System.Collections.Specialized.Tests
             new KeyValuePair<string, string>("otherkey", "otherkey-value"),
             new KeyValuePair<string, string>("nullvaluekey", null),
         };
-
-        [Theory]
-        [MemberData(nameof(ListDictionary_Empty_Data))]
-        public static void Constructor_DefaultTests(ListDictionary ld)
-        {
-            Assert.Equal(0, ld.Count);
-            Assert.False(ld.IsReadOnly);
-            Assert.Empty(ld);
-            Assert.Empty(ld.Keys);
-            Assert.Empty(ld.Values);
-            Assert.False(ld.Contains(new object()));
-            Assert.Null(ld[new object()]);
-        }
 
         [Theory]
         [InlineData(true)]
@@ -156,104 +130,6 @@ namespace System.Collections.Specialized.Tests
             Assert.Equal("hashcode".GetHashCode(), added["key".GetHashCode()]);
         }
 
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void Add_NullKeyTest(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            Assert.Throws<ArgumentNullException>("key", () => ld.Add(null, "value"));
-            Assert.Throws<ArgumentNullException>("key", () => ld[null] = "value");
-        }
-
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void ClearTest(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            Assert.Equal(data.Length, ld.Count);
-            ld.Clear();
-            Assert.Equal(0, ld.Count);
-            ld.Add("key", "value");
-            Assert.Equal(1, ld.Count);
-            ld.Clear();
-            Assert.Equal(0, ld.Count);
-        }
-
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void Contains_NullTest(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            Assert.Throws<ArgumentNullException>("key", () => ld.Contains(null));
-        }
-
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void CopyToTest(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            DictionaryEntry[] translated = data.Select(kv => new DictionaryEntry(kv.Key, kv.Value)).ToArray();
-
-            DictionaryEntry[] full = new DictionaryEntry[data.Length];
-            ld.CopyTo(full, 0);
-            Assert.Equal(translated, full);
-
-            DictionaryEntry[] large = new DictionaryEntry[data.Length * 2];
-            ld.CopyTo(large, data.Length / 2);
-            for (int i = 0; i < large.Length; i++)
-            {
-                if (i < data.Length / 2 || i >= data.Length + data.Length / 2)
-                {
-                    Assert.Equal(new DictionaryEntry(), large[i]);
-                    Assert.Null(large[i].Key);
-                    Assert.Null(large[i].Value);
-                }
-                else
-                {
-                    Assert.Equal(translated[i - data.Length / 2], large[i]);
-                }
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void CopyTo_ArgumentInvalidTest(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            Assert.Throws<ArgumentNullException>("array", () => ld.CopyTo(null, 0));
-            Assert.Throws<ArgumentOutOfRangeException>("index", () => ld.CopyTo(data, -1));
-            if (data.Length > 0)
-            {
-                Assert.Throws<ArgumentException>(() => ld.CopyTo(new KeyValuePair<string, string>[0], data.Length - 1));
-                Assert.Throws<ArgumentException>(() => ld.CopyTo(new KeyValuePair<string, string>[data.Length - 1], 0));
-                Assert.Throws<InvalidCastException>(() => ld.CopyTo(new int[data.Length], 0));
-            }
-
-            // Multidimensional array
-            Assert.Throws<ArgumentException>(() => ld.CopyTo(new KeyValuePair<string, string>[1, data.Length], 0));
-
-            // Invalid lower bound
-            Array arr = Array.CreateInstance(typeof(object), new int[] { 2 }, new int[] { 2 });
-            Assert.Throws<ArgumentException>(() => ld.CopyTo(arr, 0));
-        }
-
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void GetSetTest(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            DictionaryEntry[] translated = data.Select(kv => new DictionaryEntry(kv.Key, kv.Value)).ToArray();
-
-            foreach (KeyValuePair<string, string> kv in data)
-            {
-                Assert.Equal(kv.Value, ld[kv.Key]);
-            }
-            for (int i = 0; i < data.Length / 2; i++)
-            {
-                object temp = ld[data[i].Key];
-                ld[data[i].Key] = ld[data[data.Length - i - 1].Key];
-                ld[data[data.Length - i - 1].Key] = temp;
-            }
-            for (int i = 0; i < data.Length; i++)
-            {
-                Assert.Equal(data[data.Length - i - 1].Value, ld[data[i].Key]);
-            }
-        }
-
         [Fact]
         public static void Set_CustomComparerTest()
         {
@@ -273,97 +149,6 @@ namespace System.Collections.Specialized.Tests
             });
         }
 
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void GetSet_ArgumentInvalidTest(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            Assert.Throws<ArgumentNullException>("key", () => ld[(string)null] = "notpresent");
-            Assert.Throws<ArgumentNullException>("key", () => ld[(string)null]);
-        }
-
-        [Fact]
-        public static void IsFixedSizeTest()
-        {
-            Assert.False(new ListDictionary().IsFixedSize);
-        }
-
-        [Fact]
-        public static void IsReadOnlyTest()
-        {
-            Assert.False(new ListDictionary().IsReadOnly);
-        }
-
-        [Fact]
-        public static void IsSynchronizedTest()
-        {
-            Assert.False(new ListDictionary().IsSynchronized);
-        }
-
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void GetEnumeratorTest(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            bool repeat = true;
-            IDictionaryEnumerator enumerator = ld.GetEnumerator();
-            Assert.NotNull(enumerator);
-            while (repeat)
-            {
-                Assert.Throws<InvalidOperationException>(() => enumerator.Current);
-                foreach (KeyValuePair<string, string> element in data)
-                {
-                    Assert.True(enumerator.MoveNext());
-                    DictionaryEntry entry = (DictionaryEntry)enumerator.Current;
-                    Assert.Equal(entry, enumerator.Current);
-                    Assert.Equal(element.Key, entry.Key);
-                    Assert.Equal(element.Value, entry.Value);
-                    Assert.Equal(element.Key, enumerator.Key);
-                    Assert.Equal(element.Value, enumerator.Value);
-                }
-                Assert.False(enumerator.MoveNext());
-                Assert.Throws<InvalidOperationException>(() => enumerator.Current);
-                Assert.False(enumerator.MoveNext());
-
-                enumerator.Reset();
-                enumerator.Reset();
-                repeat = false;
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void GetEnumerator_ModifiedCollectionTest(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            IDictionaryEnumerator enumerator = ld.GetEnumerator();
-            Assert.NotNull(enumerator);
-            if (data.Length > 0)
-            {
-                Assert.True(enumerator.MoveNext());
-                DictionaryEntry current = (DictionaryEntry)enumerator.Current;
-                ld.Remove("key");
-                Assert.Equal(current, enumerator.Current);
-                Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
-                Assert.Throws<InvalidOperationException>(() => enumerator.Reset());
-            }
-            else
-            {
-                ld.Add("newKey", "newValue");
-                Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void RemoveTest(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            Assert.All(data, element =>
-            {
-                Assert.True(ld.Contains(element.Key));
-                ld.Remove(element.Key);
-                Assert.False(ld.Contains(element.Key));
-            });
-            Assert.Equal(0, ld.Count);
-        }
-
         [Fact]
         public static void Remove_CustomComparerTest()
         {
@@ -380,117 +165,7 @@ namespace System.Collections.Specialized.Tests
             });
             Assert.Equal(0, ld.Count);
         }
-
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void Remove_NotPresentTest(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            ld.Remove("notpresent");
-            Assert.Equal(data.Length, ld.Count);
-            Assert.Throws<ArgumentNullException>("key", () => ld.Remove(null));
-        }
-
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void SyncRootTest(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            object syncRoot = ld.SyncRoot;
-            Assert.NotNull(syncRoot);
-            Assert.IsType<object>(syncRoot);
-
-            Assert.Same(syncRoot, ld.SyncRoot);
-            Assert.NotSame(syncRoot, new ListDictionary().SyncRoot);
-            ListDictionary other = new ListDictionary();
-            other.Add("key", "value");
-            Assert.NotSame(syncRoot, other.SyncRoot);
-        }
-
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void KeyCollection_CopyTo_NullArgument_Test(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            ICollection keys = ld.Keys;
-            Assert.Throws<ArgumentNullException>("array", () => keys.CopyTo(null, 0));
-        }
-
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void KeyCollection_CopyTo_InvalidArgument_Test(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            ICollection keys = ld.Keys;
-            Assert.Throws<ArgumentOutOfRangeException>("index", () => keys.CopyTo(new object[0], -1));
-            Assert.Throws<ArgumentException>(null, () => keys.CopyTo(new object[data.Length], 1));
-
-            // Multidimensional array
-            Assert.Throws<ArgumentException>("array", () => keys.CopyTo(new object[data.Length, data.Length], 0));
-
-            // Invalid lower bound
-            Array arr = Array.CreateInstance(typeof(object), new int[] { 2 }, new int[] { 2 });
-            Assert.Throws<ArgumentException>(() => keys.CopyTo(arr, 0));
-        }
-
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void KeyCollection_SyncRoot_Test(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            ICollection keys = ld.Keys;
-            Assert.Same(ld.SyncRoot, keys.SyncRoot);
-        }
-
-        [Fact]
-        public static void KeyCollection_Synchronized_Test()
-        {
-            ICollection keys = new ListDictionary().Keys;
-            Assert.False(keys.IsSynchronized);
-        }
-
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void KeyCollection_GetEnumeratorTest(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            bool repeat = true;
-            IEnumerator enumerator = ld.Keys.GetEnumerator();
-            Assert.NotNull(enumerator);
-            while (repeat)
-            {
-                Assert.Throws<InvalidOperationException>(() => enumerator.Current);
-                foreach (KeyValuePair<string, string> element in data)
-                {
-                    Assert.True(enumerator.MoveNext());
-                    Assert.NotNull(enumerator.Current);
-                }
-                Assert.False(enumerator.MoveNext());
-                Assert.Throws<InvalidOperationException>(() => enumerator.Current);
-                Assert.False(enumerator.MoveNext());
-
-                enumerator.Reset();
-                enumerator.Reset();
-                repeat = false;
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(ListDictionary_Data))]
-        public static void KeyCollection_GetEnumerator_ModifiedCollectionTest(ListDictionary ld, KeyValuePair<string, string>[] data)
-        {
-            IEnumerator enumerator = ld.Keys.GetEnumerator();
-            Assert.NotNull(enumerator);
-            if (data.Length > 0)
-            {
-                Assert.True(enumerator.MoveNext());
-                object current = enumerator.Current;
-                ld.Remove("key");
-                Assert.Equal(current, enumerator.Current);
-                Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
-                Assert.Throws<InvalidOperationException>(() => enumerator.Reset());
-            }
-            else
-            {
-                ld.Add("newKey", "newValue");
-                Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
-            }
-        }
-
+        
         private static void Add(this ListDictionary ld, bool addViaSet, object key, object value)
         {
             if (addViaSet) ld[key] = value;

--- a/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
+++ b/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
@@ -46,6 +46,9 @@
     <Compile Include="HybridDictionary\HybridDictionary.SetItemTests.cs" />
     <Compile Include="HybridDictionary\HybridDictionary.ValuesTests.cs" />
     <Compile Include="HybridDictionary\HybridDictionaryTests.cs" />
+    <Compile Include="ListDictionary\ListDictionary.Values.Tests.cs" />
+    <Compile Include="ListDictionary\ListDictionary.Keys.Tests.cs" />
+    <Compile Include="ListDictionary\ListDictionary.IDictionary.Tests.cs" />
     <Compile Include="ListDictionaryTests.cs" />
     <Compile Include="NameObjectCollectionBase\MyNameObjectCollection.cs" />
     <Compile Include="NameObjectCollectionBase\NameObjectCollectionBase.GetEnumeratorTests.cs" />


### PR DESCRIPTION
As part of using the common test framework set up by @ianhays for Collections, we can also cleanup ListDictionary.

I removed duplicate tests - these should be clear.

I added a few more tests arround ICollection.SyncRoot and made some readability improvements to remove boilerplate.

/cc @ianhays @stephentoub