### PR TITLE
Add back TcpClient/UdpClient.Client properties to System.Net.Sockets

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -141,8 +141,9 @@ namespace System.Net.Security.Tests
                     Task clientAuthTask = sslStream.AuthenticateAsClientAsync("localhost", null, clientSslProtocols, false);
                     await clientAuthTask.TimeoutAfter(TestConfiguration.PassingTestTimeoutMilliseconds);
 
-                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
-                        server.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
+                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
+                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
                     Assert.True(sslStream.CipherAlgorithm != CipherAlgorithmType.Null, "Cipher algorithm should not be NULL");
                     Assert.True(sslStream.CipherStrength > 0, "Cipher strength should be greater than 0");
                 }

--- a/src/System.Net.Security/tests/FunctionalTests/ClientDefaultEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientDefaultEncryptionTest.cs
@@ -45,8 +45,9 @@ namespace System.Net.Security.Tests
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null))
                 {
                     await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
-                        serverRequireEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
+                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
+                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
                     Assert.True(sslStream.CipherAlgorithm != CipherAlgorithmType.Null, "Cipher algorithm should not be NULL");
                     Assert.True(sslStream.CipherStrength > 0, "Cipher strength should be greater than 0");
                 }
@@ -65,8 +66,9 @@ namespace System.Net.Security.Tests
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null))
                 {
                     await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
-                        serverAllowNoEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
+                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
+                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
                     Assert.True(sslStream.CipherAlgorithm != CipherAlgorithmType.Null, "Cipher algorithm should not be NULL");
                     Assert.True(sslStream.CipherStrength > 0, "Cipher strength should be greater than 0");
                 }

--- a/src/System.Net.Security/tests/FunctionalTests/DummyTcpServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/DummyTcpServer.cs
@@ -97,7 +97,8 @@ namespace System.Net.Security.Tests
             try
             {
                 result.GetAwaiter().GetResult();
-                _log.WriteLine("Server authenticated to client with encryption cipher: {0} {1}-bit strength",
+                _log.WriteLine("Server({0}) authenticated to client({1}) with encryption cipher: {2} {3}-bit strength",
+                    state.TcpClient.Client.LocalEndPoint, state.TcpClient.Client.RemoteEndPoint,
                     sslStream.CipherAlgorithm, sslStream.CipherStrength);
 
                 // Start listening for data from the client connection.
@@ -106,13 +107,15 @@ namespace System.Net.Security.Tests
             catch (AuthenticationException authEx)
             {
                 _log.WriteLine(
-                    "Server disconnecting from client during authentication.  No shared SSL/TLS algorithm. ({0})",
+                    "Server({0}) disconnecting from client({1}) during authentication.  No shared SSL/TLS algorithm. ({2})",
+                    state.TcpClient.Client.LocalEndPoint,
+                    state.TcpClient.Client.RemoteEndPoint,
                     authEx);
             }
             catch (Exception ex)
             {
-                _log.WriteLine("Server disconnecting from client during authentication.  Exception: {0}",
-                    ex.Message);
+                _log.WriteLine("Server({0}) disconnecting from client({1}) during authentication.  Exception: {2}",
+                    state.TcpClient.Client.LocalEndPoint, state.TcpClient.Client.RemoteEndPoint, ex.Message);
             }
             finally
             {

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAllowNoEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAllowNoEncryptionTest.cs
@@ -44,8 +44,9 @@ namespace System.Net.Security.Tests
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.RequireEncryption))
                 {
                     await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
-                        serverAllowNoEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
+                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
+                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
                     Assert.NotEqual(CipherAlgorithmType.Null, sslStream.CipherAlgorithm);
                     Assert.True(sslStream.CipherStrength > 0);
                 }
@@ -64,8 +65,9 @@ namespace System.Net.Security.Tests
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.AllowNoEncryption))
                 {
                     await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
-                        serverAllowNoEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
+                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
+                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
                     Assert.NotEqual(CipherAlgorithmType.Null, sslStream.CipherAlgorithm);
                     Assert.True(sslStream.CipherStrength > 0, "Cipher strength should be greater than 0");
                 }
@@ -84,8 +86,9 @@ namespace System.Net.Security.Tests
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.NoEncryption))
                 {
                     await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
-                        serverAllowNoEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
+                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
+                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
 
                     CipherAlgorithmType expected = CipherAlgorithmType.Null;
                     Assert.Equal(expected, sslStream.CipherAlgorithm);

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -169,8 +169,9 @@ namespace System.Net.Security.Tests
                     _logVerbose.WriteLine("ServerAsyncAuthenticateTest.serverAuthentication complete.");
 
                     _log.WriteLine(
-                        "Server({0}) authenticated with encryption cipher: {1} {2}-bit strength",
-                        serverEndPoint,
+                        "Server({0}) authenticated client({1}) with encryption cipher: {2} {3}-bit strength",
+                        serverConnection.Client.LocalEndPoint,
+                        serverConnection.Client.RemoteEndPoint,
                         sslServerStream.CipherAlgorithm,
                         sslServerStream.CipherStrength);
 

--- a/src/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
@@ -44,8 +44,9 @@ namespace System.Net.Security.Tests
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.RequireEncryption))
                 {
                     await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
-                        serverRequireEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
+                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
+                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
                     Assert.True(sslStream.CipherAlgorithm != CipherAlgorithmType.Null, "Cipher algorithm should not be NULL");
                     Assert.True(sslStream.CipherStrength > 0, "Cipher strength should be greater than 0");
                 }
@@ -64,8 +65,9 @@ namespace System.Net.Security.Tests
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.AllowNoEncryption))
                 {
                     await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
-                        serverRequireEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
+                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
+                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
                     Assert.True(sslStream.CipherAlgorithm != CipherAlgorithmType.Null, "Cipher algorithm should not be NULL");
                     Assert.True(sslStream.CipherStrength > 0, "Cipher strength should be greater than 0");
                 }

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -420,6 +420,7 @@ namespace System.Net.Sockets
         public TcpClient(System.Net.Sockets.AddressFamily family) { }
         protected bool Active { get { return default(bool); } set { } }
         public int Available { get { return default(int); } }
+        public System.Net.Sockets.Socket Client { get { return default(System.Net.Sockets.Socket); } set { } }
         public bool Connected { get { return default(bool); } }
         public bool ExclusiveAddressUse { get { return default(bool); } set { } }
         public System.Net.Sockets.LingerOption LingerState { get { return default(System.Net.Sockets.LingerOption); } set { } }
@@ -460,6 +461,7 @@ namespace System.Net.Sockets
         public UdpClient(System.Net.Sockets.AddressFamily family) { }
         protected bool Active { get { return default(bool); } set { } }
         public int Available { get { return default(int); } }
+        public System.Net.Sockets.Socket Client { get { return default(System.Net.Sockets.Socket); } set { } }
         public bool DontFragment { get { return default(bool); } set { } }
         public bool EnableBroadcast { get { return default(bool); } set { } }
         public bool ExclusiveAddressUse { get { return default(bool); } set { } }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Windows.cs
@@ -10,10 +10,15 @@ namespace System.Net.Sockets
     {
         private void InitializeClientSocket()
         {
-            _clientSocket = CreateSocket();
+            Client = CreateSocket();
         }
 
-        private Socket Client { get { return _clientSocket; } }
+        // Used by the class to provide the underlying network socket.
+        private Socket ClientCore
+        {
+            get { return _clientSocket; }
+            set { _clientSocket = value; }
+        }
 
         private int AvailableCore { get { return _clientSocket.Available; } }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
@@ -72,6 +72,22 @@ namespace System.Net.Sockets
 
         public int Available { get { return AvailableCore; } }
 
+        // Used by the class to provide the underlying network socket.
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)] // TODO: Remove once https://github.com/dotnet/corefx/issues/5868 is addressed.
+        public Socket Client
+        {
+            get
+            {
+                Socket s = ClientCore;
+                Debug.Assert(s != null);
+                return s;
+            }
+            set
+            {
+                ClientCore = value;
+            }
+        }
+
         public bool Connected { get { return ConnectedCore; } }
 
         public bool ExclusiveAddressUse
@@ -150,7 +166,7 @@ namespace System.Net.Sockets
 
             if (_dataStream == null)
             {
-                _dataStream = new NetworkStream(_clientSocket, true);
+                _dataStream = new NetworkStream(Client, true);
             }
 
             if (NetEventSource.Log.IsEnabled())

--- a/src/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace System.Net.Sockets
@@ -117,6 +118,19 @@ namespace System.Net.Sockets
             get
             {
                 return _clientSocket.Available;
+            }
+        }
+
+        public Socket Client
+        {
+            get
+            {
+                Debug.Assert(_clientSocket != null);
+                return _clientSocket;
+            }
+            set
+            {
+                _clientSocket = value;
             }
         }
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/AgnosticListenerTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/AgnosticListenerTest.cs
@@ -73,6 +73,8 @@ namespace System.Net.Sockets.Tests
             v6Client.ConnectAsync(IPAddress.IPv6Loopback, port).GetAwaiter().GetResult();
 
             TcpClient acceptedV6Client = listener.EndAcceptTcpClient(asyncResult);
+            Assert.Equal(AddressFamily.InterNetworkV6, acceptedV6Client.Client.RemoteEndPoint.AddressFamily);
+            Assert.Equal(AddressFamily.InterNetworkV6, v6Client.Client.RemoteEndPoint.AddressFamily);
 
             asyncResult = listener.BeginAcceptTcpClient(null, null);
 
@@ -80,6 +82,8 @@ namespace System.Net.Sockets.Tests
             v4Client.ConnectAsync(IPAddress.Loopback, port).GetAwaiter().GetResult();
 
             TcpClient acceptedV4Client = listener.EndAcceptTcpClient(asyncResult);
+            Assert.Equal(AddressFamily.InterNetworkV6, acceptedV4Client.Client.RemoteEndPoint.AddressFamily);
+            Assert.Equal(AddressFamily.InterNetwork, v4Client.Client.RemoteEndPoint.AddressFamily);
 
             v6Client.Dispose();
             acceptedV6Client.Dispose();

--- a/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -1193,5 +1193,27 @@ namespace System.Net.Sockets.Tests
 
             Assert.Throws<ArgumentNullException>(() => GetSocket().EndReceiveMessageFrom(null, ref flags, ref remote, out packetInfo));
         }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void TcpClient_ConnectAsync_StringHost_NotSupportedAfterClientAccess()
+        {
+            using (TcpClient client = new TcpClient())
+            {
+                var tmp = client.Client;
+                Assert.Throws<PlatformNotSupportedException>(() => { client.ConnectAsync("localhost", 12345); });
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void TcpClient_ConnectAsync_ArrayOfAddresses_NotSupportedAfterClientAccess()
+        {
+            using (TcpClient client = new TcpClient())
+            {
+                var tmp = client.Client;
+                Assert.Throws<PlatformNotSupportedException>(() => { client.ConnectAsync(new[] { IPAddress.Loopback }, 12345); });
+            }
+        }
     }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -600,14 +600,14 @@ namespace System.Net.Sockets.Tests
             SendRecvAPM_Stream_TCP(IPAddress.Loopback, useMultipleBuffers: false);
         }
 
-        public static readonly object[][] SendToRecvFromAsync_Datagram_UDP_MemberData = new object[][]
+        public static readonly object[][] SendToRecvFromAsync_Datagram_UDP_Socket_MemberData = new object[][]
         {
             new object[] { IPAddress.IPv6Loopback, IPAddress.IPv6Loopback },
             new object[] { IPAddress.Loopback, IPAddress.Loopback }
         };
 
         [Theory]
-        [MemberData(nameof(SendToRecvFromAsync_Datagram_UDP_MemberData))]
+        [MemberData(nameof(SendToRecvFromAsync_Datagram_UDP_Socket_MemberData))]
         public void SendToRecvFromAsync_Datagram_UDP(IPAddress leftAddress, IPAddress rightAddress)
         {
             // TODO #5185: harden against packet loss
@@ -730,6 +730,87 @@ namespace System.Net.Sockets.Tests
             {
                 Assert.NotNull(receivedChecksums[i]);
                 Assert.Equal(sentChecksums[i], (uint)receivedChecksums[i]);
+            }
+        }
+
+        public static readonly object[][] SendToRecvFromAsync_Datagram_UDP_UdpClient_MemberData = new object[][]
+        {
+            new object[] { IPAddress.IPv6Loopback, IPAddress.IPv6Loopback },
+            new object[] { IPAddress.Loopback, IPAddress.Loopback }
+        };
+
+        [Theory]
+        [MemberData(nameof(SendToRecvFromAsync_Datagram_UDP_Socket_MemberData))]
+        public void SendToRecvFromAsync_Datagram_UDP_UdpClient(IPAddress leftAddress, IPAddress rightAddress)
+        {
+            // TODO #5185: harden against packet loss
+            const int DatagramSize = 256;
+            const int DatagramsToSend = 256;
+            const int AckTimeout = 1000;
+            const int TestTimeout = 30000;
+
+            using (var left = new UdpClient(new IPEndPoint(leftAddress, 0)))
+            using (var right = new UdpClient(new IPEndPoint(rightAddress, 0)))
+            {
+                var leftEndpoint = (IPEndPoint)left.Client.LocalEndPoint;
+                var rightEndpoint = (IPEndPoint)right.Client.LocalEndPoint;
+
+                var receiverAck = new ManualResetEventSlim();
+                var senderAck = new ManualResetEventSlim();
+
+                var receivedChecksums = new uint?[DatagramsToSend];
+                int receivedDatagrams = 0;
+
+                Task receiverTask = Task.Run(async () =>
+                {
+                    for (; receivedDatagrams < DatagramsToSend; receivedDatagrams++)
+                    {
+                        UdpReceiveResult result = await left.ReceiveAsync();
+
+                        receiverAck.Set();
+                        Assert.True(senderAck.Wait(AckTimeout));
+                        senderAck.Reset();
+
+                        Assert.Equal(DatagramSize, result.Buffer.Length);
+                        Assert.Equal(rightEndpoint, result.RemoteEndPoint);
+
+                        int datagramId = (int)result.Buffer[0];
+                        Assert.Null(receivedChecksums[datagramId]);
+
+                        receivedChecksums[datagramId] = Fletcher32.Checksum(result.Buffer, 0, result.Buffer.Length);
+                    }
+                });
+
+                var sentChecksums = new uint[DatagramsToSend];
+                int sentDatagrams = 0;
+
+                Task senderTask = Task.Run(async () =>
+                {
+                    var random = new Random();
+                    var sendBuffer = new byte[DatagramSize];
+
+                    for (; sentDatagrams < DatagramsToSend; sentDatagrams++)
+                    {
+                        random.NextBytes(sendBuffer);
+                        sendBuffer[0] = (byte)sentDatagrams;
+
+                        int sent = await right.SendAsync(sendBuffer, DatagramSize, leftEndpoint);
+
+                        Assert.True(receiverAck.Wait(AckTimeout));
+                        receiverAck.Reset();
+                        senderAck.Set();
+
+                        Assert.Equal(DatagramSize, sent);
+                        sentChecksums[sentDatagrams] = Fletcher32.Checksum(sendBuffer, 0, sent);
+                    }
+                });
+
+                Assert.True(Task.WaitAll(new[] { receiverTask, senderTask }, TestTimeout));
+                for (int i = 0; i < DatagramsToSend; i++)
+                {
+                    Assert.NotNull(receivedChecksums[i]);
+                    Assert.Equal(sentChecksums[i], (uint)receivedChecksums[i]);
+                }
             }
         }
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -46,6 +46,8 @@ namespace System.Net.Sockets.Tests
                 }
 
                 Assert.True(client.Connected);
+                Assert.NotNull(client.Client);
+                Assert.Same(client.Client, client.Client);
 
                 using (NetworkStream s = client.GetStream())
                 {

--- a/src/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
@@ -4,7 +4,7 @@
 
 using System.Net.Test.Common;
 using System.Threading;
-
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Net.Sockets.Tests
@@ -53,6 +53,27 @@ namespace System.Net.Sockets.Tests
             udpClient.BeginSend(sendBytes, sendBytes.Length, remoteServer, new AsyncCallback(AsyncCompleted), udpClient);
 
             Assert.True(_waitHandle.WaitOne(Configuration.PassingTestTimeout), "Timed out while waiting for connection");
+        }
+
+        [Fact]
+        public void Client_Idempotent()
+        {
+            using (var c = new UdpClient())
+            {
+                Socket client = c.Client;
+                Assert.NotNull(client);
+                Assert.Same(client, c.Client);
+            }
+        }
+
+        [ActiveIssue(4968)]    
+        [Fact]    
+        public async Task ConnectAsync_Success()
+        {
+            using (var c = new UdpClient())
+            {
+                await c.Client.ConnectAsync("114.114.114.114", 53);
+            }
         }
 
         private void AsyncCompleted(IAsyncResult ar)


### PR DESCRIPTION
Mainly a cleaned-up revert of https://github.com/dotnet/corefx/pull/5953.