### PR TITLE
Clear the libcrypto error queue before doing SSL/TLS operations.

### DIFF
--- a/src/Native/System.Security.Cryptography.Native/pal_pkcs12.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_pkcs12.cpp
@@ -4,6 +4,8 @@
 
 #include "pal_pkcs12.h"
 
+#include <openssl/err.h>
+
 extern "C" PKCS12* CryptoNative_DecodePkcs12(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
@@ -45,5 +47,14 @@ extern "C" int32_t CryptoNative_EncodePkcs12(PKCS12* p12, uint8_t* buf)
 
 extern "C" int32_t CryptoNative_Pkcs12Parse(PKCS12* p12, const char* pass, EVP_PKEY** pkey, X509** cert, X509Stack** ca)
 {
-    return PKCS12_parse(p12, pass, pkey, cert, ca);
+    int32_t ret = PKCS12_parse(p12, pass, pkey, cert, ca);
+
+    if (ret)
+    {
+        // PKCS12_parse's main loop can put a lot of spurious errors into the
+        // error queue.  If we're returning success, clear the error queue.
+        ERR_clear_error();
+    }
+
+    return ret;
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -7,6 +7,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include <openssl/err.h>
 
 static_assert(PAL_SSL_ERROR_NONE == SSL_ERROR_NONE, "");
 static_assert(PAL_SSL_ERROR_SSL == SSL_ERROR_SSL, "");
@@ -413,11 +414,13 @@ err:
 
 extern "C" int32_t CryptoNative_SslWrite(SSL* ssl, const void* buf, int32_t num)
 {
+    ERR_clear_error();
     return SSL_write(ssl, buf, num);
 }
 
 extern "C" int32_t CryptoNative_SslRead(SSL* ssl, void* buf, int32_t num)
 {
+    ERR_clear_error();
     return SSL_read(ssl, buf, num);
 }
 
@@ -428,6 +431,7 @@ extern "C" int32_t CryptoNative_IsSslRenegotiatePending(SSL* ssl)
 
 extern "C" int32_t CryptoNative_SslShutdown(SSL* ssl)
 {
+    ERR_clear_error();
     return SSL_shutdown(ssl);
 }
 
@@ -438,6 +442,7 @@ extern "C" void CryptoNative_SslSetBio(SSL* ssl, BIO* rbio, BIO* wbio)
 
 extern "C" int32_t CryptoNative_SslDoHandshake(SSL* ssl)
 {
+    ERR_clear_error();
     return SSL_do_handshake(ssl);
 }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -75,7 +75,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue(8444, PlatformID.AnyUnix)]
         [ConditionalTheory(nameof(BackendSupportsSslConfiguration))]
         [InlineData(SslProtocols.Tls)]
         [InlineData(SslProtocols.Tls11)]


### PR DESCRIPTION
If an SSL operation fails, we call SSL_get_error to determine how to proceed.
SSL_get_error's logic is, essentially
  libcrypto_error ?? WANT_READ ?? WANT_WRITE ?? WANT_X509 ?? panic

This means that if a previous call into libcrypto on the same thread had left
something in the error queue when the operation goes into the WANT_READ state (etc)
SSL_get_error will report that the request must have failed due to something in
libcrypto.

There are two different fixes being done here:
1) PKCS12_parse is a known contributor to this problem, clear out the queue on a
successful exit.
2) Before any SSL stream operation (handshake, read, write, shutdown) clear the
queue, in case there are other functions which are leaving dangling errors.

With those mitigations in place, the intermittent errors seen during SslStream
usage should hopefully be a thing of the past.

Fixes #8444.
cc: @stephentoub @ericeil