### PR TITLE
Create lookup table for IsDefault and TypeId

### DIFF
--- a/src/System.ComponentModel.Primitives/src/System.ComponentModel.Primitives.csproj
+++ b/src/System.ComponentModel.Primitives/src/System.ComponentModel.Primitives.csproj
@@ -19,7 +19,6 @@
     <Compile Include="System\ComponentModel\BrowsableAttribute.cs" />
     <Compile Include="System\ComponentModel\CategoryAttribute.cs" />
     <Compile Include="System\ComponentModel\ComponentCollection.cs" />
-    <Compile Include="System\ComponentModel\ComponentModelExtensions.cs" />
     <Compile Include="System\ComponentModel\DescriptionAttribute.cs" />
     <Compile Include="System\ComponentModel\DesignerCategoryAttribute.cs" />
     <Compile Include="System\ComponentModel\DesignerSerializationVisibility.cs" />

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/BrowsableAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/BrowsableAttribute.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel
     ///       a property browsing window.</para>
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]
-    public sealed class BrowsableAttribute : Attribute, IIsDefaultAttribute
+    public sealed class BrowsableAttribute : Attribute
     {
         /// <summary>
         ///    <para>
@@ -70,13 +70,6 @@ namespace System.ComponentModel
         public override int GetHashCode()
         {
             return _browsable.GetHashCode();
-        }
-
-        /// <summary>
-        /// </summary>
-        bool IIsDefaultAttribute.IsDefaultAttribute()
-        {
-            return this.Equals(Default);
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/CategoryAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/CategoryAttribute.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel
     ///       visual designer.</para>
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]
-    public class CategoryAttribute : Attribute, IIsDefaultAttribute
+    public class CategoryAttribute : Attribute
     {
         private static volatile CategoryAttribute s_action;
         private static volatile CategoryAttribute s_appearance;
@@ -316,17 +316,6 @@ namespace System.ComponentModel
         protected virtual string GetLocalizedString(string value)
         {
             return SR.GetResourceString("PropertyCategory" + value, null);
-        }
-
-        /// <summary>
-        /// </summary>
-        /// <summary>
-        /// </summary>
-        /// <internalonly/>
-        /// <internalonly/>
-        bool IIsDefaultAttribute.IsDefaultAttribute()
-        {
-            return Category.Equals(Default.Category);
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/DescriptionAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/DescriptionAttribute.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel
     ///       or event.</para>
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]
-    public class DescriptionAttribute : Attribute, IIsDefaultAttribute
+    public class DescriptionAttribute : Attribute
     {
         /// <summary>
         /// <para>Specifies the default value for the <see cref='System.ComponentModel.DescriptionAttribute'/> , which is an
@@ -58,14 +58,6 @@ namespace System.ComponentModel
         public override int GetHashCode()
         {
             return Description.GetHashCode();
-        }
-
-        /// <internalonly/>
-        /// <summary>
-        /// </summary>
-        bool IIsDefaultAttribute.IsDefaultAttribute()
-        {
-            return this.Equals(Default);
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/DesignOnlyAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/DesignOnlyAttribute.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel
     ///       design time.</para>
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]
-    public sealed class DesignOnlyAttribute : Attribute, IIsDefaultAttribute
+    public sealed class DesignOnlyAttribute : Attribute
     {
         /// <summary>
         ///    <para>
@@ -54,14 +54,6 @@ namespace System.ComponentModel
         ///    </para>
         /// </summary>
         public static readonly DesignOnlyAttribute Default = No;
-
-        /// <summary>
-        /// </summary>
-        /// <internalonly/>
-        bool IIsDefaultAttribute.IsDefaultAttribute()
-        {
-            return IsDesignOnly == Default.IsDesignOnly;
-        }
 
         public override bool Equals(object obj)
         {

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/DesignerCategoryAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/DesignerCategoryAttribute.cs
@@ -8,11 +8,8 @@ namespace System.ComponentModel
     ///    <para>Specifies that the designer for a class belongs to a certain category.</para>
     /// </devdoc>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-    public sealed class DesignerCategoryAttribute : Attribute, IIsDefaultAttribute, ITypeId
+    public sealed class DesignerCategoryAttribute : Attribute
     {
-        private readonly string _category;
-        private string _typeId;
-
         /// <devdoc>
         ///    <para>
         ///       Specifies that a component marked with this category uses a
@@ -53,7 +50,7 @@ namespace System.ComponentModel
         /// </devdoc>
         public DesignerCategoryAttribute()
         {
-            _category = string.Empty;
+            Category = string.Empty;
         }
 
         /// <devdoc>
@@ -64,7 +61,7 @@ namespace System.ComponentModel
         /// </devdoc>
         public DesignerCategoryAttribute(string category)
         {
-            _category = category;
+            Category = category;
         }
 
         /// <devdoc>
@@ -72,29 +69,7 @@ namespace System.ComponentModel
         ///       Gets the name of the category.
         ///    </para>
         /// </devdoc>
-        public string Category => _category;
-
-        /// <internalonly/>
-        /// <devdoc>
-        ///    <para>
-        ///       This defines a unique ID for this attribute type. It is used
-        ///       by filtering algorithms to identify two attributes that are
-        ///       the same type. For most attributes, this just returns the
-        ///       Type instance for the attribute. DesignerAttribute overrides
-        ///       this to include the name of the category
-        ///    </para>
-        /// </devdoc>
-        object ITypeId.TypeId
-        {
-            get
-            {
-                if (_typeId == null)
-                {
-                    _typeId = GetType().FullName + Category;
-                }
-                return _typeId;
-            }
-        }
+        public string Category { get; }
 
         public override bool Equals(object obj)
         {
@@ -104,17 +79,12 @@ namespace System.ComponentModel
             }
 
             DesignerCategoryAttribute other = obj as DesignerCategoryAttribute;
-            return (other != null) && other._category == _category;
+            return other != null && other.Category == Category;
         }
 
         public override int GetHashCode()
         {
-            return _category.GetHashCode();
-        }
-
-        bool IIsDefaultAttribute.IsDefaultAttribute()
-        {
-            return _category.Equals(Default.Category);
+            return Category.GetHashCode();
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/DesignerSerializationVisibilityAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/DesignerSerializationVisibilityAttribute.cs
@@ -11,7 +11,7 @@ namespace System.ComponentModel
     ///    </para>
     /// </summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Event)]
-    public sealed class DesignerSerializationVisibilityAttribute : Attribute, IIsDefaultAttribute
+    public sealed class DesignerSerializationVisibilityAttribute : Attribute
     {
         /// <summary>
         ///    <para>
@@ -97,14 +97,6 @@ namespace System.ComponentModel
         public override int GetHashCode()
         {
             return base.GetHashCode();
-        }
-
-        /// <summary>
-        /// </summary>
-        /// <internalonly/>
-        bool IIsDefaultAttribute.IsDefaultAttribute()
-        {
-            return this.Equals(Default);
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/DisplayNameAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/DisplayNameAttribute.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes")]
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Event | AttributeTargets.Class | AttributeTargets.Method)]
-    public class DisplayNameAttribute : Attribute, IIsDefaultAttribute
+    public class DisplayNameAttribute : Attribute
     {
         /// <summary>
         /// <para>Specifies the default value for the <see cref='System.ComponentModel.DisplayNameAttribute'/> , which is an
@@ -59,14 +59,6 @@ namespace System.ComponentModel
         public override int GetHashCode()
         {
             return DisplayName.GetHashCode();
-        }
-
-        /// <internalonly/>
-        /// <summary>
-        /// </summary>
-        bool IIsDefaultAttribute.IsDefaultAttribute()
-        {
-            return this.Equals(Default);
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/ImmutableObjectAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/ImmutableObjectAttribute.cs
@@ -8,7 +8,7 @@ namespace System.ComponentModel
     ///  Specifies that a object has no sub properties that are editable.
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]
-    public sealed class ImmutableObjectAttribute : Attribute, IIsDefaultAttribute
+    public sealed class ImmutableObjectAttribute : Attribute
     {
         /// <summary>
         ///  Specifies that a object has no sub properties that are editable.
@@ -68,14 +68,6 @@ namespace System.ComponentModel
         public override int GetHashCode()
         {
             return base.GetHashCode();
-        }
-
-        /// <internalonly/>
-        /// <summary>
-        /// </summary>
-        bool IIsDefaultAttribute.IsDefaultAttribute()
-        {
-            return this.Equals(Default);
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/LocalizableAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/LocalizableAttribute.cs
@@ -8,7 +8,7 @@ namespace System.ComponentModel
     ///    <para>Specifies whether a property should be localized.</para>
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]
-    public sealed class LocalizableAttribute : Attribute, IIsDefaultAttribute
+    public sealed class LocalizableAttribute : Attribute
     {
         /// <summary>
         ///    <para>
@@ -52,14 +52,6 @@ namespace System.ComponentModel
         ///    </para>
         /// </summary>
         public static readonly LocalizableAttribute Default = No;
-
-        /// <internalonly/>
-        /// <summary>
-        /// </summary>
-        bool IIsDefaultAttribute.IsDefaultAttribute()
-        {
-            return IsLocalizable == Default.IsLocalizable;
-        }
 
         public override bool Equals(object obj)
         {

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/MergablePropertyAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/MergablePropertyAttribute.cs
@@ -10,7 +10,7 @@ namespace System.ComponentModel
     ///       other objects in a properties window.</para>
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]
-    public sealed class MergablePropertyAttribute : Attribute, IIsDefaultAttribute
+    public sealed class MergablePropertyAttribute : Attribute
     {
         /// <summary>
         ///    <para>
@@ -79,14 +79,6 @@ namespace System.ComponentModel
         public override int GetHashCode()
         {
             return base.GetHashCode();
-        }
-
-        /// <summary>
-        /// </summary>
-        /// <internalonly/>
-        bool IIsDefaultAttribute.IsDefaultAttribute()
-        {
-            return this.Equals(Default);
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/NotifyParentPropertyAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/NotifyParentPropertyAttribute.cs
@@ -11,7 +11,7 @@ namespace System.ComponentModel
     ///    </para>
     /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
-    public sealed class NotifyParentPropertyAttribute : Attribute, IIsDefaultAttribute
+    public sealed class NotifyParentPropertyAttribute : Attribute
     {
         /// <summary>
         ///    <para>
@@ -74,16 +74,6 @@ namespace System.ComponentModel
         public override int GetHashCode()
         {
             return base.GetHashCode();
-        }
-
-        /// <summary>
-        ///    <para>
-        ///       Gets whether this attribute is <see langword='true'/> by default.
-        ///    </para>
-        /// </summary>
-        bool IIsDefaultAttribute.IsDefaultAttribute()
-        {
-            return this.Equals(Default);
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/ParenthesizePropertyNameAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/ParenthesizePropertyNameAttribute.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel
     ///       properties window.</para>
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]
-    public sealed class ParenthesizePropertyNameAttribute : Attribute, IIsDefaultAttribute
+    public sealed class ParenthesizePropertyNameAttribute : Attribute
     {
         /// <summary>
         ///    <para>
@@ -70,14 +70,6 @@ namespace System.ComponentModel
         public override int GetHashCode()
         {
             return base.GetHashCode();
-        }
-
-        /// <summary>
-        /// <para>Gets a value indicating whether this attribute is set to <see langword='true'/> by default.</para>
-        /// </summary>
-        bool IIsDefaultAttribute.IsDefaultAttribute()
-        {
-            return this.Equals(Default);
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/ReadOnlyAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/ReadOnlyAttribute.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel
     ///       is read-only or read/write.</para>
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]
-    public sealed class ReadOnlyAttribute : Attribute, IIsDefaultAttribute
+    public sealed class ReadOnlyAttribute : Attribute
     {
         /// <summary>
         ///    <para>
@@ -76,17 +76,6 @@ namespace System.ComponentModel
         public override int GetHashCode()
         {
             return base.GetHashCode();
-        }
-
-        /// <internalonly/>
-        /// <summary>
-        ///    <para>
-        ///       Determines if this attribute is the default.
-        ///    </para>
-        /// </summary>
-        bool IIsDefaultAttribute.IsDefaultAttribute()
-        {
-            return this.IsReadOnly == Default.IsReadOnly;
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/RefreshPropertiesAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/RefreshPropertiesAttribute.cs
@@ -8,7 +8,7 @@ namespace System.ComponentModel
     ///    <para> Specifies how a designer refreshes when the property value is changed.</para>
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]
-    public sealed class RefreshPropertiesAttribute : Attribute, IIsDefaultAttribute
+    public sealed class RefreshPropertiesAttribute : Attribute
     {
         /// <summary>
         ///    <para>
@@ -78,14 +78,6 @@ namespace System.ComponentModel
         public override int GetHashCode()
         {
             return base.GetHashCode();
-        }
-
-        /// <summary>
-        ///    <para>Gets a value indicating whether the current attribute is the default.</para>
-        /// </summary>
-        bool IIsDefaultAttribute.IsDefaultAttribute()
-        {
-            return this.Equals(Default);
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/tests/BrowsableAttributeTests.cs
+++ b/src/System.ComponentModel.Primitives/tests/BrowsableAttributeTests.cs
@@ -21,10 +21,9 @@ namespace System.ComponentModel.Primitives.Tests
 
         [Theory]
         [MemberData(nameof(DefaultData))]
-        public void GetBrowsable(BrowsableAttribute attribute, bool expectedBrowsable, bool expectedIsDefaultValue)
+        public void GetBrowsable(BrowsableAttribute attribute, bool expectedBrowsable)
         {
             Assert.Equal(expectedBrowsable, attribute.Browsable);
-            Assert.Equal(expectedIsDefaultValue, attribute.IsDefaultAttribute());
         }
 
         [Fact]
@@ -39,21 +38,11 @@ namespace System.ComponentModel.Primitives.Tests
             Assert.True(BrowsableAttribute.Yes.Equals(BrowsableAttribute.Yes));
         }
 
-        [Fact]
-        public void DefaultValue()
-        {
-            Assert.True(BrowsableAttribute.Default.IsDefaultAttribute());
-            Assert.True(BrowsableAttribute.Yes.IsDefaultAttribute());
-            Assert.False(BrowsableAttribute.No.IsDefaultAttribute());
-            Assert.True(new BrowsableAttribute(true).IsDefaultAttribute());
-            Assert.False(new BrowsableAttribute(false).IsDefaultAttribute());
-        }
-
         private static IEnumerable<object[]> DefaultData()
         {
-            yield return new object[] { BrowsableAttribute.Yes, true, true };
-            yield return new object[] { BrowsableAttribute.Default, true, true };
-            yield return new object[] { BrowsableAttribute.No, false, false };
+            yield return new object[] { BrowsableAttribute.Yes, true };
+            yield return new object[] { BrowsableAttribute.Default, true };
+            yield return new object[] { BrowsableAttribute.No, false };
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/tests/CategoryAttributeTests.cs
+++ b/src/System.ComponentModel.Primitives/tests/CategoryAttributeTests.cs
@@ -32,35 +32,25 @@ namespace System.ComponentModel.Primitives.Tests
 
         [Theory]
         [MemberData(nameof(CategoryNameData))]
-        public void CategoryNames(CategoryAttribute attribute, string name, bool isDefault)
+        public void CategoryNames(CategoryAttribute attribute, string name)
         {
             Assert.Equal(name, attribute.Category);
-            Assert.Equal(isDefault, attribute.IsDefaultAttribute());
         }
 
         private static IEnumerable<object[]> CategoryNameData()
         {
-            yield return new object[] { CategoryAttribute.Appearance, "Appearance", false };
-            yield return new object[] { CategoryAttribute.Asynchronous, "Asynchronous", false };
-            yield return new object[] { CategoryAttribute.Behavior, "Behavior", false };
-            yield return new object[] { CategoryAttribute.Data, "Data", false };
-            yield return new object[] { CategoryAttribute.Default, "Misc", true };
-            yield return new object[] { CategoryAttribute.Design, "Design", false };
-            yield return new object[] { CategoryAttribute.DragDrop, "Drag Drop", false };
-            yield return new object[] { CategoryAttribute.Focus, "Focus", false };
-            yield return new object[] { CategoryAttribute.Key, "Key", false };
-            yield return new object[] { CategoryAttribute.Layout, "Layout", false };
-            yield return new object[] { CategoryAttribute.Mouse, "Mouse", false };
-            yield return new object[] { CategoryAttribute.WindowStyle, "Window Style", false };
-        }
-
-        [Theory]
-        [InlineData("Default", true)]
-        [InlineData("default", false)]
-        [InlineData("other", false)]
-        public void DefaultValue(string name, bool isDefault)
-        {
-            Assert.Equal(isDefault, new CategoryAttribute(name).IsDefaultAttribute());
+            yield return new object[] { CategoryAttribute.Appearance, "Appearance" };
+            yield return new object[] { CategoryAttribute.Asynchronous, "Asynchronous" };
+            yield return new object[] { CategoryAttribute.Behavior, "Behavior" };
+            yield return new object[] { CategoryAttribute.Data, "Data" };
+            yield return new object[] { CategoryAttribute.Default, "Misc" };
+            yield return new object[] { CategoryAttribute.Design, "Design" };
+            yield return new object[] { CategoryAttribute.DragDrop, "Drag Drop" };
+            yield return new object[] { CategoryAttribute.Focus, "Focus" };
+            yield return new object[] { CategoryAttribute.Key, "Key" };
+            yield return new object[] { CategoryAttribute.Layout, "Layout" };
+            yield return new object[] { CategoryAttribute.Mouse, "Mouse" };
+            yield return new object[] { CategoryAttribute.WindowStyle, "Window Style" };
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/tests/DescriptionAttributeTests.cs
+++ b/src/System.ComponentModel.Primitives/tests/DescriptionAttributeTests.cs
@@ -35,17 +35,16 @@ namespace System.ComponentModel.Primitives.Tests
 
         [Theory]
         [MemberData(nameof(DescriptionData))]
-        public void CategoryNames(DescriptionAttribute attribute, string name, bool isDefault)
+        public void CategoryNames(DescriptionAttribute attribute, string name)
         {
             Assert.Equal(name, attribute.Description);
-            Assert.Equal(isDefault, attribute.IsDefaultAttribute());
         }
 
         private static IEnumerable<object[]> DescriptionData()
         {
-            yield return new object[] { DescriptionAttribute.Default, "", true };
-            yield return new object[] { new DescriptionAttribute(""), "", true };
-            yield return new object[] { new DescriptionAttribute("other"), "other", false };
+            yield return new object[] { DescriptionAttribute.Default, "" };
+            yield return new object[] { new DescriptionAttribute(""), "" };
+            yield return new object[] { new DescriptionAttribute("other"), "other" };
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/tests/DisplayNameAttributeTests.cs
+++ b/src/System.ComponentModel.Primitives/tests/DisplayNameAttributeTests.cs
@@ -20,17 +20,16 @@ namespace System.ComponentModel.Primitives.Tests
 
         [Theory]
         [MemberData(nameof(NameData))]
-        public void NameTests(DisplayNameAttribute attribute, string name, bool isDefault)
+        public void NameTests(DisplayNameAttribute attribute, string name)
         {
             Assert.Equal(name, attribute.DisplayName);
-            Assert.Equal(isDefault, attribute.IsDefaultAttribute());
         }
 
         private static IEnumerable<object[]> NameData()
         {
-            yield return new object[] { DisplayNameAttribute.Default, "", true };
-            yield return new object[] { new DisplayNameAttribute(""), "", true };
-            yield return new object[] { new DisplayNameAttribute("other"), "other", false };
+            yield return new object[] { DisplayNameAttribute.Default, "" };
+            yield return new object[] { new DisplayNameAttribute(""), "" };
+            yield return new object[] { new DisplayNameAttribute("other"), "other" };
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/tests/ImmutableObjectAttributeTests.cs
+++ b/src/System.ComponentModel.Primitives/tests/ImmutableObjectAttributeTests.cs
@@ -33,17 +33,16 @@ namespace System.ComponentModel.Primitives.Tests
 
         [Theory]
         [MemberData(nameof(ImmutableAttributesData))]
-        public void NameTests(ImmutableObjectAttribute attribute, bool isImmutable, bool isDefault)
+        public void NameTests(ImmutableObjectAttribute attribute, bool isImmutable)
         {
             Assert.Equal(isImmutable, attribute.Immutable);
-            Assert.Equal(isDefault, attribute.IsDefaultAttribute());
         }
 
         private static IEnumerable<object[]> ImmutableAttributesData()
         {
-            yield return new object[] { ImmutableObjectAttribute.Default, false, true };
-            yield return new object[] { new ImmutableObjectAttribute(true), true, false };
-            yield return new object[] { new ImmutableObjectAttribute(false), false, true };
+            yield return new object[] { ImmutableObjectAttribute.Default, false };
+            yield return new object[] { new ImmutableObjectAttribute(true), true };
+            yield return new object[] { new ImmutableObjectAttribute(false), false };
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/tests/LocalizableAttributeTests.cs
+++ b/src/System.ComponentModel.Primitives/tests/LocalizableAttributeTests.cs
@@ -33,17 +33,16 @@ namespace System.ComponentModel.Primitives.Tests
 
         [Theory]
         [MemberData(nameof(LocalizableAttributeData))]
-        public void NameTests(LocalizableAttribute attribute, bool isLocalizable, bool isDefault)
+        public void NameTests(LocalizableAttribute attribute, bool isLocalizable)
         {
             Assert.Equal(isLocalizable, attribute.IsLocalizable);
-            Assert.Equal(isDefault, attribute.IsDefaultAttribute());
         }
 
         private static IEnumerable<object[]> LocalizableAttributeData()
         {
-            yield return new object[] { LocalizableAttribute.Default, false, true };
-            yield return new object[] { new LocalizableAttribute(true), true, false };
-            yield return new object[] { new LocalizableAttribute(false), false, true };
+            yield return new object[] { LocalizableAttribute.Default, false };
+            yield return new object[] { new LocalizableAttribute(true), true };
+            yield return new object[] { new LocalizableAttribute(false), false };
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/tests/MergablePropertyAttributeTests.cs
+++ b/src/System.ComponentModel.Primitives/tests/MergablePropertyAttributeTests.cs
@@ -33,17 +33,16 @@ namespace System.ComponentModel.Primitives.Tests
 
         [Theory]
         [MemberData(nameof(MergablePropertyAttributeData))]
-        public void NameTests(MergablePropertyAttribute attribute, bool isMergable, bool isDefault)
+        public void NameTests(MergablePropertyAttribute attribute, bool isMergable)
         {
             Assert.Equal(isMergable, attribute.AllowMerge);
-            Assert.Equal(isDefault, attribute.IsDefaultAttribute());
         }
 
         private static IEnumerable<object[]> MergablePropertyAttributeData()
         {
-            yield return new object[] { MergablePropertyAttribute.Default, true, true };
-            yield return new object[] { new MergablePropertyAttribute(true), true, true };
-            yield return new object[] { new MergablePropertyAttribute(false), false, false };
+            yield return new object[] { MergablePropertyAttribute.Default, true };
+            yield return new object[] { new MergablePropertyAttribute(true), true };
+            yield return new object[] { new MergablePropertyAttribute(false), false };
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/tests/NotifyParentPropertyAttributeTests.cs
+++ b/src/System.ComponentModel.Primitives/tests/NotifyParentPropertyAttributeTests.cs
@@ -33,17 +33,16 @@ namespace System.ComponentModel.Primitives.Tests
 
         [Theory]
         [MemberData(nameof(NotifyParentPropertyAttributeData))]
-        public void NameTests(NotifyParentPropertyAttribute attribute, bool isNotifyParent, bool isDefault)
+        public void NameTests(NotifyParentPropertyAttribute attribute, bool isNotifyParent)
         {
             Assert.Equal(isNotifyParent, attribute.NotifyParent);
-            Assert.Equal(isDefault, attribute.IsDefaultAttribute());
         }
 
         private static IEnumerable<object[]> NotifyParentPropertyAttributeData()
         {
-            yield return new object[] { NotifyParentPropertyAttribute.Default, false, true };
-            yield return new object[] { new NotifyParentPropertyAttribute(true), true, false };
-            yield return new object[] { new NotifyParentPropertyAttribute(false), false, true };
+            yield return new object[] { NotifyParentPropertyAttribute.Default, false };
+            yield return new object[] { new NotifyParentPropertyAttribute(true), true };
+            yield return new object[] { new NotifyParentPropertyAttribute(false), false };
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/tests/ParenthesizePropertyNameAttributeTests.cs
+++ b/src/System.ComponentModel.Primitives/tests/ParenthesizePropertyNameAttributeTests.cs
@@ -42,17 +42,16 @@ namespace System.ComponentModel.Primitives.Tests
 
         [Theory]
         [MemberData(nameof(ParenthesizePropertyNameAttributeData))]
-        public void NameTests(ParenthesizePropertyNameAttribute attribute, bool needParenthesis, bool isDefault)
+        public void NameTests(ParenthesizePropertyNameAttribute attribute, bool needParenthesis)
         {
             Assert.Equal(needParenthesis, attribute.NeedParenthesis);
-            Assert.Equal(isDefault, attribute.IsDefaultAttribute());
         }
 
         private static IEnumerable<object[]> ParenthesizePropertyNameAttributeData()
         {
-            yield return new object[] { ParenthesizePropertyNameAttribute.Default, false, true };
-            yield return new object[] { new ParenthesizePropertyNameAttribute(true), true, false };
-            yield return new object[] { new ParenthesizePropertyNameAttribute(false), false, true };
+            yield return new object[] { ParenthesizePropertyNameAttribute.Default, false };
+            yield return new object[] { new ParenthesizePropertyNameAttribute(true), true };
+            yield return new object[] { new ParenthesizePropertyNameAttribute(false), false };
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/tests/ReadOnlyAttributeTests.cs
+++ b/src/System.ComponentModel.Primitives/tests/ReadOnlyAttributeTests.cs
@@ -33,17 +33,16 @@ namespace System.ComponentModel.Primitives.Tests
 
         [Theory]
         [MemberData(nameof(ReadOnlyAttributeData))]
-        public void NameTests(ReadOnlyAttribute attribute, bool isReadOnly, bool isDefault)
+        public void NameTests(ReadOnlyAttribute attribute, bool isReadOnly)
         {
             Assert.Equal(isReadOnly, attribute.IsReadOnly);
-            Assert.Equal(isDefault, attribute.IsDefaultAttribute());
         }
 
         private static IEnumerable<object[]> ReadOnlyAttributeData()
         {
-            yield return new object[] { ReadOnlyAttribute.Default, false, true };
-            yield return new object[] { new ReadOnlyAttribute(true), true, false };
-            yield return new object[] { new ReadOnlyAttribute(false), false, true };
+            yield return new object[] { ReadOnlyAttribute.Default, false };
+            yield return new object[] { new ReadOnlyAttribute(true), true };
+            yield return new object[] { new ReadOnlyAttribute(false), false };
         }
     }
 }

--- a/src/System.ComponentModel.Primitives/tests/RefreshPropertiesAttributeTests.cs
+++ b/src/System.ComponentModel.Primitives/tests/RefreshPropertiesAttributeTests.cs
@@ -28,30 +28,28 @@ namespace System.ComponentModel.Primitives.Tests
         }
 
         [Theory]
-        [InlineData(RefreshProperties.All, false)]
-        [InlineData(RefreshProperties.None, true)]
-        [InlineData(RefreshProperties.Repaint, false)]
-        public void GetRefreshProperties(RefreshProperties value, bool isDefault)
+        [InlineData(RefreshProperties.All)]
+        [InlineData(RefreshProperties.None)]
+        [InlineData(RefreshProperties.Repaint)]
+        public void GetRefreshProperties(RefreshProperties value)
         {
             var attribute = new RefreshPropertiesAttribute(value);
 
             Assert.Equal(value, attribute.RefreshProperties);
-            Assert.Equal(isDefault, attribute.IsDefaultAttribute());
         }
 
         [Theory]
         [MemberData(nameof(RefreshPropertiesAttributeData))]
-        public void NameTests(RefreshPropertiesAttribute attribute, RefreshProperties refreshProperties, bool isDefault)
+        public void NameTests(RefreshPropertiesAttribute attribute, RefreshProperties refreshProperties)
         {
             Assert.Equal(refreshProperties, attribute.RefreshProperties);
-            Assert.Equal(isDefault, attribute.IsDefaultAttribute());
         }
 
         private static IEnumerable<object[]> RefreshPropertiesAttributeData()
         {
-            yield return new object[] { RefreshPropertiesAttribute.Default, RefreshProperties.None, true };
-            yield return new object[] { RefreshPropertiesAttribute.All, RefreshProperties.All, false };
-            yield return new object[] { RefreshPropertiesAttribute.Repaint, RefreshProperties.Repaint, false };
+            yield return new object[] { RefreshPropertiesAttribute.Default, RefreshProperties.None };
+            yield return new object[] { RefreshPropertiesAttribute.All, RefreshProperties.All };
+            yield return new object[] { RefreshPropertiesAttribute.Repaint, RefreshProperties.Repaint };
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -370,7 +370,7 @@ namespace System.ComponentModel
         protected virtual void OnValueChanged(object component, System.EventArgs e) { }
         public virtual void RemoveValueChanged(object component, System.EventHandler handler) { }
         public abstract void ResetValue(object component);
-        // public System.ComponentModel.DesignerSerializationVisibility SerializationVisibility { get { return default(System.ComponentModel.DesignerSerializationVisibility); } }
+        public System.ComponentModel.DesignerSerializationVisibility SerializationVisibility { get { return default(System.ComponentModel.DesignerSerializationVisibility); } }
         public abstract void SetValue(object component, object value);
         public abstract bool ShouldSerializeValue(object component);
     }

--- a/src/System.ComponentModel.TypeConverter/ref/project.json
+++ b/src/System.ComponentModel.TypeConverter/ref/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "System.Collections.NonGeneric": "4.0.0",
     "System.ComponentModel": "4.0.0",
-    "System.ComponentModel.Primitives": "4.0.0",
+    "System.ComponentModel.Primitives": "4.1.0-rc3-24117-00",
     "System.Globalization": "4.0.0",
     "System.Reflection": "4.0.0",
     "System.Runtime": "4.0.0"

--- a/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
+++ b/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
@@ -67,6 +67,7 @@
     <Compile Include="System\ComponentModel\CollectionChangeAction.cs" />
     <Compile Include="System\ComponentModel\CollectionChangeEventArgs.cs" />
     <Compile Include="System\ComponentModel\CollectionChangeEventHandler.cs" />
+    <Compile Include="System\ComponentModel\ComponentModelExtensions.cs" /> 
     <Compile Include="System\ComponentModel\CustomTypeDescriptor.cs" />
     <Compile Include="System\ComponentModel\DefaultEventAttribute.cs" />
     <Compile Include="System\ComponentModel\DefaultPropertyAttribute.cs" />
@@ -99,11 +100,6 @@
     <Compile Include="System\ComponentModel\Design\IDictionaryService.cs" />
     <Compile Include="System\ComponentModel\Design\IExtenderListService.cs" />
     <Compile Include="System\ComponentModel\Design\ITypeDescriptorFilterService.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'==''">
-    <ProjectReference Include="..\..\System.ComponentModel.Primitives\src\System.ComponentModel.Primitives.csproj">
-      <Name>System.ComponentModel.TypeConverter.Primitives</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'==''">
     <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ComponentModelExtensions.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ComponentModelExtensions.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.ComponentModel
+{
+    /// <summary>
+    /// These extension methods are used to mimic behavior from the .NET Framework where System.Attribute
+    /// had extra methods. For compatibility reasons, they are implemented with interfaces on the attributes
+    /// that need them, and then exposed via extension methods off of System.Attribute. The only difference
+    /// is that Attribute.TypeId is now accessed as Attribute.GetTypeId() as extension properties don't exist.
+    /// </summary>
+    internal static class ComponentModelExtensions
+    {
+        /// <summary>
+        /// This work around attempts to mimic the known cases where IsDefaultAttribute is true for System.ComponentModel
+        /// attributes. This does not account for derived attributes, which a few may be (most are sealed). The derived
+        /// attributes will most likely not be default as they will be overriding the default properties anyway, so this
+        /// heuristic will cover the majority of cases while allowing correct layering with System.ComponentModel.Primitives
+        /// </summary>
+        public static bool IsDefaultAttribute(this Attribute attribute)
+        {
+            Func<Attribute, bool> isDefaultAttribute;
+            return s_defaultAttributes.TryGetValue(attribute.GetType(), out isDefaultAttribute) && isDefaultAttribute(attribute);
+        }
+
+        /// <summary>
+        /// This defines a unique ID for this attribute type. It is used by filtering algorithms to identify two attributes that
+        /// are the same type. For most attributes, this just returns the Type instance for the attribute. DesignerAttribute
+        /// overrides this to include the name of the category
+        ///
+        /// This is a work around as System.Attribute does not contain the property TypeId in .NET Core. This attempts to mimic
+        /// the known cases where TypeId is is not just the type for System.ComponentModel attributes. There are two cases of this,
+        /// and both are sealed, so this lookup will cover all cases.
+        /// </summary>
+        public static object GetTypeId(this Attribute attribute)
+        {
+            Func<Attribute, object> typeId;
+            return s_typeId.TryGetValue(attribute.GetType(), out typeId)
+                ? typeId(attribute)
+                : attribute.GetType();
+        }
+
+        /// <summary>
+        /// System.Attribute in .NET Core does not have a Match method, so this provides an abstraction for it when it is used
+        /// in the TypeDescriptor classes in case anything ends up needing to customize it similar to GetTypeId or IsDefaultAttribute
+        /// </summary>
+        public static bool Match(this Attribute attribute, object obj)
+        {
+            return attribute.Equals(obj);
+        }
+
+        private static readonly Dictionary<Type, Func<Attribute, object>> s_typeId = new Dictionary<Type, Func<Attribute, object>>
+        {
+            { typeof(DesignerCategoryAttribute), attr => attr.GetType().FullName + ((DesignerCategoryAttribute)attr).Category },
+            { typeof(ProvidePropertyAttribute), attr => attr.GetType().FullName + ((ProvidePropertyAttribute)attr).PropertyName },
+        };
+
+        private static readonly Dictionary<Type, Func<Attribute, bool>> s_defaultAttributes = new Dictionary<Type, Func<Attribute, bool>>
+        {
+            { typeof(BrowsableAttribute), attr => attr.Equals(BrowsableAttribute.Default) },
+            { typeof(CategoryAttribute), attr => ((CategoryAttribute)attr).Category.Equals(CategoryAttribute.Default.Category) },
+            { typeof(DescriptionAttribute), attr => attr.Equals(DescriptionAttribute.Default) },
+            { typeof(DesignOnlyAttribute), attr => ((DesignOnlyAttribute)attr).IsDesignOnly == DesignOnlyAttribute.Default.IsDesignOnly },
+            { typeof(DisplayNameAttribute), attr => attr.Equals(DisplayNameAttribute.Default) },
+            { typeof(ImmutableObjectAttribute), attr => attr.Equals(ImmutableObjectAttribute.Default) },
+            { typeof(LocalizableAttribute), attr => ((LocalizableAttribute)attr).IsLocalizable == LocalizableAttribute.Default.IsLocalizable },
+            { typeof(MergablePropertyAttribute), attr => attr.Equals(MergablePropertyAttribute.Default) },
+            { typeof(NotifyParentPropertyAttribute), attr => attr.Equals(NotifyParentPropertyAttribute.Default) },
+            { typeof(ParenthesizePropertyNameAttribute), attr => attr.Equals(ParenthesizePropertyNameAttribute.Default) },
+            { typeof(ReadOnlyAttribute), attr => ((ReadOnlyAttribute)attr).IsReadOnly == ReadOnlyAttribute.Default.IsReadOnly },
+            { typeof(RefreshPropertiesAttribute), attr => attr.Equals(RefreshPropertiesAttribute.Default) },
+            { typeof(DesignerSerializationVisibilityAttribute), attr => attr.Equals(DesignerSerializationVisibilityAttribute.Default) },
+            { typeof(ExtenderProvidedPropertyAttribute), attr => ((ExtenderProvidedPropertyAttribute)attr).ReceiverType == null },
+            { typeof(DesignerCategoryAttribute), attr => attr.Equals(DesignerCategoryAttribute.Default.Category) }
+        };
+    }
+}

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtenderProvidedPropertyAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtenderProvidedPropertyAttribute.cs
@@ -12,7 +12,7 @@ namespace System.ComponentModel
     ///    </para>
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]
-    public sealed class ExtenderProvidedPropertyAttribute : Attribute, IIsDefaultAttribute
+    public sealed class ExtenderProvidedPropertyAttribute : Attribute
     {
         private PropertyDescriptor _extenderProperty;
         private IExtenderProvider _provider;
@@ -85,14 +85,6 @@ namespace System.ComponentModel
         public override int GetHashCode()
         {
             return base.GetHashCode();
-        }
-
-        /// <internalonly/>
-        /// <summary>
-        /// </summary>
-        bool IIsDefaultAttribute.IsDefaultAttribute()
-        {
-            return _receiverType == null;
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ProvidePropertyAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ProvidePropertyAttribute.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel
     ///       properties.</para>
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public sealed class ProvidePropertyAttribute : Attribute, ITypeId
+    public sealed class ProvidePropertyAttribute : Attribute
     {
         private readonly string _propertyName;
         private readonly string _receiverTypeName;
@@ -55,17 +55,6 @@ namespace System.ComponentModel
             get
             {
                 return _receiverTypeName;
-            }
-        }
-
-        /// <summary>
-        ///    <para>ProvidePropertyAttribute implements this to include the type name and the property name</para>
-        /// </summary>
-        object ITypeId.TypeId
-        {
-            get
-            {
-                return GetType().FullName + _propertyName;
             }
         }
 

--- a/src/System.ComponentModel.TypeConverter/src/project.json
+++ b/src/System.ComponentModel.TypeConverter/src/project.json
@@ -6,6 +6,7 @@
         "System.Collections.NonGeneric": "4.0.0",
         "System.Collections.Specialized": "4.0.0",
         "System.ComponentModel": "4.0.0",
+        "System.ComponentModel.Primitives": "4.1.0-rc3-24117-00",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
@@ -27,7 +28,7 @@
       "dependencies": {
         "System.Collections": "4.0.0",
         "System.ComponentModel": "4.0.0",
-        "System.ComponentModel.Primitives": "4.0.0",
+        "System.ComponentModel.Primitives": "4.1.0-rc3-24117-00",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.0",
         "System.Diagnostics.Tools": "4.0.0",

--- a/src/System.ComponentModel.TypeConverter/tests/AttributeCollectionTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/AttributeCollectionTests.cs
@@ -122,7 +122,6 @@ namespace System.ComponentModel.Tests
         [Theory]
         [InlineData(typeof(TestAttribute1), true)]
         [InlineData(typeof(TestAttribute2), false)]
-        [InlineData(typeof(TestAttributeWithDefaultMethodTrue), true)] // Types that are default are created and returned
         public void ItemIndexByType(Type type, bool isInCollection)
         {
             var attributes = new Attribute[]
@@ -144,7 +143,8 @@ namespace System.ComponentModel.Tests
         {
             var collection = new AttributeCollection();
 
-            Assert.Same(TestAttributeWithDefaultFieldAndDefaultAttributeMethodTrue.Default, collection[typeof(TestAttributeWithDefaultFieldAndDefaultAttributeMethodTrue)]);
+            // ReadOnlyAttribute is used as an example of an attribute that has a default value
+            Assert.Same(ReadOnlyAttribute.No, collection[typeof(ReadOnlyAttribute)]);
         }
 
         [Fact]
@@ -185,9 +185,6 @@ namespace System.ComponentModel.Tests
 
                 // This attribute is not available, so we expect a null to be returned
                 Assert.Null(collection[typeof(TestAttribute6)]);
-
-                // Attributes that are marked as the 'Default' will always be returned
-                Assert.NotNull(collection[typeof(TestAttributeWithDefaultMethodTrue)]);
             }
         }
 
@@ -262,24 +259,6 @@ namespace System.ComponentModel.Tests
         private class TestAttribute5a : Attribute { }
         private class TestAttribute5b : TestAttribute5a { }
         private class TestAttribute6 : Attribute { }
-
-        private class TestAttributeWithDefaultMethodTrue : Attribute, IIsDefaultAttribute
-        {
-            bool IIsDefaultAttribute.IsDefaultAttribute()
-            {
-                return true;
-            }
-        }
-
-        private class TestAttributeWithDefaultFieldAndDefaultAttributeMethodTrue : Attribute, IIsDefaultAttribute
-        {
-            public static readonly TestAttributeWithDefaultFieldAndDefaultAttributeMethodTrue Default = new TestAttributeWithDefaultFieldAndDefaultAttributeMethodTrue();
-
-            bool IIsDefaultAttribute.IsDefaultAttribute()
-            {
-                return true;
-            }
-        }
 
         private class TestAttributeWithDefaultFieldButNotDefault : Attribute
         {

--- a/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -75,9 +75,6 @@
     <ProjectReference Include="..\src\System.ComponentModel.TypeConverter.csproj">
       <Name>System.ComponentModel.TypeConverter</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\System.ComponentModel.Primitives\src\System.ComponentModel.Primitives.csproj">
-      <Name>System.ComponentModel.TypeConverter.Primitives</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.ComponentModel.TypeConverter/tests/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0033",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24117-00",
-    "System.ComponentModel": "4.0.1-rc3-24117-00",
+    "System.ComponentModel.Primitives": "4.1.0-rc3-24117-00",
     "System.Globalization": "4.0.11-rc3-24117-00",
     "System.Linq.Expressions": "4.1.0-rc3-24117-00",
     "System.ObjectModel": "4.0.12-rc3-24117-00",


### PR DESCRIPTION
System.ComponentModel.TypeDescriptor expects certain attributes(defined
in System.ComponentModel.Primitives) to override IsDesfaultAttribute and
TypeId from System.Attribute. This is not available on .NET Core, so an
interface had been supplied for it instead. This design required the
projects to depend on each other rather than the ref assemblies, so this
removes that dependency by creating a lookup table that should cover
the majority of the cases.

Fixes #8050 