### PR TITLE
Fix serialization issue for type with XmlNode[] property

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2885,3 +2885,10 @@ public class RecursiveCollection3 : List<RecursiveCollection>
 {
 
 }
+
+[XmlRoot()]
+public class TypeWithXmlNodeArrayProperty
+{
+    [XmlText]
+    public XmlNode[] CDATA { get; set; }
+}

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -2352,7 +2352,32 @@ namespace System.Xml.Serialization
                 switch (special.TypeDesc.Kind)
                 {
                     case TypeKind.Node:
-                        if (special.TypeDesc.Kind == TypeKind.Node) throw Globals.NotSupported("SL");
+                        MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
+                            "get_Reader",
+                            CodeGenerator.InstanceBindingFlags,
+                            Array.Empty<Type>()
+                            );
+                        MethodInfo XmlReader_ReadString = typeof(XmlReader).GetMethod(
+                            "ReadContentAsString",
+                            CodeGenerator.InstanceBindingFlags,
+                            Array.Empty<Type>()
+                            );
+                        MethodInfo XmlSerializationReader_get_Document = typeof(XmlSerializationReader).GetMethod(
+                            "get_Document",
+                            CodeGenerator.InstanceBindingFlags,
+                            Array.Empty<Type>()
+                            );
+                        MethodInfo XmlDocument_CreateTextNode = typeof(XmlDocument).GetMethod(
+                            "CreateTextNode",
+                            CodeGenerator.InstanceBindingFlags,
+                            new Type[] { typeof(String) }
+                            );
+                        ilg.Ldarg(0);
+                        ilg.Call(XmlSerializationReader_get_Document);
+                        ilg.Ldarg(0);
+                        ilg.Call(XmlSerializationReader_get_Reader);
+                        ilg.Call(XmlReader_ReadString);
+                        ilg.Call(XmlDocument_CreateTextNode);
                         break;
                     default:
                         throw new InvalidOperationException(SR.XmlInternalError);

--- a/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
+++ b/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
@@ -1777,6 +1777,18 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         Assert.Throws<ArgumentException>(() => { attrs.XmlAnyElements.Remove(item2); });
     }
 
+    [Fact]
+    public static void Xml_ArrayOfXmlNodeProperty()
+    {
+        var obj = new TypeWithXmlNodeArrayProperty()
+        {
+            CDATA = new[] { new XmlDocument().CreateCDataSection("test&test") }
+        };
+        var deserializedObj = SerializeAndDeserialize<TypeWithXmlNodeArrayProperty>(obj, @"<TypeWithXmlNodeArrayProperty xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema""><![CDATA[test&test]]></TypeWithXmlNodeArrayProperty>");
+        Assert.Equal(obj.CDATA.Length, deserializedObj.CDATA.Length);
+        Assert.Equal(obj.CDATA[0].InnerText, deserializedObj.CDATA[0].InnerText);
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, Func<XmlSerializer> serializerFactory = null,
         bool skipStringCompare = false, XmlSerializerNamespaces xns = null)
     {


### PR DESCRIPTION
XmlSerializer fails to serialize type with XmlNode[] property due to the implementation is not complete yet. This change ports the code path from Desktop to enable the scenario.

cc: @shmao @SGuyGe @zhenlan 