### PR TITLE
Skip failing System.ComponentModel.TypeConverter test

### DIFF
--- a/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
@@ -10,6 +10,7 @@ namespace System.ComponentModel.Tests
     public class MemberDescriptorTests
     {
         [Fact]
+        [ActiveIssue(8606, PlatformID.AnyUnix)]
         public void CopiedMemberDescriptorEqualsItsSource()
         {
             var attributes = new Attribute[]


### PR DESCRIPTION
This works around #8606 to unblock CI, pending a permanent fix.