### PR TITLE
Fix hang in OSX NetworkAddressChange implementation

### DIFF
--- a/src/Common/src/Interop/OSX/Interop.RunLoop.cs
+++ b/src/Common/src/Interop/OSX/Interop.RunLoop.cs
@@ -61,5 +61,16 @@ internal static partial class Interop
         /// <param name="rl">The run loop mode of rl from which to remove source.</param>
         [DllImport(Interop.Libraries.CoreFoundationLibrary)]
         internal static extern void CFRunLoopRemoveSource(CFRunLoopRef rl, CFRunLoopSourceRef source, CFStringRef mode);
+        
+        /// <summary>
+        /// Returns a bool that indicates whether the run loop is waiting for an event.
+        /// </summary>
+        /// <param name="rl">The run loop to examine.</param>
+        /// <returns>true if rl has no events to process and is blocking,
+        /// waiting for a source or timer to become ready to fire;
+        /// false if rl either is not running or is currently processing
+        /// a source, timer, or observer.</returns>
+        [DllImport(Interop.Libraries.CoreFoundationLibrary)]
+        internal static extern bool CFRunLoopIsWaiting(CFRunLoopRef rl);
     }
 }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
@@ -172,6 +172,9 @@ namespace System.Net.NetworkInformation
             Debug.Assert(s_runLoopSource != null);
             Debug.Assert(s_dynamicStoreRef != null);
 
+            // Allow RunLoop to finish current processing.
+            while (!Interop.RunLoop.CFRunLoopIsWaiting(s_runLoop)) { }
+
             Interop.RunLoop.CFRunLoopStop(s_runLoop);
             s_runLoopEndedEvent.WaitOne();
         }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
@@ -173,7 +173,7 @@ namespace System.Net.NetworkInformation
             Debug.Assert(s_dynamicStoreRef != null);
 
             // Allow RunLoop to finish current processing.
-            while (!Interop.RunLoop.CFRunLoopIsWaiting(s_runLoop)) { }
+            SpinWait.SpinUntil(() => Interop.RunLoop.CFRunLoopIsWaiting(s_runLoop));
 
             Interop.RunLoop.CFRunLoopStop(s_runLoop);
             s_runLoopEndedEvent.WaitOne();

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkChangeTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkChangeTest.cs
@@ -9,7 +9,6 @@ namespace System.Net.NetworkInformation.Tests
     public class NetworkChangeTest
     {
         [Fact]
-        [ActiveIssue(8066, PlatformID.OSX)]
         public void NetworkAddressChanged_AddRemove_Success()
         {
             NetworkAddressChangedEventHandler handler = NetworkChange_NetworkAddressChanged;


### PR DESCRIPTION
Fixes #8066 

If the NetworkAddressChanged event is quickly subscribed and unsubscribed, there is a chance we experience a deadlock in the threaded CFRunLoop implementation. It seems that if CFRunLoopStop is called too quickly after CFRunLoopStart is called, we may end up successfully calling CFRunLoopStop without actually terminating the CFRunLoopRun call which has, or is just about to, start. To work around this, I have added a call to CFRunLoopIsWaiting in order to ensure that the call to CFRunLoopRun has happened, and that thread is waiting for messages. This means that, when we finally call CFRunLoopStop, the call to CFRunLoopRun has definitely already begun and we can successfully terminate it.

This seems to be entirely a timing issue. With a debug runtime, the tests run a lot slower, and the behavior is never encountered (no hangs). With an optimized runtime, it is much more likely to occur. Without this change, around 1 in 10 test runs would hang on my test laptop. With the change, I am not seeing any hangs, and I have run the tests >1000 times in a row.