### PR TITLE
Fixing ClientCertificate functional tests for Windows 7.

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
@@ -54,11 +54,11 @@ namespace System.Net.Security.Tests
             {
                 // https://technet.microsoft.com/en-us/library/hh831771.aspx#BKMK_Changes2012R2
                 // Starting with Windows 8, the "Management of trusted issuers for client authentication" has changed:
-                // The behavior to send the Trusted Issuer List by default is off.
+                // The behavior to send the Trusted Issuers List by default is off.
                 //
-                // In Windows 7 the DN list is sent within the Server Hello. If the client selection callback isn't 
-                // used and the client certificate's issuer is not in the server's Trusted Root Authorities the client,
-                // not send the certificate.
+                // In Windows 7 the Trusted Issuers List is sent within the Server Hello TLS record. This list is built
+                // by the server using certificates from the Trusted Root Authorities certificate store.
+                // The client side will use the Trusted Issuers List, if not empty, to filter proposed certificates.
                 _clientCertificateRemovedByFilter = true;
             }
 
@@ -126,6 +126,13 @@ namespace System.Net.Security.Tests
                         Assert.True(sslServerStream.IsMutuallyAuthenticated, "sslServerStream.IsMutuallyAuthenticated");
 
                         Assert.Equal(sslServerStream.RemoteCertificate.Subject, _clientCertificate.Subject);
+                    }
+                    else
+                    {
+                        Assert.False(sslClientStream.IsMutuallyAuthenticated, "sslClientStream.IsMutuallyAuthenticated");
+                        Assert.False(sslServerStream.IsMutuallyAuthenticated, "sslServerStream.IsMutuallyAuthenticated");
+
+                        Assert.Null(sslServerStream.RemoteCertificate);
                     }
 
                     Assert.Equal(sslClientStream.RemoteCertificate.Subject, _serverCertificate.Subject);

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
@@ -14,7 +14,6 @@
   <PropertyGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  
   <PropertyGroup Condition=" '$(TargetsWindows)' == 'true' and '$(ProjectJson)' == '' ">
     <ProjectJson>win/project.json</ProjectJson>
     <ProjectLockJson>win/project.lock.json</ProjectLockJson>
@@ -33,6 +32,7 @@
   <ItemGroup>
     <Compile Include="DummyTcpServer.cs" />
     <Compile Include="TestConfiguration.cs" />
+  
     <!-- SslStream Tests -->
     <Compile Include="CertificateChainValidation.cs" />
     <Compile Include="CertificateValidationClientServer.cs" />
@@ -48,12 +48,15 @@
     <Compile Include="SslStreamNetworkStreamTest.cs" />
     <Compile Include="StreamAPMExtensions.cs" />
     <Compile Include="TransportContextTest.cs" />
+    
     <!-- NegotiateStream Tests -->
     <Compile Include="NegotiateStreamStreamToStreamTest.cs" />
-
     <Compile Include="ServiceNameCollectionTest.cs" />
 
     <!-- Common test files -->
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\CertificateConfiguration.cs">
       <Link>Common\System\Net\CertificateConfiguration.cs</Link>
     </Compile>
@@ -87,7 +90,6 @@
     <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
-
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <Compile Include="IdentityValidator.Windows.cs" />
@@ -95,7 +97,6 @@
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="IdentityValidator.Unix.cs" />
   </ItemGroup>
-  
   <ItemGroup Condition=" '$(TargetsLinux)' == 'true' ">
     <None Include="..\Scripts\setup-kdc.sh">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -125,23 +126,20 @@
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\GssSafeHandles.cs">
-       <Link>Common\Microsoft\Win32\SafeHandles\GssSafeHandles.cs</Link>
+      <Link>Common\Microsoft\Win32\SafeHandles\GssSafeHandles.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs</Link>
     </Compile>
   </ItemGroup>
-  
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\System.Net.Security.csproj">
-      <Project>{89F37791-6254-4D60-AB96-ACD3CCA0E771}</Project>
-      <Name>System.Net.Security</Name>
-      <!-- tests build as linux/osx but product binary is unix -->
-      <OSGroup Condition="'$(TargetsUnix)' == 'true'">Unix</OSGroup>
-    </ProjectReference>
-  </ItemGroup>
   <ItemGroup>
     <SupplementalTestData Include="$(PackagesDir)System.Net.TestData\1.0.0-prerelease\content\**\*.*" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Net.Security.csproj">
+      <Project>{89f37791-6254-4d60-ab96-acd3cca0e771}</Project>
+      <Name>System.Net.Security</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.Security/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/win/project.json
@@ -4,6 +4,7 @@
     "System.Collections.Concurrent": "4.0.12-rc3-24117-00",
     "System.Diagnostics.Process": "4.1.0-rc3-24117-00",
     "System.Diagnostics.Tracing": "4.1.0-rc3-24117-00",
+    "System.IO.FileSystem": "4.0.1-rc3-24117-00",
     "System.Linq.Expressions": "4.1.0-rc3-24117-00",
     "System.Net.Primitives": "4.0.11-rc3-24117-00",
     "System.Net.Sockets": "4.1.0-rc3-24117-00",


### PR DESCRIPTION
Starting with Windows 8, Schannel is not sending the Distinguished Name within the Server Hello record. This list was based on certificates present in the Trusted Root Authorities in Win7 and below: https://technet.microsoft.com/en-us/library/hh831771.aspx#BKMK_Changes2012R2

Adding OS and TRA certificate detection to the test. 
In order to run all aspects of this test on a Win7 machine, we need the client certificate issuer installed on the test machine in TRA. With this fix, the test will skip validating all aspects on machines without the issuer installed in TRA.

Fixing the csproj to be able to build, test and debug from VS.

@Priya91 @davidsh PTAL
/cc @stephentoub @bartonjs 

Fixes #8437 