### PR TITLE
Changing the version of System.Data.Common to 4.1.0

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/baseline.packages.props
+++ b/pkg/Microsoft.Private.PackageBaseline/baseline.packages.props
@@ -59,7 +59,7 @@
       <Version>4.0.0</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="System.Data.Common">
-      <Version>4.0.1</Version>
+      <Version>4.1.0</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="System.Data.SqlClient">
       <Version>4.1.0</Version>

--- a/src/System.Data.Common/ref/System.Data.Common.csproj
+++ b/src/System.Data.Common/ref/System.Data.Common.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <NuGetTargetMoniker>.NETStandard,Version=v1.0</NuGetTargetMoniker>
   </PropertyGroup>

--- a/src/System.Data.Common/src/System.Data.Common.csproj
+++ b/src/System.Data.Common/src/System.Data.Common.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{29EF8D53-8E84-4E49-B90F-5950A2FE7D54}</ProjectGuid>
     <AssemblyName>System.Data.Common</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.0</NuGetTargetMoniker>


### PR DESCRIPTION
The minor version change is due to the difference in surface area from version 4.0

Based on the convention, the surface area change should lead to version number change. 
The change in version is from .Net 4.0 to .Net 4.1
