### PR TITLE
Change FileStream useAsync default back to false

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStream.cs
@@ -12,7 +12,7 @@ namespace System.IO
     {
         internal const int DefaultBufferSize = 4096;
         private const FileShare DefaultShare = FileShare.Read;
-        private const bool DefaultUseAsync = true;
+        private const bool DefaultUseAsync = false;
         private const bool DefaultIsAsync = false;
 
         private FileStreamBase _innerStream;

--- a/src/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
@@ -59,12 +59,14 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
-        public async Task ThrowWhenHandlePositionIsChanged()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ThrowWhenHandlePositionIsChanged(bool useAsync)
         {
             string fileName = GetTestFilePath();
 
-            using (FileStream fs = new FileStream(fileName, FileMode.Create))
+            using (FileStream fs = new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, 0x100, useAsync))
             {
                 // write some data to move the position, flush to ensure OS position is updated
                 fs.Write(TestBuffer, 0, TestBuffer.Length);
@@ -76,7 +78,7 @@ namespace System.IO.Tests
                     return;
                 }
 
-                using (FileStream fsr = new FileStream(fs.SafeFileHandle, FileAccess.Read, TestBuffer.Length))
+                using (FileStream fsr = new FileStream(fs.SafeFileHandle, FileAccess.Read, TestBuffer.Length, useAsync))
                 {
                     Assert.Equal(TestBuffer.Length, fs.Position);
                     Assert.Equal(TestBuffer.Length, fsr.Position);
@@ -94,7 +96,7 @@ namespace System.IO.Tests
 
                     fs.WriteByte(0);
                     fsr.Position++;
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // Async I/O behaviors differ due to kernel-based implementation on Windows
+                    if (useAsync && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // Async I/O behaviors differ due to kernel-based implementation on Windows
                     {
                         Assert.Throws<IOException>(() => FSAssert.CompletesSynchronously(fs.ReadAsync(new byte[1], 0, 1)));
                     }

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_sfh_fa_buffer_async.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_sfh_fa_buffer_async.cs
@@ -13,8 +13,7 @@ namespace System.IO.Tests
     {
         protected sealed override FileStream CreateFileStream(SafeFileHandle handle, FileAccess access, int bufferSize)
         {
-            // default for isAsync is platform specific, we need a better way to determine this
-            return CreateFileStream(handle, access, bufferSize, true);
+            return CreateFileStream(handle, access, bufferSize, false);
         }
 
         protected virtual FileStream CreateFileStream(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)


### PR DESCRIPTION
FileStream's ctors allow the creator of the stream to specify whether asynchronous I/O should be used.  The default in the full framework is false.  When FileStream was ported to corefx, the default was changed to true.

Such a default of true can be beneficial, as it means that ReadAsync/WriteAsync calls on streams created without overriding that default will naturally use overlapped I/O on Windows, which can lead to better scalability and performance.  However, there are other ramifications, in particular for existing code and code written to be portable across .NET implementations.  For example:
- Using Read/Write on a stream created with useAsync=true ends up blocking as calls around Read/WriteAsync, making them more expensive than they'd otherwise be.  So existing code that uses a FileStream for simple read/writes may actually get slower.
- The SafeFileHandle exposed from the FileStream naturally is associated with that particular async setting, such that attempting to use it to construct a FileStream with a conflicting setting will fail with an exception.
- FileStreams constructed with useAsync=true have special behaviors around how the position of the stream is updated after an async operation is initiated, which means code written expecting one default may fail when run with a different default.
- Etc.

While there are benefits to changing the default, the cons outweigh the pros.  A developer can always opt-in to useAsync=true, but it's better to keep the default consistent across all implementations, especially for code written to be portable across those implementations.  This commit changes it back to be false.

cc: @ericstj, @ianhays, @jkotas, @ayende
https://github.com/dotnet/corefx/issues/5159