### PR TITLE
Skip failing S.CM.TypeConverter test

### DIFF
--- a/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
@@ -10,7 +10,7 @@ namespace System.ComponentModel.Tests
     public class MemberDescriptorTests
     {
         [Fact]
-        [ActiveIssue(8606, PlatformID.AnyUnix)]
+        [ActiveIssue(8606, PlatformID.Any)]
         public void CopiedMemberDescriptorEqualsItsSource()
         {
             var attributes = new Attribute[]


### PR DESCRIPTION
#8606 can also affect Windows builds, so with this change the test is skipped on all platforms.

@stephentoub 