### PR TITLE
Cleanup Average tests in System.Linq

### DIFF
--- a/src/System.Linq/tests/AverageTests.cs
+++ b/src/System.Linq/tests/AverageTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -29,17 +28,27 @@ namespace System.Linq.Tests
             Assert.Equal(q.Average(), q.Average());
         }
 
-        [Fact]
-        public void EmptyNullableFloatSource()
+        public static IEnumerable<object[]> Average_NullableFloat_TestData()
         {
-            float?[] source = { };
-            float? expected = null;
+            yield return new object[] { new float?[0], null };
+            yield return new object[] { new float?[] { float.MinValue }, float.MinValue };
+            yield return new object[] { new float?[] { 0f, 0f, 0f, 0f, 0f }, 0f };
 
+            yield return new object[] { new float?[] { 5.5f, 0, null, null, null, 15.5f, 40.5f, null, null, -23.5f }, 7.6f };
+
+            yield return new object[] { new float?[] { null, null, null, null, 45f }, 45f };
+            yield return new object[] { new float?[] { null, null, null, null, null }, null };
+        }
+
+        [Theory]
+        [MemberData(nameof(Average_NullableFloat_TestData))]
+        public void Average_NullableFoat(float?[] source, float? expected)
+        {
             Assert.Equal(expected, source.Average());
         }
 
         [Fact]
-        public void EmptyNullableFloatSourceWithSelector()
+        public void Average_NullableFloat_EmptySourceWithSelector()
         {
             float?[] source = { };
             float? expected = null;
@@ -48,71 +57,21 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void NullNFloatSource()
+        public void Average_NullableFloat_NullSource_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<float?>)null).Average());
-        }
-
-        [Fact]
-        public void NullNFloatSourceWithFunc()
-        {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<float?>)null).Average(i => i));
         }
 
         [Fact]
-        public void NullNFloatFunc()
+        public void Average_NullableFloat_NullSelector_ThrowsArgumentNullException()
         {
             Func<float?, float?> selector = null;
             Assert.Throws<ArgumentNullException>("selector", () => Enumerable.Empty<float?>().Average(selector));
         }
 
         [Fact]
-        public void SingleNullableFloatSource()
-        {
-            float?[] source = { float.MinValue };
-            float? expected = float.MinValue;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableFloatAllZeroSource()
-        {
-            float?[] source = { 0f, 0f, 0f, 0f, 0f };
-            float? expected = 0f;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableFloatSource()
-        {
-            float?[] source = { 5.5f, 0, null, null, null, 15.5f, 40.5f, null, null, -23.5f };
-            float? expected = 7.6f;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableFloatSourceOnlyOneNotNull()
-        {
-            float?[] source = { null, null, null, null, 45f };
-            float? expected = 45f;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableFloatSourceAllNull()
-        {
-            float?[] source = { null, null, null, null, null };
-            float? expected = null;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableFloatSourceAllNullWithSelector()
+        public void Average_NullableFloat_AllNullWithSelector()
         {
             float?[] source = { null, null, null, null, null };
             float? expected = null;
@@ -121,7 +80,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void NullableFloatFromSelector()
+        public void Average_NullableFloat_WithSelector()
         {
             var source = new []
             {
@@ -135,69 +94,44 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void EmptyIntSource()
+        public void Average_Int_EmptySource_ThrowsInvalidOperationException()
         {
-            int[] source = { };
+            int[] source = new int[0];
             
             Assert.Throws<InvalidOperationException>(() => source.Average());
-        }
-
-        [Fact]
-        public void EmptyIntSourceWithSelector()
-        {
-            int[] source = { };
-
             Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
         }
 
         [Fact]
-        public void NullIntSource()
+        public void Average_Int_NullSource_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<int>)null).Average());
-        }
-
-        [Fact]
-        public void NullIntSourceWithFunc()
-        {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<int>)null).Average(i => i));
         }
 
         [Fact]
-        public void NullIntFunc()
+        public void Average_Int_NullSelector_ThrowsArgumentNullException()
         {
             Func<int, int> selector = null;
             Assert.Throws<ArgumentNullException>("selector", () => Enumerable.Empty<int>().Average(selector));
         }
 
-        [Fact]
-        public void SingleElementIntSource()
+        public static IEnumerable<object[]> Average_Int_TestData()
         {
-            int[] source = { 5 };
-            double expected = 5;
+            yield return new object[] { new int[] { 5 }, 5 };
+            yield return new object[] { new int[] { 0, 0, 0, 0, 0 }, 0 };
+            yield return new object[] { new int[] { 5, -10, 15, 40, 28 }, 15.6 };
+        }
 
+        [Theory]
+        [MemberData(nameof(Average_Int_TestData))]
+        public void Average_Int(int[] source, double expected)
+        {
             Assert.Equal(expected, source.Average());
         }
 
         [Fact]
-        public void MultipleIntValuesAllZero()
-        {
-            int[] source = { 0, 0, 0, 0, 0 };
-            double expected = 0;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleIntSouce()
-        {
-            int[] source = { 5, -10, 15, 40, 28 };
-            double expected = 15.6;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleIntFromSelector()
+        public void Average_Int_WithSelector()
         {
             var source = new []
             {
@@ -210,17 +144,25 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.Average(e => e.num));
         }
 
-        [Fact]
-        public void EmptyNullableIntSource()
+        public static IEnumerable<object[]> Average_NullableInt_TestData()
         {
-            int?[] source = { };
-            double? expected = null;
+            yield return new object[] { new int?[0], null };
+            yield return new object[] { new int?[] { -5 }, -5.0 };
+            yield return new object[] { new int?[] { 0, 0, 0, 0, 0 }, 0.0 };
+            yield return new object[] { new int?[] { 5, -10, null, null, null, 15, 40, 28, null, null }, 15.6 };
+            yield return new object[] { new int?[] { null, null, null, null, 50 }, 50.0 };
+            yield return new object[] { new int?[] { null, null, null, null, null }, null };
+        }
 
+        [Theory]
+        [MemberData(nameof(Average_NullableInt_TestData))]
+        public void Average_NullableInt(int?[] source, double? expected)
+        {
             Assert.Equal(expected, source.Average());
         }
 
         [Fact]
-        public void EmptyNullableIntSourceWithSelector()
+        public void Average_NullableInt_EmptySourceWithSelector()
         {
             int?[] source = { };
             double? expected = null;
@@ -229,71 +171,21 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void NullNIntSource()
+        public void Average_NullableInt_NullSource_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<int?>)null).Average());
-        }
-
-        [Fact]
-        public void NullNIntSourceWithFunc()
-        {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<int?>)null).Average(i => i));
         }
 
         [Fact]
-        public void NullNIntFunc()
+        public void Average_NullableInt_NullSelector_ThrowsArgumentNullException()
         {
             Func<int?, int?> selector = null;
             Assert.Throws<ArgumentNullException>("selector", () => Enumerable.Empty<int?>().Average(selector));
         }
 
         [Fact]
-        public void SingleNullableIntSource()
-        {
-            int?[] source = { -5 };
-            double? expected = -5;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableIntAllZeroSource()
-        {
-            int?[] source = { 0, 0, 0, 0, 0 };
-            double? expected = 0;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableIntSource()
-        {
-            int?[] source = { 5, -10, null, null, null, 15, 40, 28, null, null };
-            double? expected = 15.6;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableIntSourceOnlyOneNotNull()
-        {
-            int?[] source = { null, null, null, null, 50 };
-            double? expected = 50;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableIntSourceAllNull()
-        {
-            int?[] source = { null, null, null, null, null };
-            double? expected = null;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableIntSourceAllNullWithSelector()
+        public void Average_NullableInt_AllNullWithSelector()
         {
             int?[] source = { null, null, null, null, null };
             double? expected = null;
@@ -302,7 +194,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void NullableIntFromSelector()
+        public void Average_NullableInt_WithSelector()
         {
             var source = new []
             {
@@ -316,69 +208,44 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void EmptyLongSource()
+        public void Average_Long_EmptySource_ThrowsInvalidOperationException()
         {
-            long[] source = { };
+            long[] source = new long[0];
 
             Assert.Throws<InvalidOperationException>(() => source.Average());
-        }
-
-        [Fact]
-        public void EmptyLongSourceWithSelector()
-        {
-            long[] source = { };
-
             Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
         }
 
         [Fact]
-        public void NullLongSource()
+        public void Average_Long_NullSource_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<long>)null).Average());
-        }
-
-        [Fact]
-        public void NullLongSourceWithFunc()
-        {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<long>)null).Average(i => i));
         }
 
         [Fact]
-        public void NullLongFunc()
+        public void Average_Long_NullSelector_ThrowsArgumentNullException()
         {
             Func<long, long> selector = null;
             Assert.Throws<ArgumentNullException>("selector", () => Enumerable.Empty<long>().Average(selector));
         }
 
-        [Fact]
-        public void SingleElementLongSource()
+        public static IEnumerable<object[]> Average_Long_TestData()
         {
-            long[] source = { Int64.MaxValue };
-            double expected = Int64.MaxValue;
-
+            yield return new object[] { new long[] { long.MaxValue }, long.MaxValue };
+            yield return new object[] { new long[] { 0, 0, 0, 0, 0 }, 0 };
+            yield return new object[] { new long[] { 5, -10, 15, 40, 28 }, 15.6 };
+        }
+        
+        [Theory]
+        [MemberData(nameof(Average_Long_TestData))]
+        public void Average_Long(long[] source, double expected)
+        {
             Assert.Equal(expected, source.Average());
         }
 
         [Fact]
-        public void MultipleLongValuesAllZero()
-        {
-            long[] source = { 0, 0, 0, 0, 0 };
-            double expected = 0;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleLongValues()
-        {
-            long[] source = { 5, -10, 15, 40, 28 };
-            double expected = 15.6;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleLongFromSelector()
+        public void Average_Long_FromSelector()
         {
             var source = new []
             {
@@ -392,24 +259,32 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void OverflowFromSummingLong()
+        public void Average_Long_SumTooLarge_ThrowsOverflowException()
         {
-            long[] source = { Int64.MaxValue, Int64.MaxValue };
+            long[] source = new long[] { long.MaxValue, long.MaxValue };
 
             Assert.Throws<OverflowException>(() => source.Average());
         }
 
-        [Fact]
-        public void EmptyNullableLongSource()
+        public static IEnumerable<object[]> Average_NullableLong_TestData()
         {
-            long?[] source = { };
-            double? expected = null;
+            yield return new object[] { new long?[0], null };
+            yield return new object[] { new long?[] { long.MaxValue }, (double)long.MaxValue };
+            yield return new object[] { new long?[] { 0, 0, 0, 0, 0 }, 0.0 };
+            yield return new object[] { new long?[] { 5, -10, null, null, null, 15, 40, 28, null, null }, 15.6 };
+            yield return new object[] { new long?[] { null, null, null, null, 50 }, 50.0 };
+            yield return new object[] { new long?[] { null, null, null, null, null }, null };
+        }
 
+        [Theory]
+        [MemberData(nameof(Average_NullableLong_TestData))]
+        public void Average_NullableLong(long?[] source, double? expected)
+        {
             Assert.Equal(expected, source.Average());
         }
 
         [Fact]
-        public void EmptyNullableLongSourceWithSelector()
+        public void Average_NullableLong_EmptySourceWithSelector()
         {
             long?[] source = { };
             double? expected = null;
@@ -418,71 +293,21 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void NullNLongSource()
+        public void Average_NullableLong_NullSource_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<long?>)null).Average());
-        }
-
-        [Fact]
-        public void NullNLongSourceWithFunc()
-        {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<long?>)null).Average(i => i));
         }
 
         [Fact]
-        public void NullNLongFunc()
+        public void Average_NullableLong_NullSelector_ThrowsArgumentNullException()
         {
             Func<long?, long?> selector = null;
             Assert.Throws<ArgumentNullException>("selector", () => Enumerable.Empty<long?>().Average(selector));
         }
 
         [Fact]
-        public void SingleNullableLongSource()
-        {
-            long?[] source = { Int64.MinValue };
-            double? expected = Int64.MinValue;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableLongAllZeroSource()
-        {
-            long?[] source = { 0, 0, 0, 0, 0 };
-            double? expected = 0;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableLongSource()
-        {
-            long?[] source = { 5, -10, null, null, null, 15, 40, 28, null, null };
-            double? expected = 15.6;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableLongSourceOnlyOneNotNull()
-        {
-            long?[] source = { null, null, null, null, 50 };
-            double? expected = 50;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableLongSourceAllNull()
-        {
-            long?[] source = { null, null, null, null, null };
-            double? expected = null;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableLongSourceAllNullWithSelector()
+        public void Average_NullableLong_AllNullWithSelector()
         {
             long?[] source = { null, null, null, null, null };
             double? expected = null;
@@ -491,7 +316,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void NullableLongFromSelector()
+        public void Average_NullableLong_WithSelector()
         {
             var source = new []
             {
@@ -505,78 +330,45 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void EmptyDoubleSource()
+        public void Average_Double_EmptySource_ThrowsInvalidOperationException()
         {
-            double[] source = { };
+            double[] source = new double[0];
 
             Assert.Throws<InvalidOperationException>(() => source.Average());
-        }
-
-        [Fact]
-        public void EmptyDoubleSourceWithSelector()
-        {
-            double[] source = { };
-
             Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
         }
 
         [Fact]
-        public void NullDoubleSource()
+        public void Average_Double_NullSource_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<double>)null).Average());
-        }
-
-        [Fact]
-        public void NullDoubleSourceWithFunc()
-        {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<double>)null).Average(i => i));
         }
 
         [Fact]
-        public void NullDoubleFunc()
+        public void Average_Double_NullSelector_ThrowsArgumentNullException()
         {
             Func<double, double> selector = null;
             Assert.Throws<ArgumentNullException>("selector", () => Enumerable.Empty<double>().Average(selector));
         }
 
-        [Fact]
-        public void SingleElementDoubleSource()
+        public static IEnumerable<object[]> Average_Double_TestData()
         {
-            double[] source = { Double.MaxValue };
-            double expected = Double.MaxValue;
+            yield return new object[] { new double[] { double.MaxValue }, double.MaxValue };
+            yield return new object[] { new double[] { 0.0, 0.0, 0.0, 0.0, 0.0 }, 0 };
+            yield return new object[] { new double[] { 5.5, -10, 15.5, 40.5, 28.5 }, 16 };
+            yield return new object[] { new double[] { 5.58, Double.NaN, 30, 4.55, 19.38 }, double.NaN };
+        }
 
+        [Theory]
+        [MemberData(nameof(Average_Double_TestData))]
+        public void Average_Double(double[] source, double expected)
+        {
             Assert.Equal(expected, source.Average());
         }
 
         [Fact]
-        public void MultipleDoubleValuesAllZero()
-        {
-            double[] source = { 0.0, 0.0, 0.0, 0.0, 0.0 };
-            double expected = 0;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleDoubleValues()
-        {
-            double[] source = { 5.5, -10, 15.5, 40.5, 28.5 };
-            double expected = 16;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleDoubleValuesIncludingNaN()
-        {
-            double[] source = { 5.58, Double.NaN, 30, 4.55, 19.38 };
-            double expected = Double.NaN;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleDoubleFromSelector()
+        public void Average_Double_WithSelector()
         {
             var source = new []
             {
@@ -589,17 +381,24 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.Average(e => e.num));
         }
 
-        [Fact]
-        public void EmptyNullableDoubleSource()
+        public static IEnumerable<object[]> Average_NullableDouble_TestData()
         {
-            double?[] source = { };
-            double? expected = null;
+            yield return new object[] { new double?[0], null };
+            yield return new object[] { new double?[] { double.MinValue }, double.MinValue };
+            yield return new object[] { new double?[] { 0, 0, 0, 0, 0 }, 0 };
+            yield return new object[] { new double?[] { 5.5, 0, null, null, null, 15.5, 40.5, null, null, -23.5 }, 7.6 };
+            yield return new object[] { new double?[] { null, null, null, null, 45 }, 45 };
+            yield return new object[] { new double?[] { -23.5, 0, Double.NaN, 54.3, 0.56 }, double.NaN };
+            yield return new object[] { new double?[] { null, null, null, null, null }, null };
+        }
 
+        public void Average_NullableDouble(double?[] source, double? expected)
+        {
             Assert.Equal(expected, source.Average());
         }
 
         [Fact]
-        public void EmptyNullableDoubleSourceWithSelector()
+        public void Average_NullableDouble_EmptySourceWithSelector()
         {
             double?[] source = { };
             double? expected = null;
@@ -608,71 +407,21 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void NullNDoubleSource()
+        public void Average_NullableDouble_NullSource_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<double?>)null).Average());
-        }
-
-        [Fact]
-        public void NullNDoubleSourceWithFunc()
-        {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<double?>)null).Average(i => i));
         }
 
         [Fact]
-        public void NullNDoubleFunc()
+        public void Average_NullableDouble_NullSelector_ThrowsArgumentNullException()
         {
             Func<double?, double?> selector = null;
             Assert.Throws<ArgumentNullException>("selector", () => Enumerable.Empty<double?>().Average(selector));
         }
 
         [Fact]
-        public void SingleNullableDoubleSource()
-        {
-            double?[] source = { Double.MinValue };
-            double? expected = Double.MinValue;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableDoubleAllZeroSource()
-        {
-            double?[] source = { 0, 0, 0, 0, 0 };
-            double? expected = 0;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableDoubleSource()
-        {
-            double?[] source = { 5.5, 0, null, null, null, 15.5, 40.5, null, null, -23.5 };
-            double? expected = 7.6;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableDoubleSourceOnlyOneNotNull()
-        {
-            double?[] source = { null, null, null, null, 45 };
-            double? expected = 45;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableDoubleSourceAllNull()
-        {
-            double?[] source = { null, null, null, null, null };
-            double? expected = null;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableDoubleSourceAllNullWithSelector()
+        public void Average_NullableDouble_AllNullWithSelector()
         {
             double?[] source = { null, null, null, null, null };
             double? expected = null;
@@ -681,16 +430,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void MultipleNullableDoubleSourceIncludingNaN()
-        {
-            double?[] source = { -23.5, 0, Double.NaN, 54.3, 0.56 };
-            double? expected = Double.NaN;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void NullableDoubleFromSelector()
+        public void Average_NullableDouble_WithSelector()
         {
             var source = new[]
             {
@@ -704,68 +444,44 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void EmptyDecimalSource()
+        public void Average_Decimal_EmptySource_ThrowsInvalidOperationException()
         {
-            decimal[] source = { };
+            decimal[] source = new decimal[0];
 
             Assert.Throws<InvalidOperationException>(() => source.Average());
-        }
-
-        [Fact]
-        public void EmptyDecimalSourceWithSelector()
-        {
-            decimal[] source = { };
-
             Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
         }
 
         [Fact]
-        public void NullDecimalSource()
+        public void Average_Decimal_NullSource_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<decimal>)null).Average());
-        }
-
-        [Fact]
-        public void NullDecimalSourceWithFunc()
-        {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<decimal>)null).Average(i => i));
         }
 
         [Fact]
-        public void NullDecimalFunc()
+        public void Average_Decimal_NullSelector_ThrowsArgumentNullException()
         {
             Func<decimal, decimal> selector = null;
             Assert.Throws<ArgumentNullException>("selector", () => Enumerable.Empty<decimal>().Average(selector));
         }
-        [Fact]
-        public void SingleElementDecimalSource()
-        {
-            decimal[] source = { Decimal.MaxValue };
-            decimal expected = Decimal.MaxValue;
 
+        public static IEnumerable<object[]> Average_Decimal_TestData()
+        {
+            yield return new object[] { new decimal[] { decimal.MaxValue }, decimal.MaxValue };
+            yield return new object[] { new decimal[] { 0.0m, 0.0m, 0.0m, 0.0m, 0.0m }, 0 };
+            yield return new object[] { new decimal[] { 5.5m, -10m, 15.5m, 40.5m, 28.5m }, 16 };
+        }
+
+        [Theory]
+        [MemberData(nameof(Average_Decimal_TestData))]
+        public void Average_Decimal(decimal[] source, decimal expected)
+        {
             Assert.Equal(expected, source.Average());
         }
 
         [Fact]
-        public void MultipleDecimalValuesAllZero()
-        {
-            decimal[] source = { 0.0m, 0.0m, 0.0m, 0.0m, 0.0m };
-            decimal expected = 0m;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleDecimalValues()
-        {
-            decimal[] source = { 5.5m, -10m, 15.5m, 40.5m, 28.5m };
-            decimal expected = 16m;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleDecimalFromSelector()
+        public void Average_Decimal_WithSelector()
         {
             var source = new[]
             {
@@ -778,17 +494,25 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.Average(e => e.num));
         }
 
-        [Fact]
-        public void EmptyNullableDecimalSource()
+        public static IEnumerable<object[]> Average_NullableDecimal_TestData()
         {
-            decimal?[] source = { };
-            decimal? expected = null;
+            yield return new object[] { new decimal?[0], null };
+            yield return new object[] { new decimal?[] { decimal.MinValue }, decimal.MinValue };
+            yield return new object[] { new decimal?[] { 0m, 0m, 0m, 0m, 0m }, 0m };
+            yield return new object[] { new decimal?[] { 5.5m, 0, null, null, null, 15.5m, 40.5m, null, null, -23.5m }, 7.6m };
+            yield return new object[] { new decimal?[] { null, null, null, null, 45m }, 45m };
+            yield return new object[] { new decimal?[] { null, null, null, null, null }, null };
+        }
 
+        [Theory]
+        [MemberData(nameof(Average_NullableDecimal_TestData))]
+        public void Average_NullableDecimal(decimal?[] source, decimal? expected)
+        {
             Assert.Equal(expected, source.Average());
         }
 
         [Fact]
-        public void EmptyNullableDecimalSourceWithSelector()
+        public void Average_NullableDecimal_EmptySourceWithSelector()
         {
             decimal?[] source = { };
             decimal? expected = null;
@@ -797,71 +521,21 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void NullNDecimalSource()
+        public void Average_NullableDecimal_NullSource_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<decimal?>)null).Average());
-        }
-
-        [Fact]
-        public void NullNDecimalSourceWithFunc()
-        {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<decimal?>)null).Average(i => i));
         }
 
         [Fact]
-        public void NullNDecimalFunc()
+        public void Average_NullableDecimal_NullSelector_ThrowsArgumentNullException()
         {
             Func<decimal?, decimal?> selector = null;
             Assert.Throws<ArgumentNullException>("selector", () => Enumerable.Empty<decimal?>().Average(selector));
         }
 
         [Fact]
-        public void SingleNullableDecimalSource()
-        {
-            decimal?[] source = { Decimal.MinValue };
-            decimal? expected = Decimal.MinValue;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableeDecimalAllZeroSource()
-        {
-            decimal?[] source = { 0m, 0m, 0m, 0m, 0m };
-            decimal? expected = 0m;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableeDecimalSource()
-        {
-            decimal?[] source = { 5.5m, 0, null, null, null, 15.5m, 40.5m, null, null, -23.5m };
-            decimal? expected = 7.6m;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableDecimalSourceOnlyOneNotNull()
-        {
-            decimal?[] source = { null, null, null, null, 45m };
-            decimal? expected = 45m;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableDecimalSourceAllNull()
-        {
-            decimal?[] source = { null, null, null, null, null };
-            decimal? expected = null;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleNullableDecimalSourceAllNullWithSelector()
+        public void Average_NullableDecimal_AllNullWithSelector()
         {
             decimal?[] source = { null, null, null, null, null };
             decimal? expected = null;
@@ -870,7 +544,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void NullableDecimalFromSelector()
+        public void Average_NullableDecimal_WithSelector()
         {
             var source = new[]
             {
@@ -884,77 +558,52 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void OverflowFromSummingDecimal()
+        public void Average_NullableDecimal_SumTooLarge_ThrowsOverflowException()
         {
-            decimal?[] source = { decimal.MaxValue, decimal.MaxValue };
+            decimal?[] source = new decimal?[] { decimal.MaxValue, decimal.MaxValue };
 
             Assert.Throws<OverflowException>(() => source.Average());
         }
 
         [Fact]
-        public void EmptyFloatSource()
+        public void Average_Float_EmptySource_ThrowsInvalidOperationException()
         {
-            float[] source = { };
+            float[] source = new float[0];
 
             Assert.Throws<InvalidOperationException>(() => source.Average());
-        }
-
-        [Fact]
-        public void EmptyFloatSourceWithSelector()
-        {
-            float[] source = { };
-
             Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
         }
 
         [Fact]
-        public void NullFloatSource()
+        public void Average_Float_NullSource_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<float>)null).Average());
-        }
-
-        [Fact]
-        public void NullFloatSourceWithFunc()
-        {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<float>)null).Average(i => i));
         }
 
         [Fact]
-        public void NullFloatFunc()
+        public void Average_Float_NullSelector_ThrowsArgumentNullException()
         {
             Func<float, float> selector = null;
             Assert.Throws<ArgumentNullException>("selector", () => Enumerable.Empty<float>().Average(selector));
         }
 
-        [Fact]
-        public void SingleElementFloatSource()
+        public static IEnumerable<object[]> Average_Float_TestData()
         {
-            float[] source = { float.MaxValue };
-            float expected = float.MaxValue;
+            yield return new object[] { new float[] { float.MaxValue }, float.MaxValue };
+            yield return new object[] { new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, 0f };
+            yield return new object[] { new float[] { 5.5f, -10f, 15.5f, 40.5f, 28.5f }, 16f };
+        }
 
+        [Theory]
+        [MemberData(nameof(Average_Float_TestData))]
+        public void Average_Float(float[] source, float expected)
+        {
             Assert.Equal(expected, source.Average());
         }
 
         [Fact]
-        public void MultipleFloatValuesAllZero()
-        {
-            float[] source = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
-            float expected = 0f;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleFloatValues()
-        {
-            float[] source = { 5.5f, -10f, 15.5f, 40.5f, 28.5f };
-            float expected = 16f;
-
-            Assert.Equal(expected, source.Average());
-        }
-
-        [Fact]
-        public void MultipleFloatFromSelector()
+        public void Average_Float_WithSelector()
         {
             var source = new[]
             {


### PR DESCRIPTION
- Take advantage of xunit
- Make it easier to add new tests
- Rename tests to follow guidelines