### PR TITLE
Allow other file handle types

### DIFF
--- a/src/Common/src/Interop/Windows/NtDll/Interop.NtQueryInformationFile.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.NtQueryInformationFile.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class NtDll
+    {
+        [DllImport(Libraries.NtDll, ExactSpelling = true)]
+        unsafe internal static extern int NtQueryInformationFile(
+            SafeFileHandle FileHandle,
+            out IO_STATUS_BLOCK IoStatusBlock,
+            void* FileInformation,
+            uint Length,
+            uint FileInformationClass);
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct IO_STATUS_BLOCK
+        {
+            IO_STATUS Status;
+            IntPtr Information;
+        }
+
+        // This isn't an actual Windows type, we have to separate it out as the size of IntPtr varies by architecture
+        // and we can't specify the size at compile time to offset the Information pointer in the status block.
+        [StructLayout(LayoutKind.Explicit)]
+        internal struct IO_STATUS
+        {
+            [FieldOffset(0)]
+            int Status;
+
+            [FieldOffset(0)]
+            IntPtr Pointer;
+        }
+
+        internal const uint FileModeInformation = 16;
+        internal const uint FILE_SYNCHRONOUS_IO_ALERT = 0x00000010;
+        internal const uint FILE_SYNCHRONOUS_IO_NONALERT = 0x00000020;
+
+        internal const int STATUS_INVALID_HANDLE = unchecked((int)0xC0000008);
+    }
+}

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -199,6 +199,7 @@
   </ItemGroup>
   <!-- Windows : Win32 only -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(EnableWinRT)' != 'true' And '$(TargetGroup)' != 'net46'">
+    <Compile Include="System\IO\Win32FileStream.Win32.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.UnsafeCreateFile.cs">
       <Link>Common\Interop\Windows\Interop.UnsafeCreateFile.cs</Link>
     </Compile>
@@ -219,6 +220,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.SetErrorMode.cs">
       <Link>Common\Interop\Windows\Interop.SetErrorMode.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Ntdll\Interop.NtQueryInformationFile.cs">
+      <Link>Common\Interop\Windows\Interop.NtQueryInformationFile.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- Windows : Win32 + WinRT -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(EnableWinRT)' == 'true'">
@@ -236,6 +240,7 @@
     </Compile>
     <Compile Include="System\IO\FileSystem.Current.MuxWin32WinRT.cs" />
     <Compile Include="System\IO\FileSystemInfo.WinRT.cs" />
+    <Compile Include="System\IO\Win32FileStream.WinRT.cs" />
     <Compile Include="System\IO\MultiplexingWin32WinRTFileSystem.cs" />
     <Compile Include="System\IO\WinRTIOExtensions.cs" />
     <Compile Include="System\IO\WinRTFileStream.cs" />

--- a/src/System.IO.FileSystem/src/System/IO/FileStream.Win32.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStream.Win32.cs
@@ -12,19 +12,12 @@ namespace System.IO
     {
         public FileStream(Microsoft.Win32.SafeHandles.SafeFileHandle handle, FileAccess access, int bufferSize)
         {
-            this._innerStream = new Win32FileStream(handle, access, bufferSize, this);
+            _innerStream = new Win32FileStream(handle, access, bufferSize, this);
         }
 
         public FileStream(Microsoft.Win32.SafeHandles.SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
         {
-            this._innerStream = new Win32FileStream(handle, access, bufferSize, isAsync, this);
-        }
-
-        static partial void ValidatePath(string fullPath, string paramName)
-        {
-            // Prevent access to your disk drives as raw block devices.
-            if (fullPath.StartsWith("\\\\.\\", StringComparison.Ordinal))
-                throw new ArgumentException(SR.Arg_DevicesNotSupported, paramName);
+            _innerStream = new Win32FileStream(handle, access, bufferSize, isAsync, this);
         }
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/FileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStream.cs
@@ -97,15 +97,11 @@ namespace System.IO
 
             string fullPath = Path.GetFullPath(path);
 
-            ValidatePath(fullPath, "path");
-
             if ((access & FileAccess.Read) != 0 && mode == FileMode.Append)
                 throw new ArgumentException(SR.Argument_InvalidAppendMode, nameof(access));
 
             this._innerStream = FileSystem.Current.Open(fullPath, mode, access, share, bufferSize, options, this);
         }
-
-        static partial void ValidatePath(string fullPath, string paramName);
 
         // InternalOpen, InternalCreate, and InternalAppend:
         // Factory methods for FileStream used by File, FileInfo, and ReadLinesIterator

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileStream.Win32.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileStream.Win32.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
+
+namespace System.IO
+{
+    internal sealed partial class Win32FileStream : FileStreamBase
+    {
+        private static bool GetDefaultIsAsync(SafeFileHandle handle)
+        {
+            return handle.IsAsync ?? !IsHandleSynchronous(handle) ?? DefaultIsAsync;
+        }
+
+        private static unsafe bool? IsHandleSynchronous(SafeFileHandle fileHandle)
+        {
+            if (fileHandle.IsInvalid)
+                return null;
+
+            Interop.NtDll.IO_STATUS_BLOCK ioStatus;
+            uint fileMode;
+
+            int status = Interop.NtDll.NtQueryInformationFile(
+                FileHandle: fileHandle,
+                IoStatusBlock: out ioStatus,
+                FileInformation: &fileMode,
+                Length: sizeof(uint),
+                FileInformationClass: Interop.NtDll.FileModeInformation);
+
+            switch (status)
+            {
+                case 0:
+                    // We we're successful
+                    break;
+                case Interop.NtDll.STATUS_INVALID_HANDLE:
+                    fileHandle.Dispose();
+                    throw Win32Marshal.GetExceptionForWin32Error(Interop.mincore.Errors.ERROR_INVALID_HANDLE);
+                default:
+                    // Something else is preventing access
+                    Debug.Fail("Unable to get the file mode information, status was" + status.ToString());
+                    return null;
+            }
+
+            // If either of these two flags are set, the file handle is synchronous (not overlapped)
+            return (fileMode & (Interop.NtDll.FILE_SYNCHRONOUS_IO_ALERT | Interop.NtDll.FILE_SYNCHRONOUS_IO_NONALERT)) > 0;
+        }
+
+        private void VerifyHandleIsSync(int fileType)
+        {
+            // As we can accurately check the handle type when we have access to NtQueryInformationFile we don't need to skip for
+            // any particular file handle type.
+
+            // If the handle was passed in without an explicit async setting, we already looked it up in GetDefaultIsAsync
+            if (!_handle.IsAsync.HasValue) return;
+
+            // If we can't check the handle, just assume it is ok.
+            if (!(IsHandleSynchronous(_handle) ?? true))
+                throw new ArgumentException(SR.Arg_HandleNotSync, "handle");
+        }
+    }
+}

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileStream.WinRT.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileStream.WinRT.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
+
+namespace System.IO
+{
+    internal sealed partial class Win32FileStream : FileStreamBase
+    {
+        private static bool GetDefaultIsAsync(SafeFileHandle handle)
+        {
+            return handle.IsAsync.HasValue ? handle.IsAsync.Value : DefaultIsAsync;
+        }
+
+        private unsafe bool? IsHandleSynchronous()
+        {
+            // Do NOT use this method on any type other than DISK. Reading or writing to a pipe may
+            // cause an app to block incorrectly, introducing a deadlock (depending on whether a write
+            // will wake up an already-blocked thread or this Win32FileStream's thread).
+
+            byte* bytes = stackalloc byte[1];
+            int numBytesReadWritten;
+            int r = -1;
+
+            // If the handle is a pipe, ReadFile will block until there
+            // has been a write on the other end.  We'll just have to deal with it,
+            // For the read end of a pipe, you can mess up and 
+            // accidentally read synchronously from an async pipe.
+            if (_canRead)
+                r = Interop.mincore.ReadFile(_handle, bytes, 0, out numBytesReadWritten, IntPtr.Zero);
+            else if (_canWrite)
+                r = Interop.mincore.WriteFile(_handle, bytes, 0, out numBytesReadWritten, IntPtr.Zero);
+
+            if (r == 0)
+            {
+                int errorCode = GetLastWin32ErrorAndDisposeHandleIfInvalid();
+                switch (errorCode)
+                {
+                    case ERROR_INVALID_PARAMETER:
+                        return false;
+                    case Interop.mincore.Errors.ERROR_INVALID_HANDLE:
+                        throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+                }
+            }
+
+            return true;
+        }
+
+        private void VerifyHandleIsSync(int fileType)
+        {
+            // The technique here only really works for FILE_TYPE_DISK. FileMode is the right thing to check, but it currently
+            // isn't available in WinRT.
+
+            if (fileType == Interop.mincore.FileTypes.FILE_TYPE_DISK)
+            {
+                // If we can't check the handle, just assume it is ok.
+                if (!(IsHandleSynchronous() ?? true))
+                    throw new ArgumentException(SR.Arg_HandleNotSync, "handle");
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm.cs
@@ -47,6 +47,20 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        public void FileModeCreateDosDevicePath()
+        {
+            using (CreateFileStream(@"\\.\" + GetTestFilePath(), FileMode.Create))
+            { }
+        }
+
+        [Fact]
+        public void FileModeCreateExtendedDosDevicePath()
+        {
+            using (CreateFileStream(@"\\?\" + GetTestFilePath(), FileMode.Create))
+            { }
+        }
+
+        [Fact]
         public void FileModeCreateExisting()
         {
             string fileName = GetTestFilePath();
@@ -200,9 +214,21 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
-        public void RawLongPathAccess_ThrowsArgumentException()
+        public void RawLongPathAccess_DoesNotThrowArgumentException()
         {
-            Assert.Throws<ArgumentException>(() => CreateFileStream("\\\\.\\disk\\access\\", FileMode.Open));
+            // We already allow \\?\ and 4.6.2 allows \\.\ when in full trust
+            try
+            {
+                CreateFileStream("\\\\.\\disk\\access\\", FileMode.Open);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(false, "should not throw Argument Exception");
+            }
+            catch (Exception)
+            {
+                // Probably a directory not found, doesn't matter
+            }
         }
     }
 }


### PR DESCRIPTION
If using `\\?\` allow handle types via the path constructor that we allow
in handle constructors.

#187 
@zippy1981, @davkean, @ericstj, @ianhays 