### PR TITLE
Remove named mutex PNSE tests that will fail soon

### DIFF
--- a/src/System.Threading/tests/MutexTests.cs
+++ b/src/System.Threading/tests/MutexTests.cs
@@ -34,13 +34,6 @@ namespace System.Threading.Tests
             }
         }
 
-        [PlatformSpecific(PlatformID.AnyUnix)]
-        [Fact]
-        public void Ctor_NamesNotSupported_Unix()
-        {
-            Assert.Throws<PlatformNotSupportedException>(() => new Mutex(false, "anyname"));
-        }
-
         [PlatformSpecific(PlatformID.Windows)]
         [Fact]
         public void Ctor_InvalidName()
@@ -101,15 +94,6 @@ namespace System.Threading.Tests
                 Assert.NotNull(resultHandle);
                 resultHandle.Dispose();
             }
-        }
-
-        [PlatformSpecific(PlatformID.AnyUnix)]
-        [Fact]
-        public void OpenExisting_NotSupported_Unix()
-        {
-            Assert.Throws<PlatformNotSupportedException>(() => Mutex.OpenExisting("anything"));
-            Mutex ewh;
-            Assert.Throws<PlatformNotSupportedException>(() => Mutex.TryOpenExisting("anything", out ewh));
         }
 
         [PlatformSpecific(PlatformID.Windows)]


### PR DESCRIPTION
The tests removed would fail soon after dotnet/coreclr#5030 is merged.

Related to dotnet/coreclr#5030
Related to #8625
Related to dotnet/coreclr#3422