### PR TITLE
Windows path tweaks

### DIFF
--- a/src/Common/tests/Tests/System/IO/PathInternal.Windows.Tests.cs
+++ b/src/Common/tests/Tests/System/IO/PathInternal.Windows.Tests.cs
@@ -10,6 +10,22 @@ using Xunit;
 public class PathInternal_Windows_Tests
 {
     [Theory
+        InlineData(@"\\?\", false)
+        InlineData(@"\\?\?", true)
+        InlineData(@"//?/", false)
+        InlineData(@"//?/*", true)
+        InlineData(@"\\.\>", true)
+        InlineData(@"C:\", false)
+        InlineData(@"C:\<", true)
+        InlineData("\"MyFile\"", true)
+        ]
+    [PlatformSpecific(PlatformID.Windows)]
+    public void HasWildcardCharacters(string path, bool expected)
+    {
+        Assert.Equal(expected, PathInternal.HasWildCardCharacters(path));
+    }
+
+    [Theory
         InlineData(PathInternal.ExtendedPathPrefix, PathInternal.ExtendedPathPrefix)
         InlineData(@"Foo", @"Foo")
         InlineData(@"C:\Foo", @"\\?\C:\Foo")

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
@@ -229,8 +229,8 @@ internal static class IOInputs
 
     public static IEnumerable<string> GetPathsLongerThanMaxLongPath(string rootPath, bool useExtendedSyntax = false)
     {
-        yield return GetLongPath(rootPath, MaxExtendedPath + 1 - (useExtendedSyntax ? 0 : ExtendedPrefix.Length), useExtendedSyntax);
-        yield return GetLongPath(rootPath, MaxExtendedPath + 2 - (useExtendedSyntax ? 0 : ExtendedPrefix.Length), useExtendedSyntax);
+        yield return GetLongPath(rootPath, MaxExtendedPath + 1, useExtendedSyntax);
+        yield return GetLongPath(rootPath, MaxExtendedPath + 2, useExtendedSyntax);
     }
 
     private static string GetLongPath(string rootPath, int characterCount, bool extended = false)

--- a/src/System.Runtime.Extensions/tests/System/IO/Path.Combine.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/Path.Combine.cs
@@ -48,6 +48,15 @@ namespace System.IO.Tests
 
             // Any path is multiple element
             yield return Path.Combine("abc", Path.Combine("def", "ghi"));
+
+            // Wildcard characters
+            yield return "*";
+            yield return "?";
+
+            // Obscure wildcard characters
+            yield return "\"";
+            yield return "<";
+            yield return ">";
         }
 
         public static IEnumerable<object[]> Combine_CommonCases_TestData()
@@ -135,10 +144,6 @@ namespace System.IO.Tests
         public static void ContainsInvalidCharWithoutRootedAfterArgumentNull_Windows()
         {
             //any path contains invalid character without rooted after (AE)
-            CommonCasesException<ArgumentException>("ab\"cd");
-            CommonCasesException<ArgumentException>("ab\"cd");
-            CommonCasesException<ArgumentException>("ab<cd");
-            CommonCasesException<ArgumentException>("ab>cd");
             CommonCasesException<ArgumentException>("ab|cd");
             CommonCasesException<ArgumentException>("ab\bcd");
             CommonCasesException<ArgumentException>("ab\0cd");
@@ -157,9 +162,6 @@ namespace System.IO.Tests
         public static void ContainsInvalidCharWithRootedAfterArgumentNull_Windows()
         {
             //any path contains invalid character with rooted after (AE)
-            CommonCasesException<ArgumentException>("ab\"cd", s_separator + "abc");
-            CommonCasesException<ArgumentException>("ab<cd", s_separator + "abc");
-            CommonCasesException<ArgumentException>("ab>cd", s_separator + "abc");
             CommonCasesException<ArgumentException>("ab|cd", s_separator + "abc");
             CommonCasesException<ArgumentException>("ab\bcd", s_separator + "abc");
             CommonCasesException<ArgumentException>("ab\tcd", s_separator + "abc");


### PR DESCRIPTION
- Simplify the path length check to match desktop
- Tweak IsPartiallyQualified to match desktop
- Update wildcards to actually match what Windows supports

It came as a surprise to me, but yes, there are more wildcard characters in Windows than "*" and "?".

https://msdn.microsoft.com/en-us/library/ff469270.aspx

You can use these other wildcards from the CMD prompt as long as you quote and escape the quote if you use it. (It is a FindFirstFile thing)

@ianhays, @ericstj, @stephentoub 