### PR TITLE
Added basic diagnostics to SqlConnection

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
@@ -12,9 +12,18 @@ namespace System.Data.SqlClient
         public const string DiagnosticListenerName = "SqlClientDiagnosticListener";
 
         private const string SqlClientPrefix = "System.Data.SqlClient.";
+
         public const string SqlBeforeExecuteCommand = SqlClientPrefix + nameof(WriteCommandBefore);
         public const string SqlAfterExecuteCommand = SqlClientPrefix + nameof(WriteCommandAfter);
         public const string SqlErrorExecuteCommand = SqlClientPrefix + nameof(WriteCommandError);
+
+        public const string SqlBeforeOpenConnection = SqlClientPrefix + nameof(WriteConnectionOpenBefore);
+        public const string SqlAfterOpenConnection = SqlClientPrefix + nameof(WriteConnectionOpenAfter);
+        public const string SqlErrorOpenConnection = SqlClientPrefix + nameof(WriteConnectionOpenError);
+
+        public const string SqlBeforeCloseConnection = SqlClientPrefix + nameof(WriteConnectionCloseBefore);
+        public const string SqlAfterCloseConnection = SqlClientPrefix + nameof(WriteConnectionCloseAfter);
+        public const string SqlErrorCloseConnection = SqlClientPrefix + nameof(WriteConnectionCloseError);
 
         public static Guid WriteCommandBefore(this DiagnosticListener @this, SqlCommand sqlCommand, [CallerMemberName] string operation = "")
         {
@@ -28,6 +37,7 @@ namespace System.Data.SqlClient
                     {
                         OperationId = operationId,
                         Operation = operation,
+                        ConnectionId = sqlCommand.Connection?.ClientConnectionId,
                         Command = sqlCommand
                     });
 
@@ -47,6 +57,7 @@ namespace System.Data.SqlClient
                     {
                         OperationId = operationId,
                         Operation = operation,
+                        ConnectionId = sqlCommand.Connection?.ClientConnectionId,
                         Command = sqlCommand,
                         Statistics = sqlCommand.Statistics?.GetDictionary(),
                         Timestamp = Stopwatch.GetTimestamp()
@@ -64,7 +75,127 @@ namespace System.Data.SqlClient
                     {
                         OperationId = operationId,
                         Operation = operation,
+                        ConnectionId = sqlCommand.Connection?.ClientConnectionId,
                         Command = sqlCommand,
+                        Exception = ex,
+                        Timestamp = Stopwatch.GetTimestamp()
+                    });
+            }
+        }
+
+        public static Guid WriteConnectionOpenBefore(this DiagnosticListener @this, SqlConnection sqlConnection, [CallerMemberName] string operation = "")
+        {
+            if (@this.IsEnabled(SqlBeforeOpenConnection))
+            {
+                Guid operationId = Guid.NewGuid();
+
+                @this.Write(
+                    SqlBeforeOpenConnection,
+                    new
+                    {
+                        OperationId = operationId,
+                        Operation = operation,
+                        Connection = sqlConnection,
+                        Timestamp = Stopwatch.GetTimestamp()
+                    });
+
+                return operationId;
+            }
+            else
+                return Guid.Empty;
+        }
+
+        public static void WriteConnectionOpenAfter(this DiagnosticListener @this, Guid operationId, SqlConnection sqlConnection, [CallerMemberName] string operation = "")
+        {
+            if (@this.IsEnabled(SqlAfterOpenConnection))
+            {
+                @this.Write(
+                    SqlAfterOpenConnection,
+                    new
+                    {
+                        OperationId = operationId,
+                        Operation = operation,
+                        ConnectionId = sqlConnection.ClientConnectionId,
+                        Connection = sqlConnection,
+                        Statistics = sqlConnection.Statistics?.GetDictionary(),
+                        Timestamp = Stopwatch.GetTimestamp()
+                    });
+            }
+        }
+
+        public static void WriteConnectionOpenError(this DiagnosticListener @this, Guid operationId, SqlConnection sqlConnection, Exception ex, [CallerMemberName] string operation = "")
+        {
+            if (@this.IsEnabled(SqlErrorOpenConnection))
+            {
+                @this.Write(
+                    SqlErrorOpenConnection,
+                    new
+                    {
+                        OperationId = operationId,
+                        Operation = operation,
+                        ConnectionId = sqlConnection.ClientConnectionId,
+                        Connection = sqlConnection,
+                        Exception = ex,
+                        Timestamp = Stopwatch.GetTimestamp()
+                    });
+            }
+        }
+
+        public static Guid WriteConnectionCloseBefore(this DiagnosticListener @this, SqlConnection sqlConnection, [CallerMemberName] string operation = "")
+        {
+            if (@this.IsEnabled(SqlBeforeCloseConnection))
+            {
+                Guid operationId = Guid.NewGuid();
+
+                @this.Write(
+                    SqlBeforeCloseConnection,
+                    new
+                    {
+                        OperationId = operationId,
+                        Operation = operation,
+                        ConnectionId = sqlConnection.ClientConnectionId,
+                        Connection = sqlConnection,
+                        Statistics = sqlConnection.Statistics?.GetDictionary(),
+                        Timestamp = Stopwatch.GetTimestamp()
+                    });
+
+                return operationId;
+            }
+            else
+                return Guid.Empty;
+        }
+
+        public static void WriteConnectionCloseAfter(this DiagnosticListener @this, Guid operationId, Guid clientConnectionId, SqlConnection sqlConnection, [CallerMemberName] string operation = "")
+        {
+            if (@this.IsEnabled(SqlAfterCloseConnection))
+            {
+                @this.Write(
+                    SqlAfterCloseConnection,
+                    new
+                    {
+                        OperationId = operationId,
+                        Operation = operation,
+                        ConnectionId = clientConnectionId,
+                        Connection = sqlConnection,
+                        Statistics = sqlConnection.Statistics?.GetDictionary(),
+                        Timestamp = Stopwatch.GetTimestamp()
+                    });
+            }
+        }
+
+        public static void WriteConnectionCloseError(this DiagnosticListener @this, Guid operationId, Guid clientConnectionId, SqlConnection sqlConnection, Exception ex, [CallerMemberName] string operation = "")
+        {
+            if (@this.IsEnabled(SqlErrorCloseConnection))
+            {
+                @this.Write(
+                    SqlErrorCloseConnection,
+                    new
+                    {
+                        OperationId = operationId,
+                        Operation = operation,
+                        ConnectionId = clientConnectionId,
+                        Connection = sqlConnection,
+                        Statistics = sqlConnection.Statistics?.GetDictionary(),
                         Exception = ex,
                         Timestamp = Stopwatch.GetTimestamp()
                     });

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -471,7 +471,7 @@ namespace System.Data.SqlClient
             // connection is already in a closed state. this doesn't seem to be a 
             // problem except for logging, as we'll get duplicate Before/After/Error
             // log entries
-            if (previousState == ConnectionState.Open)
+            if (previousState != ConnectionState.Closed)
             { 
                 operationId = s_diagnosticListener.WriteConnectionCloseBefore(this);
                 // we want to cache the ClientConnectionId for After/Error logging, as when the connection 
@@ -522,7 +522,7 @@ namespace System.Data.SqlClient
 
                 // we only want to log this if the previous state of the 
                 // connection is open, as that's the valid use-case
-                if (previousState == ConnectionState.Open)
+                if (previousState != ConnectionState.Closed)
                 { 
                     if (e != null)
                     {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -462,8 +462,28 @@ namespace System.Data.SqlClient
 
         override public void Close()
         {
+            ConnectionState previousState = State;
+            Guid operationId;
+            Guid clientConnectionId;
+
+            // during the call to Dispose() there is a redundant call to 
+            // Close(). because of this, the second time Close() is invoked the 
+            // connection is already in a closed state. this doesn't seem to be a 
+            // problem except for logging, as we'll get duplicate Before/After/Error
+            // log entries
+            if (previousState == ConnectionState.Open)
+            { 
+                operationId = s_diagnosticListener.WriteConnectionCloseBefore(this);
+                // we want to cache the ClientConnectionId for After/Error logging, as when the connection 
+                // is closed then we will lose this identifier
+                //
+                // note: caching this is only for diagnostics logging purposes
+                clientConnectionId = ClientConnectionId;
+            }
+
             SqlStatistics statistics = null;
 
+            Exception e = null;
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
@@ -491,9 +511,28 @@ namespace System.Data.SqlClient
                     ADP.TimerCurrent(out _statistics._closeTimestamp);
                 }
             }
+            catch (Exception ex)
+            {
+                e = ex;
+                throw;
+            }
             finally
             {
                 SqlStatistics.StopTimer(statistics);
+
+                // we only want to log this if the previous state of the 
+                // connection is open, as that's the valid use-case
+                if (previousState == ConnectionState.Open)
+                { 
+                    if (e != null)
+                    {
+                        s_diagnosticListener.WriteConnectionCloseError(operationId, clientConnectionId, this, e);
+                    }
+                    else
+                    {
+                        s_diagnosticListener.WriteConnectionCloseAfter(operationId, clientConnectionId, this);
+                    }
+                }
             }
         }
 
@@ -524,9 +563,13 @@ namespace System.Data.SqlClient
 
         override public void Open()
         {
+            Guid operationId = s_diagnosticListener.WriteConnectionOpenBefore(this);
+
             PrepareStatisticsForNewConnection();
 
             SqlStatistics statistics = null;
+
+            Exception e = null;
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
@@ -536,9 +579,23 @@ namespace System.Data.SqlClient
                     throw ADP.InternalError(ADP.InternalErrorCode.SynchronousConnectReturnedPending);
                 }
             }
+            catch (Exception ex)
+            {
+                e = ex;
+                throw;
+            }
             finally
             {
                 SqlStatistics.StopTimer(statistics);
+
+                if (e != null)
+                {
+                    s_diagnosticListener.WriteConnectionOpenError(operationId, this, e);
+                }
+                else
+                { 
+                    s_diagnosticListener.WriteConnectionOpenAfter(operationId, this);
+                }
             }
         }
 
@@ -750,6 +807,8 @@ namespace System.Data.SqlClient
 
         public override Task OpenAsync(CancellationToken cancellationToken)
         {
+            Guid operationId = s_diagnosticListener.WriteConnectionOpenBefore(this);
+
             PrepareStatisticsForNewConnection();
             
             SqlStatistics statistics = null;
@@ -759,6 +818,18 @@ namespace System.Data.SqlClient
 
                 TaskCompletionSource<DbConnectionInternal> completion = new TaskCompletionSource<DbConnectionInternal>();
                 TaskCompletionSource<object> result = new TaskCompletionSource<object>();
+
+                result.Task.ContinueWith((t) =>
+                {
+                    if (t.Exception != null)
+                    {
+                        s_diagnosticListener.WriteConnectionOpenError(operationId, this, t.Exception);
+                    }
+                    else
+                    { 
+                        s_diagnosticListener.WriteConnectionOpenAfter(operationId, this);
+                    }
+                });
 
                 if (cancellationToken.IsCancellationRequested)
                 {
@@ -775,6 +846,7 @@ namespace System.Data.SqlClient
                 }
                 catch (Exception e)
                 {
+                    s_diagnosticListener.WriteConnectionOpenError(operationId, this, e);
                     result.SetException(e);
                     return result.Task;
                 }
@@ -797,6 +869,11 @@ namespace System.Data.SqlClient
                 }
 
                 return result.Task;
+            }
+            catch (Exception ex)
+            {
+                s_diagnosticListener.WriteConnectionOpenError(operationId, this, ex);
+                throw;
             }
             finally
             {

--- a/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
@@ -35,6 +35,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ExecuteScalarErrorTest()
         {
@@ -53,6 +54,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ExecuteNonQueryTest()
         {
@@ -69,6 +71,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ExecuteNonQueryErrorTest()
         {
@@ -86,6 +89,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ExecuteReaderTest()
         {
@@ -103,6 +107,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ExecuteReaderErrorTest()
         {
@@ -123,6 +128,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ExecuteReaderWithCommandBehaviorTest()
         {
@@ -140,6 +146,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ExecuteXmlReaderTest()
         {
@@ -157,6 +164,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ExecuteXmlReaderErrorTest()
         {
@@ -194,6 +202,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ExecuteScalarAsyncErrorTest()
         {
@@ -212,6 +221,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ExecuteNonQueryAsyncTest()
         {
@@ -228,6 +238,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ExecuteNonQueryAsyncErrorTest()
         {
@@ -245,6 +256,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ExecuteReaderAsyncTest()
         {
@@ -262,6 +274,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ExecuteReaderAsyncErrorTest()
         {
@@ -282,6 +295,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ExecuteXmlReaderAsyncTest()
         {
@@ -299,6 +313,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ExecuteXmlReaderAsyncErrorTest()
         {
@@ -331,6 +346,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ConnectionOpenErrorTest()
         {
@@ -354,6 +370,7 @@ namespace System.Data.SqlClient.Tests
                 }
             });
         }
+
         [Fact]
         public void ConnectionOpenAsyncErrorTest()
         {


### PR DESCRIPTION
This pull request includes the basic logging for SqlConnection for the `Open()`, `OpenAsync()`, and `Close()` operations, logging `Before`, `After`, and `Error` events.