### PR TITLE
Split the OpenSsl and Cng packages at netstandard1.4 vs 1.6

### DIFF
--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngAlgorithmCore.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngAlgorithmCore.cs
@@ -75,6 +75,7 @@ namespace Internal.Cryptography
             return _lazyKey;
         }
 
+#if !NETNATIVE
         public CngKey GetOrGenerateKey(ECCurve? curve)
         {
             // If we don't have a key yet, we need to generate a random one now.
@@ -119,6 +120,7 @@ namespace Internal.Cryptography
             }
             return _lazyKey;
         }
+#endif //!NETNATIVE
 
         public void SetKey(CngKey key)
         {

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.builds
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.builds
@@ -16,6 +16,10 @@
       <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>net461</TargetGroup>
     </Project>
+    <Project Include="System.Security.Cryptography.Cng.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -18,6 +18,11 @@
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.6</NuGetTargetMoniker>
     <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsUnix)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50'">
+    <PackageTargetFramework>netstandard1.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.4</NuGetTargetMoniker>
+    <DefineConstants>$(DefineConstants);NETNATIVE</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
@@ -55,10 +60,8 @@
     <Compile Include="System\Security\Cryptography\CngUIPolicy.cs" />
     <Compile Include="System\Security\Cryptography\CngUIProtectionLevels.cs" />
     <Compile Include="System\Security\Cryptography\ECCng.HashAlgorithm.cs" />
-    <Compile Include="System\Security\Cryptography\ECCng.ImportExport.cs" />
     <Compile Include="System\Security\Cryptography\ECDsaCng.cs" />
     <Compile Include="System\Security\Cryptography\ECDsaCng.HashData.cs" />
-    <Compile Include="System\Security\Cryptography\ECDsaCng.ImportExport.cs" />
     <Compile Include="System\Security\Cryptography\ECDsaCng.Key.cs" />
     <Compile Include="System\Security\Cryptography\ECDsaCng.SignVerify.cs" />
     <Compile Include="System\Security\Cryptography\RSACng.cs" />
@@ -231,6 +234,10 @@
     <Compile Include="$(CommonPath)\System\Security\Cryptography\RSACng.SignVerify.cs">
       <Link>Common\System\Security\Cryptography\RSACng.SignVerify.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(TargetGroup)' == ''">
+    <Compile Include="System\Security\Cryptography\ECCng.ImportExport.cs" />
+    <Compile Include="System\Security\Cryptography\ECDsaCng.ImportExport.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <TargetingPackReference Include="mscorlib" />

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.EC.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.EC.cs
@@ -37,10 +37,12 @@ namespace System.Security.Cryptography
 
         internal string GetCurveName()
         {
+#if !NETNATIVE
             if (IsECNamedCurve())
             {
                 return _keyHandle.GetPropertyAsString(KeyPropertyName.ECCCurveName, CngPropertyOptions.None);
             }
+#endif //!NETNATIVE
 
             // Use hard-coded values (for use with pre-Win10 APIs)
             return GetECSpecificCurveName(); 
@@ -72,6 +74,7 @@ namespace System.Security.Cryptography
             throw new PlatformNotSupportedException(string.Format(SR.Cryptography_CurveNotSupported, algorithm));
         }
 
+#if !NETNATIVE
         /// <summary>
         ///     Return a CngProperty representing a named curve.
         /// </summary>
@@ -150,6 +153,7 @@ namespace System.Security.Cryptography
                 }
             }
         }
+#endif //!NETNATIVE
 
         /// <summary>
         /// Map a curve name to algorithm. This enables curves that worked pre-Win10

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Import.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Import.cs
@@ -26,18 +26,22 @@ namespace System.Security.Cryptography
             return Import(keyBlob, format, provider: CngProvider.MicrosoftSoftwareKeyStorageProvider);
         }
 
+#if !NETNATIVE
         internal static CngKey Import(byte[] keyBlob, ECCurve curve, CngKeyBlobFormat format)
         {
             return Import(keyBlob, curve, format, provider: CngProvider.MicrosoftSoftwareKeyStorageProvider);
         }
+#endif //!NETNATIVE
 
         public static CngKey Import(byte[] keyBlob, CngKeyBlobFormat format, CngProvider provider)
         {
+#if !NETNATIVE
             return Import(keyBlob, null, format, provider);
         }
 
         internal static CngKey Import(byte[] keyBlob, ECCurve? curve, CngKeyBlobFormat format, CngProvider provider)
         {
+#endif //!NETNATIVE
             if (keyBlob == null)
                 throw new ArgumentNullException(nameof(keyBlob));
             if (format == null)
@@ -49,7 +53,9 @@ namespace System.Security.Cryptography
             SafeNCryptKeyHandle keyHandle;
             ErrorCode errorCode;
             
+#if !NETNATIVE
             if (curve == null)
+#endif //!NETNATIVE
             {
                 errorCode = Interop.NCrypt.NCryptImportKey(providerHandle, IntPtr.Zero, format.Format, IntPtr.Zero, out keyHandle, keyBlob, keyBlob.Length, 0);
                 if (errorCode != ErrorCode.ERROR_SUCCESS)
@@ -57,6 +63,7 @@ namespace System.Security.Cryptography
                     throw errorCode.ToCryptographicException();
                 }
             }
+#if !NETNATIVE
             else
             {
                 // Call with Oid.FriendlyName because .Value will result in an invalid parameter error
@@ -102,6 +109,7 @@ namespace System.Security.Cryptography
                     throw e;
                 }
             }
+#endif //!NETNATIVE
 
             CngKey key = new CngKey(providerHandle, keyHandle);
 

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.Key.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.Key.cs
@@ -38,19 +38,26 @@ namespace System.Security.Cryptography
             }
         }
 
+#if !NETNATIVE
         public override void GenerateKey(ECCurve curve)
         {
             curve.Validate();
             _core.DisposeKey();
             GetKey(curve);
         }
+#endif
 
-        private CngKey GetKey(ECCurve? curve = null)
+        private CngKey GetKey(
+#if !NETNATIVE
+                ECCurve? curve = null
+#endif
+                )
         {
             CngKey key = null;
             CngAlgorithm algorithm = null;
             int keySize = 0;
 
+#if !NETNATIVE
             if (curve != null)
             {
                 if (curve.Value.IsNamed)
@@ -93,6 +100,7 @@ namespace System.Security.Cryptography
                 key = _core.GetOrGenerateKey(null);
             }
             else
+#endif
             {
                 // Map the current key size to a CNG algorithm name
                 keySize = KeySize;

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.cs
@@ -12,6 +12,7 @@ namespace System.Security.Cryptography
         private CngAlgorithmCore _core;
         private bool _skipKeySizeCheck;
 
+#if !NETNATIVE
         /// <summary>
         /// Create an ECDsaCng algorithm with a named curve.
         /// </summary>
@@ -27,6 +28,7 @@ namespace System.Security.Cryptography
             // Named curves generate the key immediately
             GenerateKey(curve);
         }
+#endif
 
         /// <summary>
         ///     Create an ECDsaCng algorithm with a random 521 bit key pair.

--- a/src/System.Security.Cryptography.Cng/src/project.json
+++ b/src/System.Security.Cryptography.Cng/src/project.json
@@ -17,6 +17,23 @@
         "System.Security.Cryptography.Encoding": "4.0.0-rc3-24117-00"
       }
     },
+    "netstandard1.4": {
+      "imports": [
+        "dotnet5.5"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1-rc3-24117-00",
+        "System.Diagnostics.Debug": "4.0.10",
+        "System.Diagnostics.Tools": "4.0.0",
+        "System.IO": "4.0.10",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Extensions": "4.0.0",
+        "System.Runtime.InteropServices": "4.0.20",
+        "System.Security.Cryptography.Algorithms": "4.2.0-rc3-24117-00",
+        "System.Security.Cryptography.Encoding": "4.0.0-rc3-24117-00"
+      }
+    },
     "net46": {
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -13,11 +13,14 @@
     <CLSCompliant>false</CLSCompliant>
     <PackageTargetFramework>netstandard1.6</PackageTargetFramework>
     <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetsWindows)' == 'true'">
+    <GeneratePlatformNotSupportedAssembly>true</GeneratePlatformNotSupportedAssembly>
+    <PackageTargetFramework>netstandard1.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.4</NuGetTargetMoniker>
     <!-- Clear PackageTargetRuntime on Windows to package the PlatformNotSupported assembly 
          without a RID so that it applies in desktop packages.config projects as well -->
-    <PackageTargetRuntime Condition="'$(TargetsWindows)' == 'true'">
-    </PackageTargetRuntime>
-    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetsWindows)' == 'true'">true</GeneratePlatformNotSupportedAssembly>
+    <PackageTargetRuntime></PackageTargetRuntime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />

--- a/src/System.Security.Cryptography.OpenSsl/src/project.json
+++ b/src/System.Security.Cryptography.OpenSsl/src/project.json
@@ -18,6 +18,11 @@
       "imports": [
         "dotnet5.5"
       ]
+    },
+    "netstandard1.4": {
+      "imports": [
+        "dotnet5.5"
+      ]
     }
   }
 }


### PR DESCRIPTION
This is a tactical change to fix a build break which wasn't caught in the pre-merge CI.

Restore the Windows PNSE OpenSsl package to netstandard1.4
Restore the Windows netcore50 Cng package to netstandard1.4