### PR TITLE
Fix build break in System.Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ConstantExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ConstantExpression.cs
@@ -110,15 +110,15 @@ namespace System.Linq.Expressions
         public static ConstantExpression Constant(object value, Type type)
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
-            TypeUtils.ValidateType(type);
+            TypeUtils.ValidateType(type, nameof(type));
             if (type.IsByRef)
             {
-                throw Error.TypeMustNotBeByRef();
+                throw Error.TypeMustNotBeByRef(nameof(type));
             }
 
             if (type.IsPointer)
             {
-                throw Error.TypeMustNotBePointer();
+                throw Error.TypeMustNotBePointer(nameof(type));
             }
 
             if (value == null)


### PR DESCRIPTION
cc: @VSadov, @hughbe 