### PR TITLE
Fix PLINQ test that fails rarely

### DIFF
--- a/src/System.Linq.Parallel/tests/Combinatorial/FailingParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/FailingParallelQueryCombinationTests.cs
@@ -146,7 +146,7 @@ namespace System.Linq.Parallel.Tests
             IEnumerator<int> enumerator = operation.Item(DefaultStart, DefaultSize, source.Item).GetEnumerator();
             // Spin until concat hits
             // Union-Left needs to spin more than once rarely.
-            if (operation.ToString().StartsWith("Concat") || operation.ToString().StartsWith("Union-Left:ParallelEnumerable"))
+            if (operation.ToString().StartsWith("Concat") || operation.ToString().StartsWith("Union-Left"))
             {
                 AssertThrows.Wrapped<DeliberateTestException>(() => { while (enumerator.MoveNext()) ; });
             }


### PR DESCRIPTION
The test was special casing a subset of the tests it needed to special case.
Fixes https://github.com/dotnet/corefx/issues/8677