### PR TITLE
Fix cancellation of WinHttpHandler response stream reads

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -148,7 +148,9 @@ namespace System.Net.Http
             Debug.Assert(state != null, "OnRequestReadComplete: state is null");
             Debug.Assert(state.TcsReadFromResponseStream != null, "TcsReadFromResponseStream is null");
             Debug.Assert(!state.TcsReadFromResponseStream.Task.IsCompleted, "TcsReadFromResponseStream.Task is completed");
-            
+
+            state.DisposeCtrReadFromResponseStream();
+
             // If we read to the end of the stream and we're using 'Content-Length' semantics on the response body,
             // then verify we read at least the number of bytes required.
             if (bytesRead == 0
@@ -353,6 +355,8 @@ namespace System.Net.Http
                     break;
 
                 case Interop.WinHttp.API_READ_DATA:
+                    state.DisposeCtrReadFromResponseStream();
+
                     if (asyncResult.dwError == Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED)
                     {
                         // TODO: Issue #2165. We need to pass in the cancellation token from the

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
@@ -120,6 +120,7 @@ namespace System.Net.Http
         // WinHttpResponseStream state.
         public TaskCompletionSource<int> TcsQueryDataAvailable { get; set; }
         public TaskCompletionSource<int> TcsReadFromResponseStream { get; set; }
+        public CancellationTokenRegistration CtrReadFromResponseStream { get; set; }
         public long? ExpectedBytesToRead { get; set; }
         public long CurrentBytesRead { get; set; }
 
@@ -136,6 +137,16 @@ namespace System.Net.Http
                 }
 
                 _cachedReceivePinnedBuffer = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+            }
+        }
+
+        public void DisposeCtrReadFromResponseStream()
+        {
+            if (CtrReadFromResponseStream != null)
+            {
+                WinHttpTraceHelper.Trace("WinHttpRequestState.DisposeCtrReadFromResponseStream: disposing ctr");
+                CtrReadFromResponseStream.Dispose();
+                CtrReadFromResponseStream = default(CancellationTokenRegistration);
             }
         }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
@@ -142,12 +142,9 @@ namespace System.Net.Http
 
         public void DisposeCtrReadFromResponseStream()
         {
-            if (CtrReadFromResponseStream != null)
-            {
-                WinHttpTraceHelper.Trace("WinHttpRequestState.DisposeCtrReadFromResponseStream: disposing ctr");
-                CtrReadFromResponseStream.Dispose();
-                CtrReadFromResponseStream = default(CancellationTokenRegistration);
-            }
+            WinHttpTraceHelper.Trace("WinHttpRequestState.DisposeCtrReadFromResponseStream: disposing ctr");
+            CtrReadFromResponseStream.Dispose();
+            CtrReadFromResponseStream = default(CancellationTokenRegistration);
         }
 
         #region IDisposable Members

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -256,7 +256,6 @@ namespace System.Net.Http
             WinHttpTraceHelper.Trace("WinHttpResponseStream.CancelPendingResponseStreamReadOperation");
             lock (_state.Lock)
             {
-                WinHttpTraceHelper.Trace("WinHttpResponseStream.CancelPendingResponseStreamReadOperation: in lock");
                 WinHttpTraceHelper.Trace(
                     string.Format("WinHttpResponseStream.CancelPendingResponseStreamReadOperation: {0} {1}",
                     (int)_state.TcsQueryDataAvailable.Task.Status, (int)_state.TcsReadFromResponseStream.Task.Status));

--- a/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
@@ -16,7 +16,7 @@ namespace System.Net.Http.Functional.Tests
     public class CancellationTest
     {
         // TODO: Issue #8692. Move this test server capability to Azure test server or Loopback server.
-        private const string FastHeadersSlowBodyHost = "winrtnet.corp.microsoft.com";
+        private const string FastHeadersSlowBodyHost = "<TODO>";
         private const int FastHeadersSlowBodyPort = 1337;
         private const int ResponseBodyReadDelayInMilliseconds = 15000; // 15 seconds.
         private const int ResponseBodyLength = 1024;

--- a/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/CancellationTest.cs
@@ -1,0 +1,125 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Net.Test.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class CancellationTest
+    {
+        // TODO: Issue #8692. Move this test server capability to Azure test server or Loopback server.
+        private const string FastHeadersSlowBodyHost = "winrtnet.corp.microsoft.com";
+        private const int FastHeadersSlowBodyPort = 1337;
+        private const int ResponseBodyReadDelayInMilliseconds = 15000; // 15 seconds.
+        private const int ResponseBodyLength = 1024;
+
+        private static Uri s_fastHeadersSlowBodyServer = new Uri(string.Format(
+            "http://{0}:{1}/?slow={2}&length={3}",
+            FastHeadersSlowBodyHost,
+            FastHeadersSlowBodyPort,
+            ResponseBodyReadDelayInMilliseconds,
+            ResponseBodyLength));
+            
+        private readonly ITestOutputHelper _output;
+
+        public CancellationTest(ITestOutputHelper output)
+        {
+            _output = output;
+            _output.WriteLine(s_fastHeadersSlowBodyServer.ToString());
+        }
+
+        [ActiveIssue(8663)]
+        [Fact]
+        public async Task GetIncludesReadingResponseBody_CancelUsingTimeout_TaskCanceledQuickly()
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            using (var client = new HttpClient())
+            {
+                client.Timeout = new TimeSpan(0, 0, 1);
+
+                Task<HttpResponseMessage> getResponse =
+                    client.GetAsync(s_fastHeadersSlowBodyServer, HttpCompletionOption.ResponseContentRead);
+
+                stopwatch.Restart();
+                await Assert.ThrowsAsync<TaskCanceledException>(
+                    () => getResponse);
+                stopwatch.Stop();
+                _output.WriteLine("GetAsync() completed at: {0}", stopwatch.Elapsed.ToString());
+                Assert.True(stopwatch.Elapsed < new TimeSpan(0,0,3), "Elapsed time should be short");
+            }
+        }
+
+        [ActiveIssue(8663)]
+        [Fact]
+        public async Task GetIncludesReadingResponseBody_CancelUsingToken_TaskCanceledQuickly()
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            var cts = new CancellationTokenSource();
+            using (var client = new HttpClient())
+            {
+                Task<HttpResponseMessage> getResponse =
+                    client.GetAsync(s_fastHeadersSlowBodyServer, HttpCompletionOption.ResponseContentRead, cts.Token);
+
+                Task ignore = Task.Delay(new TimeSpan(0, 0, 1)).ContinueWith(_ =>
+                {
+                    _output.WriteLine("Calling cts.Cancel() at: {0}", stopwatch.Elapsed.ToString());
+                    cts.Cancel();
+                });
+
+                stopwatch.Restart();
+                await Assert.ThrowsAsync<TaskCanceledException>(
+                    () => getResponse);
+                stopwatch.Stop();
+                _output.WriteLine("GetAsync() completed at: {0}", stopwatch.Elapsed.ToString());
+                Assert.True(stopwatch.Elapsed < new TimeSpan(0,0,3), "Elapsed time should be short");
+            }
+        }
+
+        [ActiveIssue(8692)]
+        [Fact]
+        public async Task ResponseStreamRead_CancelUsingToken_TaskCanceledQuickly()
+        {
+            var stopwatch = new Stopwatch();
+
+            stopwatch.Start();
+            using (var client = new HttpClient())
+            using (HttpResponseMessage response =
+                await client.GetAsync(s_fastHeadersSlowBodyServer, HttpCompletionOption.ResponseHeadersRead))
+            {
+                stopwatch.Stop();
+                _output.WriteLine("Time to get headers: {0}", stopwatch.Elapsed.ToString());
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                var cts = new CancellationTokenSource();
+
+                Stream stream = await response.Content.ReadAsStreamAsync();
+                byte[] buffer = new byte[ResponseBodyLength];
+                
+                Task ignore = Task.Delay(new TimeSpan(0,0,1)).ContinueWith(_ =>
+                {
+                    _output.WriteLine("Calling cts.Cancel() at: {0}", stopwatch.Elapsed.ToString());
+                    cts.Cancel();
+                });
+
+                stopwatch.Restart();
+                await Assert.ThrowsAsync<TaskCanceledException>(
+                    () => stream.ReadAsync(buffer, 0, buffer.Length, cts.Token));
+                stopwatch.Stop();
+                _output.WriteLine("ReadAsync() completed at: {0}", stopwatch.Elapsed.ToString());
+                Assert.True(stopwatch.Elapsed < new TimeSpan(0,0,3), "Elapsed time should be short");
+            }
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -55,6 +55,7 @@
       <Link>Common\System\Net\Http\LoopbackServer.cs</Link>
     </Compile>
     <Compile Include="ByteArrayContentTest.cs" />
+    <Compile Include="CancellationTest.cs" />
     <Compile Include="ChannelBindingAwareContent.cs" />
     <Compile Include="CustomContent.cs" />
     <Compile Include="DelegatingHandlerTest.cs" />


### PR DESCRIPTION
Reading from the response stream using ReadAsync() was ignoring the cancellation token passed in. To fix this, registered a delegate that will be called to dispose the WinHTTP request handle during pending I/O. This will cause the WinHTTP operation to cancel.

Added tests. For now, left them disabled to be resolved in issue #8692 next week. But wanted to get this fix in asap since it blocks partners for RTM.

Fixes #8662.