### PR TITLE
Preserve ordering in MemberDescriptor.FilterAttributesIfNeeded

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 
@@ -405,11 +406,11 @@ namespace System.ComponentModel
         {
             if (!_attributesFiltered)
             {
-                IList list;
+                List<Attribute> list;
 
                 if (!_attributesFilled)
                 {
-                    list = new ArrayList();
+                    list = new List<Attribute>();
                     try
                     {
                         FillAttributes(list);
@@ -421,18 +422,24 @@ namespace System.ComponentModel
                 }
                 else
                 {
-                    list = new ArrayList(_attributes);
+                    list = new List<Attribute>(_attributes);
                 }
 
-                Hashtable hash = new Hashtable(list.Count);
+                var set = new HashSet<object>();
 
-                foreach (Attribute attr in list)
+                for (int i = 0; i < list.Count;)
                 {
-                    hash[attr.GetTypeId()] = attr;
+                    if (set.Add(list[i].GetTypeId()))
+                    {
+                        ++i;
+                    }
+                    else
+                    {
+                        list.RemoveAt(i);
+                    }
                 }
 
-                Attribute[] newAttributes = new Attribute[hash.Values.Count];
-                hash.Values.CopyTo(newAttributes, 0);
+                Attribute[] newAttributes = list.ToArray();
 
                 lock (_lockCookie)
                 {

--- a/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
@@ -10,7 +10,6 @@ namespace System.ComponentModel.Tests
     public class MemberDescriptorTests
     {
         [Fact]
-        [ActiveIssue(8606, PlatformID.Any)]
         public void CopiedMemberDescriptorEqualsItsSource()
         {
             var attributes = new Attribute[]


### PR DESCRIPTION
Prior code used `Hashtable` to remove duplicates in the `_attributes` array, then reassigned that array with `Hashtable.Values`, sometimes changing the ordering of elements and causing `Equals` to erroneously return false. With this change, duplicates are removed without affecting the order of elements.

This fixes #8606.

@stephentoub @Tanya-Solyanik @twsouthwick 