### PR TITLE
Restructure IP address parsing tests

### DIFF
--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
@@ -10,81 +10,190 @@ namespace System.Net.Primitives.Functional.Tests
     {
         #region IPv4
 
-        [Fact]
-        public void ParseIPv4_Basic_Success()
+        [Theory]
+        [InlineData("192.168.0.1", "192.168.0.1")]
+        [InlineData("0.0.0.0", "0.0.0.0")]
+        [InlineData("0", "0.0.0.0")]
+        [InlineData("0x0", "0.0.0.0")]
+        [InlineData("255.255.255.255", "255.255.255.255")]
+        [InlineData("0xFF.0xFF.0xFF.0xFF", "255.255.255.255")]
+        [InlineData("0377.0377.0377.0377", "255.255.255.255")]
+        [InlineData("4294967294", "255.255.255.254")]
+        [InlineData("4294967295", "255.255.255.255")]
+        [InlineData("0xFFFFFFFE", "255.255.255.254")]
+        [InlineData("0xFFFFFFFF", "255.255.255.255")]
+        [InlineData("037777777776", "255.255.255.254")] // Octal
+        [InlineData("037777777777", "255.255.255.255")] // Octal
+        [InlineData("2637895963", "157.59.25.27")]
+        [InlineData("157.3873051", "157.59.25.27")]
+        [InlineData("157.6427", "157.0.25.27")]
+        [InlineData("0x9D3B191B", "157.59.25.27")]
+        [InlineData("0X9D.0x3B.0X19.0x1B", "157.59.25.27")]
+        [InlineData("0x89.0xab.0xcd.0xef", "137.171.205.239")]
+        [InlineData("157.59.25.0x1B", "157.59.25.27")]
+        [InlineData("157.59.0x001B", "157.59.0.27")]
+        [InlineData("157.0x00001B", "157.0.0.27")]
+        [InlineData("023516614433", "157.59.25.27")] // Octal
+        [InlineData("00000023516614433", "157.59.25.27")] // Octal
+        [InlineData("157.59.0x25.033", "157.59.37.27")]
+        public void ParseIPv4_Success(string address, string expected)
         {
-            Assert.Equal("192.168.0.1", IPAddress.Parse("192.168.0.1").ToString());
+            Assert.Equal(expected, IPAddress.Parse(address).ToString());
         }
 
-        [Fact]
-        public void ParseIPv4_WithSubnet_Failure()
+        [Theory]
+        [ActiveIssue(8362, ~PlatformID.OSX)]
+        [InlineData("000235.000073.0000031.00000033", "157.59.25.27")] // Octal
+        [InlineData("0235.073.031.033", "157.59.25.27")] // Octal
+        [InlineData("157.59.25.033", "157.59.25.27")] // Partial octal
+        public void ParseIPv4_Success_Octal_NonOSX(string address, string expected)
         {
-            Assert.Throws<FormatException>(() => { IPAddress.Parse("192.168.0.0/16"); });
+            Assert.Equal(expected, IPAddress.Parse(address).ToString());
         }
 
-        [Fact]
-        public void ParseIPv4_WithPort_Failure()
+        [Theory]
+        [InlineData("192.168.0.0/16")] // with subnet
+        [InlineData("192.168.0.1:80")] // with port
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(" 127.0.0.1")]
+        [InlineData("157.3B191B")] // Hex without 0x
+        [InlineData("260.156")] // Left dotted segments can't be more than 255
+        [InlineData("255.260.156")] // Left dotted segments can't be more than 255
+        [InlineData("1.1.1.0x")] // Empty trailing hex segment
+        [InlineData("...")] // Empty sections
+        [InlineData("1.1.1.")] // Empty trailing section
+        [InlineData("1..1.1")] // Empty internal section
+        [InlineData(".1.1.1")] // Empty leading section
+        [InlineData("..11.1")] // Empty sections
+        [InlineData("0xFF.0xFFFFFF.0xFF")] // Middle segment too large
+        [InlineData("0xFFFFFF.0xFF.0xFFFFFF")] // Leading segment too large
+        [InlineData("1.1\u67081.1.1")] // Unicode, Crashes .NET 4.0 IPAddress.TryParse
+        [InlineData("0000X9D.0x3B.0X19.0x1B")] // Leading zeros on hex
+        public void ParseIPv4_Failure(string address)
         {
-            Assert.Throws<FormatException>(() => { IPAddress.Parse("192.168.0.1:80"); });
+            Assert.Throws<FormatException>(() => { IPAddress.Parse(address); });
+        }
+
+        [Theory]
+        [PlatformSpecific(~PlatformID.OSX)] // There does't appear to be an OSX API that will fail for these
+        [InlineData("4294967296")] // Decimal overflow by 1
+        [InlineData("040000000000")] // Octal overflow by 1
+        [InlineData("01011101001110110001100100011011")] // Binary? Read as octal, overflows
+        [InlineData("10011101001110110001100100011011")] // Binary? Read as decimal, overflows
+        [InlineData("0x100000000")] // Hex overflow by 1
+        [InlineData("0x.1.1.1")] // Empty leading hex segment
+        public void ParseIPv4_Failure_NonOSX(string address)
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse(address); });
+        }
+
+        [Theory]
+        [ActiveIssue(8362, ~PlatformID.OSX)]
+        [InlineData("0.0.0.089")] // Octal (leading zero) but with 8 or 9
+        public void ParseIPv4_Failure_Octal_NonOSX(string address)
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse(address); });
         }
 
         #endregion
 
         #region IPv6
 
-        [Fact]
-        public void ParseIPv6_NoBrackets_Success()
+        [Theory]
+        [InlineData("Fe08::1", "fe08::1")]
+        [InlineData("[Fe08::1]", "fe08::1")]
+        [InlineData("[Fe08::1]:80", "fe08::1")]
+        [InlineData("[Fe08::1]:0xFA", "fe08::1")]
+        [InlineData("Fe08::1%13542", "fe08::1%13542")]
+        [InlineData("::", "::")]
+        [InlineData("0000:0000:0000:0000:0000:0000:0000:0000", "::")]
+        [InlineData("FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")]
+        [InlineData("0:0:0:0:0:0:0:0", "::")]
+        [InlineData("1:0:0:0:0:0:0:0", "1::")]
+        [InlineData("0:1:0:0:0:0:0:0", "0:1::")]
+        [InlineData("0:0:1:0:0:0:0:0", "0:0:1::")]
+        [InlineData("0:0:0:1:0:0:0:0", "0:0:0:1::")]
+        [InlineData("0:0:0:0:1:0:0:0", "::1:0:0:0")]
+        [InlineData("0:0:0:0:0:1:0:0", "::1:0:0")]
+        [InlineData("0:0:0:0:0:0:1:0", "::0.1.0.0")]
+        [InlineData("0:0:0:0:0:0:0:1", "::1")]
+        [InlineData("1:0:0:0:0:0:0:1", "1::1")]
+        [InlineData("1:1:0:0:0:0:0:1", "1:1::1")]
+        [InlineData("1:0:1:0:0:0:0:1", "1:0:1::1")]
+        [InlineData("1:0:0:1:0:0:0:1", "1:0:0:1::1")]
+        [InlineData("1:0:0:0:1:0:0:1", "1::1:0:0:1")]
+        [InlineData("1:0:0:0:0:1:0:1", "1::1:0:1")]
+        [InlineData("1:0:0:0:0:0:1:1", "1::1:1")]
+        [InlineData("1:1:0:0:1:0:0:1", "1:1::1:0:0:1")]
+        [InlineData("1:0:1:0:0:1:0:1", "1:0:1::1:0:1")]
+        [InlineData("1:0:0:1:0:0:1:1", "1::1:0:0:1:1")]
+        [InlineData("1:1:0:0:0:1:0:1", "1:1::1:0:1")]
+        [InlineData("1:0:0:0:1:0:1:1", "1::1:0:1:1")]
+        [InlineData("1::%1", "1::%1")]
+        [InlineData("::1%12", "::1%12")]
+        [InlineData("::%123", "::%123")]
+        [InlineData("FE08::192.168.0.1", "fe08::c0a8:1")] // Output is not IPv4 mapped
+        [InlineData("::192.168.0.1", "::192.168.0.1")]
+        [InlineData("::FFFF:192.168.0.1", "::ffff:192.168.0.1")] // SIIT
+        public void ParseIPv6_Success(string address, string expected)
         {
-            Assert.Equal("fe08::1", IPAddress.Parse("Fe08::1").ToString());
+            Assert.Equal(expected, IPAddress.Parse(address).ToString());
         }
 
-        [Fact]
-        public void ParseIPv6_Brackets_SuccessBracketsDropped()
+        [Theory]
+        [PlatformSpecific(~PlatformID.AnyUnix)] // Linux/OSX don't recognize these as IPv4 addresses
+        // Linux/OSX don't do the IPv6->IPv4 formatting for these addresses
+        [InlineData("::FFFF:0:192.168.0.1", "::ffff:0:192.168.0.1")] // SIIT
+        [InlineData("::5EFE:192.168.0.1", "::5efe:192.168.0.1")] // ISATAP
+        [InlineData("1::5EFE:192.168.0.1", "1::5efe:192.168.0.1")] // ISATAP
+        public void ParseIPv6_Success_v4_NonUnix(string address, string expected)
         {
-            Assert.Equal("fe08::1", IPAddress.Parse("[Fe08::1]").ToString());
+            Assert.Equal(expected, IPAddress.Parse(address).ToString());
         }
 
-        [Fact]
-        public void ParseIPv6_LeadingBracket_Failure()
+        [Theory]
+        [PlatformSpecific(~PlatformID.Linux)] // Linux does not appear to recognize this as a valid address
+        [InlineData("::192.168.0.010", "::192.168.0.10")] // Embedded IPv4 octal, read as decimal
+        public void ParseIPv6_Success_v4_NonLinux(string address, string expected)
         {
-            Assert.Throws<FormatException>(() => { IPAddress.Parse("[Fe08::1"); });
+            Assert.Equal(expected, IPAddress.Parse(address).ToString());
         }
 
-        [Fact]
-        public void ParseIPv6_TrailingBracket_Failure()
+        [Theory]
+        [InlineData("[Fe08::1")]
+        [InlineData("Fe08::1]")]
+        [InlineData("[Fe08::1]:80Z")]
+        [InlineData("Fe08::/64")]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("[1]")]
+        [InlineData(":1")]
+        [InlineData("1:")]
+        [InlineData("::1 ")]
+        [InlineData(" ::1")]
+        [InlineData("1::1::1")] // Ambigious
+        [InlineData("1:1\u67081:1:1")] // Unicoded. Crashes .NET 4.0 IPAddress.TryParse
+        [InlineData("FE08::260.168.0.1")] // Embedded IPv4 out of range
+        [InlineData("::192.168.0.0x0")] // Embedded IPv4 hex
+        [InlineData("[192.168.0.1]")] // Raw IPv4
+        [InlineData("G::")] // Hex out of range
+        [InlineData("FFFFF::")] // Hex out of range
+        [InlineData(":%12")] // Colon Scope
+        [InlineData("%12")] // Just Scope
+        public void ParseIPv6_Failure(string address)
         {
-            Assert.Throws<FormatException>(() => { IPAddress.Parse("Fe08::1]"); });
+            Assert.Throws<FormatException>(() => { IPAddress.Parse(address); });
         }
 
-        [Fact]
-        public void ParseIPv6_BracketsAndPort_SuccessBracketsAndPortDropped()
+        [Theory]
+        [PlatformSpecific(~PlatformID.OSX)]
+        [InlineData("::%1a")] // Alpha numeric Scope
+        public void ParseIPv6_Failure_NonOSX(string address)
         {
-            Assert.Equal("fe08::1", IPAddress.Parse("[Fe08::1]:80").ToString());
+            Assert.Throws<FormatException>(() => { IPAddress.Parse(address); });
         }
 
-        [Fact]
-        public void ParseIPv6_BracketsAndInvalidPort_Failure()
-        {
-            Assert.Throws<FormatException>(() => { IPAddress.Parse("[Fe08::1]:80Z"); });
-        }
-
-        [Fact]
-        public void ParseIPv6_BracketsAndHexPort_SuccessBracketsAndPortDropped()
-        {
-            Assert.Equal("fe08::1", IPAddress.Parse("[Fe08::1]:0xFA").ToString());
-        }
-
-        [Fact]
-        public void ParseIPv6_WithSubnet_Failure()
-        {
-            Assert.Throws<FormatException>(() => { IPAddress.Parse("Fe08::/64"); });
-        }
-
-        [Fact]
-        public void ParseIPv6_ScopeId_Success()
-        {
-            Assert.Equal("fe08::1%13542", IPAddress.Parse("Fe08::1%13542").ToString());
-        }
 
         #endregion
 

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
@@ -105,7 +105,7 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Theory]
-        [PlatformSpecific(~PlatformID.OSX)] // There does't appear to be an OSX API that will fail for these
+        [PlatformSpecific(~PlatformID.OSX)] // There doesn't appear to be an OSX API that will fail for these
         [InlineData("0x.1.1.1")] // Empty leading hex segment
         public void ParseIPv4_InvalidHex_Failure_NonOSX(string address)
         {
@@ -262,6 +262,17 @@ namespace System.Net.Primitives.Functional.Tests
         [InlineData("::5EFE:192.168.0.1", "::5efe:192.168.0.1")] // ISATAP
         [InlineData("1::5EFE:192.168.0.1", "1::5efe:192.168.0.1")] // ISATAP
         public void ParseIPv6_v4_Success_NonUnix(string address, string expected)
+        {
+            Assert.Equal(expected, IPAddress.Parse(address).ToString());
+        }
+
+        [Theory]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        // Linux/OSX don't do the IPv6->IPv4 formatting for these addresses
+        [InlineData("::FFFF:0:192.168.0.1", "::ffff:0:c0a8:1")] // SIIT
+        [InlineData("::5EFE:192.168.0.1", "::5efe:c0a8:1")] // ISATAP
+        [InlineData("1::5EFE:192.168.0.1", "1::5efe:c0a8:1")] // ISATAP
+        public void ParseIPv6_v4_Success_Unix(string address, string expected)
         {
             Assert.Equal(expected, IPAddress.Parse(address).ToString());
         }

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
@@ -42,7 +42,7 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Theory]
-        [ActiveIssue(8362, ~PlatformID.OSX)]
+        [ActiveIssue(8362, PlatformID.OSX)]
         [InlineData("000235.000073.0000031.00000033", "157.59.25.27")] // Octal
         [InlineData("0235.073.031.033", "157.59.25.27")] // Octal
         [InlineData("157.59.25.033", "157.59.25.27")] // Partial octal
@@ -89,7 +89,7 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Theory]
-        [ActiveIssue(8362, ~PlatformID.OSX)]
+        [ActiveIssue(8362, PlatformID.OSX)]
         [InlineData("0.0.0.089")] // Octal (leading zero) but with 8 or 9
         public void ParseIPv4_Failure_Octal_NonOSX(string address)
         {

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
@@ -14,29 +14,37 @@ namespace System.Net.Primitives.Functional.Tests
         [InlineData("192.168.0.1", "192.168.0.1")]
         [InlineData("0.0.0.0", "0.0.0.0")]
         [InlineData("0", "0.0.0.0")]
-        [InlineData("0x0", "0.0.0.0")]
         [InlineData("255.255.255.255", "255.255.255.255")]
-        [InlineData("0xFF.0xFF.0xFF.0xFF", "255.255.255.255")]
-        [InlineData("0377.0377.0377.0377", "255.255.255.255")]
         [InlineData("4294967294", "255.255.255.254")]
         [InlineData("4294967295", "255.255.255.255")]
-        [InlineData("0xFFFFFFFE", "255.255.255.254")]
-        [InlineData("0xFFFFFFFF", "255.255.255.255")]
-        [InlineData("037777777776", "255.255.255.254")] // Octal
-        [InlineData("037777777777", "255.255.255.255")] // Octal
-        [InlineData("2637895963", "157.59.25.27")]
         [InlineData("157.3873051", "157.59.25.27")]
         [InlineData("157.6427", "157.0.25.27")]
+        [InlineData("2637895963", "157.59.25.27")]
+        public void ParseIPv4_Decimal_Success(string address, string expected)
+        {
+            Assert.Equal(expected, IPAddress.Parse(address).ToString());
+        }
+
+        [Theory]
+        [InlineData("0xFF.0xFF.0xFF.0xFF", "255.255.255.255")]
+        [InlineData("0x0", "0.0.0.0")]
+        [InlineData("0xFFFFFFFE", "255.255.255.254")]
+        [InlineData("0xFFFFFFFF", "255.255.255.255")]
         [InlineData("0x9D3B191B", "157.59.25.27")]
         [InlineData("0X9D.0x3B.0X19.0x1B", "157.59.25.27")]
         [InlineData("0x89.0xab.0xcd.0xef", "137.171.205.239")]
-        [InlineData("157.59.25.0x1B", "157.59.25.27")]
-        [InlineData("157.59.0x001B", "157.59.0.27")]
-        [InlineData("157.0x00001B", "157.0.0.27")]
-        [InlineData("023516614433", "157.59.25.27")] // Octal
-        [InlineData("00000023516614433", "157.59.25.27")] // Octal
-        [InlineData("157.59.0x25.033", "157.59.37.27")]
-        public void ParseIPv4_Success(string address, string expected)
+        public void ParseIPv4_Hex_Success(string address, string expected)
+        {
+            Assert.Equal(expected, IPAddress.Parse(address).ToString());
+        }
+
+        [Theory]
+        [InlineData("0377.0377.0377.0377", "255.255.255.255")]
+        [InlineData("037777777776", "255.255.255.254")]
+        [InlineData("037777777777", "255.255.255.255")]
+        [InlineData("023516614433", "157.59.25.27")]
+        [InlineData("00000023516614433", "157.59.25.27")]
+        public void ParseIPv4_Octal_Success(string address, string expected)
         {
             Assert.Equal(expected, IPAddress.Parse(address).ToString());
         }
@@ -46,31 +54,78 @@ namespace System.Net.Primitives.Functional.Tests
         [InlineData("000235.000073.0000031.00000033", "157.59.25.27")] // Octal
         [InlineData("0235.073.031.033", "157.59.25.27")] // Octal
         [InlineData("157.59.25.033", "157.59.25.27")] // Partial octal
-        public void ParseIPv4_Success_Octal_NonOSX(string address, string expected)
+        public void ParseIPv4_Octal_Success_NonOSX(string address, string expected)
         {
             Assert.Equal(expected, IPAddress.Parse(address).ToString());
         }
 
         [Theory]
-        [InlineData("192.168.0.0/16")] // with subnet
-        [InlineData("192.168.0.1:80")] // with port
-        [InlineData("")]
+        [InlineData("157.59.25.0x1B", "157.59.25.27")]
+        [InlineData("157.59.0x001B", "157.59.0.27")]
+        [InlineData("157.0x00001B", "157.0.0.27")]
+        [InlineData("157.59.0x25.033", "157.59.37.27")]
+        public void ParseIPv4_MixedBase_Success(string address, string expected)
+        {
+            Assert.Equal(expected, IPAddress.Parse(address).ToString());
+        }
+
+        [Fact]
+        public void ParseIPv4_WithSubnet_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("192.168.0.0/16"); });
+        }
+
+        [Fact]
+        public void ParseIPv4_WithPort_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("192.168.0.1:80"); });
+        }
+
+        [Fact]
+        public void ParseIPv4_Empty_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse(""); });
+        }
+
+        [Theory]
         [InlineData(" ")]
         [InlineData(" 127.0.0.1")]
+        public void ParseIPv4_Whitespace_Failure(string address)
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse(address); });
+        }
+
+        [Theory]
         [InlineData("157.3B191B")] // Hex without 0x
+        [InlineData("1.1.1.0x")] // Empty trailing hex segment
+        [InlineData("0000X9D.0x3B.0X19.0x1B")] // Leading zeros on hex
+        public void ParseIPv4_InvalidHex_Failure(string address)
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse(address); });
+        }
+
+        [Theory]
+        [PlatformSpecific(~PlatformID.OSX)] // There does't appear to be an OSX API that will fail for these
+        [InlineData("0x.1.1.1")] // Empty leading hex segment
+        public void ParseIPv4_InvalidHex_Failure_NonOSX(string address)
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse(address); });
+        }
+
+        [Theory]
+        [ActiveIssue(8362, PlatformID.OSX)]
+        [InlineData("0.0.0.089")] // Octal (leading zero) but with 8 or 9
+        public void ParseIPv4_InvalidOctal_Failure(string address)
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse(address); });
+        }
+
+        [Theory]
         [InlineData("260.156")] // Left dotted segments can't be more than 255
         [InlineData("255.260.156")] // Left dotted segments can't be more than 255
-        [InlineData("1.1.1.0x")] // Empty trailing hex segment
-        [InlineData("...")] // Empty sections
-        [InlineData("1.1.1.")] // Empty trailing section
-        [InlineData("1..1.1")] // Empty internal section
-        [InlineData(".1.1.1")] // Empty leading section
-        [InlineData("..11.1")] // Empty sections
         [InlineData("0xFF.0xFFFFFF.0xFF")] // Middle segment too large
         [InlineData("0xFFFFFF.0xFF.0xFFFFFF")] // Leading segment too large
-        [InlineData("1.1\u67081.1.1")] // Unicode, Crashes .NET 4.0 IPAddress.TryParse
-        [InlineData("0000X9D.0x3B.0X19.0x1B")] // Leading zeros on hex
-        public void ParseIPv4_Failure(string address)
+        public void ParseIPv4_InvalidValue_Failure(string address)
         {
             Assert.Throws<FormatException>(() => { IPAddress.Parse(address); });
         }
@@ -82,16 +137,25 @@ namespace System.Net.Primitives.Functional.Tests
         [InlineData("01011101001110110001100100011011")] // Binary? Read as octal, overflows
         [InlineData("10011101001110110001100100011011")] // Binary? Read as decimal, overflows
         [InlineData("0x100000000")] // Hex overflow by 1
-        [InlineData("0x.1.1.1")] // Empty leading hex segment
-        public void ParseIPv4_Failure_NonOSX(string address)
+        public void ParseIPv4_InvalidValue_Failure_NonOSX(string address)
         {
             Assert.Throws<FormatException>(() => { IPAddress.Parse(address); });
         }
 
         [Theory]
-        [ActiveIssue(8362, PlatformID.OSX)]
-        [InlineData("0.0.0.089")] // Octal (leading zero) but with 8 or 9
-        public void ParseIPv4_Failure_Octal_NonOSX(string address)
+        [InlineData("1.1\u67081.1.1")] // Unicode, Crashes .NET 4.0 IPAddress.TryParse
+        public void ParseIPv4_InvalidChar_Failure(string address)
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse(address); });
+        }
+
+        [Theory]
+        [InlineData("...")] // Empty sections
+        [InlineData("1.1.1.")] // Empty trailing section
+        [InlineData("1..1.1")] // Empty internal section
+        [InlineData(".1.1.1")] // Empty leading section
+        [InlineData("..11.1")] // Empty sections
+        public void ParseIPv4_EmptySection_Failure(string address)
         {
             Assert.Throws<FormatException>(() => { IPAddress.Parse(address); });
         }
@@ -102,11 +166,6 @@ namespace System.Net.Primitives.Functional.Tests
 
         [Theory]
         [InlineData("Fe08::1", "fe08::1")]
-        [InlineData("[Fe08::1]", "fe08::1")]
-        [InlineData("[Fe08::1]:80", "fe08::1")]
-        [InlineData("[Fe08::1]:0xFA", "fe08::1")]
-        [InlineData("Fe08::1%13542", "fe08::1%13542")]
-        [InlineData("::", "::")]
         [InlineData("0000:0000:0000:0000:0000:0000:0000:0000", "::")]
         [InlineData("FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")]
         [InlineData("0:0:0:0:0:0:0:0", "::")]
@@ -130,24 +189,79 @@ namespace System.Net.Primitives.Functional.Tests
         [InlineData("1:0:0:1:0:0:1:1", "1::1:0:0:1:1")]
         [InlineData("1:1:0:0:0:1:0:1", "1:1::1:0:1")]
         [InlineData("1:0:0:0:1:0:1:1", "1::1:0:1:1")]
+        [InlineData("::", "::")]
+        public void ParseIPv6_NoBrackets_Success(string address, string expected)
+        {
+            Assert.Equal(expected, IPAddress.Parse(address).ToString());
+        }
+
+        [Fact]
+        public void ParseIPv6_Brackets_SuccessBracketsDropped()
+        {
+            Assert.Equal("fe08::1", IPAddress.Parse("[Fe08::1]").ToString());
+        }
+
+        [Fact]
+        public void ParseIPv6_LeadingBracket_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("[Fe08::1"); });
+        }
+
+        [Fact]
+        public void ParseIPv6_TrailingBracket_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("Fe08::1]"); });
+        }
+
+        [Fact]
+        public void ParseIPv6_BracketsAndPort_SuccessBracketsAndPortDropped()
+        {
+            Assert.Equal("fe08::1", IPAddress.Parse("[Fe08::1]:80").ToString());
+        }
+
+        [Fact]
+        public void ParseIPv6_BracketsAndInvalidPort_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("[Fe08::1]:80Z"); });
+        }
+
+        [Fact]
+        public void ParseIPv6_BracketsAndHexPort_SuccessBracketsAndPortDropped()
+        {
+            Assert.Equal("fe08::1", IPAddress.Parse("[Fe08::1]:0xFA").ToString());
+        }
+
+        [Fact]
+        public void ParseIPv6_WithSubnet_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("Fe08::/64"); });
+        }
+        [Theory]
+        [InlineData("Fe08::1%13542", "fe08::1%13542")]
         [InlineData("1::%1", "1::%1")]
         [InlineData("::1%12", "::1%12")]
         [InlineData("::%123", "::%123")]
-        [InlineData("FE08::192.168.0.1", "fe08::c0a8:1")] // Output is not IPv4 mapped
-        [InlineData("::192.168.0.1", "::192.168.0.1")]
-        [InlineData("::FFFF:192.168.0.1", "::ffff:192.168.0.1")] // SIIT
-        public void ParseIPv6_Success(string address, string expected)
+        public void ParseIPv6_ScopeID_Success(string address, string expected)
         {
             Assert.Equal(expected, IPAddress.Parse(address).ToString());
         }
 
         [Theory]
-        [PlatformSpecific(~PlatformID.AnyUnix)] // Linux/OSX don't recognize these as IPv4 addresses
+        [InlineData("FE08::192.168.0.1", "fe08::c0a8:1")] // Output is not IPv4 mapped
+        [InlineData("::192.168.0.1", "::192.168.0.1")]
+        [InlineData("::FFFF:192.168.0.1", "::ffff:192.168.0.1")] // SIIT
+        public void ParseIPv6_v4_Success(string address, string expected)
+        {
+            Assert.Equal(expected, IPAddress.Parse(address).ToString());
+        }
+
+        [Theory]
+        [PlatformSpecific(~PlatformID.AnyUnix)]
         // Linux/OSX don't do the IPv6->IPv4 formatting for these addresses
         [InlineData("::FFFF:0:192.168.0.1", "::ffff:0:192.168.0.1")] // SIIT
         [InlineData("::5EFE:192.168.0.1", "::5efe:192.168.0.1")] // ISATAP
         [InlineData("1::5EFE:192.168.0.1", "1::5efe:192.168.0.1")] // ISATAP
-        public void ParseIPv6_Success_v4_NonUnix(string address, string expected)
+        public void ParseIPv6_v4_Success_NonUnix(string address, string expected)
         {
             Assert.Equal(expected, IPAddress.Parse(address).ToString());
         }
@@ -155,43 +269,100 @@ namespace System.Net.Primitives.Functional.Tests
         [Theory]
         [PlatformSpecific(~PlatformID.Linux)] // Linux does not appear to recognize this as a valid address
         [InlineData("::192.168.0.010", "::192.168.0.10")] // Embedded IPv4 octal, read as decimal
-        public void ParseIPv6_Success_v4_NonLinux(string address, string expected)
+        public void ParseIPv6_v4_Success_NonLinux(string address, string expected)
         {
             Assert.Equal(expected, IPAddress.Parse(address).ToString());
         }
 
-        [Theory]
-        [InlineData("[Fe08::1")]
-        [InlineData("Fe08::1]")]
-        [InlineData("[Fe08::1]:80Z")]
-        [InlineData("Fe08::/64")]
-        [InlineData("")]
-        [InlineData(" ")]
-        [InlineData("[1]")]
-        [InlineData(":1")]
-        [InlineData("1:")]
-        [InlineData("::1 ")]
-        [InlineData(" ::1")]
-        [InlineData("1::1::1")] // Ambigious
-        [InlineData("1:1\u67081:1:1")] // Unicoded. Crashes .NET 4.0 IPAddress.TryParse
-        [InlineData("FE08::260.168.0.1")] // Embedded IPv4 out of range
-        [InlineData("::192.168.0.0x0")] // Embedded IPv4 hex
-        [InlineData("[192.168.0.1]")] // Raw IPv4
-        [InlineData("G::")] // Hex out of range
-        [InlineData("FFFFF::")] // Hex out of range
-        [InlineData(":%12")] // Colon Scope
-        [InlineData("%12")] // Just Scope
-        public void ParseIPv6_Failure(string address)
+        [Fact]
+        public void ParseIPv6_Incomplete_Failure()
         {
-            Assert.Throws<FormatException>(() => { IPAddress.Parse(address); });
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("[1]"); });
         }
 
-        [Theory]
-        [PlatformSpecific(~PlatformID.OSX)]
-        [InlineData("::%1a")] // Alpha numeric Scope
-        public void ParseIPv6_Failure_NonOSX(string address)
+        [Fact]
+        public void ParseIPv6_LeadingSingleColon_Failure()
         {
-            Assert.Throws<FormatException>(() => { IPAddress.Parse(address); });
+            Assert.Throws<FormatException>(() => { IPAddress.Parse(":1"); });
+        }
+
+        [Fact]
+        public void ParseIPv6_TrailingSingleColon_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("1:"); });
+        }
+
+        [Fact]
+        public void ParseIPv6_LeadingWhitespace_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse(" ::1"); });
+        }
+
+        [Fact]
+        public void ParseIPv6_TrailingWhitespace_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("::1 "); });
+        }
+
+        [Fact]
+        public void ParseIPv6_Ambiguous_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("1::1::1"); });
+        }
+
+        [Fact]
+        public void ParseIPv6_InvalidChar_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("1:1\u67081:1:1"); });
+        }
+
+        [Fact]
+        public void ParseIPv6_v4_OutOfRange_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("FE08::260.168.0.1"); });
+        }
+
+        [Fact]
+        public void ParseIPv6_v4_Hex_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("::192.168.0.0x0"); });
+        }
+
+        [Fact]
+        public void ParseIPv6_Rawv4_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("[192.168.0.1]"); });
+        }
+
+        [Fact]
+        public void ParseIPv6_InvalidHex_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("G::"); });
+        }
+
+        [Fact]
+        public void ParseIPv6_InvalidValue_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("FFFFF::"); });
+        }
+
+        [Fact]
+        public void ParseIPv6_ColonScope_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse(":%12"); });
+        }
+
+        [Fact]
+        public void ParseIPv6_JustScope_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("%12"); });
+        }
+
+        [Fact]
+        [PlatformSpecific(~PlatformID.OSX)]
+        public void ParseIPv6_AlphaNumericScope_Failure()
+        {
+            Assert.Throws<FormatException>(() => { IPAddress.Parse("::%1a"); });
         }
 
 

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -19,146 +19,144 @@ namespace System.PrivateUri.Tests
             ParseIPv4Address(IPAddress.Loopback.ToString());
         }
 
-        [Fact]
-        public void UriIPv4Host_Any_Success()
+        [Theory]
+        [InlineData("0.0.0.0", "0.0.0.0")]
+        [InlineData("0", "0.0.0.0")]
+        [InlineData("0x0", "0.0.0.0")]
+        public void UriIPv4Host_Any_Success(string address, string expected)
         {
-            // IPAddress.Any
-            ParseIPv4Address("0.0.0.0");
-            ParseIPv4Address("0");
-            ParseIPv4Address("0x0");
+            ParseIPv4Address(address, expected);
         }
 
-        [Fact]
-        public void UriIPv4Host_None_Success()
+        [Theory]
+        // 255.255.255.255
+        [InlineData("255.255.255.255", "255.255.255.255")]
+        [InlineData("0xFF.0xFF.0xFF.0xFF", "255.255.255.255")]
+        [InlineData("0377.0377.0377.0377", "255.255.255.255")]
+        // Biggest value 4.0 supported in this format
+        [InlineData("4294967294", "255.255.255.254")]
+        [InlineData("0xFFFFFFFE", "255.255.255.254")]
+        [InlineData("037777777776", "255.255.255.254")] // Octal
+        // IPAddress doesn't support these formats, except on XP / 2003?
+        [InlineData("4294967295", "255.255.255.255")]
+        [InlineData("0xFFFFFFFF", "255.255.255.255")]
+        [InlineData("037777777777", "255.255.255.255")] // Octal
+        public void UriIPv4Host_None_Success(string address, string expected)
         {
-            // 255.255.255.255
-            ParseIPv4Address("255.255.255.255");
-            ParseIPv4Address("0xFF.0xFF.0xFF.0xFF");
-            ParseIPv4Address("0377.0377.0377.0377");
-
-            // Biggest value 4.0 supported in this format
-            ParseIPv4Address((UInt32.MaxValue - 1).ToString());
-            ParseIPv4Address("0x" + (UInt32.MaxValue - 1).ToString("X"));
-            ParseIPv4Address("037777777776"); // Octal
-
-            // IPAddress doesn't support these formats, except on XP / 2003?
-            ParseIPv4Address(UInt32.MaxValue.ToString());
-            ParseIPv4Address("0x" + UInt32.MaxValue.ToString("X"));
-            ParseIPv4Address("037777777777"); // Octal
+            ParseIPv4Address(address, expected);
         }
 
         [Fact]
         public void UriIPv4Host_FullDec_Success()
         {
-            ParseIPv4Address("2637895963");
+            ParseIPv4Address("2637895963", expected: "157.59.25.27");
         }
 
-        [Fact]
-        public void UriIPv4Host_PartialDec_Success()
+        [Theory]
+        [InlineData("157.3873051", "157.59.25.27")]
+        [InlineData("157.6427", "157.0.25.27")]
+        public void UriIPv4Host_PartialDec_Success(string address, string expected)
         {
-            ParseIPv4Address("157.3873051");
-            ParseIPv4Address("157.6427");
+            ParseIPv4Address(address, expected);
         }
 
         [Fact]
         public void UriIPv4Host_FullHex_Success()
         {
-            ParseIPv4Address("0x9D3B191B");
+            ParseIPv4Address("0x9D3B191B", expected: "157.59.25.27");
         }
 
         [Fact]
         public void UriIPv4Host_DottedHex_Success()
         {
-            ParseIPv4Address("0X9D.0x3B.0X19.0x1B");
+            ParseIPv4Address("0X9D.0x3B.0X19.0x1B", expected: "157.59.25.27");
         }
 
         [Fact]
         public void UriIPv4Host_DottedHexLowerCase_Success()
         {
-            ParseIPv4Address("0x89.0xab.0xcd.0xef");
+            ParseIPv4Address("0x89.0xab.0xcd.0xef", expected: "137.171.205.239");
         }
 
-        [Fact]
-        public void UriIPv4Host_PartialHex_Success()
+        [Theory]
+        [InlineData("157.59.25.0x1B", "157.59.25.27")]
+        [InlineData("157.59.0x001B", "157.59.0.27")]
+        [InlineData("157.0x00001B", "157.0.0.27")]
+        public void UriIPv4Host_PartialHex_Success(string address, string expected)
         {
-            ParseIPv4Address("157.59.25.0x1B");
-            ParseIPv4Address("157.59.0x001B");
-            ParseIPv4Address("157.0x00001B");
+            ParseIPv4Address(address, expected);
         }
 
         [Fact]
         public void UriIPv4Host_FullOctal_Success()
         {
             // 4.0 Uri truncates the leading zeros and reads these as decimal
-            ParseIPv4Address("023516614433");
+            ParseIPv4Address("023516614433", expected: "157.59.25.27");
         }
 
         [Fact]
         public void UriIPv4Host_FullOctalExtraLeadingZeros_Success()
         {
             // 4.0 Uri truncates the leading zeros and reads these as decimal
-            ParseIPv4Address("00000023516614433");
+            ParseIPv4Address("00000023516614433", expected: "157.59.25.27");
         }
 
         [Fact]
-        [ActiveIssue(8362, PlatformID.OSX)]
         public void UriIPv4Host_DottedOctal_Success()
         {
             // 4.0 Uri truncates the leading zeros and reads these as decimal
-            ParseIPv4Address("0235.073.031.033");
+            ParseIPv4Address("0235.073.031.033", expected: "157.59.25.27");
         }
 
         [Fact]
-        [ActiveIssue(8362, PlatformID.OSX)]
         public void UriIPv4Host_DottedOctalExtraLeadingZeros_Success()
         {
             // 4.0 Uri truncates the leading zeros and reads these as decimal
-            ParseIPv4Address("000235.000073.0000031.00000033");
+            ParseIPv4Address("000235.000073.0000031.00000033", expected: "157.59.25.27");
         }
 
         [Fact]
-        [ActiveIssue(8362, PlatformID.OSX)]
         public void UriIPv4Host_PartialOctal_Success()
         {
             // 4.0 Uri truncates the leading zeros and reads these as decimal
-            ParseIPv4Address("157.59.25.033");
+            ParseIPv4Address("157.59.25.033", expected: "157.59.25.27");
         }
 
         [Fact]
         public void UriIPv4Host_PartDecHexOct_Success()
         {
             // 4.0 Uri truncates the leading zeros and reads these as decimal
-            ParseIPv4Address("157.59.0x25.033");
+            ParseIPv4Address("157.59.0x25.033", expected: "157.59.37.27");
         }
 
-        [Fact]
-        [ActiveIssue(8361, PlatformID.AnyUnix)]
-        public void UriIPv4Host_BadAddresses_AllFail()
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("127.0.0.1 ")]
+        [InlineData(" 127.0.0.1")]
+        [InlineData("157.3B191B")] // Hex without 0x
+        [InlineData("260.156")] // Left dotted segments can't be more than 255
+        [InlineData("255.260.156")] // Left dotted segments can't be more than 255
+        [InlineData("1.1.1.0x")] // Empty trailing hex segment
+        [InlineData("0x.1.1.1")] // Empty leading hex segment
+        [InlineData("...")] // Empty sections
+        [InlineData("1.1.1.")] // Empty trailing section
+        [InlineData("1..1.1")] // Empty internal section
+        [InlineData(".1.1.1")] // Empty leading section
+        [InlineData("..11.1")] // Empty sections
+        [InlineData("0xFF.0xFFFFFF.0xFF")] // Middle segment too large
+        [InlineData("0xFFFFFF.0xFF.0xFFFFFF")] // Leading segment too large
+        [InlineData("1.1\u67081.1.1")] // Unicode, Crashes .NET 4.0 IPAddress.TryParse
+        [InlineData("0000X9D.0x3B.0X19.0x1B")] // Leading zeros on hex
+        [InlineData("01011101001110110001100100011011")] // Binary? Read as octal, overflows
+        [InlineData("10011101001110110001100100011011")] // Binary? Read as decimal, overflows
+        [InlineData("040000000000")] // Octal overflow by 1
+        [InlineData("4294967296")] // Decimal overflow by 1
+        [InlineData("0x100000000")] // Hex overflow by 1
+        [InlineData("0.0.0.089")] // Octal (leading zero) but with 8 or 9
+        public void UriIPv4Host_BadAddresses_AllFail(string address)
         {
-            ParseBadIPv4Address("");
-            ParseBadIPv4Address(" ");
-            ParseBadIPv4Address(IPAddress.Loopback.ToString() + " ");
-            ParseBadIPv4Address(" " + IPAddress.Loopback.ToString());
-            ParseBadIPv4Address("157.3B191B"); // Hex without 0x
-            ParseBadIPv4Address("260.156"); // Left dotted segments can't be more than 255
-            ParseBadIPv4Address("255.260.156"); // Left dotted segments can't be more than 255
-            ParseBadIPv4Address("1.1.1.0x"); // Empty trailing hex segment
-            ParseBadIPv4Address("0x.1.1.1"); // Empty leading hex segment
-            ParseBadIPv4Address("..."); // Empty sections
-            ParseBadIPv4Address("1.1.1."); // Empty trailing section
-            ParseBadIPv4Address("1..1.1"); // Empty internal section
-            ParseBadIPv4Address(".1.1.1"); // Empty leading section
-            ParseBadIPv4Address("..11.1"); // Empty sections
-            ParseBadIPv4Address("0xFF.0xFFFFFF.0xFF"); // Middle segment too large
-            ParseBadIPv4Address("0xFFFFFF.0xFF.0xFFFFFF"); // Leading segment too large
-            ParseBadIPv4Address("1.1\u67081.1.1"); // Unicode, Crashes .NET 4.0 IPAddress.TryParse
-            ParseBadIPv4Address("0000X9D.0x3B.0X19.0x1B"); // Leading zeros on hex
-            ParseBadIPv4Address("01011101001110110001100100011011"); // Binary? Read as octal, overflows
-            ParseBadIPv4Address("10011101001110110001100100011011"); // Binary? Read as decimal, overflows
-            ParseBadIPv4Address("040000000000"); // Octal overflow by 1
-            ParseBadIPv4Address("4294967296"); // Decimal overflow by 1
-            ParseBadIPv4Address("0x100000000"); // Hex overflow by 1
-            ParseBadIPv4Address("0.0.0.089"); // Octal (leading zero) but with 8 or 9
+            ParseBadIPv4Address(address);
         }
 
         [Fact]
@@ -195,22 +193,23 @@ namespace System.PrivateUri.Tests
 
         private void ParseIPv4Address(string ipv4String)
         {
-            IPAddress address; // Sanity test
-            Assert.True(IPAddress.TryParse(ipv4String, out address), ipv4String);
-            Assert.Equal(AddressFamily.InterNetwork, address.AddressFamily);
+            ParseIPv4Address(ipv4String, expected: ipv4String);
+        }
 
+        private void ParseIPv4Address(string ipv4String, string expected)
+        {
             // TryCreate
             Uri testUri;
             Assert.True(Uri.TryCreate("http://" + ipv4String, UriKind.Absolute, out testUri), ipv4String);
             Assert.Equal(UriHostNameType.IPv4, testUri.HostNameType);
-            Assert.Equal(address.ToString(), testUri.Host);
-            Assert.Equal(address.ToString(), testUri.DnsSafeHost);
+            Assert.Equal(expected, testUri.Host);
+            Assert.Equal(expected, testUri.DnsSafeHost);
 
             // Constructor
             testUri = new Uri("http://" + ipv4String);
             Assert.Equal(UriHostNameType.IPv4, testUri.HostNameType);
-            Assert.Equal(address.ToString(), testUri.Host);
-            Assert.Equal(address.ToString(), testUri.DnsSafeHost);
+            Assert.Equal(expected, testUri.Host);
+            Assert.Equal(expected, testUri.DnsSafeHost);
 
             // CheckHostName
             Assert.Equal(UriHostNameType.IPv4, Uri.CheckHostName(ipv4String));
@@ -218,9 +217,6 @@ namespace System.PrivateUri.Tests
 
         private void ParseBadIPv4Address(string badIpv4String)
         {
-            IPAddress address; // Sanity test
-            Assert.False(IPAddress.TryParse(badIpv4String, out address), badIpv4String);
-
             // CheckHostName
             Assert.NotEqual(UriHostNameType.IPv4, Uri.CheckHostName(badIpv4String));
 
@@ -249,13 +245,13 @@ namespace System.PrivateUri.Tests
         [InlineData("0000:0000:0000:0000:0000:0000:0000:0000")]
         public void UriIPv6Host_Any_Success(string address)
         {
-            ParseIPv6Address(address);
+            ParseIPv6Address(address, expected: "::");
         }
 
         [Fact]
         public void UriIPv6Host_MaxValue_Success()
         {
-            ParseIPv6Address("FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF");
+            ParseIPv6Address("FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF", expected: "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
         }
 
         [Fact]
@@ -265,31 +261,30 @@ namespace System.PrivateUri.Tests
         }
 
         [Theory]
-        [InlineData("0:0:0:0:0:0:0:0")]
-        [InlineData("1:0:0:0:0:0:0:0")]
-        [InlineData("0:1:0:0:0:0:0:0")]
-        [InlineData("0:0:1:0:0:0:0:0")]
-        [InlineData("0:0:0:1:0:0:0:0")]
-        [InlineData("0:0:0:0:1:0:0:0")]
-        [InlineData("0:0:0:0:0:1:0:0")]
-        [InlineData("0:0:0:0:0:0:1:0")]
-        [InlineData("0:0:0:0:0:0:0:1")]
-        [InlineData("1:0:0:0:0:0:0:1")]
-        [InlineData("1:0:0:0:0:0:0:1")]
-        [InlineData("1:1:0:0:0:0:0:1")]
-        [InlineData("1:0:1:0:0:0:0:1")]
-        [InlineData("1:0:0:1:0:0:0:1")]
-        [InlineData("1:0:0:0:1:0:0:1")]
-        [InlineData("1:0:0:0:0:1:0:1")]
-        [InlineData("1:0:0:0:0:0:1:1")]
-        [InlineData("1:1:0:0:1:0:0:1")]
-        [InlineData("1:0:1:0:0:1:0:1")]
-        [InlineData("1:0:0:1:0:0:1:1")]
-        [InlineData("1:1:0:0:0:1:0:1")]
-        [InlineData("1:0:0:0:1:0:1:1")]
-        public void UriIPv6Host_CompressionRangeSelection_Success(string address)
+        [InlineData("0:0:0:0:0:0:0:0", "::")]
+        [InlineData("1:0:0:0:0:0:0:0", "1::")]
+        [InlineData("0:1:0:0:0:0:0:0", "0:1::")]
+        [InlineData("0:0:1:0:0:0:0:0", "0:0:1::")]
+        [InlineData("0:0:0:1:0:0:0:0", "0:0:0:1::")]
+        [InlineData("0:0:0:0:1:0:0:0", "::1:0:0:0")]
+        [InlineData("0:0:0:0:0:1:0:0", "::1:0:0")]
+        [InlineData("0:0:0:0:0:0:1:0", "::0.1.0.0")]
+        [InlineData("0:0:0:0:0:0:0:1", "::1")]
+        [InlineData("1:0:0:0:0:0:0:1", "1::1")]
+        [InlineData("1:1:0:0:0:0:0:1", "1:1::1")]
+        [InlineData("1:0:1:0:0:0:0:1", "1:0:1::1")]
+        [InlineData("1:0:0:1:0:0:0:1", "1:0:0:1::1")]
+        [InlineData("1:0:0:0:1:0:0:1", "1::1:0:0:1")]
+        [InlineData("1:0:0:0:0:1:0:1", "1::1:0:1")]
+        [InlineData("1:0:0:0:0:0:1:1", "1::1:1")]
+        [InlineData("1:1:0:0:1:0:0:1", "1:1::1:0:0:1")]
+        [InlineData("1:0:1:0:0:1:0:1", "1:0:1::1:0:1")]
+        [InlineData("1:0:0:1:0:0:1:1", "1::1:0:0:1:1")]
+        [InlineData("1:1:0:0:0:1:0:1", "1:1::1:0:1")]
+        [InlineData("1:0:0:0:1:0:1:1", "1::1:0:1:1")]
+        public void UriIPv6Host_CompressionRangeSelection_Success(string address, string expected)
         {
-            ParseIPv6Address(address);
+            ParseIPv6Address(address, expected);
         }
 
         [Theory]
@@ -302,17 +297,16 @@ namespace System.PrivateUri.Tests
         }
 
         [Theory]
-        [ActiveIssue(8360, PlatformID.AnyUnix)]
-        [InlineData("FE08::192.168.0.1")] // Output is not IPv4 mapped
-        [InlineData("::192.168.0.1")]
-        [InlineData("::FFFF:192.168.0.1")] // SIIT
-        [InlineData("::FFFF:0:192.168.0.1")] // SIIT
-        [InlineData("::5EFE:192.168.0.1")] // ISATAP
-        [InlineData("1::5EFE:192.168.0.1")] // ISATAP
-        [InlineData("::192.168.0.010")] // Embedded IPv4 octal, read as decimal
-        public void UriIPv6Host_EmbeddedIPv4_Success(string address)
+        [InlineData("FE08::192.168.0.1", "fe08::c0a8:1")] // Output is not IPv4 mapped
+        [InlineData("::192.168.0.1", "::192.168.0.1")]
+        [InlineData("::FFFF:192.168.0.1", "::ffff:192.168.0.1")] // SIIT
+        [InlineData("::FFFF:0:192.168.0.1", "::ffff:0:192.168.0.1")] // SIIT
+        [InlineData("::5EFE:192.168.0.1", "::5efe:192.168.0.1")] // ISATAP
+        [InlineData("1::5EFE:192.168.0.1", "1::5efe:192.168.0.1")] // ISATAP
+        [InlineData("::192.168.0.010", "::192.168.0.10")] // Embedded IPv4 octal, read as decimal
+        public void UriIPv6Host_EmbeddedIPv4_Success(string address, string expected)
         {
-            ParseIPv6Address(address);
+            ParseIPv6Address(address, expected);
         }
 
         [Theory]
@@ -341,31 +335,29 @@ namespace System.PrivateUri.Tests
 
         #region Helpers
 
-        // IPAddress parsing succeeds, Uri parsing succeeds, and the canonicalized results match.
         private void ParseIPv6Address(string ipv6String)
         {
-            IPAddress address; // Sanity test
-            Assert.True(IPAddress.TryParse(ipv6String, out address), ipv6String);
-            Assert.Equal(AddressFamily.InterNetworkV6, address.AddressFamily);
+            ParseIPv6Address(ipv6String, expected: ipv6String);
+        }
 
-            string expectedResult = address.ToString();
-            string expectedResultWithBrackets = "[" +
-                ((address.ScopeId == 0) ? expectedResult
-                    : expectedResult.Substring(0, expectedResult.IndexOf('%'))) // Drop scope id
-                + "]";
+        private void ParseIPv6Address(string ipv6String, string expected)
+        {
+            // Host property returns bracketed address without the scope ID
+            int scopeIndex = expected.IndexOf('%');
+            string expectedResultWithBrackets = $"[{((scopeIndex == -1) ? expected : expected.Substring(0, scopeIndex))}]";
 
             // TryCreate
             Uri testUri;
             Assert.True(Uri.TryCreate("http://[" + ipv6String + "]", UriKind.Absolute, out testUri), ipv6String);
             Assert.Equal(UriHostNameType.IPv6, testUri.HostNameType);
             Assert.Equal(expectedResultWithBrackets, testUri.Host);
-            Assert.Equal(expectedResult, testUri.DnsSafeHost);
+            Assert.Equal(expected, testUri.DnsSafeHost);
 
             // Constructor
             testUri = new Uri("http://[" + ipv6String + "]");
             Assert.Equal(UriHostNameType.IPv6, testUri.HostNameType);
             Assert.Equal(expectedResultWithBrackets, testUri.Host);
-            Assert.Equal(expectedResult, testUri.DnsSafeHost);
+            Assert.Equal(expected, testUri.DnsSafeHost);
 
             // CheckHostName
             Assert.Equal(UriHostNameType.IPv6, Uri.CheckHostName(ipv6String));
@@ -373,10 +365,6 @@ namespace System.PrivateUri.Tests
 
         private void ParseBadIPv6Address(string badIpv6String)
         {
-            IPAddress address; // Sanity test
-            Assert.True(!IPAddress.TryParse(badIpv6String, out address)
-                || address.AddressFamily != AddressFamily.InterNetworkV6, badIpv6String);
-
             // CheckHostName
             Assert.NotEqual(UriHostNameType.IPv6, Uri.CheckHostName(badIpv6String));
 


### PR DESCRIPTION
- The System.Uri tests were relying on IPAddress.Parse to validate their results.  Changed these to hard-code known good results, so we're no longer dependent on IPAddress.Parse to validate System.Uri.
- The IPAddress.Parse tests were missing many cases that were covered in the System.Uri tests.  Added these cases to the IPAddress tests.
- Restructured all of these as "theories."
- Marked known differences between platforms for various IPAddress.Parse cases.

This represents the "fix" for most of the platform differences in IPAddress.Parse, which we have decided should simply behave as the underlying platform does.  One exception is #8362, which we can still fix by switching from `getaddrinfo` to `inet_aton` on OSX.

Closes #8361.
Closes #8360.

@stephentoub @CIPop 