### PR TITLE
Fix ApiComat issues for System.Data

### DIFF
--- a/src/Common/src/System/Data/Common/BasicFieldNameLookup.cs
+++ b/src/Common/src/System/Data/Common/BasicFieldNameLookup.cs
@@ -41,7 +41,7 @@ namespace System.Data.ProviderBase
             GenerateLookup();
         }
 
-        public BasicFieldNameLookup(DbDataReader reader)
+        public BasicFieldNameLookup(IDataReader reader)
         {
             int length = reader.FieldCount;
             string[] fieldNames = new string[length];

--- a/src/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/System.Data.Common/ref/System.Data.Common.cs
@@ -396,7 +396,7 @@ namespace System.Data.Common
     }
     public partial class DbEnumerator : System.Collections.IEnumerator
     {
-        public DbEnumerator(System.Data.Common.DbDataReader reader, bool closeReader) { }
+        public DbEnumerator(System.Data.IDataReader reader, bool closeReader) { }
         public object Current { get; }
         public bool MoveNext() { return default(bool); }
         public void Reset() { }

--- a/src/System.Data.Common/src/ApiCompatBaseline.net451.txt
+++ b/src/System.Data.Common/src/ApiCompatBaseline.net451.txt
@@ -1,1 +1,0 @@
-MembersMustExist : Member 'System.Data.Common.DbEnumerator..ctor(System.Data.Common.DbDataReader, System.Boolean)' does not exist in the implementation but it does exist in the contract.

--- a/src/System.Data.Common/src/System/Data/Common/DbEnumerator.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbEnumerator.cs
@@ -15,14 +15,14 @@ namespace System.Data.Common
 {
     public class DbEnumerator : IEnumerator
     {
-        internal DbDataReader _reader;
+        internal IDataReader _reader;
         internal DbDataRecord _current;
         internal SchemaInfo[] _schemaInfo; // shared schema info among all the data records
         private BasicFieldNameLookup _fieldNameLookup;
 
         private bool _closeReader;
 
-        public DbEnumerator(DbDataReader reader, bool closeReader)
+        public DbEnumerator(IDataReader reader, bool closeReader)
         {
             if (null == reader)
             {


### PR DESCRIPTION
The `DbEnumerator` accepts `IDataReader` as input in .Net f/w 4.5.1 
This change modifies `DbEnumerator` to use `IDataReader` in the constructor so that the API can be compatible with .Net 4.5.1 and allows the access of API in CoreFX System.Data.Common 4.1.0.0

Changes include 
1. Change of `DbEnumerator` constr to have `IDataReader` 
2. Change contract to reflect 1
3. Change `BasicFieldNameLookup` constr to have `IDataReader`

Fixes #6937 