### PR TITLE
Update corefx build.cmd to emit msbuild.err and msbuild.wrn 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ bld/
 [Bb]in/
 [Oo]bj/
 msbuild.log
+msbuild.err
+msbuild.wrn
 
 # Cross building rootfs
 cross/rootfs/

--- a/build.cmd
+++ b/build.cmd
@@ -103,7 +103,7 @@ call :build %__args%
 goto :AfterBuild
 
 :build
-%_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /v:minimal /clp:Summary /nodeReuse:false /flp:v=normal;LogFile="%_buildlog%";Append "/l:BinClashLogger,%_binclashLoggerDll%;LogFile=%_binclashlog%" !unprocessedBuildArgs! %_buildpostfix%
+%_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /v:minimal /clp:Summary /nodeReuse:false /flp:v=normal;LogFile="%_buildlog%";Append /flp2:warningsonly;logfile=%~dp0msbuild.wrn /flp3:errorsonly;logfile=%~dp0msbuild.err "/l:BinClashLogger,%_binclashLoggerDll%;LogFile=%_binclashlog%" !unprocessedBuildArgs! %_buildpostfix%
 set BUILDERRORLEVEL=%ERRORLEVEL%
 goto :eof
 


### PR DESCRIPTION
…as well as msbuild.log. These are useful as they will contain only errors and only warnings, respectively.
Note that msbuild doesn't flush the files continuously, so they may not flush to disk until the build finishes.