### PR TITLE
Disable event filtering on OSX FSW

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.WaitForChanged.cs
@@ -125,7 +125,6 @@ namespace System.IO.Tests
             }
         }
 
-        [ActiveIssue(8547, PlatformID.OSX)]
         [Theory]
         [InlineData(WatcherChangeTypes.Created)]
         [InlineData(WatcherChangeTypes.Deleted)]


### PR DESCRIPTION
The OSX FileSystemWatcher coalesces past events of a file into new events. Previously we did some special work to try to filter out those extraneous events to better match the FSW inotify/win32 behavior. However, this had the consequence that we filtered out some valid events. This commit modifies the behavior to raise an event for exactly every flag that the OS API sets. It also modifies the OSX tests to no longer assert that an event *didn't* occur, but to only assert that an event *did* occur.

resolves #8547