### PR TITLE
Special-case FSW tests for Win7

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.NotifyFilter.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.NotifyFilter.cs
@@ -161,6 +161,8 @@ namespace System.IO.Tests
                     expected |= WatcherChangeTypes.Changed;
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && ((filter & OSXFiltersForModify) > 0))
                     expected |= WatcherChangeTypes.Changed;
+                else if (PlatformDetection.IsWindows7 && filter == NotifyFilters.Attributes) // win7 FSW Size change passes the Attribute filter
+                    expected |= WatcherChangeTypes.Changed;
                 ExpectEvent(watcher, expected, action, expectedPath: file.Path);
             }
         }
@@ -197,8 +199,9 @@ namespace System.IO.Tests
                 WatcherChangeTypes expected = 0;
                 if (filter == NotifyFilters.Security)
                     expected |= WatcherChangeTypes.Changed;
+                else if (PlatformDetection.IsWindows7 && filter == NotifyFilters.Attributes) // win7 FSW Security change passes the Attribute filter
+                    expected |= WatcherChangeTypes.Changed;
                 ExpectEvent(watcher, expected, action, expectedPath: file.Path);
-
             }
         }
 

--- a/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
+++ b/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
@@ -47,6 +47,9 @@
     <Compile Include="$(CommonTestPath)\System\IO\TempDirectory.cs">
       <Link>Common\System\IO\TempDirectory.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />


### PR DESCRIPTION
A few of the FSW tests are failing from differences between the win7 FSW behavior and the win8+ FSW behavior.

resolves #8436

@stephentoub @Priya91 