### PR TITLE
Remove AssemblyLoadContext.InitializeDefaultContext method

### DIFF
--- a/src/System.Runtime.Loader/ref/System.Runtime.Loader.cs
+++ b/src/System.Runtime.Loader/ref/System.Runtime.Loader.cs
@@ -22,7 +22,6 @@ namespace System.Runtime.Loader
         public static System.Runtime.Loader.AssemblyLoadContext Default { get { return default(System.Runtime.Loader.AssemblyLoadContext); } }
         public static System.Reflection.AssemblyName GetAssemblyName(string assemblyPath) { return default(System.Reflection.AssemblyName); }
         public static System.Runtime.Loader.AssemblyLoadContext GetLoadContext(System.Reflection.Assembly assembly) { return default(System.Runtime.Loader.AssemblyLoadContext); }
-        public static void InitializeDefaultContext(System.Runtime.Loader.AssemblyLoadContext context) { }
         protected abstract System.Reflection.Assembly Load(System.Reflection.AssemblyName assemblyName);
         public System.Reflection.Assembly LoadFromAssemblyName(System.Reflection.AssemblyName assemblyName) { return default(System.Reflection.Assembly); }
         public System.Reflection.Assembly LoadFromAssemblyPath(string assemblyPath) { return default(System.Reflection.Assembly); }

--- a/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
@@ -117,22 +117,5 @@ namespace System.Runtime.Loader.Tests
 
             Assert.NotNull(context);
         }
-
-        [Fact]
-        public static void InitializeDefaultContextTest()
-        {
-            // The coreclr binding model will become locked upon loading the first assembly that is not on the TPA list, or
-            // upon initializing the default context for the first time. For this test, test assemblies are located alongside
-            // corerun, and hence will be on the TPA list. So, we should be able to set the default context once successfully,
-            // and fail on the second try.
-
-            var loadContext = new ResourceAssemblyLoadContext();
-            AssemblyLoadContext.InitializeDefaultContext(loadContext);
-            Assert.Equal(loadContext, AssemblyLoadContext.Default);
-
-            loadContext = new ResourceAssemblyLoadContext();
-            Assert.Throws(typeof(InvalidOperationException), 
-                () => AssemblyLoadContext.InitializeDefaultContext(loadContext));
-        }
     }
 }


### PR DESCRIPTION
This method is no longer necessary after we have introduced Resolving event, it is hard to use correctly (https://github.com/dotnet/coreclr/pull/5034). It is best to not have it at all.

We have been working with Roslyn (https://github.com/dotnet/roslyn/pull/11423) and others to stop using it.