### PR TITLE
Remove dead code from System.Net.CredentialCache

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
+++ b/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
@@ -16,17 +16,6 @@ namespace System.Net
         private readonly Dictionary<CredentialHostKey, NetworkCredential> _cacheForHosts = new Dictionary<CredentialHostKey, NetworkCredential>();
         internal int _version;
 
-        private int _numbDefaultCredInCache = 0;
-
-        // [thread token optimization] The resulting counter of default credential resided in the cache.
-        internal bool IsDefaultInCache
-        {
-            get
-            {
-                return _numbDefaultCredInCache != 0;
-            }
-        }
-
         /// <devdoc>
         ///  <para>
         ///    Initializes a new instance of the <see cref='System.Net.CredentialCache'/> class.
@@ -63,10 +52,6 @@ namespace System.Net
             }
 
             _cache.Add(key, credential);
-            if (credential is SystemNetworkCredential)
-            {
-                ++_numbDefaultCredInCache;
-            }
         }
 
 
@@ -103,10 +88,6 @@ namespace System.Net
             }
 
             _cacheForHosts.Add(key, credential);
-            if (credential is SystemNetworkCredential)
-            {
-                ++_numbDefaultCredInCache;
-            }
         }
 
 
@@ -133,15 +114,7 @@ namespace System.Net
                 GlobalLog.Print("CredentialCache::Remove() Removing key:[" + key.ToString() + "]");
             }
 
-            NetworkCredential value;
-            if (_cache.TryGetValue(key, out value))
-            {
-                if (value is SystemNetworkCredential)
-                {
-                    --_numbDefaultCredInCache;
-                }
-                _cache.Remove(key);
-            }
+            _cache.Remove(key);
         }
 
 
@@ -168,15 +141,7 @@ namespace System.Net
                 GlobalLog.Print("CredentialCache::Remove() Removing key:[" + key.ToString() + "]");
             }
 
-            NetworkCredential value;
-            if (_cacheForHosts.TryGetValue(key, out value))
-            {
-                if (value is SystemNetworkCredential)
-                {
-                    --_numbDefaultCredInCache;
-                }
-                _cacheForHosts.Remove(key);
-            }
+            _cacheForHosts.Remove(key);
         }
 
         /// <devdoc>


### PR DESCRIPTION
Remove an internal property on `CredentialCache` that is not used anywhere in CoreFX.

In the full framework, the internal property is only used in [two places](http://referencesource.microsoft.com/#System/net/System/Net/CredentialCache.cs,7f6f0db537998048,references), inside `HttpWebRequest` and `SmtpClient`.

cc: @davidsh, @CIPop