### PR TITLE
Disable test library (openssl) from projectreference -> package dependency conversion (#8722)

### DIFF
--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>System.Security.Cryptography.OpenSsl.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.OpenSsl.Tests</RootNamespace>
     <UnsupportedPlatforms>Windows_NT</UnsupportedPlatforms>
+    <KeepAllProjectReferences>true</KeepAllProjectReferences>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Release|AnyCPU'" />


### PR DESCRIPTION
Port change from master to unblock release/1.0.0-rc2 builds in build pipeline.

https://github.com/dotnet/corefx/issues/8721

/cc @jhendrixMSFT @steveharter @bartonjs @joshfree @stephentoub 