### PR TITLE
Fix System.Runtime tests on non EN cultures

### DIFF
--- a/src/System.Runtime/tests/Helpers.cs
+++ b/src/System.Runtime/tests/Helpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using System.Reflection;
 using System.Reflection.Emit;
 
@@ -26,6 +27,18 @@ namespace System.Tests
             }
 
             return s_nonRuntimeType;
+        }
+
+        public static string LocalizeDecimalString(string decimalString, IFormatProvider provider)
+        {
+            // Takes in a string with a decimal (e.g. 579.5) and converts it to a format the
+            // current culture will understand.
+            string decimalDelimeter = NumberFormatInfo.CurrentInfo.NumberDecimalSeparator;
+            if (decimalDelimeter == "." || (provider != null && provider != NumberFormatInfo.CurrentInfo) )
+            {
+                return decimalString;
+            }
+            return decimalString?.Replace(".", decimalDelimeter);
         }
     }
 }

--- a/src/System.Runtime/tests/Helpers.cs
+++ b/src/System.Runtime/tests/Helpers.cs
@@ -29,16 +29,18 @@ namespace System.Tests
             return s_nonRuntimeType;
         }
 
-        public static string LocalizeDecimalString(string decimalString, IFormatProvider provider)
+        public static void PerformActionWithCulture(CultureInfo culture, Action test)
         {
-            // Takes in a string with a decimal (e.g. 579.5) and converts it to a format the
-            // current culture will understand.
-            string decimalDelimeter = NumberFormatInfo.CurrentInfo.NumberDecimalSeparator;
-            if (decimalDelimeter == "." || (provider != null && provider != NumberFormatInfo.CurrentInfo) )
+            CultureInfo originalCulture = CultureInfo.CurrentCulture;
+            try
             {
-                return decimalString;
+                CultureInfo.CurrentCulture = culture;
+                test();
             }
-            return decimalString?.Replace(".", decimalDelimeter);
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
         }
     }
 }

--- a/src/System.Runtime/tests/System/DateTimeOffsetTests.cs
+++ b/src/System.Runtime/tests/System/DateTimeOffsetTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
@@ -320,9 +319,9 @@ namespace System.Tests
 
         public static IEnumerable<object[]> Add_TimeSpan_TestData()
         {
-            yield return new object[] { new DateTimeOffset(new DateTime(1000)), new TimeSpan(10), new DateTimeOffset(new DateTime(1010)) };
-            yield return new object[] { new DateTimeOffset(new DateTime(1000)), TimeSpan.Zero, new DateTimeOffset(new DateTime(1000)) };
-            yield return new object[] { new DateTimeOffset(new DateTime(1000)), new TimeSpan(-10), new DateTimeOffset(new DateTime(990)) };
+            yield return new object[] { new DateTimeOffset(new DateTime(1000, DateTimeKind.Utc)), new TimeSpan(10), new DateTimeOffset(new DateTime(1010, DateTimeKind.Utc)) };
+            yield return new object[] { new DateTimeOffset(new DateTime(1000, DateTimeKind.Utc)), TimeSpan.Zero, new DateTimeOffset(new DateTime(1000, DateTimeKind.Utc)) };
+            yield return new object[] { new DateTimeOffset(new DateTime(1000, DateTimeKind.Utc)), new TimeSpan(-10), new DateTimeOffset(new DateTime(990, DateTimeKind.Utc)) };
         }
 
         [Theory]
@@ -495,9 +494,9 @@ namespace System.Tests
 
         public static IEnumerable<object[]> AddTicks_TestData()
         {
-            yield return new object[] { new DateTimeOffset(new DateTime(1000)), 10, new DateTimeOffset(new DateTime(1010)) };
-            yield return new object[] { new DateTimeOffset(new DateTime(1000)), 0, new DateTimeOffset(new DateTime(1000)) };
-            yield return new object[] { new DateTimeOffset(new DateTime(1000)), -10, new DateTimeOffset(new DateTime(990)) };
+            yield return new object[] { new DateTimeOffset(new DateTime(1000, DateTimeKind.Utc)), 10, new DateTimeOffset(new DateTime(1010, DateTimeKind.Utc)) };
+            yield return new object[] { new DateTimeOffset(new DateTime(1000, DateTimeKind.Utc)), 0, new DateTimeOffset(new DateTime(1000, DateTimeKind.Utc)) };
+            yield return new object[] { new DateTimeOffset(new DateTime(1000, DateTimeKind.Utc)), -10, new DateTimeOffset(new DateTime(990, DateTimeKind.Utc)) };
         }
 
         [Theory]
@@ -671,7 +670,7 @@ namespace System.Tests
         [Fact]
         public static void ToLocalTime()
         {
-            DateTimeOffset dateTimeOffset = new DateTimeOffset(new DateTime(1000));
+            DateTimeOffset dateTimeOffset = new DateTimeOffset(new DateTime(1000, DateTimeKind.Utc));
             Assert.Equal(new DateTimeOffset(dateTimeOffset.UtcDateTime.ToLocalTime()), dateTimeOffset.ToLocalTime());
         }
         
@@ -705,9 +704,9 @@ namespace System.Tests
 
         public static IEnumerable<object[]> Compare_TestData()
         {
-            yield return new object[] { new DateTimeOffset(new DateTime(1000)), new DateTimeOffset(new DateTime(1000)), 0 };
-            yield return new object[] { new DateTimeOffset(new DateTime(1000)), new DateTimeOffset(new DateTime(1001)), -1 };
-            yield return new object[] { new DateTimeOffset(new DateTime(1000)), new DateTimeOffset(new DateTime(999)), 1 };
+            yield return new object[] { new DateTimeOffset(new DateTime(1000, DateTimeKind.Utc)), new DateTimeOffset(new DateTime(1000, DateTimeKind.Utc)), 0 };
+            yield return new object[] { new DateTimeOffset(new DateTime(1000, DateTimeKind.Utc)), new DateTimeOffset(new DateTime(1001, DateTimeKind.Utc)), -1 };
+            yield return new object[] { new DateTimeOffset(new DateTime(1000, DateTimeKind.Utc)), new DateTimeOffset(new DateTime(999, DateTimeKind.Utc)), 1 };
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/DecimalTests.cs
+++ b/src/System.Runtime/tests/System/DecimalTests.cs
@@ -529,10 +529,9 @@ namespace System.Tests
 
         public static IEnumerable<object[]> Parse_Valid_TestData()
         {
-            NumberFormatInfo nullFormat = null;
             NumberStyles defaultStyle = NumberStyles.Float;
 
-            var emptyFormat = new NumberFormatInfo();
+            var emptyFormat = NumberFormatInfo.CurrentInfo;
 
             var customFormat1 = new NumberFormatInfo();
             customFormat1.CurrencySymbol = "$";
@@ -547,37 +546,35 @@ namespace System.Tests
             var customFormat4 = new NumberFormatInfo();
             customFormat4.NumberDecimalSeparator = ".";
 
-            yield return new object[] { "-123", defaultStyle, nullFormat, -123m };
-            yield return new object[] { "0", defaultStyle, nullFormat, 0m };
-            yield return new object[] { "123", defaultStyle, nullFormat, 123m };
-            yield return new object[] { "  123  ", defaultStyle, nullFormat, 123m };
-            yield return new object[] { "567.89", defaultStyle, nullFormat, 567.89m };
-            yield return new object[] { "-567.89", defaultStyle, nullFormat, -567.89m };
+            yield return new object[] { "-123", defaultStyle, null, -123m };
+            yield return new object[] { "0", defaultStyle, null, 0m };
+            yield return new object[] { "123", defaultStyle, null, 123m };
+            yield return new object[] { "  123  ", defaultStyle, null, 123m };
+            yield return new object[] { (567.89m).ToString(), defaultStyle, null, 567.89m };
+            yield return new object[] { (-567.89m).ToString(), defaultStyle, null, -567.89m };
 
-            yield return new object[] { "79228162514264337593543950335", defaultStyle, nullFormat, 79228162514264337593543950335m };
-            yield return new object[] { "-79228162514264337593543950335", defaultStyle, nullFormat, -79228162514264337593543950335m };
+            yield return new object[] { "79228162514264337593543950335", defaultStyle, null, 79228162514264337593543950335m };
+            yield return new object[] { "-79228162514264337593543950335", defaultStyle, null, -79228162514264337593543950335m };
             yield return new object[] { "79,228,162,514,264,337,593,543,950,335", NumberStyles.AllowThousands, customFormat3, 79228162514264337593543950335m };
 
-            yield return new object[] { "123.1", NumberStyles.AllowDecimalPoint, nullFormat, 123.1m };
-            yield return new object[] { 1000.ToString("N0"), NumberStyles.AllowThousands, nullFormat, 1000m };
+            yield return new object[] { (123.1m).ToString(), NumberStyles.AllowDecimalPoint, null, 123.1m };
+            yield return new object[] { 1000.ToString("N0"), NumberStyles.AllowThousands, null, 1000m };
 
             yield return new object[] { "123", NumberStyles.Any, emptyFormat, 123m };
-            yield return new object[] { "123.567", NumberStyles.Any, emptyFormat, 123.567m };
+            yield return new object[] { (123.567m).ToString(), NumberStyles.Any, emptyFormat, 123.567m };
             yield return new object[] { "123", NumberStyles.Float, emptyFormat, 123m };
             yield return new object[] { "$1000", NumberStyles.Currency, customFormat1, 1000m };
             yield return new object[] { "123.123", NumberStyles.Float, customFormat2, 123.123m };
             yield return new object[] { "(123)", NumberStyles.AllowParentheses, customFormat2, -123m };
 
             // Number buffer limit ran out (string too long)
-            yield return new object[] { "1234567890123456789012345.678456", defaultStyle, emptyFormat, 1234567890123456789012345.6785m };
+            yield return new object[] { "1234567890123456789012345.678456", defaultStyle, customFormat4, 1234567890123456789012345.6785m };
         }
 
         [Theory]
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse(string value, NumberStyles style, IFormatProvider provider, decimal expected)
         {
-            value = Helpers.LocalizeDecimalString(value, provider);
-
             bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;
             decimal result;
             if ((style & ~NumberStyles.Integer) == 0 && style != NumberStyles.None)
@@ -613,38 +610,35 @@ namespace System.Tests
 
         public static IEnumerable<object[]> Parse_Invalid_TestData()
         {
-            NumberFormatInfo nullFormat = null;
             NumberStyles defaultStyle = NumberStyles.Float;
 
             var customFormat = new NumberFormatInfo();
             customFormat.CurrencySymbol = "$";
             customFormat.NumberDecimalSeparator = ".";
 
-            yield return new object[] { null, defaultStyle, nullFormat, typeof(ArgumentNullException) };
-            yield return new object[] { "79228162514264337593543950336", defaultStyle, nullFormat, typeof(OverflowException) };
-            yield return new object[] { "", defaultStyle, nullFormat, typeof(FormatException) };
-            yield return new object[] { " ", defaultStyle, nullFormat, typeof(FormatException) };
-            yield return new object[] { "Garbage", defaultStyle, nullFormat, typeof(FormatException) };
+            yield return new object[] { null, defaultStyle, null, typeof(ArgumentNullException) };
+            yield return new object[] { "79228162514264337593543950336", defaultStyle, null, typeof(OverflowException) };
+            yield return new object[] { "", defaultStyle, null, typeof(FormatException) };
+            yield return new object[] { " ", defaultStyle, null, typeof(FormatException) };
+            yield return new object[] { "Garbage", defaultStyle, null, typeof(FormatException) };
 
-            yield return new object[] { "ab", defaultStyle, nullFormat, typeof(FormatException) }; // Hex value
-            yield return new object[] { "(123)", defaultStyle, nullFormat, typeof(FormatException) }; // Parentheses
-            yield return new object[] { 100.ToString("C0"), defaultStyle, nullFormat, typeof(FormatException) }; // Currency
+            yield return new object[] { "ab", defaultStyle, null, typeof(FormatException) }; // Hex value
+            yield return new object[] { "(123)", defaultStyle, null, typeof(FormatException) }; // Parentheses
+            yield return new object[] { 100.ToString("C0"), defaultStyle, null, typeof(FormatException) }; // Currency
 
-            yield return new object[] { "123.456", NumberStyles.Integer, nullFormat, typeof(FormatException) }; // Decimal
-            yield return new object[] { "  123.456", NumberStyles.None, nullFormat, typeof(FormatException) }; // Leading space
-            yield return new object[] { "123.456   ", NumberStyles.None, nullFormat, typeof(FormatException) }; // Leading space
-            yield return new object[] { "1E23", NumberStyles.None, nullFormat, typeof(FormatException) }; // Exponent
+            yield return new object[] { (123.456m).ToString(), NumberStyles.Integer, null, typeof(FormatException) }; // Decimal
+            yield return new object[] { "  " + (123.456m).ToString(), NumberStyles.None, null, typeof(FormatException) }; // Leading space
+            yield return new object[] { (123.456m).ToString() + "   ", NumberStyles.None, null, typeof(FormatException) }; // Leading space
+            yield return new object[] { "1E23", NumberStyles.None, null, typeof(FormatException) }; // Exponent
 
-            yield return new object[] { "ab", NumberStyles.None, nullFormat, typeof(FormatException) }; // Hex value
-            yield return new object[] { "  123  ", NumberStyles.None, nullFormat, typeof(FormatException) }; // Trailing and leading whitespace
+            yield return new object[] { "ab", NumberStyles.None, null, typeof(FormatException) }; // Hex value
+            yield return new object[] { "  123  ", NumberStyles.None, null, typeof(FormatException) }; // Trailing and leading whitespace
         }
 
         [Theory]
         [MemberData(nameof(Parse_Invalid_TestData))]
         public static void Parse_Invalid(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
         {
-            value = Helpers.LocalizeDecimalString(value, provider);
-
             bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;
             decimal result;
             if ((style & ~NumberStyles.Integer) == 0 && style != NumberStyles.None && (style & NumberStyles.AllowLeadingWhite) == (style & NumberStyles.AllowTrailingWhite))
@@ -990,20 +984,19 @@ namespace System.Tests
 
         public static IEnumerable<object[]> ToString_TestData()
         {
-            var emptyFormat = NumberFormatInfo.CurrentInfo;
-            yield return new object[] { decimal.MinValue, "G", emptyFormat, "-79228162514264337593543950335" };
-            yield return new object[] { (decimal)-4567, "G", emptyFormat, "-4567" };
-            yield return new object[] { (decimal)-4567.89101, "G", emptyFormat, "-4567.89101" };
-            yield return new object[] { (decimal)0, "G", emptyFormat, "0" };
-            yield return new object[] { (decimal)4567, "G", emptyFormat, "4567" };
-            yield return new object[] { (decimal)4567.89101, "G", emptyFormat, "4567.89101" };
-            yield return new object[] { decimal.MaxValue, "G", emptyFormat, "79228162514264337593543950335" };
+            yield return new object[] { decimal.MinValue, "G", null, "-79228162514264337593543950335" };
+            yield return new object[] { (decimal)-4567, "G", null, "-4567" };
+            yield return new object[] { (decimal)-4567.89101, "G", null, "-4567.89101" };
+            yield return new object[] { (decimal)0, "G", null, "0" };
+            yield return new object[] { (decimal)4567, "G", null, "4567" };
+            yield return new object[] { (decimal)4567.89101, "G", null, "4567.89101" };
+            yield return new object[] { decimal.MaxValue, "G", null, "79228162514264337593543950335" };
 
-            yield return new object[] { decimal.MinusOne, "G", emptyFormat, "-1" };
-            yield return new object[] { decimal.Zero, "G", emptyFormat, "0" };
-            yield return new object[] { decimal.One, "G", emptyFormat, "1" };
+            yield return new object[] { decimal.MinusOne, "G", null, "-1" };
+            yield return new object[] { decimal.Zero, "G", null, "0" };
+            yield return new object[] { decimal.One, "G", null, "1" };
 
-            yield return new object[] { (decimal)2468, "N", emptyFormat, string.Format("{0:N}", 2468.00) };
+            yield return new object[] { (decimal)2468, "N", null, "2,468.00" };
 
             // Changing the negative pattern doesn't do anything without also passing in a format string
             var customFormat1 = new NumberFormatInfo();
@@ -1028,27 +1021,28 @@ namespace System.Tests
         [MemberData(nameof(ToString_TestData))]
         public static void ToString(decimal f, string format, IFormatProvider provider, string expected)
         {
-            expected = Helpers.LocalizeDecimalString(expected, provider);
-
-            bool isDefaultProvider = (provider == null || provider == NumberFormatInfo.CurrentInfo);
-            if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
             {
+                bool isDefaultProvider = provider == null;
+                if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")
+                {
+                    if (isDefaultProvider)
+                    {
+                        Assert.Equal(expected, f.ToString());
+                        Assert.Equal(expected, f.ToString((IFormatProvider)null));
+                    }
+                    Assert.Equal(expected, f.ToString(provider));
+                }
                 if (isDefaultProvider)
                 {
-                    Assert.Equal(expected, f.ToString());
-                    Assert.Equal(expected, f.ToString((IFormatProvider)null));
+                    Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant())); // If format is upper case, then exponents are printed in upper case
+                    Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant())); // If format is lower case, then exponents are printed in lower case
+                    Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant(), null));
+                    Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant(), null));
                 }
-                Assert.Equal(expected, f.ToString(provider));
-            }
-            if (isDefaultProvider)
-            {
-                Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant())); // If format is upper case, then exponents are printed in upper case
-                Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant())); // If format is lower case, then exponents are printed in lower case
-                Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant(), null));
-                Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant(), null));
-            }
-            Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant(), provider));
-            Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant(), provider));
+                Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant(), provider));
+                Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant(), provider));
+            });
         }
 
         [Fact]

--- a/src/System.Runtime/tests/System/Int32Tests.cs
+++ b/src/System.Runtime/tests/System/Int32Tests.cs
@@ -273,8 +273,6 @@ namespace System.Tests
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse(string value, NumberStyles style, IFormatProvider provider, int expected)
         {
-            value = Helpers.LocalizeDecimalString(value, provider);
-
             bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;
             int result;
             if ((style & ~NumberStyles.Integer) == 0 && style != NumberStyles.None)
@@ -404,7 +402,7 @@ namespace System.Tests
 
             // AllowDecimalPoint
             NumberFormatInfo decimalFormat = new NumberFormatInfo() { NumberDecimalSeparator = "." };
-            yield return new object[] { "67.90", NumberStyles.AllowDecimalPoint, null, typeof(OverflowException) };
+            yield return new object[] { (67.9).ToString(), NumberStyles.AllowDecimalPoint, null, typeof(OverflowException) };
 
             // Parsing integers doesn't allow NaN, PositiveInfinity or NegativeInfinity
             NumberFormatInfo doubleFormat = new NumberFormatInfo()
@@ -443,8 +441,6 @@ namespace System.Tests
         [MemberData(nameof(Parse_Invalid_TestData))]
         public static void Parse_Invalid(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
         {
-            value = Helpers.LocalizeDecimalString(value, provider);
-
             bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;
             int result;
             if ((style & ~NumberStyles.Integer) == 0 && style != NumberStyles.None && (style & NumberStyles.AllowLeadingWhite) == (style & NumberStyles.AllowTrailingWhite))

--- a/src/System.Runtime/tests/System/Int32Tests.cs
+++ b/src/System.Runtime/tests/System/Int32Tests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Xunit;
@@ -274,7 +273,9 @@ namespace System.Tests
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse(string value, NumberStyles style, IFormatProvider provider, int expected)
         {
-            bool isDefaultProvider = provider == null || provider == new NumberFormatInfo();
+            value = Helpers.LocalizeDecimalString(value, provider);
+
+            bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;
             int result;
             if ((style & ~NumberStyles.Integer) == 0 && style != NumberStyles.None)
             {
@@ -299,11 +300,11 @@ namespace System.Tests
             if (isDefaultProvider)
             {
                 // Use Parse(string, NumberStyles) or Parse(string, NumberStyles, IFormatProvider)
-                Assert.True(int.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.True(int.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
                 Assert.Equal(expected, result);
                 
                 Assert.Equal(expected, int.Parse(value, style));
-                Assert.Equal(expected, int.Parse(value, style, new NumberFormatInfo()));
+                Assert.Equal(expected, int.Parse(value, style, NumberFormatInfo.CurrentInfo));
             }
         }
 
@@ -442,7 +443,9 @@ namespace System.Tests
         [MemberData(nameof(Parse_Invalid_TestData))]
         public static void Parse_Invalid(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
         {
-            bool isDefaultProvider = provider == null || provider == new NumberFormatInfo();
+            value = Helpers.LocalizeDecimalString(value, provider);
+
+            bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;
             int result;
             if ((style & ~NumberStyles.Integer) == 0 && style != NumberStyles.None && (style & NumberStyles.AllowLeadingWhite) == (style & NumberStyles.AllowTrailingWhite))
             {
@@ -467,11 +470,11 @@ namespace System.Tests
             if (isDefaultProvider)
             {
                 // Use Parse(string, NumberStyles) or Parse(string, NumberStyles, IFormatProvider)
-                Assert.False(int.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.False(int.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
                 Assert.Equal(default(int), result);
 
                 Assert.Throws(exceptionType, () => int.Parse(value, style));
-                Assert.Throws(exceptionType, () => int.Parse(value, style, new NumberFormatInfo()));
+                Assert.Throws(exceptionType, () => int.Parse(value, style, NumberFormatInfo.CurrentInfo));
             }
         }
 

--- a/src/System.Runtime/tests/System/SingleTests.cs
+++ b/src/System.Runtime/tests/System/SingleTests.cs
@@ -196,19 +196,18 @@ namespace System.Tests
 
         public static IEnumerable<object[]> ToString_TestData()
         {
-            var emptyFormat = NumberFormatInfo.CurrentInfo;
-            yield return new object[] { float.MinValue, "G", emptyFormat, "-3.402823E+38" };
-            yield return new object[] { (float)-4567, "G", emptyFormat, "-4567" };
-            yield return new object[] { (float)-4567.89101, "G", emptyFormat, "-4567.891" };
-            yield return new object[] { (float)0, "G", emptyFormat, "0" };
-            yield return new object[] { (float)4567, "G", emptyFormat, "4567" };
-            yield return new object[] { (float)4567.89101, "G", emptyFormat, "4567.891" };
-            yield return new object[] { float.MaxValue, "G", emptyFormat, "3.402823E+38" };
+            yield return new object[] { float.MinValue, "G", null, "-3.402823E+38" };
+            yield return new object[] { (float)-4567, "G", null, "-4567" };
+            yield return new object[] { (float)-4567.89101, "G", null, "-4567.891" };
+            yield return new object[] { (float)0, "G", null, "0" };
+            yield return new object[] { (float)4567, "G", null, "4567" };
+            yield return new object[] { (float)4567.89101, "G", null, "4567.891" };
+            yield return new object[] { float.MaxValue, "G", null, "3.402823E+38" };
 
-            yield return new object[] { float.Epsilon, "G", emptyFormat, "1.401298E-45" };
-            yield return new object[] { float.NaN, "G", emptyFormat, "NaN" };
+            yield return new object[] { float.Epsilon, "G", null, "1.401298E-45" };
+            yield return new object[] { float.NaN, "G", null, "NaN" };
 
-            yield return new object[] { (float)2468, "N", emptyFormat, string.Format("{0:N}", 2468.00) };
+            yield return new object[] { (float)2468, "N", null, "2,468.00" };
 
             // Changing the negative pattern doesn't do anything without also passing in a format string
             var customNegativePattern = new NumberFormatInfo() { NumberNegativePattern = 0 };
@@ -242,27 +241,28 @@ namespace System.Tests
         [MemberData(nameof(ToString_TestData))]
         public static void ToString(float f, string format, IFormatProvider provider, string expected)
         {
-            expected = Helpers.LocalizeDecimalString(expected, provider);
-
-            bool isDefaultProvider = (provider == null || provider == NumberFormatInfo.CurrentInfo);
-            if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
             {
+                bool isDefaultProvider = provider == null;
+                if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")
+                {
+                    if (isDefaultProvider)
+                    {
+                        Assert.Equal(expected, f.ToString());
+                        Assert.Equal(expected, f.ToString((IFormatProvider)null));
+                    }
+                    Assert.Equal(expected, f.ToString(provider));
+                }
                 if (isDefaultProvider)
                 {
-                    Assert.Equal(expected, f.ToString());
-                    Assert.Equal(expected, f.ToString((IFormatProvider)null));
+                    Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant())); // If format is upper case, then exponents are printed in upper case
+                    Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant())); // If format is lower case, then exponents are printed in lower case
+                    Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant(), null));
+                    Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant(), null));
                 }
-                Assert.Equal(expected, f.ToString(provider));
-            }
-            if (isDefaultProvider)
-            {
-                Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant())); // If format is upper case, then exponents are printed in upper case
-                Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant())); // If format is lower case, then exponents are printed in lower case
-                Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant(), null));
-                Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant(), null));
-            }
-            Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant(), provider));
-            Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant(), provider));
+                Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant(), provider));
+                Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant(), provider));
+            });
         }
 
         [Fact]
@@ -276,10 +276,9 @@ namespace System.Tests
         public static IEnumerable<object[]> Parse_Valid_TestData()
         {
             // Defaults: AllowLeadingWhite | AllowTrailingWhite | AllowLeadingSign | AllowDecimalPoint | AllowExponent | AllowThousands
-            NumberFormatInfo nullFormat = null;
             NumberStyles defaultStyle = NumberStyles.Float;
 
-            var emptyFormat = new NumberFormatInfo();
+            NumberFormatInfo emptyFormat = NumberFormatInfo.CurrentInfo;
 
             var dollarSignCommaSeparatorFormat = new NumberFormatInfo()
             {
@@ -294,19 +293,19 @@ namespace System.Tests
 
             NumberFormatInfo invariantFormat = NumberFormatInfo.InvariantInfo;
 
-            yield return new object[] { "-123", defaultStyle, nullFormat, (float)-123 };
-            yield return new object[] { "0", defaultStyle, nullFormat, (float)0 };
-            yield return new object[] { "123", defaultStyle, nullFormat, (float)123 };
-            yield return new object[] { "  123  ", defaultStyle, nullFormat, (float)123 };
-            yield return new object[] { "567.89", defaultStyle, nullFormat, (float)567.89 };
-            yield return new object[] { "-567.89", defaultStyle, nullFormat, (float)-567.89 };
-            yield return new object[] { "1E23", defaultStyle, nullFormat, (float)1E23 };
+            yield return new object[] { "-123", defaultStyle, null, (float)-123 };
+            yield return new object[] { "0", defaultStyle, null, (float)0 };
+            yield return new object[] { "123", defaultStyle, null, (float)123 };
+            yield return new object[] { "  123  ", defaultStyle, null, (float)123 };
+            yield return new object[] { (567.89f).ToString(), defaultStyle, null, (float)567.89 };
+            yield return new object[] { (-567.89f).ToString(), defaultStyle, null, (float)-567.89 };
+            yield return new object[] { "1E23", defaultStyle, null, (float)1E23 };
 
-            yield return new object[] { "123.1", NumberStyles.AllowDecimalPoint, nullFormat, (float)123.1 };
-            yield return new object[] { 1000.ToString("N0"), NumberStyles.AllowThousands, nullFormat, (float)1000 };
+            yield return new object[] { (123.1f).ToString(), NumberStyles.AllowDecimalPoint, null, (float)123.1 };
+            yield return new object[] { 1000.ToString("N0"), NumberStyles.AllowThousands, null, (float)1000 };
 
             yield return new object[] { "123", NumberStyles.Any, emptyFormat, (float)123 };
-            yield return new object[] { "123.567", NumberStyles.Any, emptyFormat, 123.567 };
+            yield return new object[] { (123.567f).ToString(), NumberStyles.Any, emptyFormat, 123.567 };
             yield return new object[] { "123", NumberStyles.Float, emptyFormat, (float)123 };
             yield return new object[] { "$1,000", NumberStyles.Currency, dollarSignCommaSeparatorFormat, (float)1000 };
             yield return new object[] { "$1000", NumberStyles.Currency, dollarSignCommaSeparatorFormat, (float)1000 };
@@ -322,8 +321,6 @@ namespace System.Tests
         [MemberData(nameof(Parse_Valid_TestData))]
         public static void Parse(string value, NumberStyles style, IFormatProvider provider, float expected)
         {
-            value = Helpers.LocalizeDecimalString(value, provider);
-
             bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;
             float result;
             if ((style & ~NumberStyles.Integer) == 0 && style != NumberStyles.None)
@@ -359,37 +356,34 @@ namespace System.Tests
 
         public static IEnumerable<object[]> Parse_Invalid_TestData()
         {
-            NumberFormatInfo nullFormat = null;
             NumberStyles defaultStyle = NumberStyles.Float;
 
             var dollarSignDecimalSeparatorFormat = new NumberFormatInfo();
             dollarSignDecimalSeparatorFormat.CurrencySymbol = "$";
             dollarSignDecimalSeparatorFormat.NumberDecimalSeparator = ".";
 
-            yield return new object[] { null, defaultStyle, nullFormat, typeof(ArgumentNullException) };
-            yield return new object[] { "", defaultStyle, nullFormat, typeof(FormatException) };
-            yield return new object[] { " ", defaultStyle, nullFormat, typeof(FormatException) };
-            yield return new object[] { "Garbage", defaultStyle, nullFormat, typeof(FormatException) };
+            yield return new object[] { null, defaultStyle, null, typeof(ArgumentNullException) };
+            yield return new object[] { "", defaultStyle, null, typeof(FormatException) };
+            yield return new object[] { " ", defaultStyle, null, typeof(FormatException) };
+            yield return new object[] { "Garbage", defaultStyle, null, typeof(FormatException) };
 
-            yield return new object[] { "ab", defaultStyle, nullFormat, typeof(FormatException) }; // Hex value
-            yield return new object[] { "(123)", defaultStyle, nullFormat, typeof(FormatException) }; // Parentheses
-            yield return new object[] { 100.ToString("C0"), defaultStyle, nullFormat, typeof(FormatException) }; // Currency
+            yield return new object[] { "ab", defaultStyle, null, typeof(FormatException) }; // Hex value
+            yield return new object[] { "(123)", defaultStyle, null, typeof(FormatException) }; // Parentheses
+            yield return new object[] { 100.ToString("C0"), defaultStyle, null, typeof(FormatException) }; // Currency
 
-            yield return new object[] { "123.456", NumberStyles.Integer, nullFormat, typeof(FormatException) }; // Decimal
-            yield return new object[] { "  123.456", NumberStyles.None, nullFormat, typeof(FormatException) }; // Leading space
-            yield return new object[] { "123.456   ", NumberStyles.None, nullFormat, typeof(FormatException) }; // Leading space
-            yield return new object[] { "1E23", NumberStyles.None, nullFormat, typeof(FormatException) }; // Exponent
+            yield return new object[] { (123.456f).ToString(), NumberStyles.Integer, null, typeof(FormatException) }; // Decimal
+            yield return new object[] { "  " + (123.456f).ToString(), NumberStyles.None, null, typeof(FormatException) }; // Leading space
+            yield return new object[] { (123.456f).ToString() + "   ", NumberStyles.None, null, typeof(FormatException) }; // Leading space
+            yield return new object[] { "1E23", NumberStyles.None, null, typeof(FormatException) }; // Exponent
 
-            yield return new object[] { "ab", NumberStyles.None, nullFormat, typeof(FormatException) }; // Negative hex value
-            yield return new object[] { "  123  ", NumberStyles.None, nullFormat, typeof(FormatException) }; // Trailing and leading whitespace
+            yield return new object[] { "ab", NumberStyles.None, null, typeof(FormatException) }; // Negative hex value
+            yield return new object[] { "  123  ", NumberStyles.None, null, typeof(FormatException) }; // Trailing and leading whitespace
         }
 
         [Theory]
         [MemberData(nameof(Parse_Invalid_TestData))]
         public static void Parse_Invalid(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
         {
-            value = Helpers.LocalizeDecimalString(value, provider);
-
             bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;
             float result;
             if ((style & ~NumberStyles.Integer) == 0 && style != NumberStyles.None && (style & NumberStyles.AllowLeadingWhite) == (style & NumberStyles.AllowTrailingWhite))

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1070,7 +1070,7 @@ namespace System.Tests
         public static void IndexOf_TurkishI()
         {
             string s = "Turkish I \u0131s TROUBL\u0130NG!";
-            PerformActionWithCulture(new CultureInfo("tr-TR"), () =>
+            Helpers.PerformActionWithCulture(new CultureInfo("tr-TR"), () =>
             {
                 string value = "\u0130";
                 Assert.Equal(19, s.IndexOf(value));
@@ -1085,7 +1085,7 @@ namespace System.Tests
                 Assert.Equal(10, s.IndexOf(value, StringComparison.Ordinal));
                 Assert.Equal(10, s.IndexOf(value, StringComparison.OrdinalIgnoreCase));
             });
-            PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
             {
                 string value = "\u0130";
                 Assert.Equal(19, s.IndexOf(value));
@@ -1096,7 +1096,7 @@ namespace System.Tests
                 Assert.Equal(10, s.IndexOf(value, StringComparison.CurrentCulture));
                 Assert.Equal(10, s.IndexOf(value, StringComparison.CurrentCultureIgnoreCase));
             });
-            PerformActionWithCulture(new CultureInfo("en-US"), () =>
+            Helpers.PerformActionWithCulture(new CultureInfo("en-US"), () =>
             {
                 string value = "\u0130";
                 Assert.Equal(19, s.IndexOf(value));
@@ -1114,7 +1114,7 @@ namespace System.Tests
         {
             string source = "dzsdzs";
             string target = "ddzs";
-            PerformActionWithCulture(new CultureInfo("hu-HU"), () =>
+            Helpers.PerformActionWithCulture(new CultureInfo("hu-HU"), () =>
             {
             /* 
              There are differences between Windows and ICU regarding contractions.
@@ -1130,7 +1130,7 @@ namespace System.Tests
                 Assert.Equal(-1, source.IndexOf(target, StringComparison.Ordinal));
                 Assert.Equal(-1, source.IndexOf(target, StringComparison.OrdinalIgnoreCase));
             });
-            PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
             {
                 Assert.Equal(-1, source.IndexOf(target));
                 Assert.Equal(-1, source.IndexOf(target, StringComparison.CurrentCulture));
@@ -1143,7 +1143,7 @@ namespace System.Tests
         {
             string s = "Exhibit a\u0300\u00C0";
             string value = "\u00C0";
-            PerformActionWithCulture(new CultureInfo("en-US"), () =>
+            Helpers.PerformActionWithCulture(new CultureInfo("en-US"), () =>
             {
                 Assert.Equal(10, s.IndexOf(value));
                 Assert.Equal(10, s.IndexOf(value, StringComparison.CurrentCulture));
@@ -1151,7 +1151,7 @@ namespace System.Tests
                 Assert.Equal(10, s.IndexOf(value, StringComparison.Ordinal));
                 Assert.Equal(10, s.IndexOf(value, StringComparison.OrdinalIgnoreCase));
             });
-            PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
             {
                 Assert.Equal(10, s.IndexOf(value));
                 Assert.Equal(10, s.IndexOf(value, StringComparison.CurrentCulture));
@@ -1159,7 +1159,7 @@ namespace System.Tests
             });
 
             value = "a\u0300"; // this diacritic combines with preceding character
-            PerformActionWithCulture(new CultureInfo("en-US"), () =>
+            Helpers.PerformActionWithCulture(new CultureInfo("en-US"), () =>
             {
                 Assert.Equal(8, s.IndexOf(value));
                 Assert.Equal(8, s.IndexOf(value, StringComparison.CurrentCulture));
@@ -1167,7 +1167,7 @@ namespace System.Tests
                 Assert.Equal(8, s.IndexOf(value, StringComparison.Ordinal));
                 Assert.Equal(8, s.IndexOf(value, StringComparison.OrdinalIgnoreCase));
             });
-            PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
             {
                 Assert.Equal(8, s.IndexOf(value));
                 Assert.Equal(8, s.IndexOf(value, StringComparison.CurrentCulture));
@@ -1180,7 +1180,7 @@ namespace System.Tests
         {
             string s = "Foo\u0400Bar";
             string value = "\u0400";
-            PerformActionWithCulture(new CultureInfo("en-US"), () =>
+            Helpers.PerformActionWithCulture(new CultureInfo("en-US"), () =>
             {
                 Assert.Equal(3, s.IndexOf(value));
                 Assert.Equal(3, s.IndexOf(value, StringComparison.CurrentCulture));
@@ -1188,7 +1188,7 @@ namespace System.Tests
                 Assert.Equal(3, s.IndexOf(value, StringComparison.Ordinal));
                 Assert.Equal(3, s.IndexOf(value, StringComparison.OrdinalIgnoreCase));
             });
-            PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
             {
                 Assert.Equal(3, s.IndexOf(value));
                 Assert.Equal(3, s.IndexOf(value, StringComparison.CurrentCulture));
@@ -1196,7 +1196,7 @@ namespace System.Tests
             });
 
             value = "bar";
-            PerformActionWithCulture(new CultureInfo("en-US"), () =>
+            Helpers.PerformActionWithCulture(new CultureInfo("en-US"), () =>
             {
                 Assert.Equal(-1, s.IndexOf(value));
                 Assert.Equal(-1, s.IndexOf(value, StringComparison.CurrentCulture));
@@ -1204,7 +1204,7 @@ namespace System.Tests
                 Assert.Equal(-1, s.IndexOf(value, StringComparison.Ordinal));
                 Assert.Equal(4, s.IndexOf(value, StringComparison.OrdinalIgnoreCase));
             });
-            PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
             {
                 Assert.Equal(-1, s.IndexOf(value));
                 Assert.Equal(-1, s.IndexOf(value, StringComparison.CurrentCulture));
@@ -1569,7 +1569,7 @@ namespace System.Tests
         public static void LastIndexOf_TurkishI()
         {
             string s = "Turkish I \u0131s TROUBL\u0130NG!";
-            PerformActionWithCulture(new CultureInfo("tr-TR"), () =>
+            Helpers.PerformActionWithCulture(new CultureInfo("tr-TR"), () =>
             {
                 string value = "\u0130";
                 Assert.Equal(19, s.LastIndexOf(value));
@@ -1584,7 +1584,7 @@ namespace System.Tests
                 Assert.Equal(10, s.LastIndexOf(value, StringComparison.Ordinal));
                 Assert.Equal(10, s.LastIndexOf(value, StringComparison.OrdinalIgnoreCase));
             });
-            PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
             {
                 string value = "\u0130";
                 Assert.Equal(19, s.LastIndexOf(value));
@@ -1595,7 +1595,7 @@ namespace System.Tests
                 Assert.Equal(10, s.LastIndexOf(value, StringComparison.CurrentCulture));
                 Assert.Equal(10, s.LastIndexOf(value, StringComparison.CurrentCultureIgnoreCase));
             });
-            PerformActionWithCulture(new CultureInfo("en-US"), () =>
+            Helpers.PerformActionWithCulture(new CultureInfo("en-US"), () =>
             {
                 string value = "\u0130";
                 Assert.Equal(19, s.LastIndexOf(value));
@@ -1973,21 +1973,21 @@ namespace System.Tests
         [Fact]
         public static void ToLower_TurkishI()
         {
-            PerformActionWithCulture(new CultureInfo("tr-TR"), () =>
+            Helpers.PerformActionWithCulture(new CultureInfo("tr-TR"), () =>
             {
                 Assert.True("H\u0049 World".ToLower().Equals("h\u0131 world", StringComparison.Ordinal));
                 Assert.True("H\u0130 World".ToLower().Equals("h\u0069 world", StringComparison.Ordinal));
                 Assert.True("H\u0131 World".ToLower().Equals("h\u0131 world", StringComparison.Ordinal));
             });
 
-            PerformActionWithCulture(new CultureInfo("en-US"), () =>
+            Helpers.PerformActionWithCulture(new CultureInfo("en-US"), () =>
             {
                 Assert.True("H\u0049 World".ToLower().Equals("h\u0069 world", StringComparison.Ordinal));
                 Assert.True("H\u0130 World".ToLower().Equals("h\u0069 world", StringComparison.Ordinal));
                 Assert.True("H\u0131 World".ToLower().Equals("h\u0131 world", StringComparison.Ordinal));
             });
 
-            PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
             {
                 Assert.True("H\u0049 World".ToLower().Equals("h\u0069 world", StringComparison.Ordinal));
                 Assert.True("H\u0130 World".ToLower().Equals("h\u0130 world", StringComparison.Ordinal));
@@ -2024,21 +2024,21 @@ namespace System.Tests
         [Fact]
         public static void ToUpper_TurkishI()
         {
-            PerformActionWithCulture(new CultureInfo("tr-TR"), () =>
+            Helpers.PerformActionWithCulture(new CultureInfo("tr-TR"), () =>
             {
                 Assert.True("H\u0069 World".ToUpper().Equals("H\u0130 WORLD", StringComparison.Ordinal));
                 Assert.True("H\u0130 World".ToUpper().Equals("H\u0130 WORLD", StringComparison.Ordinal));
                 Assert.True("H\u0131 World".ToUpper().Equals("H\u0049 WORLD", StringComparison.Ordinal));
             });
 
-            PerformActionWithCulture(new CultureInfo("en-US"), () =>
+            Helpers.PerformActionWithCulture(new CultureInfo("en-US"), () =>
             {
                 Assert.True("H\u0069 World".ToUpper().Equals("H\u0049 WORLD", StringComparison.Ordinal));
                 Assert.True("H\u0130 World".ToUpper().Equals("H\u0130 WORLD", StringComparison.Ordinal));
                 Assert.True("H\u0131 World".ToUpper().Equals("H\u0049 WORLD", StringComparison.Ordinal));
             });
 
-            PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
             {
                 Assert.True("H\u0069 World".ToUpper().Equals("H\u0049 WORLD", StringComparison.Ordinal));
                 Assert.True("H\u0130 World".ToUpper().Equals("H\u0130 WORLD", StringComparison.Ordinal));
@@ -2167,20 +2167,6 @@ namespace System.Tests
                         yield return new object[] { source, source.Substring(i, subLen), i, comparison };
                     }
                 }
-            }
-        }
-
-        private static void PerformActionWithCulture(CultureInfo culture, Action test)
-        {
-            CultureInfo originalCulture = CultureInfo.CurrentCulture;
-            try
-            {
-                CultureInfo.CurrentCulture = culture;
-                test();
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = originalCulture;
             }
         }
 

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Tests;
 using System.Text;
 using Xunit;
 
@@ -251,6 +252,8 @@ namespace System.Text.Tests
         [InlineData("", -4.56, "-4.56")]
         public static void Append_Decimal(string original, double doubleValue, string expected)
         {
+            expected = Helpers.LocalizeDecimalString(expected, null);
+
             var builder = new StringBuilder(original);
             builder.Append(new decimal(doubleValue));
             Assert.Equal(expected, builder.ToString());
@@ -271,6 +274,8 @@ namespace System.Text.Tests
         [InlineData("", -4.56, "-4.56")]
         public static void Append_Double(string original, double value, string expected)
         {
+            expected = Helpers.LocalizeDecimalString(expected, null);
+
             var builder = new StringBuilder(original);
             builder.Append(value);
             Assert.Equal(expected, builder.ToString());
@@ -393,6 +398,8 @@ namespace System.Text.Tests
         [InlineData("", (float)-4.56, "-4.56")]
         public static void Append_Float(string original, float value, string expected)
         {
+            expected = Helpers.LocalizeDecimalString(expected, null);
+
             var builder = new StringBuilder(original);
             builder.Append(value);
             Assert.Equal(expected, builder.ToString());
@@ -1116,6 +1123,8 @@ namespace System.Text.Tests
         [InlineData("Hello", 5, (float)-4.56, "Hello-4.56")]
         public static void Insert_Float(string original, int index, float value, string expected)
         {
+            expected = Helpers.LocalizeDecimalString(expected, null);
+
             var builder = new StringBuilder(original);
             builder.Insert(index, value);
             Assert.Equal(expected, builder.ToString());
@@ -1228,6 +1237,8 @@ namespace System.Text.Tests
         [InlineData("Hello", 5, -4.56, "Hello-4.56")]
         public static void Insert_Double(string original, int index, double value, string expected)
         {
+            expected = Helpers.LocalizeDecimalString(expected, null);
+
             var builder = new StringBuilder(original);
             builder.Insert(index, value);
             Assert.Equal(expected, builder.ToString());
@@ -1250,6 +1261,8 @@ namespace System.Text.Tests
         [InlineData("Hello", 5, -4.56, "Hello-4.56")]
         public static void Insert_Decimal(string original, int index, double doubleValue, string expected)
         {
+            expected = Helpers.LocalizeDecimalString(expected, null);
+
             var builder = new StringBuilder(original);
             builder.Insert(index, new decimal(doubleValue));
             Assert.Equal(expected, builder.ToString());

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Tests;
@@ -252,11 +251,12 @@ namespace System.Text.Tests
         [InlineData("", -4.56, "-4.56")]
         public static void Append_Decimal(string original, double doubleValue, string expected)
         {
-            expected = Helpers.LocalizeDecimalString(expected, null);
-
-            var builder = new StringBuilder(original);
-            builder.Append(new decimal(doubleValue));
-            Assert.Equal(expected, builder.ToString());
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
+            {
+                var builder = new StringBuilder(original);
+                builder.Append(new decimal(doubleValue));
+                Assert.Equal(expected, builder.ToString());
+            });
         }
 
         [Fact]
@@ -274,11 +274,12 @@ namespace System.Text.Tests
         [InlineData("", -4.56, "-4.56")]
         public static void Append_Double(string original, double value, string expected)
         {
-            expected = Helpers.LocalizeDecimalString(expected, null);
-
-            var builder = new StringBuilder(original);
-            builder.Append(value);
-            Assert.Equal(expected, builder.ToString());
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
+            {
+                var builder = new StringBuilder(original);
+                builder.Append(value);
+                Assert.Equal(expected, builder.ToString());
+            });
         }
 
         [Fact]
@@ -398,11 +399,12 @@ namespace System.Text.Tests
         [InlineData("", (float)-4.56, "-4.56")]
         public static void Append_Float(string original, float value, string expected)
         {
-            expected = Helpers.LocalizeDecimalString(expected, null);
-
-            var builder = new StringBuilder(original);
-            builder.Append(value);
-            Assert.Equal(expected, builder.ToString());
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
+            {
+                var builder = new StringBuilder(original);
+                builder.Append(value);
+                Assert.Equal(expected, builder.ToString());
+            });
         }
 
         [Fact]
@@ -1123,11 +1125,12 @@ namespace System.Text.Tests
         [InlineData("Hello", 5, (float)-4.56, "Hello-4.56")]
         public static void Insert_Float(string original, int index, float value, string expected)
         {
-            expected = Helpers.LocalizeDecimalString(expected, null);
-
-            var builder = new StringBuilder(original);
-            builder.Insert(index, value);
-            Assert.Equal(expected, builder.ToString());
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
+            {
+                var builder = new StringBuilder(original);
+                builder.Insert(index, value);
+                Assert.Equal(expected, builder.ToString());
+            });
         }
 
         [Fact]
@@ -1237,11 +1240,12 @@ namespace System.Text.Tests
         [InlineData("Hello", 5, -4.56, "Hello-4.56")]
         public static void Insert_Double(string original, int index, double value, string expected)
         {
-            expected = Helpers.LocalizeDecimalString(expected, null);
-
-            var builder = new StringBuilder(original);
-            builder.Insert(index, value);
-            Assert.Equal(expected, builder.ToString());
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
+            {
+                var builder = new StringBuilder(original);
+                builder.Insert(index, value);
+                Assert.Equal(expected, builder.ToString());
+            });
         }
 
         [Fact]
@@ -1261,11 +1265,12 @@ namespace System.Text.Tests
         [InlineData("Hello", 5, -4.56, "Hello-4.56")]
         public static void Insert_Decimal(string original, int index, double doubleValue, string expected)
         {
-            expected = Helpers.LocalizeDecimalString(expected, null);
-
-            var builder = new StringBuilder(original);
-            builder.Insert(index, new decimal(doubleValue));
-            Assert.Equal(expected, builder.ToString());
+            Helpers.PerformActionWithCulture(CultureInfo.InvariantCulture, () =>
+            {
+                var builder = new StringBuilder(original);
+                builder.Insert(index, new decimal(doubleValue));
+                Assert.Equal(expected, builder.ToString());
+            });
         }
 
         [Fact]


### PR DESCRIPTION
- Fix DateTimeOffset tests to create dates from DateTimeKind.Utc not
DateTimeKind.Unspecified (I think this is because we previously adjusted for time zones causing a negative number)
- Fix tests for Parse for Decimal, Double and Single to obey the
IFormatProvider parameter
- Add a helper to convert a string containing an English decimal ('.')
to the current culture

I didn't want to turn these tests into using the Invariant culture, as the tests by nature should have different results on different cultures and we want to make sure that everything works.

I've ran tests by setting my culture to the Czech Repuplic (cs-CZ) as this was the culture in the issue reported. Originally there were failures, now there are none. 

Fixes #8753

/cc @tarekgh @stephentoub @svick