### PR TITLE
Enable GetEra and GetDayOfWeek negative tests in Globalization.Calendars tests

### DIFF
--- a/src/System.Globalization.Calendars/tests/CalendarHelpers.cs
+++ b/src/System.Globalization.Calendars/tests/CalendarHelpers.cs
@@ -134,7 +134,7 @@ namespace System.Globalization.Tests
                     }
                 }
                 // Year is invalid
-                yield return new object[] { calendar, MinCalendarYearInEra(calendar, MinEra(calendar)) - 1,month, day, MinEra(calendar), "year" };
+                yield return new object[] { calendar, MinCalendarYearInEra(calendar, MinEra(calendar)) - 1, month, day, MinEra(calendar), "year" };
 
                 // Era is invalid
                 yield return new object[] { calendar, calendar.GetYear(calendar.MaxSupportedDateTime), month, day, MinEra(calendar) - 2, "era" };
@@ -356,12 +356,12 @@ namespace System.Globalization.Tests
         public static void ToFourDigitYear_Invalid(Calendar calendar)
         {
             Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToFourDigitYear(-1));
-            // JapaneseCalandar allows any inputs below the max year
-            if (!(calendar is JapaneseCalendar))
-            {
-                //Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToFourDigitYear(MinDateTimeInEra(calendar, MinEra(calendar)) - 2));
-            }
             Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToFourDigitYear(MaxCalendarYearInEra(calendar, MaxEra(calendar)) + 1));
+            
+            if (!(calendar is JapaneseLunisolarCalendar))
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("year", () => calendar.ToFourDigitYear(MinCalendarYearInEra(calendar, MinEra(calendar)) - 2));
+            }
         }
 
         [Theory]
@@ -377,8 +377,14 @@ namespace System.Globalization.Tests
         [MemberData(nameof(DateTime_TestData))]
         public static void GetEra_Invalid(Calendar calendar, DateTime dt)
         {
-            // TODO: This fails for HebrewCalendar, TaiwanLunisolarCalendar and JapaneseLunisolarCalendar
-            // Assert.Throws<ArgumentOutOfRangeException>(() => calendar.GetEra(dt));
+            if (calendar is JapaneseCalendar || calendar is HebrewCalendar || calendar is TaiwanLunisolarCalendar || calendar is JapaneseLunisolarCalendar)
+            {
+                calendar.GetEra(dt);
+            }
+            else
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => calendar.GetEra(dt));
+            }
         }
 
         [Theory]
@@ -413,10 +419,14 @@ namespace System.Globalization.Tests
         [MemberData(nameof(DateTime_TestData))]
         public static void GetDayOfWeek_Invalid(Calendar calendar, DateTime dt)
         {
-            // TODO: this fails (expected) for lunar and lunarsolar calendars.
-            // Calendar.AlgorithmType is not exposed in corefx so how do we test for this?
-            // HijiriCalendar, UmAlQuraCalendar, PersianCalendar, HebrewCalendar
-            // Assert.Throws<ArgumentOutOfRangeException>("time", () => calendar.GetDayOfWeek(dt));
+            if (calendar is HijriCalendar || calendar is UmAlQuraCalendar || calendar is PersianCalendar || calendar is HebrewCalendar)
+            {
+                calendar.GetDayOfWeek(dt);
+            }
+            else
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("time", () => calendar.GetDayOfWeek(dt));
+            }
         }
     }
 }

--- a/src/System.Globalization.Calendars/tests/CalendarHelpers.cs
+++ b/src/System.Globalization.Calendars/tests/CalendarHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -377,7 +378,8 @@ namespace System.Globalization.Tests
         [MemberData(nameof(DateTime_TestData))]
         public static void GetEra_Invalid(Calendar calendar, DateTime dt)
         {
-            if (calendar is JapaneseCalendar || calendar is HebrewCalendar || calendar is TaiwanLunisolarCalendar || calendar is JapaneseLunisolarCalendar)
+        	// JapaneseCalendar throws on Unix (ICU), but not on Windows
+            if ((calendar is JapaneseCalendar && PlatformDetection.IsWindows) || calendar is HebrewCalendar || calendar is TaiwanLunisolarCalendar || calendar is JapaneseLunisolarCalendar)
             {
                 calendar.GetEra(dt);
             }

--- a/src/System.Globalization.Calendars/tests/System.Globalization.Calendars.Tests.csproj
+++ b/src/System.Globalization.Calendars/tests/System.Globalization.Calendars.Tests.csproj
@@ -115,6 +115,10 @@
     <Compile Include="ThaiBuddhistCalendar\ThaiBuddhistCalendarToFourDigitYear.cs" />
     <Compile Include="ThaiBuddhistCalendar\ThaiBuddhistCalendarTwoDigitYearMax.cs" />
     <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs" />
+    <!-- Helpers -->
+    <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
+      <Link>Common\System\PlatformDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Globalization.Calendars/tests/project.json
+++ b/src/System.Globalization.Calendars/tests/project.json
@@ -3,6 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24117-00",
     "System.Globalization": "4.0.11-rc3-24117-00",
     "System.Globalization.Calendars": "4.0.1-rc3-24117-00",
+    "System.IO.FileSystem": "4.0.1-rc3-24117-00",
     "System.Linq.Expressions": "4.1.0-rc3-24117-00",
     "System.ObjectModel": "4.0.12-rc3-24117-00",
     "System.Runtime.Extensions": "4.1.0-rc3-24117-00",


### PR DESCRIPTION
Exclude certain calendars that don't do error checking (e.g. lunar and
lunarsolar calendars)
Fixes #6775

/cc @tarekgh