### PR TITLE
Cleanup compound operator tests in System.Dynamic.Runtime

### DIFF
--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Common.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Common.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Dynamic.Operator.Tests
+{
+    public static class LiftCommon
+    {
+        public static bool? s_bool = null;
+        public static byte? s_byte = null;
+        public static char? s_char = null;
+        public static decimal? s_decimal = null;
+        public static double? s_double = null;
+        public static float? s_float = null;
+        public static int? s_int = null;
+        public static long? s_long = null;
+        public static object s_object = new object();
+        public static sbyte? s_sbyte = null;
+        public static short? s_short = 6;
+        public static string s_string = "a";
+        public static uint? s_uint = null;
+        public static ulong? s_ulong = 2;
+        public static ushort? s_ushort = 7;
+    }
+
+    public static class TypeCommon
+    {
+        public static bool s_bool = true;
+        public static byte s_byte = 1;
+        public static char s_char = 'a';
+        public static decimal s_decimal = 1M;
+        public static double s_double = 10.1;
+        public static float s_float = 10.1f;
+        public static int s_int = 10;
+        public static long s_long = 5;
+        public static object s_object = new object();
+        public static sbyte s_sbyte = 10;
+        public static short s_short = 6;
+        public static string s_string = "a";
+        public static uint s_uint = 15;
+        public static ulong s_ulong = 2;
+        public static ushort s_ushort = 7;
+    }
+}

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.AndEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.AndEqual.cs
@@ -2,3756 +2,580 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.bol.bol;
-    // <Title> Generated tests for &= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(40,74\).*CS0168</Expects>
-    using System;
+using static Dynamic.Operator.Tests.LiftCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class AndEqualLiftTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+            d &= s_bool;
+
+            d = true;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "bool?", "bool"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "bool", "byte?"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "bool", "ushort?"))
-                        result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.bte.bte;
-    // <Title> Generated tests for &= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = (byte)1;
+            d &= s_byte;
+
+            d = (byte)1;
+            d &= s_char;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+
+            d = (byte)1;
+            d &= s_int;
+
+            d = (byte)1;
+            d &= s_long;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+
+            d = (byte)1;
+            d &= s_sbyte;
+
+            d = (byte)1;
+            d &= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = (byte)1;
+            d &= s_uint;
+
+            d = (byte)1;
+            d &= s_ulong;
+
+            d = (byte)1;
+            d &= s_short;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "byte", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.chr.chr;
-    // <Title> Generated tests for &= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = 'a';
+            d &= s_byte;
+
+            d = 'a';
+            d &= s_char;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+
+            d = 'a';
+            d &= s_int;
+
+            d = 'a';
+            d &= s_long;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+
+            d = 'a';
+            d &= s_sbyte;
+
+            d = 'a';
+            d &= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = 'a';
+            d &= s_uint;
+
+            d = 'a';
+            d &= s_ulong;
+
+            d = 'a';
+            d &= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "char", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.dcml.dcml;
-    // <Title> Generated tests for &= operator decimal Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_byte);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_char);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_int);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_long);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_sbyte);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_short);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_uint);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ushort);
+
+            d = 1m;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "decimal", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "decimal", "double?"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.dbl.dbl;
-    // <Title> Generated tests for &= operator double Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10.1d;
+
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "double", "byte?"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "double", "sbyte?"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.flt.flt;
-    // <Title> Generated tests for &= operator float Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10.1f;
+
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "float", "char?"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "float", "float?"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.integereger.integereger;
-    // <Title> Generated tests for &= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = 10;
+            d &= s_byte;
+
+            d = 10;
+            d &= s_char;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+
+            d = 10;
+            d &= s_int;
+
+            d = 10;
+            d &= s_long;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+
+            d = 10;
+            d &= s_sbyte;
+
+            d = 10;
+            d &= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = 10;
+            d &= s_uint;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+
+            d = 10;
+            d &= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "int", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.lng.lng;
-    // <Title> Generated tests for &= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = 10L;
+            d &= s_byte;
+
+            d = 10L;
+            d &= s_char;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+
+            d = 10L;
+            d &= s_int;
+
+            d = 10L;
+            d &= s_long;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+
+            d = 10L;
+            d &= s_sbyte;
+
+            d = 10L;
+            d &= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = 10L;
+            d &= s_uint;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+
+            d = 10L;
+            d &= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "long", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.obj.obj;
-    // <Title> Generated tests for &= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "object", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "object", "ulong?"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.sbte.sbte;
-    // <Title> Generated tests for &= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = (sbyte)10;
+            d &= s_byte;
+
+            d = (sbyte)10;
+            d &= s_char;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+
+            d = (sbyte)10;
+            d &= s_int;
+
+            d = (sbyte)10;
+            d &= s_long;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+
+            d = (sbyte)10;
+            d &= s_sbyte;
+
+            d = (sbyte)10;
+            d &= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = (sbyte)10;
+            d &= s_uint;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+
+            d = (sbyte)10;
+            d &= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "sbyte", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.shrt.shrt;
-    // <Title> Generated tests for &= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = (short)10;
+            d &= s_byte;
+
+            d = (short)10;
+            d &= s_char;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+
+            d = (short)10;
+            d &= s_int;
+
+            d = (short)10;
+            d &= s_long;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+
+            d = (short)10;
+            d &= s_sbyte;
+
+            d = (short)10;
+            d &= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = (short)10;
+            d &= s_uint;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+
+            d = (short)10;
+            d &= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "short", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.str.str;
-    // <Title> Generated tests for &= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "abc";
+
+            Assert.Throws<RuntimeBinderException>(() => d &=s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d &=s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d &=s_char);
+            Assert.Throws<RuntimeBinderException>(() => d &=s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &=s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &=s_float);
+            Assert.Throws<RuntimeBinderException>(() => d &=s_int);
+            Assert.Throws<RuntimeBinderException>(() => d &=s_long);
+            Assert.Throws<RuntimeBinderException>(() => d &=s_object);
+            Assert.Throws<RuntimeBinderException>(() => d &=s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d &=s_short);
+            Assert.Throws<RuntimeBinderException>(() => d &=s_string);
+            Assert.Throws<RuntimeBinderException>(() => d &=s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d &=s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d &=s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "string", "byte?"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "string", "float?"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for &= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = (uint)10;
+            d &= s_byte;
+
+            d = (uint)10;
+            d &= s_char;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+
+            d = (uint)10;
+            d &= s_int;
+
+            d = (uint)10;
+            d &= s_long;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+
+            d = (uint)10;
+            d &= s_sbyte;
+
+            d = (uint)10;
+            d &= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = (uint)10;
+            d &= s_uint;
+
+            d = (uint)10;
+            d &= s_ulong;
+
+            d = (uint)10;
+            d &= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "uint", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.ulng.ulng;
-    // <Title> Generated tests for &= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = (ulong)10;
+            d &= s_byte;
+
+            d = (ulong)10;
+            d &= s_char;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = (ulong)10;
+            d &= s_uint;
+
+            d = (ulong)10;
+            d &= s_ulong;
+
+            d = (ulong)10;
+            d &= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "ulong", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.AndEqual.ushrt.ushrt;
-    // <Title> Generated tests for &= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "ushort", "bool?"))
-                        result = false;
-                }
-            }
+            d = (ushort)10;
+            d &= s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            d &= s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d &= s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            d &= s_long;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d &= s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            d &= s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d &= s_uint;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            d &= s_ulong;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d &= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.DivideEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.DivideEqual.cs
@@ -2,3806 +2,657 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.bol.bol;
-    // <Title> Generated tests for /= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
+using static Dynamic.Operator.Tests.LiftCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class DivideEqualLiftTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "bool", "ulong?"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "bool", "ushort?"))
-                        result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.bte.bte;
-    // <Title> Generated tests for /= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = (byte)1;
+            d /= s_byte;
+
+            d = (byte)1;
+            d /= s_char;
+
+            d = (byte)1;
+            d /= s_decimal;
+
+            d = (byte)1;
+            d /= s_double;
+
+            d = (byte)1;
+            d /= s_float;
+
+            d = (byte)1;
+            d /= s_int;
+
+            d = (byte)1;
+            d /= s_long;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = (byte)1;
+            d /= s_sbyte;
+
+            d = (byte)1;
+            d /= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = (byte)1;
+            d /= s_uint;
+
+            d = (byte)1;
+            d /= s_ulong;
+
+            d = (byte)1;
+            d /= s_short;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "byte", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.chr.chr;
-    // <Title> Generated tests for /= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = 'a';
+            d /= s_byte;
+
+            d = 'a';
+            d /= s_char;
+
+            d = 'a';
+            d /= s_decimal;
+
+            d = 'a';
+            d /= s_double;
+
+            d = 'a';
+            d /= s_float;
+
+            d = 'a';
+            d /= s_int;
+
+            d = 'a';
+            d /= s_long;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = 'a';
+            d /= s_sbyte;
+
+            d = 'a';
+            d /= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = 'a';
+            d /= s_uint;
+
+            d = 'a';
+            d /= s_ulong;
+
+            d = 'a';
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "char", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.dcml.dcml;
-    // <Title> Generated tests for /= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = 1m;
+            d /= s_byte;
+
+            d = 1m;
+            d /= s_char;
+
+            d = 1m;
+            d /= s_decimal;
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_double);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_float);
+
+            d = 1m;
+            d /= s_int;
+
+            d = 1m;
+            d /= s_long;
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = 1m;
+            d /= s_sbyte;
+
+            d = 1m;
+            d /= s_short;
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = 1m;
+            d /= s_uint;
+
+            d = 1m;
+            d /= s_ulong;
+
+            d = 1m;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "decimal", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.dbl.dbl;
-    // <Title> Generated tests for /= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10.1d;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = 10.1d;
+            d /= s_byte;
+
+            d = 10.1d;
+            d /= s_char;
+
+            d = 10.1d;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_decimal);
+
+            d = 10.1d;
+            d /= s_double;
+
+            d = 10.1d;
+            d /= s_float;
+
+            d = 10.1d;
+            d /= s_int;
+
+            d = 10.1d;
+            d /= s_long;
+
+            d = 10.1d;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d /= s_sbyte;
+
+            d = 10.1d;
+            d /= s_short;
+
+            d = 10.1d;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = 10.1d;
+            d /= s_uint;
+
+            d = 10.1d;
+            d /= s_ulong;
+
+            d = 10.1d;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "double", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.flt.flt;
-    // <Title> Generated tests for /= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10.1f;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = 10.1f;
+            d /= s_byte;
+
+            d = 10.1f;
+            d /= s_char;
+
+            d = 10.1f;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_decimal);
+
+            d = 10.1f;
+            d /= s_double;
+
+            d = 10.1f;
+            d /= s_float;
+
+            d = 10.1f;
+            d /= s_int;
+
+            d = 10.1f;
+            d /= s_long;
+
+            d = 10.1f;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = 10.1f;
+            d /= s_sbyte;
+
+            d = 10.1f;
+            d /= s_short;
+
+            d = 10.1f;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = 10.1f;
+            d /= s_uint;
+
+            d = 10.1f;
+            d /= s_ulong;
+
+            d = 10.1f;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "float", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.integereger.integereger;
-    // <Title> Generated tests for /= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = 10;
+            d /= s_byte;
+
+            d = 10;
+            d /= s_char;
+
+            d = 10;
+            d /= s_decimal;
+
+            d = 10;
+            d /= s_double;
+
+            d = 10;
+            d /= s_float;
+
+            d = 10;
+            d /= s_int;
+
+            d = 10;
+            d /= s_long;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = 10;
+            d /= s_sbyte;
+
+            d = 10;
+            d /= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = 10;
+            d /= s_uint;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ulong);
+
+            d = 10;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "int", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.lng.lng;
-    // <Title> Generated tests for /= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = 10L;
+            d /= s_byte;
+
+            d = 10L;
+            d /= s_char;
+
+            d = 10L;
+            d /= s_decimal;
+
+            d = 10L;
+            d /= s_double;
+
+            d = 10L;
+            d /= s_float;
+
+            d = 10L;
+            d /= s_int;
+
+            d = 10L;
+            d /= s_long;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = 10L;
+            d /= s_sbyte;
+
+            d = 10L;
+            d /= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = 10L;
+            d /= s_uint;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ulong);
+
+            d = 10L;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "long", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.obj.obj;
-    // <Title> Generated tests for /= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "object", "byte?"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "object", "char?"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.sbte.sbte;
-    // <Title> Generated tests for /= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = (sbyte)10;
+            d /= s_byte;
+
+            d = (sbyte)10;
+            d /= s_char;
+
+            d = (sbyte)10;
+            d /= s_decimal;
+
+            d = (sbyte)10;
+            d /= s_double;
+
+            d = (sbyte)10;
+            d /= s_float;
+
+            d = (sbyte)10;
+            d /= s_int;
+
+            d = (sbyte)10;
+            d /= s_long;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = (sbyte)10;
+            d /= s_sbyte;
+
+            d = (sbyte)10;
+            d /= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = (sbyte)10;
+            d /= s_uint;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ulong);
+
+            d = (sbyte)10;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "sbyte", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.shrt.shrt;
-    // <Title> Generated tests for /= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = (short)10;
+            d /= s_byte;
+
+            d = (short)10;
+            d /= s_char;
+
+            d = (short)10;
+            d /= s_decimal;
+
+            d = (short)10;
+            d /= s_double;
+
+            d = (short)10;
+            d /= s_float;
+
+            d = (short)10;
+            d /= s_int;
+
+            d = (short)10;
+            d /= s_long;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = (short)10;
+            d /= s_sbyte;
+
+            d = (short)10;
+            d /= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = (short)10;
+            d /= s_uint;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d / s_ulong);
+
+            d = (short)10;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "short", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.str.str;
-    // <Title> Generated tests for /= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "abc";
+
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "string", "int?"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "string", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for /= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = (uint)10;
+            d /= s_byte;
+
+            d = (uint)10;
+            d /= s_char;
+
+            d = (uint)10;
+            d /= s_decimal;
+
+            d = (uint)10;
+            d /= s_double;
+
+            d = (uint)10;
+            d /= s_float;
+
+            d = (uint)10;
+            d /= s_int;
+
+            d = (uint)10;
+            d /= s_long;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = (uint)10;
+            d /= s_sbyte;
+
+            d = (uint)10;
+            d /= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = (uint)10;
+            d /= s_uint;
+
+            d = (uint)10;
+            d /= s_ulong;
+
+            d = (uint)10;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "uint", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.ulng.ulng;
-    // <Title> Generated tests for /= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = (ulong)10;
+            d /= s_byte;
+
+            d = (ulong)10;
+            d /= s_char;
+
+            d = (ulong)10;
+            d /= s_decimal;
+
+            d = (ulong)10;
+            d /= s_double;
+
+            d = (ulong)10;
+            d /= s_float;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d / s_long);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_short);
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = (ulong)10;
+            d /= s_uint;
+
+            d = (ulong)10;
+            d /= s_ulong;
+
+            d = (ulong)10;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "ulong", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.DivideEqual.ushrt.ushrt;
-    // <Title> Generated tests for /= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d /= s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d /= s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d /= s_decimal;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d /= s_double;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d /= s_float;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d /= s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d /= s_long;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d /= s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d /= s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "ushort", "string"))
-                        result = false;
-                }
-            }
+            d = (ushort)10;
+            d /= s_uint;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d /= s_ulong;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d /= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.ModEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.ModEqual.cs
@@ -2,3806 +2,655 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.bol.bol;
-    // <Title> Generated tests for %= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
+using static Dynamic.Operator.Tests.LiftCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class ModEqualLiftTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "bool", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "bool", "char?"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.bte.bte;
-    // <Title> Generated tests for %= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = (byte)1;
+            d %= s_byte;
+
+            d = (byte)1;
+            d %= s_char;
+
+            d = (byte)1;
+            d %= s_decimal;
+
+            d = (byte)1;
+            d %= s_double;
+
+            d = (byte)1;
+            d %= s_float;
+
+            d = (byte)1;
+            d %= s_int;
+
+            d = (byte)1;
+            d %= s_long;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = (byte)1;
+            d %= s_sbyte;
+
+            d = (byte)1;
+            d %= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = (byte)1;
+            d %= s_uint;
+
+            d = (byte)1;
+            d %= s_ulong;
+
+            d = (byte)1;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "byte", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.chr.chr;
-    // <Title> Generated tests for %= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = 'a';
+            d %= s_byte;
+
+            d = 'a';
+            d %= s_char;
+
+            d = 'a';
+            d %= s_decimal;
+
+            d = 'a';
+            d %= s_double;
+
+            d = 'a';
+            d %= s_float;
+
+            d = 'a';
+            d %= s_int;
+
+            d = 'a';
+            d %= s_long;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = 'a';
+            d %= s_sbyte;
+
+            d = 'a';
+            d %= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = 'a';
+            d %= s_uint;
+
+            d = 'a';
+            d %= s_ulong;
+
+            d = 'a';
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "char", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.dcml.dcml;
-    // <Title> Generated tests for %= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = 10m;
+            d %= s_byte;
+
+            d = 10m;
+            d %= s_char;
+
+            d = 10m;
+            d %= s_decimal;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_float);
+
+            d = 10m;
+            d %= s_int;
+
+            d = 10m;
+            d %= s_long;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = 10m;
+            d %= s_sbyte;
+
+            d = 10m;
+            d %= s_short;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = 10m;
+            d %= s_uint;
+
+            d = 10m;
+            d %= s_ulong;
+
+            d = 10m;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "decimal", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.dbl.dbl;
-    // <Title> Generated tests for %= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = 10d;
+            d %= s_byte;
+
+            d = 10d;
+            d %= s_char;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_decimal);
+
+            d = 10d;
+            d %= s_double;
+
+            d = 10d;
+            d %= s_float;
+
+            d = 10d;
+            d %= s_int;
+
+            d = 10d;
+            d %= s_long;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = 10d;
+            d %= s_sbyte;
+
+            d = 10d;
+            d %= s_short;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = 10d;
+            d %= s_uint;
+
+            d = 10d;
+            d %= s_ulong;
+
+            d = 10d;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "double", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.flt.flt;
-    // <Title> Generated tests for %= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = 10f;
+            d %= s_byte;
+
+            d = 10f;
+            d %= s_char;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_decimal);
+
+            d = 10f;
+            d %= s_double;
+
+            d = 10f;
+            d %= s_float;
+
+            d = 10f;
+            d %= s_int;
+
+            d = 10f;
+            d %= s_long;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = 10f;
+            d %= s_sbyte;
+
+            d = 10f;
+            d %= s_short;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = 10f;
+            d %= s_uint;
+
+            d = 10f;
+            d %= s_ulong;
+
+            d = 10f;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "float", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.integereger.integereger;
-    // <Title> Generated tests for %= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = 10;
+            d %= s_byte;
+
+            d = 10;
+            d %= s_char;
+
+            d = 10;
+            d %= s_decimal;
+
+            d = 10;
+            d %= s_double;
+
+            d = 10;
+            d %= s_float;
+
+            d = 10;
+            d %= s_int;
+
+            d = 10;
+            d %= s_long;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = 10;
+            d %= s_sbyte;
+
+            d = 10;
+            d %= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = 10;
+            d %= s_uint;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ulong);
+
+            d = 10;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "int", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.lng.lng;
-    // <Title> Generated tests for %= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = 10L;
+            d %= s_byte;
+
+            d = 10L;
+            d %= s_char;
+
+            d = 10L;
+            d %= s_decimal;
+
+            d = 10L;
+            d %= s_double;
+
+            d = 10L;
+            d %= s_float;
+
+            d = 10L;
+            d %= s_int;
+
+            d = 10L;
+            d %= s_long;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = 10L;
+            d %= s_sbyte;
+
+            d = 10L;
+            d %= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = 10L;
+            d %= s_uint;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ulong);
+
+            d = 10L;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "long", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.obj.obj;
-    // <Title> Generated tests for %= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "object", "uint?"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "object", "ushort?"))
-                        result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.sbte.sbte;
-    // <Title> Generated tests for %= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = (sbyte)10;
+            d %= s_byte;
+
+            d = (sbyte)10;
+            d %= s_char;
+
+            d = (sbyte)10;
+            d %= s_decimal;
+
+            d = (sbyte)10;
+            d %= s_double;
+
+            d = (sbyte)10;
+            d %= s_float;
+
+            d = (sbyte)10;
+            d %= s_int;
+
+            d = (sbyte)10;
+            d %= s_long;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = (sbyte)10;
+            d %= s_sbyte;
+
+            d = (sbyte)10;
+            d %= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = (sbyte)10;
+            d %= s_uint;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ulong);
+
+            d = (sbyte)10;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "sbyte", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.shrt.shrt;
-    // <Title> Generated tests for %= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = (short)10;
+            d %= s_byte;
+
+            d = (short)10;
+            d %= s_char;
+
+            d = (short)10;
+            d %= s_decimal;
+
+            d = (short)10;
+            d %= s_double;
+
+            d = (short)10;
+            d %= s_float;
+
+            d = (short)10;
+            d %= s_int;
+
+            d = (short)10;
+            d %= s_long;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = (short)10;
+            d %= s_sbyte;
+
+            d = (short)10;
+            d %= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = (short)10;
+            d %= s_uint;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ulong);
+
+            d = (short)10;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "short", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.str.str;
-    // <Title> Generated tests for %= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "a";
+
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "string", "sbyte?"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "string", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for /= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = (uint)10;
+            d %= s_byte;
+
+            d = (uint)10;
+            d %= s_char;
+
+            d = (uint)10;
+            d %= s_decimal;
+
+            d = (uint)10;
+            d %= s_double;
+
+            d = (uint)10;
+            d %= s_float;
+
+            d = (uint)10;
+            d %= s_int;
+
+            d = (uint)10;
+            d %= s_long;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = (uint)10;
+            d %= s_sbyte;
+
+            d = (uint)10;
+            d %= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = (uint)10;
+            d %= s_uint;
+
+            d = (uint)10;
+            d %= s_ulong;
+
+            d = (uint)10;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "uint", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.ulng.ulng;
-    // <Title> Generated tests for %= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = (ulong)10;
+            d %= s_byte;
+
+            d = (ulong)10;
+            d %= s_char;
+
+            d = (ulong)10;
+            d %= s_decimal;
+
+            d = (ulong)10;
+            d %= s_double;
+
+            d = (ulong)10;
+            d %= s_float;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = (ulong)10;
+            d %= s_uint;
+
+            d = (ulong)10;
+            d %= s_ulong;
+
+            d = (ulong)10;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "ulong", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ModEqual.ushrt.ushrt;
-    // <Title> Generated tests for %= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d %= s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d %= s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d %= s_decimal;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d %= s_double;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d %= s_float;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d %= s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d %= s_long;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d %= s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d %= s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "ushort", "string"))
-                        result = false;
-                }
-            }
+            d = (ushort)10;
+            d %= s_uint;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d %= s_ulong;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d %= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.MultiEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.MultiEqual.cs
@@ -2,3806 +2,655 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.bol.bol;
-    // <Title> Generated tests for *= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
+using static Dynamic.Operator.Tests.LiftCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class TimesEqualLiftTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "bool", "byte?"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "bool", "double?"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.bte.bte;
-    // <Title> Generated tests for *= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = (byte)1;
+            d *= s_byte;
+
+            d = (byte)1;
+            d *= s_char;
+
+            d = (byte)1;
+            d *= s_decimal;
+
+            d = (byte)1;
+            d *= s_double;
+
+            d = (byte)1;
+            d *= s_float;
+
+            d = (byte)1;
+            d *= s_int;
+
+            d = (byte)1;
+            d *= s_long;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = (byte)1;
+            d *= s_sbyte;
+
+            d = (byte)1;
+            d *= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = (byte)1;
+            d *= s_uint;
+
+            d = (byte)1;
+            d *= s_ulong;
+
+            d = (byte)1;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "byte", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.chr.chr;
-    // <Title> Generated tests for *= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = 'a';
+            d *= s_byte;
+
+            d = 'a';
+            d *= s_char;
+
+            d = 'a';
+            d *= s_decimal;
+
+            d = 'a';
+            d *= s_double;
+
+            d = 'a';
+            d *= s_float;
+
+            d = 'a';
+            d *= s_int;
+
+            d = 'a';
+            d *= s_long;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = 'a';
+            d *= s_sbyte;
+
+            d = 'a';
+            d *= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = 'a';
+            d *= s_uint;
+
+            d = 'a';
+            d *= s_ulong;
+
+            d = 'a';
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "char", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.dcml.dcml;
-    // <Title> Generated tests for *= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = 10m;
+            d *= s_byte;
+
+            d = 10m;
+            d *= s_char;
+
+            d = 10m;
+            d *= s_decimal;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_float);
+
+            d = 10m;
+            d *= s_int;
+
+            d = 10m;
+            d *= s_long;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = 10m;
+            d *= s_sbyte;
+
+            d = 10m;
+            d *= s_short;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = 10m;
+            d *= s_uint;
+
+            d = 10m;
+            d *= s_ulong;
+
+            d = 10m;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "decimal", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.dbl.dbl;
-    // <Title> Generated tests for *= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = 10d;
+            d *= s_byte;
+
+            d = 10d;
+            d *= s_char;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_decimal);
+
+            d = 10d;
+            d *= s_double;
+
+            d = 10d;
+            d *= s_float;
+
+            d = 10d;
+            d *= s_int;
+
+            d = 10d;
+            d *= s_long;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = 10d;
+            d *= s_sbyte;
+
+            d = 10d;
+            d *= s_short;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = 10d;
+            d *= s_uint;
+
+            d = 10d;
+            d *= s_ulong;
+
+            d = 10d;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "double", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.flt.flt;
-    // <Title> Generated tests for *= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = 10f;
+            d *= s_byte;
+
+            d = 10f;
+            d *= s_char;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_decimal);
+
+            d = 10f;
+            d *= s_double;
+
+            d = 10f;
+            d *= s_float;
+
+            d = 10f;
+            d *= s_int;
+
+            d = 10f;
+            d *= s_long;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = 10f;
+            d *= s_sbyte;
+
+            d = 10f;
+            d *= s_short;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = 10f;
+            d *= s_uint;
+
+            d = 10f;
+            d *= s_ulong;
+
+            d = 10f;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "float", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.integereger.integereger;
-    // <Title> Generated tests for *= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = 10;
+            d *= s_byte;
+
+            d = 10;
+            d *= s_char;
+
+            d = 10;
+            d *= s_decimal;
+
+            d = 10;
+            d *= s_double;
+
+            d = 10;
+            d *= s_float;
+
+            d = 10;
+            d *= s_int;
+
+            d = 10;
+            d *= s_long;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = 10;
+            d *= s_sbyte;
+
+            d = 10;
+            d *= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = 10;
+            d *= s_uint;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ulong);
+
+            d = 10;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "int", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.lng.lng;
-    // <Title> Generated tests for *= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = 10L;
+            d *= s_byte;
+
+            d = 10L;
+            d *= s_char;
+
+            d = 10L;
+            d *= s_decimal;
+
+            d = 10L;
+            d *= s_double;
+
+            d = 10L;
+            d *= s_float;
+
+            d = 10L;
+            d *= s_int;
+
+            d = 10L;
+            d *= s_long;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = 10L;
+            d *= s_sbyte;
+
+            d = 10L;
+            d *= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = 10L;
+            d *= s_uint;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ulong);
+
+            d = 10L;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "long", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.obj.obj;
-    // <Title> Generated tests for *= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "object", "byte?"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "object", "long?"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.sbte.sbte;
-    // <Title> Generated tests for *= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = (sbyte)10;
+            d *= s_byte;
+
+            d = (sbyte)10;
+            d *= s_char;
+
+            d = (sbyte)10;
+            d *= s_decimal;
+
+            d = (sbyte)10;
+            d *= s_double;
+
+            d = (sbyte)10;
+            d *= s_float;
+
+            d = (sbyte)10;
+            d *= s_int;
+
+            d = (sbyte)10;
+            d *= s_long;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = (sbyte)10;
+            d *= s_sbyte;
+
+            d = (sbyte)10;
+            d *= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = (sbyte)10;
+            d *= s_uint;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ulong);
+
+            d = (sbyte)10;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "sbyte", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.shrt.shrt;
-    // <Title> Generated tests for *= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = (short)10;
+            d *= s_byte;
+
+            d = (short)10;
+            d *= s_char;
+
+            d = (short)10;
+            d *= s_decimal;
+
+            d = (short)10;
+            d *= s_double;
+
+            d = (short)10;
+            d *= s_float;
+
+            d = (short)10;
+            d *= s_int;
+
+            d = (short)10;
+            d *= s_long;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = (short)10;
+            d *= s_sbyte;
+
+            d = (short)10;
+            d *= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = (short)10;
+            d *= s_uint;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ulong);
+
+            d = (short)10;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "short", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.str.str;
-    // <Title> Generated tests for *= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "a";
+
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "string", "byte?"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "string", "double?"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for *= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = (uint)10;
+            d *= s_byte;
+
+            d = (uint)10;
+            d *= s_char;
+
+            d = (uint)10;
+            d *= s_decimal;
+
+            d = (uint)10;
+            d *= s_double;
+
+            d = (uint)10;
+            d *= s_float;
+
+            d = (uint)10;
+            d *= s_int;
+
+            d = (uint)10;
+            d *= s_long;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = (uint)10;
+            d *= s_sbyte;
+
+            d = (uint)10;
+            d *= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = (uint)10;
+            d *= s_uint;
+
+            d = (uint)10;
+            d *= s_ulong;
+
+            d = (uint)10;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "uint", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.ulng.ulng;
-    // <Title> Generated tests for *= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = (ulong)10;
+            d *= s_byte;
+
+            d = (ulong)10;
+            d *= s_char;
+
+            d = (ulong)10;
+            d *= s_decimal;
+
+            d = (ulong)10;
+            d *= s_double;
+
+            d = (ulong)10;
+            d *= s_float;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = (ulong)10;
+            d *= s_uint;
+
+            d = (ulong)10;
+            d *= s_ulong;
+
+            d = (ulong)10;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "ulong", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.MultiEqual.ushrt.ushrt;
-    // <Title> Generated tests for *= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d *= s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d *= s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d *= s_decimal;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d *= s_double;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d *= s_float;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d *= s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d *= s_long;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d *= s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d *= s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "ushort", "string"))
-                        result = false;
-                }
-            }
+            d = (ushort)10;
+            d *= s_uint;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d *= s_ulong;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d *= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.OrEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.OrEqual.cs
@@ -2,3756 +2,566 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.bol.bol;
-    // <Title> Generated tests for |= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(40,74\).*CS0168</Expects>
-    using System;
+using static Dynamic.Operator.Tests.LiftCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class OrEqualLiftTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+            d |= s_bool;
+
+            d = true;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "bool?", "bool"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "bool", "byte?"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "bool", "ushort?"))
-                        result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.bte.bte;
-    // <Title> Generated tests for |= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = (byte)1;
+            d |= s_byte;
+
+            d = (byte)1;
+            d |= s_char;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+
+            d = (byte)1;
+            d |= s_int;
+
+            d = (byte)1;
+            d |= s_long;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+
+            d = (byte)1;
+            d |= s_sbyte;
+
+            d = (byte)1;
+            d |= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = (byte)1;
+            d |= s_uint;
+
+            d = (byte)1;
+            d |= s_ulong;
+
+            d = (byte)1;
+            d |= s_short;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "byte", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.chr.chr;
-    // <Title> Generated tests for |= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = 'a';
+            d |= s_byte;
+
+            d = 'a';
+            d |= s_char;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+
+            d = 'a';
+            d |= s_int;
+
+            d = 'a';
+            d |= s_long;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+
+            d = 'a';
+            d |= s_sbyte;
+
+            d = 'a';
+            d |= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = 'a';
+            d |= s_uint;
+
+            d = 'a';
+            d |= s_ulong;
+
+            d = 'a';
+            d |= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "char", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.dcml.dcml;
-    // <Title> Generated tests for |= operator decimal Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_byte);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_char);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_int);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_long);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_sbyte);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_short);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_uint);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "decimal", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "decimal", "short?"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.dbl.dbl;
-    // <Title> Generated tests for |= operator double Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10.1d;
+
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "double", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "double", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.flt.flt;
-    // <Title> Generated tests for |= operator float Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10.1f;
+
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "float", "byte?"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "float", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.integereger.integereger;
-    // <Title> Generated tests for |= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = 10;
+            d |= s_byte;
+
+            d = 10;
+            d |= s_char;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+
+            d = 10;
+            d |= s_int;
+
+            d = 10;
+            d |= s_long;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+
+            d = 10;
+            d |= s_sbyte;
+
+            d = 10;
+            d |= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = 10;
+            d |= s_uint;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+
+            d = 10;
+            d |= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "int", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.lng.lng;
-    // <Title> Generated tests for |= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = 10L;
+            d |= s_byte;
+
+            d = 10L;
+            d |= s_char;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+
+            d = 10L;
+            d |= s_int;
+
+            d = 10L;
+            d |= s_long;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+
+            d = 10L;
+            d |= s_sbyte;
+
+            d = 10L;
+            d |= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = 10L;
+            d |= s_uint;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+
+            d = 10L;
+            d |= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "long", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.obj.obj;
-    // <Title> Generated tests for |= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "object", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "object", "int?"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.sbte.sbte;
-    // <Title> Generated tests for |= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = (sbyte)10;
+            d |= s_byte;
+
+            d = (sbyte)10;
+            d |= s_char;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+
+            d = (sbyte)10;
+            d |= s_int;
+
+            d = (sbyte)10;
+            d |= s_long;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+
+            d = (sbyte)10;
+            d |= s_sbyte;
+
+            d = (sbyte)10;
+            d |= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = (sbyte)10;
+            d |= s_uint;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+
+            d = (sbyte)10;
+            d |= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "sbyte", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.shrt.shrt;
-    // <Title> Generated tests for |= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = (short)10;
+            d |= s_byte;
+
+            d = (short)10;
+            d |= s_char;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+
+            d = (short)10;
+            d |= s_int;
+
+            d = (short)10;
+            d |= s_long;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+
+            d = (short)10;
+            d |= s_sbyte;
+
+            d = (short)10;
+            d |= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = (short)10;
+            d |= s_uint;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+
+            d = (short)10;
+            d |= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "short", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.str.str;
-    // <Title> Generated tests for |= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "abc";
+
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "string", "char?"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "string", "int?"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for |= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = (uint)10;
+            d |= s_byte;
+
+            d = (uint)10;
+            d |= s_char;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+
+            d = (uint)10;
+            d |= s_int;
+
+            d = (uint)10;
+            d |= s_long;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+
+            d = (uint)10;
+            d |= s_sbyte;
+
+            d = (uint)10;
+            d |= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = (uint)10;
+            d |= s_uint;
+
+            d = (uint)10;
+            d |= s_ulong;
+
+            d = (uint)10;
+            d |= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "uint", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.ulng.ulng;
-    // <Title> Generated tests for |= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = (ulong)10;
+            d |= s_byte;
+
+            d = (ulong)10;
+            d |= s_char;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = (ulong)10;
+            d |= s_uint;
+
+            d = (ulong)10;
+            d |= s_ulong;
+
+            d = (ulong)10;
+            d |= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "ulong", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.OrEqual.ushrt.ushrt;
-    // <Title> Generated tests for |= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "ushort", "bool?"))
-                        result = false;
-                }
-            }
+            d = (ushort)10;
+            d |= s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            d |= s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d |= s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d |= s_long;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            d |= s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            d |= s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            d |= s_uint;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            d |= s_ulong;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d |= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.PlusEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.PlusEqual.cs
@@ -2,3710 +2,692 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.bol.bol;
-    // <Title> Generated tests for += operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
+using static Dynamic.Operator.Tests.LiftCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class PlusEqualLiftTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d += s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d += s_char);
+            Assert.Throws<RuntimeBinderException>(() => d += s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d += s_double);
+            Assert.Throws<RuntimeBinderException>(() => d += s_float);
+            Assert.Throws<RuntimeBinderException>(() => d += s_int);
+            Assert.Throws<RuntimeBinderException>(() => d += s_long);
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+            Assert.Throws<RuntimeBinderException>(() => d += s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d += s_short);
+
+            d = true;
+            d += s_string;
+
+            d = true;
+            Assert.Throws<RuntimeBinderException>(() => d += s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d += s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d += s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d11; //After +=, d type change to string
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.bte.bte;
-    // <Title> Generated tests for += operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(193,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(209,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = (byte)1;
+            d += s_byte;
+
+            d = (byte)1;
+            d += s_char;
+
+            d = (byte)1;
+            d += s_decimal;
+
+            d = (byte)1;
+            d += s_double;
+
+            d = (byte)1;
+            d += s_float;
+
+            d = (byte)1;
+            d += s_int;
+
+            d = (byte)1;
+            d += s_long;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = (byte)1;
+            d += s_sbyte;
+
+            d = (byte)1;
+            d += s_short;
+
+            d = (byte)1;
+            d += s_string;
+
+            d = (byte)1;
+            d += s_uint;
+
+            d = (byte)1;
+            d += s_ulong;
+
+            d = (byte)1;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "byte", "string"))
-                    //    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.chr.chr;
-    // <Title> Generated tests for += operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(193,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(209,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = 'a';
+            d += s_byte;
+
+            d = 'a';
+            d += s_char;
+
+            d = 'a';
+            d += s_decimal;
+
+            d = 'a';
+            d += s_double;
+
+            d = 'a';
+            d += s_float;
+
+            d = 'a';
+            d += s_int;
+
+            d = 'a';
+            d += s_long;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = 'a';
+            d += s_sbyte;
+
+            d = 'a';
+            d += s_short;
+
+            d = 'a';
+            d += s_string;
+
+            d = 'a';
+            d += s_uint;
+
+            d = 'a';
+            d += s_ulong;
+
+            d = 'a';
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "char", "string"))
-                    //    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.dcml.dcml;
-    // <Title> Generated tests for += operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(193,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(209,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = 10m;
+            d += s_byte;
+
+            d = 10m;
+            d += s_char;
+
+            d = 10m;
+            d += s_decimal;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d += s_double);
+            Assert.Throws<RuntimeBinderException>(() => d += s_float);
+
+            d = 10m;
+            d += s_int;
+
+            d = 10m;
+            d += s_long;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = 10m;
+            d += s_sbyte;
+
+            d = 10m;
+            d += s_short;
+
+            d = 10m;
+            d += s_string;
+
+            d = 10m;
+            d += s_uint;
+
+            d = 10m;
+            d += s_ulong;
+
+            d = 10m;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "decimal", "string"))
-                    //    result = false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.dbl.dbl;
-    // <Title> Generated tests for += operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(193,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(209,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = 10d;
+            d += s_byte;
+
+            d = 10d;
+            d += s_char;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d += s_decimal);
+
+            d = 10d;
+            d += s_double;
+
+            d = 10d;
+            d += s_float;
+
+            d = 10d;
+            d += s_int;
+
+            d = 10d;
+            d += s_long;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = 10d;
+            d += s_sbyte;
+
+            d = 10d;
+            d += s_short;
+
+            d = 10d;
+            d += s_string;
+
+            d = 10d;
+            d += s_uint;
+
+            d = 10d;
+            d += s_ulong;
+
+            d = 10d;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "double", "string"))
-                    //    result = false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.flt.flt;
-    // <Title> Generated tests for += operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(193,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(209,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = 10f;
+            d += s_byte;
+
+            d = 10f;
+            d += s_char;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d += s_decimal);
+
+            d = 10f;
+            d += s_double;
+
+            d = 10f;
+            d += s_float;
+
+            d = 10f;
+            d += s_int;
+
+            d = 10f;
+            d += s_long;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = 10f;
+            d += s_sbyte;
+
+            d = 10f;
+            d += s_short;
+
+            d = 10f;
+            d += s_string;
+
+            d = 10f;
+            d += s_uint;
+
+            d = 10f;
+            d += s_ulong;
+
+            d = 10f;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "float", "string"))
-                    //    result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.integereger.integereger;
-    // <Title> Generated tests for += operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(193,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(209,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = 10;
+            d += s_byte;
+
+            d = 10;
+            d += s_char;
+
+            d = 10;
+            d += s_decimal;
+
+            d = 10;
+            d += s_double;
+
+            d = 10;
+            d += s_float;
+
+            d = 10;
+            d += s_int;
+
+            d = 10;
+            d += s_long;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = 10;
+            d += s_sbyte;
+
+            d = 10;
+            d += s_short;
+
+            d = 10;
+            d += s_string;
+
+            d = 10;
+            d += s_uint;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_ulong);
+
+            d = 10;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "int", "string"))
-                    //    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.lng.lng;
-    // <Title> Generated tests for += operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(193,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(209,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = 10L;
+            d += s_byte;
+
+            d = 10L;
+            d += s_char;
+
+            d = 10L;
+            d += s_decimal;
+
+            d = 10L;
+            d += s_double;
+
+            d = 10L;
+            d += s_float;
+
+            d = 10L;
+            d += s_int;
+
+            d = 10L;
+            d += s_long;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = 10L;
+            d += s_sbyte;
+
+            d = 10L;
+            d += s_short;
+
+            d = 10L;
+            d += s_string;
+
+            d = 10L;
+            d += s_uint;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d += s_ulong);
+
+            d = 10L;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "long", "string"))
-                    //    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.obj.obj;
-    // <Title> Generated tests for += operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d += s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d += s_char);
+            Assert.Throws<RuntimeBinderException>(() => d += s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d += s_double);
+            Assert.Throws<RuntimeBinderException>(() => d += s_float);
+            Assert.Throws<RuntimeBinderException>(() => d += s_int);
+            Assert.Throws<RuntimeBinderException>(() => d += s_long);
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+            Assert.Throws<RuntimeBinderException>(() => d += s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d += s_short);
+
+            d = new object();
+            d += s_string;
+
+            d = new object();
+            Assert.Throws<RuntimeBinderException>(() => d += s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d += s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d += s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "object", "double?"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "object", "int?"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                d += d11;
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.sbte.sbte;
-    // <Title> Generated tests for += operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(193,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(209,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = (sbyte)10;
+            d += s_byte;
+
+            d = (sbyte)10;
+            d += s_char;
+
+            d = (sbyte)10;
+            d += s_decimal;
+
+            d = (sbyte)10;
+            d += s_double;
+
+            d = (sbyte)10;
+            d += s_float;
+
+            d = (sbyte)10;
+            d += s_int;
+
+            d = (sbyte)10;
+            d += s_long;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = (sbyte)10;
+            d += s_sbyte;
+
+            d = (sbyte)10;
+            d += s_short;
+
+            d = (sbyte)10;
+            d += s_string;
+
+            d = (sbyte)10;
+            d += s_uint;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_ulong);
+
+            d = (sbyte)10;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "sbyte", "string"))
-                    //    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.shrt.shrt;
-    // <Title> Generated tests for += operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(193,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(209,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = (short)10;
+            d += s_byte;
+
+            d = (short)10;
+            d += s_char;
+
+            d = (short)10;
+            d += s_decimal;
+
+            d = (short)10;
+            d += s_double;
+
+            d = (short)10;
+            d += s_float;
+
+            d = (short)10;
+            d += s_int;
+
+            d = (short)10;
+            d += s_long;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = (short)10;
+            d += s_sbyte;
+
+            d = (short)10;
+            d += s_short;
+
+            d = (short)10;
+            d += s_string;
+
+            d = (short)10;
+            d += s_uint;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_ulong);
+
+            d = (short)10;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "short", "string"))
-                    //    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.str.str;
-    // <Title> Generated tests for += operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "a";
+            d += s_bool;
+
+            d = "a";
+            d += s_byte;
+
+            d = "a";
+            d += s_char;
+
+            d = "a";
+            d += s_decimal;
+
+            d = "a";
+            d += s_double;
+
+            d = "a";
+            d += s_float;
+
+            d = "a";
+            d += s_int;
+
+            d = "a";
+            d += s_long;
+
+            d = "a";
+            d += s_object;
+
+            d = "a";
+            d += s_sbyte;
+
+            d = "a";
+            d += s_short;
+
+            d = "a";
+            d += s_string;
+
+            d = "a";
+            d += s_uint;
+
+            d = "a";
+            d += s_ulong;
+
+            d = "a";
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d0;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d1;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d2;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d3;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d4;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d5;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d6;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d7;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d8;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d9;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d10;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d11;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d12;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d13;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for += operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(193,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(209,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = (uint)10;
+            d += s_byte;
+
+            d = (uint)10;
+            d += s_char;
+
+            d = (uint)10;
+            d += s_decimal;
+
+            d = (uint)10;
+            d += s_double;
+
+            d = (uint)10;
+            d += s_float;
+
+            d = (uint)10;
+            d += s_int;
+
+            d = (uint)10;
+            d += s_long;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = (uint)10;
+            d += s_sbyte;
+
+            d = (uint)10;
+            d += s_short;
+
+            d = (uint)10;
+            d += s_string;
+
+            d = (uint)10;
+            d += s_uint;
+
+            d = (uint)10;
+            d += s_ulong;
+
+            d = (uint)10;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "uint", "string"))
-                    //    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.ulng.ulng;
-    // <Title> Generated tests for += operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(193,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(209,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = (ulong)10;
+            d += s_byte;
+
+            d = (ulong)10;
+            d += s_char;
+
+            d = (ulong)10;
+            d += s_decimal;
+
+            d = (ulong)10;
+            d += s_double;
+
+            d = (ulong)10;
+            d += s_float;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_int);
+            Assert.Throws<RuntimeBinderException>(() => d += s_long);
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+            Assert.Throws<RuntimeBinderException>(() => d += s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d += s_short);
+
+            d = (ulong)10;
+            d += s_string;
+
+            d = (ulong)10;
+            d += s_uint;
+
+            d = (ulong)10;
+            d += s_ulong;
+
+            d = (ulong)10;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "ulong", "string"))
-                    //    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.PlusEqual.ushrt.ushrt;
-    // <Title> Generated tests for += operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(193,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(209,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d += s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_decimal;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_double;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_float;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_long;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d += s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_string;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "ushort", "string"))
-                    //    result = false;
-                }
-            }
+            d = (ushort)10;
+            d += s_uint;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_ulong;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d += s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.ShiftLeftEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.ShiftLeftEqual.cs
@@ -2,3279 +2,514 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.bol.bol;
-    // <Title> Generated tests for <<= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
+using static Dynamic.Operator.Tests.LiftCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class ShiftLeftEqualLiftTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "bool", "char?"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "bool", "double?"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.bte.bte;
-    // <Title> Generated tests for <<= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+
+            d = (byte)1;
+            d <<= s_byte;
+
+            d = (byte)1;
+            d <<= s_char;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+
+            d = (byte)1;
+            d <<= s_int;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+
+            d = (byte)1;
+            d <<= s_sbyte;
+
+            d = (byte)1;
+            d <<= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+
+            d = (byte)1;
+            d <<= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "byte", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d <<= d1;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d <<= d2;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "byte", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d <<= d6;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "byte", "long?"))
-                        result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "byte", "uint?"))
-                        result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.chr.chr;
-    // <Title> Generated tests for <<= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+
+            d = 'a';
+            d <<= s_byte;
+
+            d = 'a';
+            d <<= s_char;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+
+            d = 'a';
+            d <<= s_int;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+
+            d = 'a';
+            d <<= s_sbyte;
+
+            d = 'a';
+            d <<= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+
+            d = 'a';
+            d <<= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "char", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d <<= d1;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d <<= d2;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "char", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d <<= d6;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.dcml.dcml;
-    // <Title> Generated tests for <<= operator decimal Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10m;
+
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "decimal", "char?"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "decimal", "double?"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.dbl.dbl;
-    // <Title> Generated tests for <<= operator double Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10d;
+
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "double", "double?"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "double", "int?"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.flt.flt;
-    // <Title> Generated tests for <<= operator float Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10f;
+
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "float", "float?"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "float", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.integereger.integereger;
-    // <Title> Generated tests for <<= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+
+            d = 10;
+            d <<= s_byte;
+
+            d = 10;
+            d <<= s_char;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+
+            d = 10;
+            d <<= s_int;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+
+            d = 10;
+            d <<= s_sbyte;
+
+            d = 10;
+            d <<= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+
+            d = 10;
+            d <<= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "int", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d <<= d1;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d <<= d2;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "int", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d <<= d6;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.lng.lng;
-    // <Title> Generated tests for <<= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+
+            d = 10L;
+            d <<= s_byte;
+
+            d = 10L;
+            d <<= s_char;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+
+            d = 10L;
+            d <<= s_int;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+
+            d = 10L;
+            d <<= s_sbyte;
+
+            d = 10L;
+            d <<= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+
+            d = 10L;
+            d <<= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "long", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                d <<= d1;
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                d <<= d2;
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "long", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                d <<= d6;
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.obj.obj;
-    // <Title> Generated tests for <<= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "object", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "object", "ushort?"))
-                        result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.sbte.sbte;
-    // <Title> Generated tests for <<= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+
+            d = (sbyte)10;
+            d <<= s_byte;
+
+            d = (sbyte)10;
+            d <<= s_char;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+
+            d = (sbyte)10;
+            d <<= s_int;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d << s_long);
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+
+            d = (sbyte)10;
+            d <<= s_sbyte;
+
+            d = (sbyte)10;
+            d <<= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+
+            d = (sbyte)10;
+            d <<= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "sbyte", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d <<= d1;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d <<= d2;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "sbyte", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d <<= d6;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.shrt.shrt;
-    // <Title> Generated tests for <<= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+
+            d = (short)10;
+            d <<= s_byte;
+
+            d = (short)10;
+            d <<= s_char;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+
+            d = (short)10;
+            d <<= s_int;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d << s_long);
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+
+            d = (short)10;
+            d <<= s_sbyte;
+
+            d = (short)10;
+            d <<= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+
+            d = (short)10;
+            d <<= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "short", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d <<= d1;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d <<= d2;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "short", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d <<= d6;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.str.str;
-    // <Title> Generated tests for <<= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "a";
+
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "string", "byte?"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "string", "double?"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for <<= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+
+            d = (uint)10;
+            d <<= s_byte;
+
+            d = (uint)10;
+            d <<= s_char;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+
+            d = (uint)10;
+            d <<= s_int;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+
+            d = (uint)10;
+            d <<= s_sbyte;
+
+            d = (uint)10;
+            d <<= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+
+            d = (uint)10;
+            d <<= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "uint", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d <<= d1;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d <<= d2;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "uint", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d <<= d6;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.ulng.ulng;
-    // <Title> Generated tests for <<= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+
+            d = (ulong)10;
+            d <<= s_byte;
+
+            d = (ulong)10;
+            d <<= s_char;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+
+            d = (ulong)10;
+            d <<= s_int;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+
+            d = (ulong)10;
+            d <<= s_sbyte;
+
+            d = (ulong)10;
+            d <<= s_short;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+
+            d = (ulong)10;
+            d <<= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "ulong", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                d <<= d1;
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                d <<= d2;
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "ulong", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                d <<= d6;
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftLeftEqual.ushrt.ushrt;
-    // <Title> Generated tests for <<= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "ushort", "bool?"))
-                        result = false;
-                }
-            }
+            d = (ushort)10;
+            d <<= s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d <<= d1;
-            }
+            d = (ushort)10;
+            d <<= s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d <<= d2;
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "ushort", "decimal?"))
-                        result = false;
-                }
-            }
+            d = (ushort)10;
+            d <<= s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d <<= s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d <<= d6;
-            }
+            d = (ushort)10;
+            d <<= s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d <<= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.ShiftRightEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.ShiftRightEqual.cs
@@ -2,3275 +2,514 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.bol.bol;
-    // <Title> Generated tests for >>= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
+using static Dynamic.Operator.Tests.LiftCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class ShiftRightEqualLiftTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "bool", "uint?"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "bool", "ushort?"))
-                        result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.bte.bte;
-    // <Title> Generated tests for >>= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+
+            d = (byte)1;
+            d >>= s_byte;
+
+            d = (byte)1;
+            d >>= s_char;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+
+            d = (byte)1;
+            d >>= s_int;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+
+            d = (byte)1;
+            d >>= s_sbyte;
+
+            d = (byte)1;
+            d >>= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+
+            d = (byte)1;
+            d >>= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "byte", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d >>= d1;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d >>= d2;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "byte", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d >>= d6;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.chr.chr;
-    // <Title> Generated tests for >>= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+
+            d = 'a';
+            d >>= s_byte;
+
+            d = 'a';
+            d >>= s_char;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+
+            d = 'a';
+            d >>= s_int;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+
+            d = 'a';
+            d >>= s_sbyte;
+
+            d = 'a';
+            d >>= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+
+            d = 'a';
+            d >>= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "char", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d >>= d1;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d >>= d2;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "char", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d >>= d6;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.dcml.dcml;
-    // <Title> Generated tests for >>= operator decimal Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10m;
+
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "decimal", "sbyte?"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "decimal", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.dbl.dbl;
-    // <Title> Generated tests for >>= operator double Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10d;
+
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "double", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "double", "short?"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.flt.flt;
-    // <Title> Generated tests for >>= operator float Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10f;
+
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "float", "char?"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "float", "double?"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.integereger.integereger;
-    // <Title> Generated tests for >>= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+
+            d = 10;
+            d >>= s_byte;
+
+            d = 10;
+            d >>= s_char;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+
+            d = 10;
+            d >>= s_int;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+
+            d = 10;
+            d >>= s_sbyte;
+
+            d = 10;
+            d >>= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+
+            d = 10;
+            d >>= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "int", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d >>= d1;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d >>= d2;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "int", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d >>= d6;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.lng.lng;
-    // <Title> Generated tests for >>= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+
+            d = 10L;
+            d >>= s_byte;
+
+            d = 10L;
+            d >>= s_char;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+
+            d = 10L;
+            d >>= s_int;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+
+            d = 10L;
+            d >>= s_sbyte;
+
+            d = 10L;
+            d >>= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+
+            d = 10L;
+            d >>= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "long", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                d >>= d1;
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                d >>= d2;
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "long", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                d >>= d6;
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10;
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.obj.obj;
-    // <Title> Generated tests for >>= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "object", "char?"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "object", "double?"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.sbte.sbte;
-    // <Title> Generated tests for >>= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+
+            d = (sbyte)10;
+            d >>= s_byte;
+
+            d = (sbyte)10;
+            d >>= s_char;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+
+            d = (sbyte)10;
+            d >>= s_int;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d << s_long);
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+
+            d = (sbyte)10;
+            d >>= s_sbyte;
+
+            d = (sbyte)10;
+            d >>= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+
+            d = (sbyte)10;
+            d >>= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "sbyte", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d >>= d1;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d >>= d2;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "sbyte", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d >>= d6;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.shrt.shrt;
-    // <Title> Generated tests for >>= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+
+            d = (short)10;
+            d >>= s_byte;
+
+            d = (short)10;
+            d >>= s_char;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+
+            d = (short)10;
+            d >>= s_int;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d << s_long);
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+
+            d = (short)10;
+            d >>= s_sbyte;
+
+            d = (short)10;
+            d >>= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+
+            d = (short)10;
+            d >>= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "short", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d >>= d1;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d >>= d2;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "short", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d >>= d6;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.str.str;
-    // <Title> Generated tests for >>= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "a";
+
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "string", "uint?"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "string", "ushort?"))
-                        result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for >>= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+
+            d = (uint)10;
+            d >>= s_byte;
+
+            d = (uint)10;
+            d >>= s_char;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+
+            d = (uint)10;
+            d >>= s_int;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+
+            d = (uint)10;
+            d >>= s_sbyte;
+
+            d = (uint)10;
+            d >>= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+
+            d = (uint)10;
+            d >>= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "uint", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d >>= d1;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d >>= d2;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "uint", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d >>= d6;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.ulng.ulng;
-    // <Title> Generated tests for >>= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+
+            d = (ulong)10;
+            d >>= s_byte;
+
+            d = (ulong)10;
+            d >>= s_char;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+
+            d = (ulong)10;
+            d >>= s_int;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+
+            d = (ulong)10;
+            d >>= s_sbyte;
+
+            d = (ulong)10;
+            d >>= s_short;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+
+            d = (ulong)10;
+            d >>= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "ulong", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                d >>= d1;
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                d >>= d2;
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "ulong", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                d >>= d6;
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.ShiftRightEqual.ushrt.ushrt;
-    // <Title> Generated tests for >>= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "ushort", "bool?"))
-                        result = false;
-                }
-            }
+            d = (ushort)10;
+            d >>= s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d >>= d1;
-            }
+            d = (ushort)10;
+            d >>= s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d >>= d2;
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "ushort", "decimal?"))
-                        result = false;
-                }
-            }
+            d = (ushort)10;
+            d >>= s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d >>= s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d >>= d6;
-            }
+            d = (ushort)10;
+            d >>= s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-                {
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d >>= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.SubEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.SubEqual.cs
@@ -2,3806 +2,665 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.bol.bol;
-    // <Title> Generated tests for -= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
+using static Dynamic.Operator.Tests.LiftCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class MinusEqualsLiftTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_short);
+
+            d = true;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = true;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "bool", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "bool", "float?"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.bte.bte;
-    // <Title> Generated tests for -= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = (byte)1;
+            d -= s_byte;
+
+            d = (byte)1;
+            d -= s_char;
+
+            d = (byte)1;
+            d -= s_decimal;
+
+            d = (byte)1;
+            d -= s_double;
+
+            d = (byte)1;
+            d -= s_float;
+
+            d = (byte)1;
+            d -= s_int;
+
+            d = (byte)1;
+            d -= s_long;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = (byte)1;
+            d -= s_sbyte;
+
+            d = (byte)1;
+            d -= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = (byte)1;
+            d -= s_uint;
+
+            d = (byte)1;
+            d -= s_ulong;
+
+            d = (byte)1;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "byte", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.chr.chr;
-    // <Title> Generated tests for -= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = 'a';
+            d -= s_byte;
+
+            d = 'a';
+            d -= s_char;
+
+            d = 'a';
+            d -= s_decimal;
+
+            d = 'a';
+            d -= s_double;
+
+            d = 'a';
+            d -= s_float;
+
+            d = 'a';
+            d -= s_int;
+
+            d = 'a';
+            d -= s_long;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = 'a';
+            d -= s_sbyte;
+
+            d = 'a';
+            d -= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = 'a';
+            d -= s_uint;
+
+            d = 'a';
+            d -= s_ulong;
+
+            d = 'a';
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "char", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.dcml.dcml;
-    // <Title> Generated tests for -= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = 10m;
+            d -= s_byte;
+
+            d = 10m;
+            d -= s_char;
+
+            d = 10m;
+            d -= s_decimal;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_float);
+
+            d = 10m;
+            d -= s_int;
+
+            d = 10m;
+            d -= s_long;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = 10m;
+            d -= s_sbyte;
+
+            d = 10m;
+            d -= s_short;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = 10m;
+            d -= s_uint;
+
+            d = 10m;
+            d -= s_ulong;
+
+            d = 10m;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "decimal", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                decimal a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.dbl.dbl;
-    // <Title> Generated tests for -= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = 10d;
+            d -= s_byte;
+
+            d = 10d;
+            d -= s_char;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_decimal);
+
+            d = 10d;
+            d -= s_double;
+
+            d = 10d;
+            d -= s_float;
+
+            d = 10d;
+            d -= s_int;
+
+            d = 10d;
+            d -= s_long;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = 10d;
+            d -= s_sbyte;
+
+            d = 10d;
+            d -= s_short;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = 10d;
+            d -= s_uint;
+
+            d = 10d;
+            d -= s_ulong;
+
+            d = 10d;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "double", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.flt.flt;
-    // <Title> Generated tests for -= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = 10f;
+            d -= s_byte;
+
+            d = 10f;
+            d -= s_char;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_decimal);
+
+            d = 10f;
+            d -= s_double;
+
+            d = 10f;
+            d -= s_float;
+
+            d = 10f;
+            d -= s_int;
+
+            d = 10f;
+            d -= s_long;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = 10f;
+            d -= s_sbyte;
+
+            d = 10f;
+            d -= s_short;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = 10f;
+            d -= s_uint;
+
+            d = 10f;
+            d -= s_ulong;
+
+            d = 10f;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "float", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.integereger.integereger;
-    // <Title> Generated tests for -= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = 10;
+            d -= s_byte;
+
+            d = 10;
+            d -= s_char;
+
+            d = 10;
+            d -= s_decimal;
+
+            d = 10;
+            d -= s_double;
+
+            d = 10;
+            d -= s_float;
+
+            d = 10;
+            d -= s_int;
+
+            d = 10;
+            d -= s_long;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = 10;
+            d -= s_sbyte;
+
+            d = 10;
+            d -= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = 10;
+            d -= s_uint;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ulong);
+
+            d = 10;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "int", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.lng.lng;
-    // <Title> Generated tests for -= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = 10L;
+            d -= s_byte;
+
+            d = 10L;
+            d -= s_char;
+
+            d = 10L;
+            d -= s_decimal;
+
+            d = 10L;
+            d -= s_double;
+
+            d = 10L;
+            d -= s_float;
+
+            d = 10L;
+            d -= s_int;
+
+            d = 10L;
+            d -= s_long;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = 10L;
+            d -= s_sbyte;
+
+            d = 10L;
+            d -= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = 10L;
+            d -= s_uint;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ulong);
+
+            d = 10L;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "long", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.obj.obj;
-    // <Title> Generated tests for -= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_short);
+
+            d = new object();
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = new object();
+            Assert.Throws<RuntimeBinderException>(() => d -= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "object", "sbyte?"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "object", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.sbte.sbte;
-    // <Title> Generated tests for -= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = (sbyte)10;
+            d -= s_byte;
+
+            d = (sbyte)10;
+            d -= s_char;
+
+            d = (sbyte)10;
+            d -= s_decimal;
+
+            d = (sbyte)10;
+            d -= s_double;
+
+            d = (sbyte)10;
+            d -= s_float;
+
+            d = (sbyte)10;
+            d -= s_int;
+
+            d = (sbyte)10;
+            d -= s_long;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = (sbyte)10;
+            d -= s_sbyte;
+
+            d = (sbyte)10;
+            d -= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = (sbyte)10;
+            d -= s_uint;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ulong);
+
+            d = (sbyte)10;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "sbyte", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.shrt.shrt;
-    // <Title> Generated tests for -= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = (short)10;
+            d -= s_byte;
+
+            d = (short)10;
+            d -= s_char;
+
+            d = (short)10;
+            d -= s_decimal;
+
+            d = (short)10;
+            d -= s_double;
+
+            d = (short)10;
+            d -= s_float;
+
+            d = (short)10;
+            d -= s_int;
+
+            d = (short)10;
+            d -= s_long;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = (short)10;
+            d -= s_sbyte;
+
+            d = (short)10;
+            d -= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = (short)10;
+            d -= s_uint;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ulong);
+
+            d = (short)10;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "short", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.str.str;
-    // <Title> Generated tests for -= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "a";
+
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "string", "double?"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "string", "int?"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for -= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = (uint)10;
+            d -= s_byte;
+
+            d = (uint)10;
+            d -= s_char;
+
+            d = (uint)10;
+            d -= s_decimal;
+
+            d = (uint)10;
+            d -= s_double;
+
+            d = (uint)10;
+            d -= s_float;
+
+            d = (uint)10;
+            d -= s_int;
+
+            d = (uint)10;
+            d -= s_long;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = (uint)10;
+            d -= s_sbyte;
+
+            d = (uint)10;
+            d -= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = (uint)10;
+            d -= s_uint;
+
+            d = (uint)10;
+            d -= s_ulong;
+
+            d = (uint)10;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "uint", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.ulng.ulng;
-    // <Title> Generated tests for -= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = (ulong)10;
+            d -= s_byte;
+
+            d = (ulong)10;
+            d -= s_char;
+
+            d = (ulong)10;
+            d -= s_decimal;
+
+            d = (ulong)10;
+            d -= s_double;
+
+            d = (ulong)10;
+            d -= s_float;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_short);
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = (ulong)10;
+            d -= s_uint;
+
+            d = (ulong)10;
+            d -= s_ulong;
+
+            d = (ulong)10;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "ulong", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.SubEqual.ushrt.ushrt;
-    // <Title> Generated tests for -= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(207,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d -= s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d -= s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d -= s_decimal;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d -= s_double;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d -= s_float;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d -= s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d -= s_long;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d -= s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d -= s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "ushort", "string"))
-                        result = false;
-                }
-            }
+            d = (ushort)10;
+            d -= s_uint;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "uint?", "byte"))
-                    //    result = false;
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d -= s_ulong;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d -= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.XOREqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.lift.XOREqual.cs
@@ -2,3756 +2,566 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.bol.bol;
-    // <Title> Generated tests for ^= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(40,74\).*CS0168</Expects>
-    using System;
+using static Dynamic.Operator.Tests.LiftCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class XorEqualLiftTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+            d ^= s_bool;
+
+            d = true;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "bool?", "bool"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "bool", "byte?"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "bool", "ushort?"))
-                        result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.bte.bte;
-    // <Title> Generated tests for ^= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = (byte)1;
+            d ^= s_byte;
+
+            d = (byte)1;
+            d ^= s_char;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+
+            d = (byte)1;
+            d ^= s_int;
+
+            d = (byte)1;
+            d ^= s_long;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+
+            d = (byte)1;
+            d ^= s_sbyte;
+
+            d = (byte)1;
+            d ^= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = (byte)1;
+            d ^= s_uint;
+
+            d = (byte)1;
+            d ^= s_ulong;
+
+            d = (byte)1;
+            d ^= s_short;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "byte", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.chr.chr;
-    // <Title> Generated tests for ^= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = 'a';
+            d ^= s_byte;
+
+            d = 'a';
+            d ^= s_char;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+
+            d = 'a';
+            d ^= s_int;
+
+            d = 'a';
+            d ^= s_long;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+
+            d = 'a';
+            d ^= s_sbyte;
+
+            d = 'a';
+            d ^= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = 'a';
+            d ^= s_uint;
+
+            d = 'a';
+            d ^= s_ulong;
+
+            d = 'a';
+            d ^= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "char", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.dcml.dcml;
-    // <Title> Generated tests for ^= operator decimal Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_byte);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_char);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_int);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_long);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_sbyte);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_short);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_uint);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "decimal", "decimal?"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "decimal", "double?"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.dbl.dbl;
-    // <Title> Generated tests for ^= operator double Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10.1d;
+
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "double", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "double", "short?"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.flt.flt;
-    // <Title> Generated tests for ^= operator float Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10.1f;
+
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "float", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "float", "ulong?"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.integereger.integereger;
-    // <Title> Generated tests for ^= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = 10;
+            d ^= s_byte;
+
+            d = 10;
+            d ^= s_char;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+
+            d = 10;
+            d ^= s_int;
+
+            d = 10;
+            d ^= s_long;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+
+            d = 10;
+            d ^= s_sbyte;
+
+            d = 10;
+            d ^= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = 10;
+            d ^= s_uint;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+
+            d = 10;
+            d ^= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "int", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.lng.lng;
-    // <Title> Generated tests for ^= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = 10L;
+            d ^= s_byte;
+
+            d = 10L;
+            d ^= s_char;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+
+            d = 10L;
+            d ^= s_int;
+
+            d = 10L;
+            d ^= s_long;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+
+            d = 10L;
+            d ^= s_sbyte;
+
+            d = 10L;
+            d ^= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = 10L;
+            d ^= s_uint;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+
+            d = 10L;
+            d ^= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "long", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                long a = 10L;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.obj.obj;
-    // <Title> Generated tests for ^= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "object", "int?"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "object", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.sbte.sbte;
-    // <Title> Generated tests for ^= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = (sbyte)10;
+            d ^= s_byte;
+
+            d = (sbyte)10;
+            d ^= s_char;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+
+            d = (sbyte)10;
+            d ^= s_int;
+
+            d = (sbyte)10;
+            d ^= s_long;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+
+            d = (sbyte)10;
+            d ^= s_sbyte;
+
+            d = (sbyte)10;
+            d ^= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = (sbyte)10;
+            d ^= s_uint;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+
+            d = (sbyte)10;
+            d ^= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "sbyte", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.shrt.shrt;
-    // <Title> Generated tests for ^= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = (short)10;
+            d ^= s_byte;
+
+            d = (short)10;
+            d ^= s_char;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+
+            d = (short)10;
+            d ^= s_int;
+
+            d = (short)10;
+            d ^= s_long;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+
+            d = (short)10;
+            d ^= s_sbyte;
+
+            d = (short)10;
+            d ^= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = (short)10;
+            d ^= s_uint;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+
+            d = (short)10;
+            d ^= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "short", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.str.str;
-    // <Title> Generated tests for ^= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "abc";
+
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "string", "long?"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "string", "sbyte?"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.uintegereger.uintegereger;
-    // <Title> Generated tests for ^= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = (uint)10;
+            d ^= s_byte;
+
+            d = (uint)10;
+            d ^= s_char;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+
+            d = (uint)10;
+            d ^= s_int;
+
+            d = (uint)10;
+            d ^= s_long;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+
+            d = (uint)10;
+            d ^= s_sbyte;
+
+            d = (uint)10;
+            d ^= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = (uint)10;
+            d ^= s_uint;
+
+            d = (uint)10;
+            d ^= s_ulong;
+
+            d = (uint)10;
+            d ^= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "uint", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.ulng.ulng;
-    // <Title> Generated tests for ^= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = (ulong)10;
+            d ^= s_byte;
+
+            d = (ulong)10;
+            d ^= s_char;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = (ulong)10;
+            d ^= s_uint;
+
+            d = (ulong)10;
+            d ^= s_ulong;
+
+            d = (ulong)10;
+            d ^= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "ulong", "bool?"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.lift.XOREqual.ushrt.ushrt;
-    // <Title> Generated tests for ^= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(56,74\).*CS0168</Expects>
-    //<Expects Status=warning>\(72,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool? d0 = null;
-            byte? d1 = null;
-            char? d2 = null;
-            decimal? d3 = null;
-            double? d4 = null;
-            float? d5 = null;
-            int? d6 = null;
-            long? d7 = null;
-            object d8 = new object();
-            sbyte? d9 = null;
-            short? d10 = 6;
-            string d11 = "a";
-            uint? d12 = null;
-            ulong? d13 = 2;
-            ushort? d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "ushort", "bool?"))
-                        result = false;
-                }
-            }
+            d = (ushort)10;
+            d ^= s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "int?", "byte"))
-                    //    result = false;
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            d ^= s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d ^= s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d ^= s_long;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            d ^= s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            d ^= s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            d ^= s_uint;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
+            d = (ushort)10;
+            d ^= s_ulong;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as above, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d ^= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.AndEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.AndEqual.cs
@@ -2,3430 +2,580 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.bol.bol;
-    // <Title> Generated tests for &= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
+using static Dynamic.Operator.Tests.TypeCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class AndEqualTypeTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+            d &= s_bool;
+
+            d = true;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                d &= d0;
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "bool", "byte"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.bte.bte;
-    // <Title> Generated tests for &= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = (byte)1;
+            d &= s_byte;
+
+            d = (byte)1;
+            d &= s_char;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+
+            d = (byte)1;
+            d &= s_int;
+
+            d = (byte)1;
+            d &= s_long;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+
+            d = (byte)1;
+            d &= s_sbyte;
+
+            d = (byte)1;
+            d &= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = (byte)1;
+            d &= s_uint;
+
+            d = (byte)1;
+            d &= s_ulong;
+
+            d = (byte)1;
+            d &= s_short;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d &= d1;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d &= d2;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d &= d6;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d &= d7;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d &= d9;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d &= d10;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d &= d12;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d &= d13;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d &= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.chr.chr;
-    // <Title> Generated tests for &= operator char Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = 'a';
+            d &= s_byte;
+
+            d = 'a';
+            d &= s_char;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+
+            d = 'a';
+            d &= s_int;
+
+            d = 'a';
+            d &= s_long;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+
+            d = 'a';
+            d &= s_sbyte;
+
+            d = 'a';
+            d &= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = 'a';
+            d &= s_uint;
+
+            d = 'a';
+            d &= s_ulong;
+
+            d = 'a';
+            d &= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d &= d2;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "char", "decimal"))
-                        result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.dcml.dcml;
-    // <Title> Generated tests for &= operator decimal Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_byte);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_char);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_int);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_long);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_sbyte);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_short);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_uint);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ushort);
+
+            d = 1m;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "decimal", "decimal"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.dbl.dbl;
-    // <Title> Generated tests for &= operator double Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10.1d;
+
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "double", "double"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.flt.flt;
-    // <Title> Generated tests for &= operator float Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10.1f;
+
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "float", "float"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.integereger.integereger;
-    // <Title> Generated tests for &= operator int Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = 10;
+            d &= s_byte;
+
+            d = 10;
+            d &= s_char;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+
+            d = 10;
+            d &= s_int;
+
+            d = 10;
+            d &= s_long;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+
+            d = 10;
+            d &= s_sbyte;
+
+            d = 10;
+            d &= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = 10;
+            d &= s_uint;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+
+            d = 10;
+            d &= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d &= d2;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "int", "decimal"))
-                        result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.lng.lng;
-    // <Title> Generated tests for &= operator long Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = 10L;
+            d &= s_byte;
+
+            d = 10L;
+            d &= s_char;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+
+            d = 10L;
+            d &= s_int;
+
+            d = 10L;
+            d &= s_long;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+
+            d = 10L;
+            d &= s_sbyte;
+
+            d = 10L;
+            d &= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = 10L;
+            d &= s_uint;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+
+            d = 10L;
+            d &= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d &= d1;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d &= d2;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d &= d6;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d &= d7;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d &= d9;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d &= d10;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d &= d12;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "long", "ulong"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d &= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.obj.obj;
-    // <Title> Generated tests for &= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "object", "ushort"))
-                        result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.sbte.sbte;
-    // <Title> Generated tests for &= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = (sbyte)10;
+            d &= s_byte;
+
+            d = (sbyte)10;
+            d &= s_char;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+
+            d = (sbyte)10;
+            d &= s_int;
+
+            d = (sbyte)10;
+            d &= s_long;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+
+            d = (sbyte)10;
+            d &= s_sbyte;
+
+            d = (sbyte)10;
+            d &= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = (sbyte)10;
+            d &= s_uint;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+
+            d = (sbyte)10;
+            d &= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d &= d2;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "sbyte", "decimal"))
-                        result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.shrt.shrt;
-    // <Title> Generated tests for &= operator short Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = (short)10;
+            d &= s_byte;
+
+            d = (short)10;
+            d &= s_char;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+
+            d = (short)10;
+            d &= s_int;
+
+            d = (short)10;
+            d &= s_long;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+
+            d = (short)10;
+            d &= s_sbyte;
+
+            d = (short)10;
+            d &= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = (short)10;
+            d &= s_uint;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+
+            d = (short)10;
+            d &= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d &= d2;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "short", "decimal"))
-                        result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.str.str;
-    // <Title> Generated tests for &= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "abc";
+
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "string", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for &= operator uint Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = (uint)10;
+            d &= s_byte;
+
+            d = (uint)10;
+            d &= s_char;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+
+            d = (uint)10;
+            d &= s_int;
+
+            d = (uint)10;
+            d &= s_long;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+
+            d = (uint)10;
+            d &= s_sbyte;
+
+            d = (uint)10;
+            d &= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = (uint)10;
+            d &= s_uint;
+
+            d = (uint)10;
+            d &= s_ulong;
+
+            d = (uint)10;
+            d &= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d &= d2;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "uint", "decimal"))
-                        result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.ulng.ulng;
-    // <Title> Generated tests for &= operator ulong Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
+
+            d = (ulong)10;
+            d &= s_byte;
+
+            d = (ulong)10;
+            d &= s_char;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
+
+            d = (ulong)10;
+            d &= s_uint;
+
+            d = (ulong)10;
+            d &= s_ulong;
+
+            d = (ulong)10;
+            d &= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d &= d1;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d &= d2;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "ulong", "int"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d &= d12;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d &= d13;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d &= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.AndEqual.ushrt.ushrt;
-    // <Title> Generated tests for &= operator ushort Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d &= s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d &= s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d &= d2;
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_decimal);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "&=", "ushort", "decimal"))
-                        result = false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_double);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_float);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d &= s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d &= s_long;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d &= s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d &= s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d &= s_string);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d &= s_uint;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d &= s_ulong;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d13;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d &= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d &= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.DivideEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.DivideEqual.cs
@@ -2,3331 +2,657 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.bol.bol;
-    // <Title> Generated tests for /= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
+using static Dynamic.Operator.Tests.TypeCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class DivideEqualTypeTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "bool", "byte"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.bte.bte;
-    // <Title> Generated tests for /= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = (byte)1;
+            d /= s_byte;
+
+            d = (byte)1;
+            d /= s_char;
+
+            d = (byte)1;
+            d /= s_decimal;
+
+            d = (byte)1;
+            d /= s_double;
+
+            d = (byte)1;
+            d /= s_float;
+
+            d = (byte)1;
+            d /= s_int;
+
+            d = (byte)1;
+            d /= s_long;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = (byte)1;
+            d /= s_sbyte;
+
+            d = (byte)1;
+            d /= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = (byte)1;
+            d /= s_uint;
+
+            d = (byte)1;
+            d /= s_ulong;
+
+            d = (byte)1;
+            d /= s_short;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d /= d1;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d /= d2;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d /= d6;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d /= d7;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d /= d9;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d /= d10;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d /= d12;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d /= d13;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d /= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.chr.chr;
-    // <Title> Generated tests for /= operator char Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(73,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = 'a';
+            d /= s_byte;
+
+            d = 'a';
+            d /= s_char;
+
+            d = 'a';
+            d /= s_decimal;
+
+            d = 'a';
+            d /= s_double;
+
+            d = 'a';
+            d /= s_float;
+
+            d = 'a';
+            d /= s_int;
+
+            d = 'a';
+            d /= s_long;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = 'a';
+            d /= s_sbyte;
+
+            d = 'a';
+            d /= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = 'a';
+            d /= s_uint;
+
+            d = 'a';
+            d /= s_ulong;
+
+            d = 'a';
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d /= d2;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "char", "decimal"))
-                    //    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.dcml.dcml;
-    // <Title> Generated tests for /= operator decimal Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = 1m;
+            d /= s_byte;
+
+            d = 1m;
+            d /= s_char;
+
+            d = 1m;
+            d /= s_decimal;
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_double);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_float);
+
+            d = 1m;
+            d /= s_int;
+
+            d = 1m;
+            d /= s_long;
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = 1m;
+            d /= s_sbyte;
+
+            d = 1m;
+            d /= s_short;
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = 1m;
+            d /= s_uint;
+
+            d = 1m;
+            d /= s_ulong;
+
+            d = 1m;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d /= d1;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d /= d2;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d /= d3;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "decimal", "double"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d /= d6;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d /= d7;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d /= d9;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d /= d10;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d /= d12;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d /= d13;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d /= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.dbl.dbl;
-    // <Title> Generated tests for /= operator double Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10.1d;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = 10.1d;
+            d /= s_byte;
+
+            d = 10.1d;
+            d /= s_char;
+
+            d = 10.1d;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_decimal);
+
+            d = 10.1d;
+            d /= s_double;
+
+            d = 10.1d;
+            d /= s_float;
+
+            d = 10.1d;
+            d /= s_int;
+
+            d = 10.1d;
+            d /= s_long;
+
+            d = 10.1d;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d /= s_sbyte;
+
+            d = 10.1d;
+            d /= s_short;
+
+            d = 10.1d;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = 10.1d;
+            d /= s_uint;
+
+            d = 10.1d;
+            d /= s_ulong;
+
+            d = 10.1d;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d /= d1;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d /= d2;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d /= d4;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d /= d5;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d /= d6;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d /= d7;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d /= d9;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d /= d10;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "double", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d /= d12;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d /= d13;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d /= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.flt.flt;
-    // <Title> Generated tests for /= operator float Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10.1f;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = 10.1f;
+            d /= s_byte;
+
+            d = 10.1f;
+            d /= s_char;
+
+            d = 10.1f;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_decimal);
+
+            d = 10.1f;
+            d /= s_double;
+
+            d = 10.1f;
+            d /= s_float;
+
+            d = 10.1f;
+            d /= s_int;
+
+            d = 10.1f;
+            d /= s_long;
+
+            d = 10.1f;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = 10.1f;
+            d /= s_sbyte;
+
+            d = 10.1f;
+            d /= s_short;
+
+            d = 10.1f;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = 10.1f;
+            d /= s_uint;
+
+            d = 10.1f;
+            d /= s_ulong;
+
+            d = 10.1f;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d /= d1;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d /= d2;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d /= d5;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d /= d6;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d /= d7;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d /= d9;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d /= d10;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "float", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d /= d12;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d /= d13;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d /= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.integereger.integereger;
-    // <Title> Generated tests for /= operator int Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(73,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = 10;
+            d /= s_byte;
+
+            d = 10;
+            d /= s_char;
+
+            d = 10;
+            d /= s_decimal;
+
+            d = 10;
+            d /= s_double;
+
+            d = 10;
+            d /= s_float;
+
+            d = 10;
+            d /= s_int;
+
+            d = 10;
+            d /= s_long;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = 10;
+            d /= s_sbyte;
+
+            d = 10;
+            d /= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = 10;
+            d /= s_uint;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ulong);
+
+            d = 10;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d /= d2;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "int", "decimal"))
-                    //    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            // ulong 's behavior is not same as others
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.lng.lng;
-    // <Title> Generated tests for /= operator long Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = 10L;
+            d /= s_byte;
+
+            d = 10L;
+            d /= s_char;
+
+            d = 10L;
+            d /= s_decimal;
+
+            d = 10L;
+            d /= s_double;
+
+            d = 10L;
+            d /= s_float;
+
+            d = 10L;
+            d /= s_int;
+
+            d = 10L;
+            d /= s_long;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = 10L;
+            d /= s_sbyte;
+
+            d = 10L;
+            d /= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = 10L;
+            d /= s_uint;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ulong);
+
+            d = 10L;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d /= d1;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d /= d2;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d /= d6;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d /= d7;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "long", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d /= d9;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d /= d10;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d /= d12;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d /= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.obj.obj;
-    // <Title> Generated tests for /= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "object", "sbyte"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.sbte.sbte;
-    // <Title> Generated tests for /= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = (sbyte)10;
+            d /= s_byte;
+
+            d = (sbyte)10;
+            d /= s_char;
+
+            d = (sbyte)10;
+            d /= s_decimal;
+
+            d = (sbyte)10;
+            d /= s_double;
+
+            d = (sbyte)10;
+            d /= s_float;
+
+            d = (sbyte)10;
+            d /= s_int;
+
+            d = (sbyte)10;
+            d /= s_long;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = (sbyte)10;
+            d /= s_sbyte;
+
+            d = (sbyte)10;
+            d /= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = (sbyte)10;
+            d /= s_uint;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ulong);
+
+            d = (sbyte)10;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d /= d9;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.shrt.shrt;
-    // <Title> Generated tests for /= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = (short)10;
+            d /= s_byte;
+
+            d = (short)10;
+            d /= s_char;
+
+            d = (short)10;
+            d /= s_decimal;
+
+            d = (short)10;
+            d /= s_double;
+
+            d = (short)10;
+            d /= s_float;
+
+            d = (short)10;
+            d /= s_int;
+
+            d = (short)10;
+            d /= s_long;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = (short)10;
+            d /= s_sbyte;
+
+            d = (short)10;
+            d /= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = (short)10;
+            d /= s_uint;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d / s_ulong);
+
+            d = (short)10;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d /= d9;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.str.str;
-    // <Title> Generated tests for /= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "abc";
+
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "string", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for /= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = (uint)10;
+            d /= s_byte;
+
+            d = (uint)10;
+            d /= s_char;
+
+            d = (uint)10;
+            d /= s_decimal;
+
+            d = (uint)10;
+            d /= s_double;
+
+            d = (uint)10;
+            d /= s_float;
+
+            d = (uint)10;
+            d /= s_int;
+
+            d = (uint)10;
+            d /= s_long;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+
+            d = (uint)10;
+            d /= s_sbyte;
+
+            d = (uint)10;
+            d /= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = (uint)10;
+            d /= s_uint;
+
+            d = (uint)10;
+            d /= s_ulong;
+
+            d = (uint)10;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d /= d9;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.ulng.ulng;
-    // <Title> Generated tests for /= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
+
+            d = (ulong)10;
+            d /= s_byte;
+
+            d = (ulong)10;
+            d /= s_char;
+
+            d = (ulong)10;
+            d /= s_decimal;
+
+            d = (ulong)10;
+            d /= s_double;
+
+            d = (ulong)10;
+            d /= s_float;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d / s_long);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d /= s_short);
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
+
+            d = (ulong)10;
+            d /= s_uint;
+
+            d = (ulong)10;
+            d /= s_ulong;
+
+            d = (ulong)10;
+            d /= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    // result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d9;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "/=", "ulong", "sbyte"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.DivideEqual.ushrt.ushrt;
-    // <Title> Generated tests for /= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d /= s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d /= s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d /= s_decimal;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d /= s_double;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d /= s_float;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
+            d = (ushort)10;
+            d /= s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d /= s_long;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d /= s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d /= d9;
-            }
+            d = (ushort)10;
+            d /= s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d /= s_string);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d /= s_uint;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d /= s_ulong;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d /= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d /= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.ModEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.ModEqual.cs
@@ -2,3331 +2,655 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.bol.bol;
-    // <Title> Generated tests for %= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
+using static Dynamic.Operator.Tests.TypeCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class ModEqualTypeTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "bool", "ushort"))
-                        result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.bte.bte;
-    // <Title> Generated tests for %= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = (byte)1;
+            d %= s_byte;
+
+            d = (byte)1;
+            d %= s_char;
+
+            d = (byte)1;
+            d %= s_decimal;
+
+            d = (byte)1;
+            d %= s_double;
+
+            d = (byte)1;
+            d %= s_float;
+
+            d = (byte)1;
+            d %= s_int;
+
+            d = (byte)1;
+            d %= s_long;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = (byte)1;
+            d %= s_sbyte;
+
+            d = (byte)1;
+            d %= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = (byte)1;
+            d %= s_uint;
+
+            d = (byte)1;
+            d %= s_ulong;
+
+            d = (byte)1;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d %= d1;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d %= d2;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d %= d6;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d %= d7;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d %= d9;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d %= d10;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d %= d12;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d %= d13;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d %= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.chr.chr;
-    // <Title> Generated tests for %= operator char Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(73,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = 'a';
+            d %= s_byte;
+
+            d = 'a';
+            d %= s_char;
+
+            d = 'a';
+            d %= s_decimal;
+
+            d = 'a';
+            d %= s_double;
+
+            d = 'a';
+            d %= s_float;
+
+            d = 'a';
+            d %= s_int;
+
+            d = 'a';
+            d %= s_long;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = 'a';
+            d %= s_sbyte;
+
+            d = 'a';
+            d %= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = 'a';
+            d %= s_uint;
+
+            d = 'a';
+            d %= s_ulong;
+
+            d = 'a';
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d %= d2;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "char", "decimal"))
-                    //    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.dcml.dcml;
-    // <Title> Generated tests for %= operator decimal Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = 10m;
+            d %= s_byte;
+
+            d = 10m;
+            d %= s_char;
+
+            d = 10m;
+            d %= s_decimal;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_float);
+
+            d = 10m;
+            d %= s_int;
+
+            d = 10m;
+            d %= s_long;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = 10m;
+            d %= s_sbyte;
+
+            d = 10m;
+            d %= s_short;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = 10m;
+            d %= s_uint;
+
+            d = 10m;
+            d %= s_ulong;
+
+            d = 10m;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d %= d1;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d %= d2;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d %= d3;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d %= d6;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d %= d7;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d %= d9;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d %= d10;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "decimal", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d %= d12;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d %= d13;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d %= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.dbl.dbl;
-    // <Title> Generated tests for %= operator double Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = 10d;
+            d %= s_byte;
+
+            d = 10d;
+            d %= s_char;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_decimal);
+
+            d = 10d;
+            d %= s_double;
+
+            d = 10d;
+            d %= s_float;
+
+            d = 10d;
+            d %= s_int;
+
+            d = 10d;
+            d %= s_long;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = 10d;
+            d %= s_sbyte;
+
+            d = 10d;
+            d %= s_short;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = 10d;
+            d %= s_uint;
+
+            d = 10d;
+            d %= s_ulong;
+
+            d = 10d;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d %= d1;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d %= d2;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d %= d4;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d %= d5;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d %= d6;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d %= d7;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "double", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d %= d9;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d %= d10;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d %= d12;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d %= d13;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d %= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.flt.flt;
-    // <Title> Generated tests for %= operator float Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = 10f;
+            d %= s_byte;
+
+            d = 10f;
+            d %= s_char;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_decimal);
+
+            d = 10f;
+            d %= s_double;
+
+            d = 10f;
+            d %= s_float;
+
+            d = 10f;
+            d %= s_int;
+
+            d = 10f;
+            d %= s_long;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = 10f;
+            d %= s_sbyte;
+
+            d = 10f;
+            d %= s_short;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = 10f;
+            d %= s_uint;
+
+            d = 10f;
+            d %= s_ulong;
+
+            d = 10f;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d %= d1;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d %= d2;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d %= d5;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d %= d6;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d %= d7;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d %= d9;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d %= d10;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "float", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d %= d12;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d %= d13;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d %= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.integereger.integereger;
-    // <Title> Generated tests for %= operator int Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(73,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = 10;
+            d %= s_byte;
+
+            d = 10;
+            d %= s_char;
+
+            d = 10;
+            d %= s_decimal;
+
+            d = 10;
+            d %= s_double;
+
+            d = 10;
+            d %= s_float;
+
+            d = 10;
+            d %= s_int;
+
+            d = 10;
+            d %= s_long;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = 10;
+            d %= s_sbyte;
+
+            d = 10;
+            d %= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = 10;
+            d %= s_uint;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ulong);
+
+            d = 10;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d %= d2;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "int", "decimal"))
-                    //    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            // ulong 's behavior is not same as others
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.lng.lng;
-    // <Title> Generated tests for %= operator long Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = 10L;
+            d %= s_byte;
+
+            d = 10L;
+            d %= s_char;
+
+            d = 10L;
+            d %= s_decimal;
+
+            d = 10L;
+            d %= s_double;
+
+            d = 10L;
+            d %= s_float;
+
+            d = 10L;
+            d %= s_int;
+
+            d = 10L;
+            d %= s_long;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = 10L;
+            d %= s_sbyte;
+
+            d = 10L;
+            d %= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = 10L;
+            d %= s_uint;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ulong);
+
+            d = 10L;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d %= d1;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d %= d2;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d %= d6;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d %= d7;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "long", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d %= d9;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d %= d10;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d %= d12;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d %= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.obj.obj;
-    // <Title> Generated tests for %= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "object", "char"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.sbte.sbte;
-    // <Title> Generated tests for %= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = (sbyte)10;
+            d %= s_byte;
+
+            d = (sbyte)10;
+            d %= s_char;
+
+            d = (sbyte)10;
+            d %= s_decimal;
+
+            d = (sbyte)10;
+            d %= s_double;
+
+            d = (sbyte)10;
+            d %= s_float;
+
+            d = (sbyte)10;
+            d %= s_int;
+
+            d = (sbyte)10;
+            d %= s_long;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = (sbyte)10;
+            d %= s_sbyte;
+
+            d = (sbyte)10;
+            d %= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = (sbyte)10;
+            d %= s_uint;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ulong);
+
+            d = (sbyte)10;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d %= d9;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.shrt.shrt;
-    // <Title> Generated tests for %= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = (short)10;
+            d %= s_byte;
+
+            d = (short)10;
+            d %= s_char;
+
+            d = (short)10;
+            d %= s_decimal;
+
+            d = (short)10;
+            d %= s_double;
+
+            d = (short)10;
+            d %= s_float;
+
+            d = (short)10;
+            d %= s_int;
+
+            d = (short)10;
+            d %= s_long;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = (short)10;
+            d %= s_sbyte;
+
+            d = (short)10;
+            d %= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = (short)10;
+            d %= s_uint;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ulong);
+
+            d = (short)10;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d %= d9;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.str.str;
-    // <Title> Generated tests for %= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "a";
+
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "string", "float"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for %= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = (uint)10;
+            d %= s_byte;
+
+            d = (uint)10;
+            d %= s_char;
+
+            d = (uint)10;
+            d %= s_decimal;
+
+            d = (uint)10;
+            d %= s_double;
+
+            d = (uint)10;
+            d %= s_float;
+
+            d = (uint)10;
+            d %= s_int;
+
+            d = (uint)10;
+            d %= s_long;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+
+            d = (uint)10;
+            d %= s_sbyte;
+
+            d = (uint)10;
+            d %= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = (uint)10;
+            d %= s_uint;
+
+            d = (uint)10;
+            d %= s_ulong;
+
+            d = (uint)10;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d %= d9;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.ulng.ulng;
-    // <Title> Generated tests for %= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
+
+            d = (ulong)10;
+            d %= s_byte;
+
+            d = (ulong)10;
+            d %= s_char;
+
+            d = (ulong)10;
+            d %= s_decimal;
+
+            d = (ulong)10;
+            d %= s_double;
+
+            d = (ulong)10;
+            d %= s_float;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
+
+            d = (ulong)10;
+            d %= s_uint;
+
+            d = (ulong)10;
+            d %= s_ulong;
+
+            d = (ulong)10;
+            d %= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    // result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d9;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "%=", "ulong", "sbyte"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ModEqual.ushrt.ushrt;
-    // <Title> Generated tests for %= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d %= s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d %= s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d %= s_decimal;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d %= s_double;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d %= s_float;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
+            d = (ushort)10;
+            d %= s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d %= s_long;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d %= s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d %= d9;
-            }
+            d = (ushort)10;
+            d %= s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d %= s_string);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d %= s_uint;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d %= s_ulong;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d %= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d %= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.MultiEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.MultiEqual.cs
@@ -2,3331 +2,655 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.bol.bol;
-    // <Title> Generated tests for *= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
+using static Dynamic.Operator.Tests.TypeCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class TimesEqualTypeTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "bool", "char"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.bte.bte;
-    // <Title> Generated tests for *= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = (byte)1;
+            d *= s_byte;
+
+            d = (byte)1;
+            d *= s_char;
+
+            d = (byte)1;
+            d *= s_decimal;
+
+            d = (byte)1;
+            d *= s_double;
+
+            d = (byte)1;
+            d *= s_float;
+
+            d = (byte)1;
+            d *= s_int;
+
+            d = (byte)1;
+            d *= s_long;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = (byte)1;
+            d *= s_sbyte;
+
+            d = (byte)1;
+            d *= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = (byte)1;
+            d *= s_uint;
+
+            d = (byte)1;
+            d *= s_ulong;
+
+            d = (byte)1;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d *= d1;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d *= d2;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d *= d6;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d *= d7;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d *= d9;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d *= d10;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d *= d12;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d *= d13;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d *= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.chr.chr;
-    // <Title> Generated tests for *= operator char Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(73,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = 'a';
+            d *= s_byte;
+
+            d = 'a';
+            d *= s_char;
+
+            d = 'a';
+            d *= s_decimal;
+
+            d = 'a';
+            d *= s_double;
+
+            d = 'a';
+            d *= s_float;
+
+            d = 'a';
+            d *= s_int;
+
+            d = 'a';
+            d *= s_long;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = 'a';
+            d *= s_sbyte;
+
+            d = 'a';
+            d *= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = 'a';
+            d *= s_uint;
+
+            d = 'a';
+            d *= s_ulong;
+
+            d = 'a';
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d *= d2;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "char", "decimal"))
-                    //    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.dcml.dcml;
-    // <Title> Generated tests for *= operator decimal Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = 10m;
+            d *= s_byte;
+
+            d = 10m;
+            d *= s_char;
+
+            d = 10m;
+            d *= s_decimal;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_float);
+
+            d = 10m;
+            d *= s_int;
+
+            d = 10m;
+            d *= s_long;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = 10m;
+            d *= s_sbyte;
+
+            d = 10m;
+            d *= s_short;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = 10m;
+            d *= s_uint;
+
+            d = 10m;
+            d *= s_ulong;
+
+            d = 10m;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "decimal", "bool"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d *= d1;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d *= d2;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d *= d3;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d *= d6;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d *= d7;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d *= d9;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d *= d10;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d *= d12;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d *= d13;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d *= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.dbl.dbl;
-    // <Title> Generated tests for *= operator double Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = 10d;
+            d *= s_byte;
+
+            d = 10d;
+            d *= s_char;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_decimal);
+
+            d = 10d;
+            d *= s_double;
+
+            d = 10d;
+            d *= s_float;
+
+            d = 10d;
+            d *= s_int;
+
+            d = 10d;
+            d *= s_long;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = 10d;
+            d *= s_sbyte;
+
+            d = 10d;
+            d *= s_short;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = 10d;
+            d *= s_uint;
+
+            d = 10d;
+            d *= s_ulong;
+
+            d = 10d;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d *= d1;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d *= d2;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d *= d4;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d *= d5;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d *= d6;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d *= d7;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "double", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d *= d9;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d *= d10;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d *= d12;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d *= d13;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d *= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.flt.flt;
-    // <Title> Generated tests for *= operator float Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = 10f;
+            d *= s_byte;
+
+            d = 10f;
+            d *= s_char;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_decimal);
+
+            d = 10f;
+            d *= s_double;
+
+            d = 10f;
+            d *= s_float;
+
+            d = 10f;
+            d *= s_int;
+
+            d = 10f;
+            d *= s_long;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = 10f;
+            d *= s_sbyte;
+
+            d = 10f;
+            d *= s_short;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = 10f;
+            d *= s_uint;
+
+            d = 10f;
+            d *= s_ulong;
+
+            d = 10f;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d *= d1;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d *= d2;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d *= d5;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d *= d6;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d *= d7;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d *= d9;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d *= d10;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "float", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d *= d12;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d *= d13;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d *= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.integereger.integereger;
-    // <Title> Generated tests for *= operator int Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(73,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = 10;
+            d *= s_byte;
+
+            d = 10;
+            d *= s_char;
+
+            d = 10;
+            d *= s_decimal;
+
+            d = 10;
+            d *= s_double;
+
+            d = 10;
+            d *= s_float;
+
+            d = 10;
+            d *= s_int;
+
+            d = 10;
+            d *= s_long;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = 10;
+            d *= s_sbyte;
+
+            d = 10;
+            d *= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = 10;
+            d *= s_uint;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ulong);
+
+            d = 10;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d *= d2;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "int", "decimal"))
-                    //    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            // ulong 's behavior is not same as others
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.lng.lng;
-    // <Title> Generated tests for *= operator long Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = 10L;
+            d *= s_byte;
+
+            d = 10L;
+            d *= s_char;
+
+            d = 10L;
+            d *= s_decimal;
+
+            d = 10L;
+            d *= s_double;
+
+            d = 10L;
+            d *= s_float;
+
+            d = 10L;
+            d *= s_int;
+
+            d = 10L;
+            d *= s_long;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = 10L;
+            d *= s_sbyte;
+
+            d = 10L;
+            d *= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = 10L;
+            d *= s_uint;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ulong);
+
+            d = 10L;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d *= d1;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d *= d2;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d *= d6;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d *= d7;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "long", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d *= d9;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d *= d10;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d *= d12;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d *= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.obj.obj;
-    // <Title> Generated tests for *= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "object", "uint"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.sbte.sbte;
-    // <Title> Generated tests for *= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = (sbyte)10;
+            d *= s_byte;
+
+            d = (sbyte)10;
+            d *= s_char;
+
+            d = (sbyte)10;
+            d *= s_decimal;
+
+            d = (sbyte)10;
+            d *= s_double;
+
+            d = (sbyte)10;
+            d *= s_float;
+
+            d = (sbyte)10;
+            d *= s_int;
+
+            d = (sbyte)10;
+            d *= s_long;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = (sbyte)10;
+            d *= s_sbyte;
+
+            d = (sbyte)10;
+            d *= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = (sbyte)10;
+            d *= s_uint;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ulong);
+
+            d = (sbyte)10;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d *= d9;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.shrt.shrt;
-    // <Title> Generated tests for *= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = (short)10;
+            d *= s_byte;
+
+            d = (short)10;
+            d *= s_char;
+
+            d = (short)10;
+            d *= s_decimal;
+
+            d = (short)10;
+            d *= s_double;
+
+            d = (short)10;
+            d *= s_float;
+
+            d = (short)10;
+            d *= s_int;
+
+            d = (short)10;
+            d *= s_long;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = (short)10;
+            d *= s_sbyte;
+
+            d = (short)10;
+            d *= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = (short)10;
+            d *= s_uint;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ulong);
+
+            d = (short)10;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d *= d9;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.str.str;
-    // <Title> Generated tests for *= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "a";
+
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "string", "bool"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for *= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = (uint)10;
+            d *= s_byte;
+
+            d = (uint)10;
+            d *= s_char;
+
+            d = (uint)10;
+            d *= s_decimal;
+
+            d = (uint)10;
+            d *= s_double;
+
+            d = (uint)10;
+            d *= s_float;
+
+            d = (uint)10;
+            d *= s_int;
+
+            d = (uint)10;
+            d *= s_long;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+
+            d = (uint)10;
+            d *= s_sbyte;
+
+            d = (uint)10;
+            d *= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = (uint)10;
+            d *= s_uint;
+
+            d = (uint)10;
+            d *= s_ulong;
+
+            d = (uint)10;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    // result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d *= d9;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.ulng.ulng;
-    // <Title> Generated tests for *= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
+
+            d = (ulong)10;
+            d *= s_byte;
+
+            d = (ulong)10;
+            d *= s_char;
+
+            d = (ulong)10;
+            d *= s_decimal;
+
+            d = (ulong)10;
+            d *= s_double;
+
+            d = (ulong)10;
+            d *= s_float;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
+
+            d = (ulong)10;
+            d *= s_uint;
+
+            d = (ulong)10;
+            d *= s_ulong;
+
+            d = (ulong)10;
+            d *= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    // result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d9;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "*=", "ulong", "sbyte"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.MultiEqual.ushrt.ushrt;
-    // <Title> Generated tests for *= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d *= s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d *= s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d *= s_decimal;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d *= s_double;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d *= s_float;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
+            d = (ushort)10;
+            d *= s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d *= s_long;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d *= s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d *= d9;
-            }
+            d = (ushort)10;
+            d *= s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d *= s_string);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d *= s_uint;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d *= s_ulong;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d *= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d *= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.OrEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.OrEqual.cs
@@ -2,3430 +2,566 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.bol.bol;
-    // <Title> Generated tests for |= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
+using static Dynamic.Operator.Tests.TypeCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class OrEqualTypeTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+            d |= s_bool;
+
+            d = true;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                d |= d0;
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "bool", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.bte.bte;
-    // <Title> Generated tests for &= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = (byte)1;
+            d |= s_byte;
+
+            d = (byte)1;
+            d |= s_char;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+
+            d = (byte)1;
+            d |= s_int;
+
+            d = (byte)1;
+            d |= s_long;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+
+            d = (byte)1;
+            d |= s_sbyte;
+
+            d = (byte)1;
+            d |= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = (byte)1;
+            d |= s_uint;
+
+            d = (byte)1;
+            d |= s_ulong;
+
+            d = (byte)1;
+            d |= s_short;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d |= d1;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d |= d2;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d |= d6;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d |= d7;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d |= d9;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d |= d10;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d |= d12;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d |= d13;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d |= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.chr.chr;
-    // <Title> Generated tests for &= operator char Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = 'a';
+            d |= s_byte;
+
+            d = 'a';
+            d |= s_char;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+
+            d = 'a';
+            d |= s_int;
+
+            d = 'a';
+            d |= s_long;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+
+            d = 'a';
+            d |= s_sbyte;
+
+            d = 'a';
+            d |= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = 'a';
+            d |= s_uint;
+
+            d = 'a';
+            d |= s_ulong;
+
+            d = 'a';
+            d |= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d |= d2;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "char", "decimal"))
-                        result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.dcml.dcml;
-    // <Title> Generated tests for |= operator decimal Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_byte);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_char);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_int);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_long);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_sbyte);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_short);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_uint);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "decimal", "byte"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.dbl.dbl;
-    // <Title> Generated tests for |= operator double Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10.1d;
+
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "double", "bool"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.flt.flt;
-    // <Title> Generated tests for |= operator float Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10.1f;
+
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "float", "float"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.integereger.integereger;
-    // <Title> Generated tests for &= operator int Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = 10;
+            d |= s_byte;
+
+            d = 10;
+            d |= s_char;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+
+            d = 10;
+            d |= s_int;
+
+            d = 10;
+            d |= s_long;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+
+            d = 10;
+            d |= s_sbyte;
+
+            d = 10;
+            d |= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = 10;
+            d |= s_uint;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+
+            d = 10;
+            d |= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d |= d2;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "int", "decimal"))
-                        result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.lng.lng;
-    // <Title> Generated tests for |= operator long Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = 10L;
+            d |= s_byte;
+
+            d = 10L;
+            d |= s_char;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+
+            d = 10L;
+            d |= s_int;
+
+            d = 10L;
+            d |= s_long;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+
+            d = 10L;
+            d |= s_sbyte;
+
+            d = 10L;
+            d |= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = 10L;
+            d |= s_uint;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+
+            d = 10L;
+            d |= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d |= d1;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d |= d2;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d |= d6;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d |= d7;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d |= d9;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d |= d10;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d |= d12;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "long", "ulong"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d |= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.obj.obj;
-    // <Title> Generated tests for |= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "object", "ulong"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.sbte.sbte;
-    // <Title> Generated tests for &= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = (sbyte)10;
+            d |= s_byte;
+
+            d = (sbyte)10;
+            d |= s_char;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+
+            d = (sbyte)10;
+            d |= s_int;
+
+            d = (sbyte)10;
+            d |= s_long;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+
+            d = (sbyte)10;
+            d |= s_sbyte;
+
+            d = (sbyte)10;
+            d |= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = (sbyte)10;
+            d |= s_uint;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+
+            d = (sbyte)10;
+            d |= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d |= d2;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "sbyte", "decimal"))
-                        result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.shrt.shrt;
-    // <Title> Generated tests for &= operator short Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = (short)10;
+            d |= s_byte;
+
+            d = (short)10;
+            d |= s_char;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+
+            d = (short)10;
+            d |= s_int;
+
+            d = (short)10;
+            d |= s_long;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+
+            d = (short)10;
+            d |= s_sbyte;
+
+            d = (short)10;
+            d |= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = (short)10;
+            d |= s_uint;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+
+            d = (short)10;
+            d |= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d |= d2;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "short", "decimal"))
-                        result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.str.str;
-    // <Title> Generated tests for |= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "abc";
+
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "string", "short"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for &= operator uint Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = (uint)10;
+            d |= s_byte;
+
+            d = (uint)10;
+            d |= s_char;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+
+            d = (uint)10;
+            d |= s_int;
+
+            d = (uint)10;
+            d |= s_long;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+
+            d = (uint)10;
+            d |= s_sbyte;
+
+            d = (uint)10;
+            d |= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = (uint)10;
+            d |= s_uint;
+
+            d = (uint)10;
+            d |= s_ulong;
+
+            d = (uint)10;
+            d |= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d |= d2;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "uint", "decimal"))
-                        result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.ulng.ulng;
-    // <Title> Generated tests for |= operator ulong Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
+
+            d = (ulong)10;
+            d |= s_byte;
+
+            d = (ulong)10;
+            d |= s_char;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
+
+            d = (ulong)10;
+            d |= s_uint;
+
+            d = (ulong)10;
+            d |= s_ulong;
+
+            d = (ulong)10;
+            d |= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d |= d1;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d |= d2;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "ulong", "sbyte"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d |= d12;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d |= d13;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d |= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.OrEqual.ushrt.ushrt;
-    // <Title> Generated tests for &= operator ushort Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d |= s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d |= s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d |= d2;
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d |= s_float);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "|=", "ushort", "decimal"))
-                        result = false;
-                }
-            }
+            d = (ushort)10;
+            d |= s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d |= s_long;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d |= s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d |= s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d |= s_string);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d |= s_uint;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d |= s_ulong;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d13;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d |= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d |= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.PlusEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.PlusEqual.cs
@@ -2,3229 +2,692 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.bol.bol;
-    // <Title> Generated tests for += operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(183,74\).*CS0168</Expects>
-    using System;
+using static Dynamic.Operator.Tests.TypeCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class PlusEqualTypeTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d += s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d += s_char);
+            Assert.Throws<RuntimeBinderException>(() => d += s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d += s_double);
+            Assert.Throws<RuntimeBinderException>(() => d += s_float);
+            Assert.Throws<RuntimeBinderException>(() => d += s_int);
+            Assert.Throws<RuntimeBinderException>(() => d += s_long);
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+            Assert.Throws<RuntimeBinderException>(() => d += s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d += s_short);
+
+            d = true;
+            d += s_string;
+
+            d = true;
+            Assert.Throws<RuntimeBinderException>(() => d += s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d += s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d += s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConv, e.Message, "string", "bool"))
-                    //    result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.bte.bte;
-    // <Title> Generated tests for += operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = (byte)1;
+            d += s_byte;
+
+            d = (byte)1;
+            d += s_char;
+
+            d = (byte)1;
+            d += s_decimal;
+
+            d = (byte)1;
+            d += s_double;
+
+            d = (byte)1;
+            d += s_float;
+
+            d = (byte)1;
+            d += s_int;
+
+            d = (byte)1;
+            d += s_long;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = (byte)1;
+            d += s_sbyte;
+
+            d = (byte)1;
+            d += s_short;
+
+            d = (byte)1;
+            d += s_string;
+
+            d = (byte)1;
+            d += s_uint;
+
+            d = (byte)1;
+            d += s_ulong;
+
+            d = (byte)1;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d += d1;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d += d2;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d += d6;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d += d7;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d += d9;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d += d10;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d += d12;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d += d13;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d += d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.chr.chr;
-    // <Title> Generated tests for += operator char Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(73,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = 'a';
+            d += s_byte;
+
+            d = 'a';
+            d += s_char;
+
+            d = 'a';
+            d += s_decimal;
+
+            d = 'a';
+            d += s_double;
+
+            d = 'a';
+            d += s_float;
+
+            d = 'a';
+            d += s_int;
+
+            d = 'a';
+            d += s_long;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = 'a';
+            d += s_sbyte;
+
+            d = 'a';
+            d += s_short;
+
+            d = 'a';
+            d += s_string;
+
+            d = 'a';
+            d += s_uint;
+
+            d = 'a';
+            d += s_ulong;
+
+            d = 'a';
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d += d2;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "char", "decimal"))
-                    //    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.dcml.dcml;
-    // <Title> Generated tests for += operator decimal Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(134,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = 10m;
+            d += s_byte;
+
+            d = 10m;
+            d += s_char;
+
+            d = 10m;
+            d += s_decimal;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d += s_double);
+            Assert.Throws<RuntimeBinderException>(() => d += s_float);
+
+            d = 10m;
+            d += s_int;
+
+            d = 10m;
+            d += s_long;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = 10m;
+            d += s_sbyte;
+
+            d = 10m;
+            d += s_short;
+
+            d = 10m;
+            d += s_string;
+
+            d = 10m;
+            d += s_uint;
+
+            d = 10m;
+            d += s_ulong;
+
+            d = 10m;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d += d1;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d += d2;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d += d3;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d += d6;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d += d7;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d += d9;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d += d10;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConv, e.Message, "string", "decimal"))
-                    //    result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d += d12;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d += d13;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d += d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.dbl.dbl;
-    // <Title> Generated tests for += operator double Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = 10d;
+            d += s_byte;
+
+            d = 10d;
+            d += s_char;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d += s_decimal);
+
+            d = 10d;
+            d += s_double;
+
+            d = 10d;
+            d += s_float;
+
+            d = 10d;
+            d += s_int;
+
+            d = 10d;
+            d += s_long;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = 10d;
+            d += s_sbyte;
+
+            d = 10d;
+            d += s_short;
+
+            d = 10d;
+            d += s_string;
+
+            d = 10d;
+            d += s_uint;
+
+            d = 10d;
+            d += s_ulong;
+
+            d = 10d;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d += d1;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d += d2;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d += d4;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d += d5;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d += d6;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d += d7;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "double", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d += d9;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d += d10;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d += d12;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d += d13;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d += d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.flt.flt;
-    // <Title> Generated tests for += operator float Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(135,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = 10f;
+            d += s_byte;
+
+            d = 10f;
+            d += s_char;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d += s_decimal);
+
+            d = 10f;
+            d += s_double;
+
+            d = 10f;
+            d += s_float;
+
+            d = 10f;
+            d += s_int;
+
+            d = 10f;
+            d += s_long;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = 10f;
+            d += s_sbyte;
+
+            d = 10f;
+            d += s_short;
+
+            d = 10f;
+            d += s_string;
+
+            d = 10f;
+            d += s_uint;
+
+            d = 10f;
+            d += s_ulong;
+
+            d = 10f;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d += d1;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d += d2;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d += d5;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d += d6;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d += d7;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d += d9;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d += d10;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "float", "string"))
-                    //    result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d += d12;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d += d13;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d += d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.integereger.integereger;
-    // <Title> Generated tests for += operator int Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(73,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = 10;
+            d += s_byte;
+
+            d = 10;
+            d += s_char;
+
+            d = 10;
+            d += s_decimal;
+
+            d = 10;
+            d += s_double;
+
+            d = 10;
+            d += s_float;
+
+            d = 10;
+            d += s_int;
+
+            d = 10;
+            d += s_long;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = 10;
+            d += s_sbyte;
+
+            d = 10;
+            d += s_short;
+
+            d = 10;
+            d += s_string;
+
+            d = 10;
+            d += s_uint;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_ulong);
+
+            d = 10;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d += d2;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "int", "decimal"))
-                    //    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            // ulong 's behavior is not same as others
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.lng.lng;
-    // <Title> Generated tests for += operator long Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = 10L;
+            d += s_byte;
+
+            d = 10L;
+            d += s_char;
+
+            d = 10L;
+            d += s_decimal;
+
+            d = 10L;
+            d += s_double;
+
+            d = 10L;
+            d += s_float;
+
+            d = 10L;
+            d += s_int;
+
+            d = 10L;
+            d += s_long;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = 10L;
+            d += s_sbyte;
+
+            d = 10L;
+            d += s_short;
+
+            d = 10L;
+            d += s_string;
+
+            d = 10L;
+            d += s_uint;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d += s_ulong);
+
+            d = 10L;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d += d1;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d += d2;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d += d6;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d += d7;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "long", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d += d9;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d += d10;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d += d12;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d += d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.obj.obj;
-    // <Title> Generated tests for += operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d += s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d += s_char);
+            Assert.Throws<RuntimeBinderException>(() => d += s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d += s_double);
+            Assert.Throws<RuntimeBinderException>(() => d += s_float);
+            Assert.Throws<RuntimeBinderException>(() => d += s_int);
+            Assert.Throws<RuntimeBinderException>(() => d += s_long);
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+            Assert.Throws<RuntimeBinderException>(() => d += s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d += s_short);
+
+            d = new object();
+            d += s_string;
+
+            d = new object();
+            Assert.Throws<RuntimeBinderException>(() => d += s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d += s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d += s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "object", "double"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                d += d11;
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.sbte.sbte;
-    // <Title> Generated tests for += operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = (sbyte)10;
+            d += s_byte;
+
+            d = (sbyte)10;
+            d += s_char;
+
+            d = (sbyte)10;
+            d += s_decimal;
+
+            d = (sbyte)10;
+            d += s_double;
+
+            d = (sbyte)10;
+            d += s_float;
+
+            d = (sbyte)10;
+            d += s_int;
+
+            d = (sbyte)10;
+            d += s_long;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = (sbyte)10;
+            d += s_sbyte;
+
+            d = (sbyte)10;
+            d += s_short;
+
+            d = (sbyte)10;
+            d += s_string;
+
+            d = (sbyte)10;
+            d += s_uint;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_ulong);
+
+            d = (sbyte)10;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d += d9;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.shrt.shrt;
-    // <Title> Generated tests for += operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = (short)10;
+            d += s_byte;
+
+            d = (short)10;
+            d += s_char;
+
+            d = (short)10;
+            d += s_decimal;
+
+            d = (short)10;
+            d += s_double;
+
+            d = (short)10;
+            d += s_float;
+
+            d = (short)10;
+            d += s_int;
+
+            d = (short)10;
+            d += s_long;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = (short)10;
+            d += s_sbyte;
+
+            d = (short)10;
+            d += s_short;
+
+            d = (short)10;
+            d += s_string;
+
+            d = (short)10;
+            d += s_uint;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_ulong);
+
+            d = (short)10;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d += d9;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.str.str;
-    // <Title> Generated tests for += operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "a";
+            d += s_bool;
+
+            d = "a";
+            d += s_byte;
+
+            d = "a";
+            d += s_char;
+
+            d = "a";
+            d += s_decimal;
+
+            d = "a";
+            d += s_double;
+
+            d = "a";
+            d += s_float;
+
+            d = "a";
+            d += s_int;
+
+            d = "a";
+            d += s_long;
+
+            d = "a";
+            d += s_object;
+
+            d = "a";
+            d += s_sbyte;
+
+            d = "a";
+            d += s_short;
+
+            d = "a";
+            d += s_string;
+
+            d = "a";
+            d += s_uint;
+
+            d = "a";
+            d += s_ulong;
+
+            d = "a";
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d0;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d1;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d2;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d3;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d4;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d5;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d6;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d7;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d8;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d9;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d10;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d11;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d12;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d13;
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                d += d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for += operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = (uint)10;
+            d += s_byte;
+
+            d = (uint)10;
+            d += s_char;
+
+            d = (uint)10;
+            d += s_decimal;
+
+            d = (uint)10;
+            d += s_double;
+
+            d = (uint)10;
+            d += s_float;
+
+            d = (uint)10;
+            d += s_int;
+
+            d = (uint)10;
+            d += s_long;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+
+            d = (uint)10;
+            d += s_sbyte;
+
+            d = (uint)10;
+            d += s_short;
+
+            d = (uint)10;
+            d += s_string;
+
+            d = (uint)10;
+            d += s_uint;
+
+            d = (uint)10;
+            d += s_ulong;
+
+            d = (uint)10;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d += d9;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.ulng.ulng;
-    // <Title> Generated tests for += operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
+
+            d = (ulong)10;
+            d += s_byte;
+
+            d = (ulong)10;
+            d += s_char;
+
+            d = (ulong)10;
+            d += s_decimal;
+
+            d = (ulong)10;
+            d += s_double;
+
+            d = (ulong)10;
+            d += s_float;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_int);
+            Assert.Throws<RuntimeBinderException>(() => d += s_long);
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
+            Assert.Throws<RuntimeBinderException>(() => d += s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d += s_short);
+
+            d = (ulong)10;
+            d += s_string;
+
+            d = (ulong)10;
+            d += s_uint;
+
+            d = (ulong)10;
+            d += s_ulong;
+
+            d = (ulong)10;
+            d += s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    // result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d9;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "+=", "ulong", "sbyte"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.PlusEqual.ushrt.ushrt;
-    // <Title> Generated tests for += operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d += s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_decimal;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_double;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_float;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
+            d = (ushort)10;
+            d += s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_long;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d += s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d += s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d += d9;
-            }
+            d = (ushort)10;
+            d += s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_string;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d11;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_uint;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d += s_ulong;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d += d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d += s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.ShiftLeftEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.ShiftLeftEqual.cs
@@ -2,3254 +2,514 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.bol.bol;
-    // <Title> Generated tests for <<= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
+using static Dynamic.Operator.Tests.TypeCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class ShiftLeftEqualTypeTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "bool", "short"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d <<= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.bte.bte;
-    // <Title> Generated tests for <<= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+
+            d = (byte)1;
+            d <<= s_byte;
+
+            d = (byte)1;
+            d <<= s_char;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+
+            d = (byte)1;
+            d <<= s_int;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+
+            d = (byte)1;
+            d <<= s_sbyte;
+
+            d = (byte)1;
+            d <<= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+
+            d = (byte)1;
+            d <<= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d <<= d1;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d <<= d2;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d <<= d6;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "byte", "uint"))
-                        result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.chr.chr;
-    // <Title> Generated tests for <<= operator char Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+
+            d = 'a';
+            d <<= s_byte;
+
+            d = 'a';
+            d <<= s_char;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+
+            d = 'a';
+            d <<= s_int;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+
+            d = 'a';
+            d <<= s_sbyte;
+
+            d = 'a';
+            d <<= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+
+            d = 'a';
+            d <<= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "char", "bool"))
-                        result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d <<= d1;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d <<= d2;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d <<= d6;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.dcml.dcml;
-    // <Title> Generated tests for <<= operator decimal Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10m;
+
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "decimal", "byte"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d <<= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.dbl.dbl;
-    // <Title> Generated tests for <<= operator double Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10d;
+
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "double", "char"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d <<= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.flt.flt;
-    // <Title> Generated tests for <<= operator float Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10f;
+
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "float", "decimal"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d <<= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.integereger.integereger;
-    // <Title> Generated tests for <<= operator int Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+
+            d = 10;
+            d <<= s_byte;
+
+            d = 10;
+            d <<= s_char;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+
+            d = 10;
+            d <<= s_int;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+
+            d = 10;
+            d <<= s_sbyte;
+
+            d = 10;
+            d <<= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+
+            d = 10;
+            d <<= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d <<= d1;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d <<= d2;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d <<= d6;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "int", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.lng.lng;
-    // <Title> Generated tests for <<= operator long Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+
+            d = 10L;
+            d <<= s_byte;
+
+            d = 10L;
+            d <<= s_char;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+
+            d = 10L;
+            d <<= s_int;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+
+            d = 10L;
+            d <<= s_sbyte;
+
+            d = 10L;
+            d <<= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+
+            d = 10L;
+            d <<= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "long", "bool"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d <<= d1;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d <<= d2;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d <<= d6;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.obj.obj;
-    // <Title> Generated tests for <<= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d <<= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "object", "ushort"))
-                        result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.sbte.sbte;
-    // <Title> Generated tests for <<= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+
+            d = (sbyte)10;
+            d <<= s_byte;
+
+            d = (sbyte)10;
+            d <<= s_char;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+
+            d = (sbyte)10;
+            d <<= s_int;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d << s_long);
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+
+            d = (sbyte)10;
+            d <<= s_sbyte;
+
+            d = (sbyte)10;
+            d <<= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+
+            d = (sbyte)10;
+            d <<= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d <<= d1;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d <<= d2;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d <<= d6;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "sbyte", "uint"))
-                        result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.shrt.shrt;
-    // <Title> Generated tests for <<= operator short Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+
+            d = (short)10;
+            d <<= s_byte;
+
+            d = (short)10;
+            d <<= s_char;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+
+            d = (short)10;
+            d <<= s_int;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d << s_long);
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+
+            d = (short)10;
+            d <<= s_sbyte;
+
+            d = (short)10;
+            d <<= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+
+            d = (short)10;
+            d <<= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                d <<= d1;
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                d <<= d2;
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                d <<= d6;
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "short", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.str.str;
-    // <Title> Generated tests for <<= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "a";
+
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "string", "short"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d <<= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for <<= operator uint Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+
+            d = (uint)10;
+            d <<= s_byte;
+
+            d = (uint)10;
+            d <<= s_char;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+
+            d = (uint)10;
+            d <<= s_int;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+
+            d = (uint)10;
+            d <<= s_sbyte;
+
+            d = (uint)10;
+            d <<= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+
+            d = (uint)10;
+            d <<= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                d <<= d1;
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                d <<= d2;
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                d <<= d6;
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "uint", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.ulng.ulng;
-    // <Title> Generated tests for <<= operator ulong Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
+
+            d = (ulong)10;
+            d <<= s_byte;
+
+            d = (ulong)10;
+            d <<= s_char;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
+
+            d = (ulong)10;
+            d <<= s_int;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
+
+            d = (ulong)10;
+            d <<= s_sbyte;
+
+            d = (ulong)10;
+            d <<= s_short;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
+
+            d = (ulong)10;
+            d <<= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d <<= d1;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d <<= d2;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d <<= d6;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "ulong", "long"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftLeftEqual.ushrt.ushrt;
-    // <Title> Generated tests for <<= operator ushort Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d <<= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d <<= s_byte;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                d <<= d1;
-            }
+            d = (ushort)10;
+            d <<= s_char;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                d <<= d2;
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_float);
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d <<= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d <<= s_int;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d <<= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "<<=", "ushort", "double"))
-                        result = false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_object);
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d <<= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d <<= s_sbyte;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                d <<= d6;
-            }
+            d = (ushort)10;
+            d <<= s_short;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d <<= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d <<= s_ulong);
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d <<= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 7;
-                dynamic d = a;
-                d <<= d9;
-            }
-
-            {
-                ushort a = 7;
-                dynamic d = a;
-                d <<= d10;
-            }
-
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d <<= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d <<= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d <<= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 7;
-                dynamic d = a;
-                d <<= d14;
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d <<= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.ShiftRightEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.ShiftRightEqual.cs
@@ -2,3254 +2,514 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.bol.bol;
-    // <Title> Generated tests for >>= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
+using static Dynamic.Operator.Tests.TypeCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class ShiftRightEqualTypeTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d >>= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "bool", "ushort"))
-                        result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.bte.bte;
-    // <Title> Generated tests for >>= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+
+            d = (byte)1;
+            d >>= s_byte;
+
+            d = (byte)1;
+            d >>= s_char;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+
+            d = (byte)1;
+            d >>= s_int;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+
+            d = (byte)1;
+            d >>= s_sbyte;
+
+            d = (byte)1;
+            d >>= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+
+            d = (byte)1;
+            d >>= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d >>= d1;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d >>= d2;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d >>= d6;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "byte", "uint"))
-                        result = false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.chr.chr;
-    // <Title> Generated tests for >>= operator char Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+
+            d = 'a';
+            d >>= s_byte;
+
+            d = 'a';
+            d >>= s_char;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+
+            d = 'a';
+            d >>= s_int;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+
+            d = 'a';
+            d >>= s_sbyte;
+
+            d = 'a';
+            d >>= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+
+            d = 'a';
+            d >>= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d >>= d1;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d >>= d2;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d >>= d6;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "char", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.dcml.dcml;
-    // <Title> Generated tests for >>= operator decimal Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10m;
+
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "decimal", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d >>= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.dbl.dbl;
-    // <Title> Generated tests for >>= operator double Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10d;
+
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "double", "short"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d >>= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.flt.flt;
-    // <Title> Generated tests for >>= operator float Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10f;
+
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "float", "sbyte"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d >>= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.integereger.integereger;
-    // <Title> Generated tests for >>= operator int Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+
+            d = 10;
+            d >>= s_byte;
+
+            d = 10;
+            d >>= s_char;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+
+            d = 10;
+            d >>= s_int;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+
+            d = 10;
+            d >>= s_sbyte;
+
+            d = 10;
+            d >>= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+
+            d = 10;
+            d >>= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d >>= d1;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d >>= d2;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "int", "double"))
-                        result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d >>= d6;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.lng.lng;
-    // <Title> Generated tests for >>= operator long Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+
+            d = 10L;
+            d >>= s_byte;
+
+            d = 10L;
+            d >>= s_char;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+
+            d = 10L;
+            d >>= s_int;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+
+            d = 10L;
+            d >>= s_sbyte;
+
+            d = 10L;
+            d >>= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+
+            d = 10L;
+            d >>= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "long", "bool"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d >>= d1;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d >>= d2;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d >>= d6;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.obj.obj;
-    // <Title> Generated tests for >>= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "object", "byte"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d >>= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.sbte.sbte;
-    // <Title> Generated tests for >>= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+
+            d = (sbyte)10;
+            d >>= s_byte;
+
+            d = (sbyte)10;
+            d >>= s_char;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+
+            d = (sbyte)10;
+            d >>= s_int;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d << s_long);
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+
+            d = (sbyte)10;
+            d >>= s_sbyte;
+
+            d = (sbyte)10;
+            d >>= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+
+            d = (sbyte)10;
+            d >>= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d >>= d1;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d >>= d2;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "sbyte", "double"))
-                        result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d >>= d6;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.shrt.shrt;
-    // <Title> Generated tests for >>= operator short Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+
+            d = (short)10;
+            d >>= s_byte;
+
+            d = (short)10;
+            d >>= s_char;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+
+            d = (short)10;
+            d >>= s_int;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d << s_long);
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+
+            d = (short)10;
+            d >>= s_sbyte;
+
+            d = (short)10;
+            d >>= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+
+            d = (short)10;
+            d >>= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                d >>= d1;
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                d >>= d2;
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "short", "float"))
-                        result = false;
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                d >>= d6;
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 6;
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.str.str;
-    // <Title> Generated tests for >>= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "a";
+
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "string", "float"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d >>= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for >>= operator uint Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+
+            d = (uint)10;
+            d >>= s_byte;
+
+            d = (uint)10;
+            d >>= s_char;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+
+            d = (uint)10;
+            d >>= s_int;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+
+            d = (uint)10;
+            d >>= s_sbyte;
+
+            d = (uint)10;
+            d >>= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+
+            d = (uint)10;
+            d >>= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                d >>= d1;
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                d >>= d2;
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                d >>= d6;
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "uint", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 15;
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.ulng.ulng;
-    // <Title> Generated tests for >>= operator ulong Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
+
+            d = (ulong)10;
+            d >>= s_byte;
+
+            d = (ulong)10;
+            d >>= s_char;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
+
+            d = (ulong)10;
+            d >>= s_int;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
+
+            d = (ulong)10;
+            d >>= s_sbyte;
+
+            d = (ulong)10;
+            d >>= s_short;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
+
+            d = (ulong)10;
+            d >>= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d >>= d1;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d >>= d2;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "ulong", "float"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d >>= d6;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.ShiftRightEqual.ushrt.ushrt;
-    // <Title> Generated tests for >>= operator ushort Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d >>= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d >>= s_byte;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                d >>= d1;
-            }
+            d = (ushort)10;
+            d >>= s_char;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                d >>= d2;
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_float);
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d >>= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d >>= s_int;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d >>= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_object);
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d >>= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d >>= s_sbyte;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                d >>= d6;
-            }
+            d = (ushort)10;
+            d >>= s_short;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d >>= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d >>= s_ulong);
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d >>= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 7;
-                dynamic d = a;
-                d >>= d9;
-            }
-
-            {
-                ushort a = 7;
-                dynamic d = a;
-                d >>= d10;
-            }
-
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d >>= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, ">>=", "ushort", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d >>= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d >>= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 7;
-                dynamic d = a;
-                d >>= d14;
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d >>= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.SubEqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.SubEqual.cs
@@ -2,3331 +2,665 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.bol.bol;
-    // <Title> Generated tests for -= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
+using static Dynamic.Operator.Tests.TypeCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class MinusEqualsTypeTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_short);
+
+            d = true;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = true;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "bool", "bool"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.bte.bte;
-    // <Title> Generated tests for -= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = (byte)1;
+            d -= s_byte;
+
+            d = (byte)1;
+            d -= s_char;
+
+            d = (byte)1;
+            d -= s_decimal;
+
+            d = (byte)1;
+            d -= s_double;
+
+            d = (byte)1;
+            d -= s_float;
+
+            d = (byte)1;
+            d -= s_int;
+
+            d = (byte)1;
+            d -= s_long;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = (byte)1;
+            d -= s_sbyte;
+
+            d = (byte)1;
+            d -= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = (byte)1;
+            d -= s_uint;
+
+            d = (byte)1;
+            d -= s_ulong;
+
+            d = (byte)1;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d -= d1;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d -= d2;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d -= d6;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d -= d7;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d -= d9;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d -= d10;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d -= d12;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d -= d13;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d -= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.chr.chr;
-    // <Title> Generated tests for -= operator char Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(73,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = 'a';
+            d -= s_byte;
+
+            d = 'a';
+            d -= s_char;
+
+            d = 'a';
+            d -= s_decimal;
+
+            d = 'a';
+            d -= s_double;
+
+            d = 'a';
+            d -= s_float;
+
+            d = 'a';
+            d -= s_int;
+
+            d = 'a';
+            d -= s_long;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = 'a';
+            d -= s_sbyte;
+
+            d = 'a';
+            d -= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = 'a';
+            d -= s_uint;
+
+            d = 'a';
+            d -= s_ulong;
+
+            d = 'a';
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d -= d2;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "char", "decimal"))
-                    //    result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.dcml.dcml;
-    // <Title> Generated tests for -= operator decimal Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = 10m;
+            d -= s_byte;
+
+            d = 10m;
+            d -= s_char;
+
+            d = 10m;
+            d -= s_decimal;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_float);
+
+            d = 10m;
+            d -= s_int;
+
+            d = 10m;
+            d -= s_long;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = 10m;
+            d -= s_sbyte;
+
+            d = 10m;
+            d -= s_short;
+
+            d = 10m;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = 10m;
+            d -= s_uint;
+
+            d = 10m;
+            d -= s_ulong;
+
+            d = 10m;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d -= d1;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d -= d2;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d -= d3;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "decimal", "float"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d -= d6;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d -= d7;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d -= d9;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d -= d10;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d -= d12;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d -= d13;
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                d -= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.dbl.dbl;
-    // <Title> Generated tests for -= operator double Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = 10d;
+            d -= s_byte;
+
+            d = 10d;
+            d -= s_char;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_decimal);
+
+            d = 10d;
+            d -= s_double;
+
+            d = 10d;
+            d -= s_float;
+
+            d = 10d;
+            d -= s_int;
+
+            d = 10d;
+            d -= s_long;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = 10d;
+            d -= s_sbyte;
+
+            d = 10d;
+            d -= s_short;
+
+            d = 10d;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = 10d;
+            d -= s_uint;
+
+            d = 10d;
+            d -= s_ulong;
+
+            d = 10d;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d -= d1;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d -= d2;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "double", "decimal"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d -= d4;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d -= d5;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d -= d6;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d -= d7;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d -= d9;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d -= d10;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d -= d12;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d -= d13;
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                d -= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.flt.flt;
-    // <Title> Generated tests for -= operator float Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = 10f;
+            d -= s_byte;
+
+            d = 10f;
+            d -= s_char;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_decimal);
+
+            d = 10f;
+            d -= s_double;
+
+            d = 10f;
+            d -= s_float;
+
+            d = 10f;
+            d -= s_int;
+
+            d = 10f;
+            d -= s_long;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = 10f;
+            d -= s_sbyte;
+
+            d = 10f;
+            d -= s_short;
+
+            d = 10f;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = 10f;
+            d -= s_uint;
+
+            d = 10f;
+            d -= s_ulong;
+
+            d = 10f;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d -= d1;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d -= d2;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d -= d5;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d -= d6;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d -= d7;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d -= d9;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d -= d10;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "float", "string"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d -= d12;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d -= d13;
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                d -= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.integereger.integereger;
-    // <Title> Generated tests for -= operator int Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(73,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = 10;
+            d -= s_byte;
+
+            d = 10;
+            d -= s_char;
+
+            d = 10;
+            d -= s_decimal;
+
+            d = 10;
+            d -= s_double;
+
+            d = 10;
+            d -= s_float;
+
+            d = 10;
+            d -= s_int;
+
+            d = 10;
+            d -= s_long;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = 10;
+            d -= s_sbyte;
+
+            d = 10;
+            d -= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = 10;
+            d -= s_uint;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ulong);
+
+            d = 10;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d -= d2;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "int", "decimal"))
-                    //    result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            // ulong 's behavior is not same as others
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.lng.lng;
-    // <Title> Generated tests for -= operator long Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = 10L;
+            d -= s_byte;
+
+            d = 10L;
+            d -= s_char;
+
+            d = 10L;
+            d -= s_decimal;
+
+            d = 10L;
+            d -= s_double;
+
+            d = 10L;
+            d -= s_float;
+
+            d = 10L;
+            d -= s_int;
+
+            d = 10L;
+            d -= s_long;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = 10L;
+            d -= s_sbyte;
+
+            d = 10L;
+            d -= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = 10L;
+            d -= s_uint;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ulong);
+
+            d = 10L;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d -= d1;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d -= d2;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d -= d6;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d -= d7;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "long", "object"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d -= d9;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d -= d10;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d -= d12;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d -= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.obj.obj;
-    // <Title> Generated tests for -= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_short);
+
+            d = new object();
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = new object();
+            Assert.Throws<RuntimeBinderException>(() => d -= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "object", "int"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.sbte.sbte;
-    // <Title> Generated tests for -= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = (sbyte)10;
+            d -= s_byte;
+
+            d = (sbyte)10;
+            d -= s_char;
+
+            d = (sbyte)10;
+            d -= s_decimal;
+
+            d = (sbyte)10;
+            d -= s_double;
+
+            d = (sbyte)10;
+            d -= s_float;
+
+            d = (sbyte)10;
+            d -= s_int;
+
+            d = (sbyte)10;
+            d -= s_long;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = (sbyte)10;
+            d -= s_sbyte;
+
+            d = (sbyte)10;
+            d -= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = (sbyte)10;
+            d -= s_uint;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ulong);
+
+            d = (sbyte)10;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d -= d9;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.shrt.shrt;
-    // <Title> Generated tests for -= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = (short)10;
+            d -= s_byte;
+
+            d = (short)10;
+            d -= s_char;
+
+            d = (short)10;
+            d -= s_decimal;
+
+            d = (short)10;
+            d -= s_double;
+
+            d = (short)10;
+            d -= s_float;
+
+            d = (short)10;
+            d -= s_int;
+
+            d = (short)10;
+            d -= s_long;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = (short)10;
+            d -= s_sbyte;
+
+            d = (short)10;
+            d -= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = (short)10;
+            d -= s_uint;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ulong);
+
+            d = (short)10;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d -= d9;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.str.str;
-    // <Title> Generated tests for -= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "a";
+
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "string", "int"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.uintegereger.uintegereger;
-    // <Title> Generated tests for -= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = (uint)10;
+            d -= s_byte;
+
+            d = (uint)10;
+            d -= s_char;
+
+            d = (uint)10;
+            d -= s_decimal;
+
+            d = (uint)10;
+            d -= s_double;
+
+            d = (uint)10;
+            d -= s_float;
+
+            d = (uint)10;
+            d -= s_int;
+
+            d = (uint)10;
+            d -= s_long;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+
+            d = (uint)10;
+            d -= s_sbyte;
+
+            d = (uint)10;
+            d -= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = (uint)10;
+            d -= s_uint;
+
+            d = (uint)10;
+            d -= s_ulong;
+
+            d = (uint)10;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                d -= d9;
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.ulng.ulng;
-    // <Title> Generated tests for -= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
+
+            d = (ulong)10;
+            d -= s_byte;
+
+            d = (ulong)10;
+            d -= s_char;
+
+            d = (ulong)10;
+            d -= s_decimal;
+
+            d = (ulong)10;
+            d -= s_double;
+
+            d = (ulong)10;
+            d -= s_float;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d -= s_short);
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
+
+            d = (ulong)10;
+            d -= s_uint;
+
+            d = (ulong)10;
+            d -= s_ulong;
+
+            d = (ulong)10;
+            d -= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    // result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result = false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d9;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "-=", "ulong", "sbyte"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            {
-                ulong a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result = false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result = false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.SubEqual.ushrt.ushrt;
-    // <Title> Generated tests for -= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d -= s_byte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d -= s_char;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d -= s_decimal;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d3;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d -= s_double;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d4;
-                    // result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d -= s_float;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d5;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    result &= false;
-                    //if (!ErrorVerifier.Verify(ErrorMessageId.NoImplicitConvCast, e.Message, "float", "sbyte"))
-                    //    result = false;
-                }
-            }
+            d = (ushort)10;
+            d -= s_int;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d -= s_long;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_object);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d -= s_sbyte;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                d -= d9;
-            }
+            d = (ushort)10;
+            d -= s_short;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d -= s_string);
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d -= s_uint;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d -= s_ulong;
 
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ushort a = 10;
-                dynamic d = a;
-                try
-                {
-                    d -= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d -= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.XOREqual.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.type.XOREqual.cs
@@ -2,3427 +2,566 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.bol.bol
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.bol.bol;
-    // <Title> Generated tests for ^= operator bool Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
+using static Dynamic.Operator.Tests.TypeCommon;
 
-    public class Test
+namespace Dynamic.Operator.Tests
+{
+    public class XorEqualTypeTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Bool()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = true;
+            d ^= s_bool;
+
+            d = true;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                bool a = true;
-                dynamic d = a;
-                d ^= d0;
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "bool", "byte"))
-                        result = false;
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                bool a = true;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.bte.bte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.bte.bte;
-    // <Title> Generated tests for ^= operator byte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Byte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = (byte)1;
+            d ^= s_byte;
+
+            d = (byte)1;
+            d ^= s_char;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+
+            d = (byte)1;
+            d ^= s_int;
+
+            d = (byte)1;
+            d ^= s_long;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+
+            d = (byte)1;
+            d ^= s_sbyte;
+
+            d = (byte)1;
+            d ^= s_short;
+
+            d = (byte)1;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = (byte)1;
+            d ^= s_uint;
+
+            d = (byte)1;
+            d ^= s_ulong;
+
+            d = (byte)1;
+            d ^= s_short;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d ^= d1;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d ^= d2;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    // result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d ^= d6;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d ^= d7;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d ^= d9;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d ^= d10;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d ^= d12;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d ^= d13;
-            }
-
-            {
-                byte a = 1;
-                dynamic d = a;
-                d ^= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.chr.chr
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.chr.chr;
-    // <Title> Generated tests for ^= operator char Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Char()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = 'a';
+            d ^= s_byte;
+
+            d = 'a';
+            d ^= s_char;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+
+            d = 'a';
+            d ^= s_int;
+
+            d = 'a';
+            d ^= s_long;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+
+            d = 'a';
+            d ^= s_sbyte;
+
+            d = 'a';
+            d ^= s_short;
+
+            d = 'a';
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = 'a';
+            d ^= s_uint;
+
+            d = 'a';
+            d ^= s_ulong;
+
+            d = 'a';
+            d ^= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                d ^= d2;
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "char", "decimal"))
-                        result = false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                char a = 'a';
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.dcml.dcml
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.dcml.dcml;
-    // <Title> Generated tests for ^= operator decimal Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Decimal()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_byte);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_char);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_int);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_long);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_sbyte);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_short);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_uint);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+
+            d = 1m;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "decimal", "bool"))
-                        result = false;
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                decimal a = 1M;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.dbl.dbl
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.dbl.dbl;
-    // <Title> Generated tests for ^= operator double Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Double()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10.1d;
+
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "double", "bool"))
-                        result = false;
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                double a = 10.1;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.flt.flt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.flt.flt;
-    // <Title> Generated tests for ^= operator float Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Float()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10.1f;
+
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "float", "bool"))
-                        result = false;
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                float a = 10.1f;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.integereger.integereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.integereger.integereger;
-    // <Title> Generated tests for ^= operator int Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Int()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = 10;
+            d ^= s_byte;
+
+            d = 10;
+            d ^= s_char;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+
+            d = 10;
+            d ^= s_int;
+
+            d = 10;
+            d ^= s_long;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+
+            d = 10;
+            d ^= s_sbyte;
+
+            d = 10;
+            d ^= s_short;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = 10;
+            d ^= s_uint;
+
+            d = 10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+
+            d = 10;
+            d ^= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                d ^= d2;
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "int", "decimal"))
-                        result = false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            // ulong 's behavior is not same as others
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                int a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.lng.lng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.lng.lng;
-    // <Title> Generated tests for ^= operator long Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Long()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = 10L;
+            d ^= s_byte;
+
+            d = 10L;
+            d ^= s_char;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+
+            d = 10L;
+            d ^= s_int;
+
+            d = 10L;
+            d ^= s_long;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+
+            d = 10L;
+            d ^= s_sbyte;
+
+            d = 10L;
+            d ^= s_short;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = 10L;
+            d ^= s_uint;
+
+            d = 10L;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+
+            d = 10L;
+            d ^= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "long", "bool"))
-                        result = false;
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d ^= d1;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d ^= d2;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d ^= d6;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d ^= d7;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d ^= d9;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d ^= d10;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d ^= d12;
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                long a = 5;
-                dynamic d = a;
-                d ^= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.obj.obj
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.obj.obj;
-    // <Title> Generated tests for ^= operator object Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Object()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = new object();
+
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "object", "bool"))
-                        result = false;
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                object a = new object();
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.sbte.sbte
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.sbte.sbte;
-    // <Title> Generated tests for ^= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SByte()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = (sbyte)10;
+            d ^= s_byte;
+
+            d = (sbyte)10;
+            d ^= s_char;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+
+            d = (sbyte)10;
+            d ^= s_int;
+
+            d = (sbyte)10;
+            d ^= s_long;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+
+            d = (sbyte)10;
+            d ^= s_sbyte;
+
+            d = (sbyte)10;
+            d ^= s_short;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = (sbyte)10;
+            d ^= s_uint;
+
+            d = (sbyte)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+
+            d = (sbyte)10;
+            d ^= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    // result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                d ^= d9;
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                sbyte a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.shrt.shrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.shrt.shrt;
-    // <Title> Generated tests for ^= operator sbyte Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(110,74\).*CS0168</Expects>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Short()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = (short)10;
+            d ^= s_byte;
+
+            d = (short)10;
+            d ^= s_char;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+
+            d = (short)10;
+            d ^= s_int;
+
+            d = (short)10;
+            d ^= s_long;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+
+            d = (short)10;
+            d ^= s_sbyte;
+
+            d = (short)10;
+            d ^= s_short;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = (short)10;
+            d ^= s_uint;
+
+            d = (short)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+
+            d = (short)10;
+            d ^= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    //result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                d ^= d9;
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                short a = 10;
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    //result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.str.str
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.str.str;
-    // <Title> Generated tests for ^= operator string Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void String()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = "abc";
+
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_byte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_char);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_uint);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ulong);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_ushort);
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "string", "bool"))
-                        result = false;
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d1;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d2;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                string a = "a";
-                dynamic d = a;
-                try
-                {
-                    d ^= d14;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.uintegereger.uintegereger
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.uintegereger.uintegereger;
-    // <Title> Generated tests for ^= operator ushort Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UInt()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = (uint)10;
+            d ^= s_byte;
+
+            d = (uint)10;
+            d ^= s_char;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+
+            d = (uint)10;
+            d ^= s_int;
+
+            d = (uint)10;
+            d ^= s_long;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+
+            d = (uint)10;
+            d ^= s_sbyte;
+
+            d = (uint)10;
+            d ^= s_short;
+
+            d = (uint)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = (uint)10;
+            d ^= s_uint;
+
+            d = (uint)10;
+            d ^= s_ulong;
+
+            d = (uint)10;
+            d ^= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                uint a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "uint", "bool"))
-                        result = false;
-                }
-            }
-
-            {
-                uint a = 7;
-                dynamic d = a;
-                d ^= d1;
-            }
-
-            {
-                uint a = 7;
-                dynamic d = a;
-                d ^= d2;
-            }
-
-            {
-                uint a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                uint a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                uint a = 7;
-                dynamic d = a;
-                d ^= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.ulng.ulng
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.ulng.ulng;
-    // <Title> Generated tests for ^= operator ulong Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ULong()
         {
-            Assert.Equal(0, MainMethod(null));
+            dynamic d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
+
+            d = (ulong)10;
+            d ^= s_byte;
+
+            d = (ulong)10;
+            d ^= s_char;
+
+            d = (ulong)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_int);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_long);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_sbyte);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_short);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
+
+            d = (ulong)10;
+            d ^= s_uint;
+
+            d = (ulong)10;
+            d ^= s_ulong;
+
+            d = (ulong)10;
+            d ^= s_ushort;
         }
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "ulong", "bool"))
-                        result = false;
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d ^= d1;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d ^= d2;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d ^= d12;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d ^= d13;
-            }
-
-            {
-                ulong a = 2;
-                dynamic d = a;
-                d ^= d14;
-            }
-
-            return result ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.ushrt.ushrt
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compound.type.XOREqual.ushrt.ushrt;
-    // <Title> Generated tests for ^= operator ushort Type.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    // <Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UShort()
         {
-            Assert.Equal(0, MainMethod(null));
-        }
+            dynamic d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_bool);
 
-        public static int MainMethod(string[] ars)
-        {
-            bool result = true;
-            bool d0 = true;
-            byte d1 = 1;
-            char d2 = 'a';
-            decimal d3 = 1M;
-            double d4 = 10.1;
-            float d5 = 10.1f;
-            int d6 = 10;
-            long d7 = 5;
-            object d8 = new object();
-            sbyte d9 = 10;
-            short d10 = 6;
-            string d11 = "a";
-            uint d12 = 15;
-            ulong d13 = 2;
-            ushort d14 = 7;
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d0;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-                {
-                    if (!ErrorVerifier.Verify(ErrorMessageId.BadBinaryOps, e.Message, "^=", "ushort", "bool"))
-                        result = false;
-                }
-            }
+            d = (ushort)10;
+            d ^= s_byte;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                d ^= d1;
-            }
+            d = (ushort)10;
+            d ^= s_char;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                d ^= d2;
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_decimal);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_double);
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_float);
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d3;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d ^= s_int;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d4;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            d ^= s_long;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d5;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_object);
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d6;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d ^= s_sbyte;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d7;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d ^= s_short;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d8;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
+            d = (ushort)10;
+            Assert.Throws<RuntimeBinderException>(() => d ^= s_string);
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d9;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d ^= s_uint;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d10;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
+            d = (ushort)10;
+            d ^= s_ulong;
 
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d11;
-                    result &= false;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                }
-            }
-
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d12;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ushort a = 7;
-                dynamic d = a;
-                try
-                {
-                    d ^= d13;
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException) // same error as others, no need to verify
-                {
-                    result &= false;
-                }
-            }
-
-            {
-                ushort a = 7;
-                dynamic d = a;
-                d ^= d14;
-            }
-
-            return result ? 0 : 1;
+            d = (ushort)10;
+            d ^= s_ushort;
         }
     }
-    //</Code>
 }

--- a/src/System.Dynamic.Runtime/tests/System.Dynamic.Runtime.Tests.csproj
+++ b/src/System.Dynamic.Runtime/tests/System.Dynamic.Runtime.Tests.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CallInfoTests.cs" />
+    <Compile Include="Dynamic.Context\Common.cs" />
     <Compile Include="Dynamic.Context\Conformance.dynamic.context.attribute.cs" />
     <Compile Include="Dynamic.Context\Conformance.dynamic.context.delegateEvent.delegate.cs" />
     <Compile Include="Dynamic.Context\Conformance.dynamic.context.ExplicitImple.basic.cs" />


### PR DESCRIPTION
This shouldn't be as much of pain to review as the diff may suggest: there was a **lot** of code duplication and custom exception handling.

Contributes to #3133, #915, #516

/cc @VSadov @stephentoub @JonHanna