### PR TITLE
Cleanup some method tests in System.Dynamic.Runtime

### DIFF
--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.method.genmethod.genclass.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.method.genmethod.genclass.cs
@@ -2,55 +2,31 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth
+namespace Dynamic.GenericClass.GenericMethod.Tests
 {
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass001.genclass001;
-    using System;
-    using System.Collections.Generic;
+    public class EmptyClass { }
 
-    public class C
+    public interface EmptyInterface { }
+
+    public class GenericClass<T>
     {
-    }
+        public U Method_ReturnsU<U>(U u) => u;
 
-    public interface I
-    {
-    }
+        public U Method_ReturnsU<U>(T t) => default(U);
 
-    public class MemberClass<T>
-    {
-        #region Instance methods
-        public U Method_ReturnsU<U>(U u)
-        {
-            return u;
-        }
+        public U Method_ReturnsU<U, V>(T t, V v) => default(U);
 
-        public U Method_ReturnsU<U>(T t)
-        {
-            return default(U);
-        }
+        public T Method_ReturnsT<U>(params U[] d) => default(T);
 
-        public U Method_ReturnsU<U, V>(T t, V v)
-        {
-            return default(U);
-        }
+        public T Method_ReturnsT<U>(float x, T t, U u) => default(T);
 
-        public T Method_ReturnsT<U>(params U[] d)
-        {
-            return default(T);
-        }
-
-        public T Method_ReturnsT<U>(float x, T t, U u)
-        {
-            return default(T);
-        }
-
-        public T Method_ReturnsT<U>(U u)
-        {
-            return default(T);
-        }
+        public T Method_ReturnsT<U>(U u) => default(T);
 
         public T Method_ReturnsT<U, V>(out U u, ref V v)
         {
@@ -58,20 +34,11 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
             return default(T);
         }
 
-        public int Method_ReturnsInt(T t)
-        {
-            return 1;
-        }
+        public int Method_ReturnsInt(T t) => 1;
 
-        public string Method_ReturnsString<U>(T t, U u)
-        {
-            return "foo";
-        }
+        public string Method_ReturnsString<U>(T t, U u) => "foo";
 
-        public float Method_ReturnsFloat<U, V>(T t, dynamic d, U u)
-        {
-            return 3.4f;
-        }
+        public float Method_ReturnsFloat<U, V>(T t, dynamic d, U u) => 3.4f;
 
         public float Method_ReturnsFloat<U, V>(T t, dynamic d, U u, ref decimal dec)
         {
@@ -79,22 +46,12 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
             return 3.4f;
         }
 
-        public dynamic Method_ReturnsDynamic(T t)
-        {
-            return t;
-        }
+        public dynamic Method_ReturnsDynamic(T t) => t;
 
-        public dynamic Method_ReturnsDynamic<U>(T t, U u, dynamic d)
-        {
-            return u;
-        }
+        public dynamic Method_ReturnsDynamic<U>(T t, U u, dynamic d) => u;
 
-        public dynamic Method_ReturnsDynamic<U, V>(T t, U u, V v, dynamic d)
-        {
-            return v;
-        }
-
-        #region Constraints on methods that have a new type parameter
+        public dynamic Method_ReturnsDynamic<U, V>(T t, U u, V v, dynamic d) => v;
+        
         public U Method_ReturnsUConstraint<U>(U u) where U : class
         {
             return null;
@@ -137,7 +94,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
 
         //These are negative methods... you should not be able to call them with the dynamic type because the dynamic type would not satisfy the constraints
         //you cannot call this like: Method_ReturnsUConstraint<dynamic>(d); because object does not derive from C
-        public U Method_ReturnsUNegConstraint<U>(U u) where U : C
+        public U Method_ReturnsUNegConstraint<U>(U u) where U : EmptyClass
         {
             return null;
         }
@@ -147,15 +104,13 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
             return default(T);
         }
 
-        public float Method_ReturnsFloatNegConstraint<U, V>(T t, dynamic d, U u, ref decimal dec) where V : U where U : I
+        public float Method_ReturnsFloatNegConstraint<U, V>(T t, dynamic d, U u, ref decimal dec) where V : U where U : EmptyInterface
         {
             dec = 3m;
             return 3.4f;
         }
-
-        #endregion
-        #region Nested class
-        public class NestedMemberClass<U>
+        
+        public class NestedGenericClass<U>
         {
             public U Method_ReturnsU(T t)
             {
@@ -194,12 +149,9 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
                 return 4;
             }
         }
-        #endregion
-        #endregion
     }
 
-    public class MemberClassWithClassConstraint<T>
-        where T : class
+    public class GenericClassWithClassConstraint<T> where T : class
     {
         public int Method_ReturnsInt<U>() where U : T
         {
@@ -212,8 +164,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
         }
     }
 
-    public class MemberClassWithNewConstraint<T>
-        where T : new()
+    public class GenericClassWithNewConstraint<T> where T : new()
     {
         public U Method_ReturnsU<U>() where U : T
         {
@@ -226,8 +177,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
         }
     }
 
-    public class MemberClassWithAnotherTypeConstraint<T, U>
-        where T : U
+    public class GenericClassWithAnotherTypeConstraint<T, U> where T : U
     {
         public U Method_ReturnsU()
         {
@@ -239,10 +189,8 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
             return default(T);
         }
     }
-
-    #region Negative tests - you should not be able to construct this with a dynamic object
-    public class MemberClassWithUDClassConstraint<T>
-        where T : C
+    
+    public class GenericClassWithUDClassConstraint<T> where T : EmptyClass
     {
         public U Method_ReturnsU<U>() where U : T, new()
         {
@@ -250,1651 +198,392 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
         }
     }
 
-    public class MemberClassWithStructConstraint<T>
-        where T : struct
+    public class GenericClassWithStructConstraint<T> where T : struct
     {
-        public U Method_ReturnsU<U>()
-        {
-            return default(U);
-        }
+        public U Method_ReturnsU<U>() => default(U);
     }
 
-    public class MemberClassWithInterfaceConstraint<T>
-        where T : I
+    public class GenericClassWithInterfaceConstraint<T> where T : EmptyInterface
     {
         public dynamic Method_ReturnsDynamic<U, V>(int x, U u, V v) where V : U where U : T
         {
             return default(T);
         }
     }
-    #endregion
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass001.genclass001
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass001.genclass001;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
+    public class GenericMethodGenericClassTests
     {
+        public class NestedClass : GenericMethodGenericClassTests { }
+
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody1()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            if (Test.TestMethod() != 0)
-                return 1;
-            return 0;
-        }
-
-        public static int TestMethod()
-        {
-            dynamic mc = new MemberClass<int>();
-            int ret = mc.Method_ReturnsT<string>(string.Empty, "ab", null);
+            dynamic d = new GenericClass<int>();
+            int ret = d.Method_ReturnsT<string>(string.Empty, "ab", null);
             dynamic d1 = string.Empty;
             dynamic d2 = "ab";
-            ret += mc.Method_ReturnsT(d1, d2, null);
-            return ret;
+            ret += d.Method_ReturnsT(d1, d2, null);
+            Assert.Equal(0, ret);
         }
-    } //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass002.genclass002
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass002.genclass002;
-    // <Title> Tests generic class generic method used inside #if, #else block.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            if (Test.TestMethod() != null)
-                return 1;
-            return 0;
-        }
-
-        public static object TestMethod()
+        public static void IfElseBlock()
         {
 #if c1
-dynamic mc = new MemberClass<int>();
+dynamic mc = new GenericClass<int>();
 return (Test)mc.Method_ReturnsUConstraint<Test>(new Test());
- #else
-            dynamic mc = new MemberClass<int>();
-            object ret = mc.Method_ReturnsUConstraint<string>("1");
-            try
-            {
-                return (int)mc.Method_ReturnsUConstraint<string>(1);
-            }
-            catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-            {
-                if (ErrorVerifier.Verify(ErrorMessageId.NewConstraintNotSatisfied, e.Message, "MemberClass<T>.Method_ReturnsUConstraint<U>(T)", "U", "string"))
-                    return ret;
-            }
-
-            return new object();
+#else
+            dynamic d = new GenericClass<int>();
+            Assert.Null(d.Method_ReturnsUConstraint<string>("1"));
+            Assert.Throws<RuntimeBinderException>(() => (int)d.Method_ReturnsUConstraint<string>(1));
 #endif
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass003.genclass003
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass003.genclass003;
-    // <Title> Tests generic class generic method used in implicitly-typed variable initializer.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private static dynamic s_mc = new MemberClass<string>();
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ImplicitlyTypedVariableInitializer()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            var loc = (int)s_mc.Method_ReturnsU<int>(null);
-            if (loc != 0)
-                return 1;
-            return 0;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass006.genclass006
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass006.genclass006;
-    // <Title> Tests generic class generic method used in implicit or explicit operator.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy1 = new MemberClass<int>();
-            long result1 = (int)dy1.Method_ReturnsDynamic(1); //implicit
-            dynamic dy2 = new MemberClass<long>();
-            int result2 = (int)dy2.Method_ReturnsDynamic(1L); //explicit
-            return (result1 == result2) ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass007.genclass007
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass007.genclass007;
-    // <Title> Tests generic class generic method used in implicit operator.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        public class InnerTest1
-        {
-            public int field;
-            public static implicit operator InnerTest2(InnerTest1 t1)
-            {
-                dynamic dy = new MemberClass<InnerTest1>();
-                return new InnerTest2()
-                {
-                    field = (int)dy.Method_ReturnsU<int>(t1.field + 1)
-                }
-
-                ;
-            }
-        }
-
-        public class InnerTest2
-        {
-            public int field;
+            dynamic d = new GenericClass<string>();
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ImplicitExplicitOperator()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic dy1 = new GenericClass<int>();
+            long result1 = (int)dy1.Method_ReturnsDynamic(1); // implicit
+            dynamic dy2 = new GenericClass<long>();
+            int result2 = (int)dy2.Method_ReturnsDynamic(1L); // explicit
+            Assert.Equal(result1, result2);
         }
 
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass<InnerTest2>();
-            InnerTest2 result1 = (InnerTest1)dy.Method_ReturnsDynamic<InnerTest1>(new InnerTest2()
-            {
-                field = 0
-            }
-
-            , new InnerTest1()
-            {
-                field = 10
-            }
-
-            , 0); //implicit
-            return (result1.field == 11) ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass008.genclass008
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass008.genclass008;
-    // <Title> Tests generic class generic method used in foreach expression.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ForeachExpressionBody()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>();
-            List<string> list = new List<string>()
-            {
-            null, string.Empty, "Test"
-            }
-
-            ;
+            dynamic d = new GenericClass<string>();
+            List<string> list = new List<string>() { null, string.Empty, "Test" };
             List<string> list2 = new List<string>();
-            foreach (dynamic s in (IEnumerable)mc.Method_ReturnsDynamic<int, IEnumerable>(null, 0, list, string.Empty))
+            foreach (dynamic s in (IEnumerable)d.Method_ReturnsDynamic<int, IEnumerable>(null, 0, list, string.Empty))
             {
                 list2.Add(s);
             }
 
-            if (list2.Count == 3 && list2[0] == null && list2[1] == string.Empty && list2[2] == "Test")
-            {
-                return 0;
-            }
-            else
-                return 1;
+            Assert.Equal(new List<string>() { null, string.Empty, "Test" }, list2);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass009.genclass009
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass009.genclass009;
-    // <Title> Tests generic class generic method used in the foreach loop body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ForeachLoopBody()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>();
-            var list1 = new List<int>()
-            {
-            0, 1, 2
-            }
-
-            ;
-            var list2 = new List<int>();
+            dynamic mc = new GenericClass<string>();
+            List<int> list1 = new List<int>() { 0, 1, 2 };
+            List<int> list2 = new List<int>();
             foreach (int s in list1)
             {
                 list2.Add((int)mc.Method_ReturnsU<int, string>(null, null) + s);
             }
 
-            if (list2.Count == 3 && list2[0] == 0 && list2[1] == 1 && list2[2] == 2)
-            {
-                return 0;
-            }
-            else
-                return 1;
+            Assert.Equal(new List<int>() { 0, 1, 2 }, list2);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass010.genclass010
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass010.genclass010;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody2()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic mc = new GenericClass<string>();
+            Assert.Null((string)mc.Method_ReturnsT<long>(1.11f, string.Empty, 1L));
         }
 
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>();
-            if ((string)mc.Method_ReturnsT<long>(1.11f, string.Empty, 1L) == null)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass011.genclass011
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass011.genclass011;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test : I
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<int>();
-            if ((int)mc.Method_ReturnsT<I>(new Test()) == 0)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass012.genclass012
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass012.genclass012;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
+        public static void StaticMethodBody3()
         {
             string u = "Test";
             int v = 10;
-            dynamic mc = new MemberClass<long>();
-            long result = (long)mc.Method_ReturnsT<string, int>(out u, ref v);
-            if (result == 0 && u == null && v == 10)
-                return 0;
-            else
-                return 1;
+            dynamic d = new GenericClass<long>();
+            long result = (long)d.Method_ReturnsT<string, int>(out u, ref v);
+
+            Assert.Equal(0, result);
+            Assert.Equal(10, v);
+            Assert.Null(u);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass013.genclass013
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass013.genclass013;
-    // <Title> Tests generic class generic method used in while/do expression</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void WhileDoExpression()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<int>();
-            int[] array = new int[]
-            {
-            1, 2, 1, 3, 1
-            }
-
-            ;
+            dynamic d = new GenericClass<int>();
+            int[] array = new int[] { 1, 2, 1, 3, 1 };
             int i = 0;
-            while (i < array.Length && array[i] >= (int)mc.Method_ReturnsInt(array[i]))
+            while (i < array.Length && array[i] >= (int)d.Method_ReturnsInt(array[i]))
             {
-                array[i] = (int)mc.Method_ReturnsInt(array[i]);
+                array[i] = (int)d.Method_ReturnsInt(array[i]);
                 i++;
             }
 
             while (i < array.Length)
             {
-                if (array[i] != 1)
-                    return 1;
+                Assert.False(true);
+                Assert.Equal(1, array[i]);
             }
-
-            return 0;
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass014.genclass014
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass014.genclass014;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody4()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic d = new GenericClass<string>();
+            float result = (float)d.Method_ReturnsFloat<int, EmptyClass>(null, new EmptyClass(), 0);
+            Assert.Equal(3.4f, result);
         }
 
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>();
-            float result = (float)mc.Method_ReturnsFloat<int, C>(null, new C(), 0);
-            if (result == 3.4f)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass015.genclass015
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass015.genclass015;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
+        [Fact]
+        public static void StaticMethodBody5()
         {
             decimal dec = 0M;
-            dynamic mc = new MemberClass<string>();
-            float result = (float)mc.Method_ReturnsFloat<int, C>(null, new C(), 0, ref dec);
-            if (result == 3.4f && dec == 3M)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass016.genclass016
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass016.genclass016;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private int _field;
-        public Test()
-        {
-            _field = 10;
+            dynamic d = new GenericClass<string>();
+            float result = (float)d.Method_ReturnsFloat<int, EmptyClass>(null, new EmptyClass(), 0, ref dec);
+            Assert.Equal(3.4f, result);
+            Assert.Equal(3M, dec);
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody6()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>();
-            Test result = null;
-            try
-            {
-                result = (Test)mc.Method_ReturnsUConstraint<Test>(null);
-            }
-            catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-            {
-                if (ErrorVerifier.Verify(ErrorMessageId.AmbigCall, e.Message, "MemberClass<string>.Method_ReturnsUConstraint<Test>(Test)", "MemberClass<string>.Method_ReturnsUConstraint<Test>(string)"))
-                    result = new Test()
-                    {
-                        _field = 10
-                    }
-
-                    ;
-            }
-
-            if (result != null && result._field == 10)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass017.genclass017
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass017.genclass017;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        internal int Field;
-        public Test()
-        {
-            Field = 10;
-        }
-
-        public class InnerTest : Test
-        {
-            public InnerTest()
-            {
-                Field = 11;
-            }
+            dynamic d = new GenericClass<int>();
+            Assert.Throws<RuntimeBinderException>(() => (string)d.Method_ReturnsDynamicConstraint<string>(10, null, d));
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody7()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>();
-            Test result = (Test)mc.Method_ReturnsUConstraint<Test, InnerTest>(null, new InnerTest()
-            {
-                Field = 0
-            }
-
-            );
-            if (result == null)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass018.genclass018
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass018.genclass018;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<int>();
-            string result = "a";
-            try
-            {
-                result = (string)mc.Method_ReturnsDynamicConstraint<string>(10, null, mc);
-            }
-            catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-            {
-                if (ErrorVerifier.Verify(ErrorMessageId.NewConstraintNotSatisfied, e.Message, "MemberClass<T>.Method_ReturnsDynamicConstraint<U>(T, U, object)", "U", "string"))
-                    result = string.Empty;
-            }
-
-            if (result == string.Empty)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass019.genclass019
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass019.genclass019;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>();
+            dynamic d = new GenericClass<string>();
             dynamic mc2 = "Test2";
             dynamic mc3 = "Test3";
-            string result = (string)mc.Method_ReturnsDynamicConstraint<string, C>(null, mc2, new C(), mc3);
-            if (result == "Test2" && (string)mc3 == "Test3")
-                return 0;
-            else
-                return 1;
+            string result = (string)d.Method_ReturnsDynamicConstraint<string, EmptyClass>(null, mc2, new EmptyClass(), mc3);
+            Assert.Equal("Test2", result);
+            Assert.Equal("Test3", (string)mc3);
         }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass020.genclass020
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass020.genclass020;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        internal int Field;
-        public class InnerTest : Test
-        {
-        }
-
         
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            decimal dec = 10M;
-            dynamic mc = new MemberClass<Test>();
-            Test mc2 = new Test()
-            {
-                Field = 2
-            }
-
-            ;
-            dynamic dy2 = mc2;
-            Test mc3 = new InnerTest()
-            {
-                Field = 3
-            }
-
-            ;
-            float result = (float)mc.Method_ReturnsFloatConstraint<Test, InnerTest>(mc2, dy2, mc3, ref dec);
-            if (dec == 3M && result == 3.4f)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass021.genclass021
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass021.genclass021;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        internal int Field;
-        public class InnerTest : Test
-        {
-        }
-
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody_DynamicTypeDoesNotSatisfyConstraints()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic d = new GenericClass<string>();
+            GenericMethodGenericClassTests test = new GenericMethodGenericClassTests();
+            dynamic d2 = test;
+            Assert.Throws<RuntimeBinderException>(() => (string)d.Method_ReturnsTNegConstraint<GenericMethodGenericClassTests>(d2));
         }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<Test>();
-            Test mc2 = new Test()
-            {
-                Field = 2
-            }
-
-            ;
-            dynamic dy2 = mc2;
-            Test mc3 = new InnerTest()
-            {
-                Field = 3
-            }
-
-            ;
-            string result = (string)mc.Method_ReturnsStringConstraint<Test, InnerTest>(mc2, dy2, mc3);
-            if (result == string.Empty)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass023.genclass023
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass023.genclass023;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // Negative: dynamic type would not satisfy the constraints.
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>();
-            Test t = new Test();
-            dynamic dy = t;
-            try
-            {
-                string result = (string)mc.Method_ReturnsTNegConstraint<Test>(dy);
-            }
-            catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-            {
-                if (ErrorVerifier.Verify(ErrorMessageId.ValConstraintNotSatisfied, e.Message, "MemberClass<T>.Method_ReturnsTNegConstraint<U>(U)", "U", "Test"))
-                    return 0;
-            }
-
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass024.genclass024
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass024.genclass024;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test : I
-    {
-        internal int Field;
-        public class InnerTest : Test
-        {
-        }
-
         
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<Test>();
-            Test mc2 = new Test()
-            {
-                Field = 2
-            }
-
-            ;
-            dynamic dy2 = mc2;
-            Test mc3 = new InnerTest()
-            {
-                Field = 3
-            }
-
-            ;
-            dynamic dy3 = mc3;
-            decimal dec = 3;
-            decimal result = (decimal)mc.Method_ReturnsFloatNegConstraint<Test, InnerTest>(dy2, dy2, dy3, ref dec);
-            if (result != 3.4M)
-                return 1;
-            return 0;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass025.genclass025
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass025.genclass025;
-    // <Title> Tests generic class generic method used in anonymous method.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void AnonymousMethod()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>.NestedMemberClass<int>();
+            dynamic d = new GenericClass<string>.NestedGenericClass<int>();
             Func<string, int> func = delegate (string arg)
             {
-                return (int)mc.Method_ReturnsU(null);
-            }
-
-            ;
-            if (func(null) == 0)
-                return 0;
-            else
-                return 1;
+                return (int)d.Method_ReturnsU(null);
+            };
+            Assert.Equal(0, func(null));
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass026.genclass026
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass026.genclass026;
-    // <Title> Tests generic class generic method used in lambda expression.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void LambdaExpression()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic d = new GenericClass<string>.NestedGenericClass<int>();
+            Func<int, int, string> func = (int arg1, int arg2) => (string)d.Method_ReturnsT(arg1, arg1);
+            Assert.Null(func(1, 2));
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void StaticMethodBody8()
         {
-            dynamic mc = new MemberClass<string>.NestedMemberClass<int>();
-            Func<int, int, string> func = (int arg1, int arg2) => (string)mc.Method_ReturnsT(arg1, arg1);
-            if (func(1, 2) == null)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass027.genclass027
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass027.genclass027;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>.NestedMemberClass<int>();
+            dynamic mc = new GenericClass<string>.NestedGenericClass<int>();
             int u = 10;
             string v = "Test";
             string result = (string)mc.Method_ReturnsT<string>(out u, ref v);
-            if (u == 0 && v == "Test" && result == null)
-                return 0;
-            else
-                return 1;
+            Assert.Equal(0, u);
+            Assert.Equal("Test", v);
+            Assert.Null(result);
         }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass028.genclass028
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass028.genclass028;
-    // <Title> Tests generic class generic method used in volatile field initializer.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private dynamic _mc = new MemberClass<string>.NestedMemberClass<string>();
-        private dynamic _dy = "Me";
-        private volatile dynamic _field;
-        public Test()
-        {
-            _field = _mc.Method_ReturnsDynamic(null, "Test", _dy);
-        }
-
+        
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody9()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            Test t = new Test();
-            if ((string)t._field == "Test")
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass030.genclass030
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass030.genclass030;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<Test>.NestedMemberClass<Test>();
-            Test t = new Test();
+            dynamic mc = new GenericClass<GenericMethodGenericClassTests>.NestedGenericClass<GenericMethodGenericClassTests>();
+            GenericMethodGenericClassTests t = new GenericMethodGenericClassTests();
             dynamic dy = t;
             decimal result = (decimal)mc.Method_ReturnsDecimal<int>(t, dy, t);
-            if (result == 3.4M)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass031.genclass031
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass031.genclass031;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            Assert.Equal(3.4M, result);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void StaticMethodBody10()
         {
             double dec = 1.1D;
-            dynamic mc = new MemberClass<Test>.NestedMemberClass<Test>();
-            Test t = new Test();
+            dynamic mc = new GenericClass<GenericMethodGenericClassTests>.NestedGenericClass<GenericMethodGenericClassTests>();
+            GenericMethodGenericClassTests t = new GenericMethodGenericClassTests();
             dynamic dy = t;
             byte result = (byte)mc.Method_ReturnsByte<int>(t, dy, t, ref dec);
-            if (result == 4 && dec == 3)
-                return 0;
-            else
-                return 1;
+            Assert.Equal(4, result);
+            Assert.Equal(3, dec);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass032.genclass032
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass032.genclass032;
-    // <Title> Tests generic class generic method used in the default section statement list.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private static int s_field = 1;
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void DefaultSwitchStatement()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClassWithClassConstraint<string>();
-            int result = 0;
-            switch (s_field)
+            dynamic mc = new GenericClassWithClassConstraint<string>();
+            int result = -1;
+            switch (result)
             {
                 case 0:
-                    result = -1;
                     break;
                 default:
                     result = (int)mc.Method_ReturnsInt<string>();
                     break;
             }
-
-            if (result == 1)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass033.genclass033
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass033.genclass033;
-    // <Title> Tests generic class generic method used in the switch section statement list.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private static int s_field = 0;
-        public class InnerTest : Test
-        {
+            Assert.Equal(1, result);
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SwitchStatement()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClassWithClassConstraint<Test>();
-            Test result = new InnerTest();
+            dynamic mc = new GenericClassWithClassConstraint<GenericMethodGenericClassTests>();
+            GenericMethodGenericClassTests result = new NestedClass();
             dynamic innertest = result;
-            switch (s_field)
+            int field = 0;
+            switch (field)
             {
                 case 0:
-                    result = (Test)mc.Method_ReturnsT<InnerTest, InnerTest>(3.2M, innertest);
+                    result = (GenericMethodGenericClassTests)mc.Method_ReturnsT<NestedClass, NestedClass>(3.2M, innertest);
                     break;
                 default:
                     break;
             }
-
-            if (result == null)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass034.genclass034
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass034.genclass034;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        public class InnerTest : Test
-        {
+            Assert.Null(result);
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody11()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClassWithNewConstraint<Test>();
-            InnerTest result = (InnerTest)mc.Method_ReturnsU<InnerTest>();
-            if (result == null)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass035.genclass035
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass035.genclass035;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private int _field;
-        public Test()
-        {
-            _field = 10;
-        }
-
-        public class InnerTest : Test
-        {
-            public InnerTest()
-            {
-                _field = 11;
-            }
+            dynamic mc = new GenericClassWithNewConstraint<GenericMethodGenericClassTests>();
+            NestedClass result = (NestedClass)mc.Method_ReturnsU<NestedClass>();
+            Assert.Null(result);
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody12()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClassWithNewConstraint<Test>();
-            var t = new InnerTest()
-            {
-                _field = 0
-            }
-
-            ;
-            Test result = (Test)mc.Method_ReturnsDynamic<InnerTest>(t, t);
-            if (result._field == 10)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass036.genclass036
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass036.genclass036;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        public class InnerTest : Test
-        {
+            dynamic d = new GenericClassWithAnotherTypeConstraint<NestedClass, NestedClass>();
+            GenericMethodGenericClassTests result = (GenericMethodGenericClassTests)d.Method_ReturnsU();
+            Assert.Null(result);
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ImplicitlyTypedVariableInitializer2()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClassWithAnotherTypeConstraint<InnerTest, Test>();
-            Test result = (Test)mc.Method_ReturnsU();
-            if (result == null)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass037.genclass037
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass037.genclass037;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        public class InnerTest : Test
-        {
-        }
-
-        public class InnerTest2 : Test
-        {
-        }
-
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClassWithAnotherTypeConstraint<InnerTest, Test>();
-            InnerTest result = (InnerTest)mc.Method_ReturnsDynamic<InnerTest2>(0, new Test(), new InnerTest2());
-            if (result == null)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass038.genclass038
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass038.genclass038;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // Negative:dynamic type would not satisfy the constraints
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test : C
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClassWithUDClassConstraint<C>();
+            dynamic d = new GenericClass<string>();
+            bool threwRuntimeBinderException = false;
             try
             {
-                dynamic result = mc.Method_ReturnsU<dynamic>();
+                var loc = d.Method_ReturnsU(null);
             }
-            catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
+            catch (RuntimeBinderException)
             {
-                if (ErrorVerifier.Verify(ErrorMessageId.GenericConstraintNotSatisfiedRefType, e.Message, "MemberClassWithUDClassConstraint<T>.Method_ReturnsU<U>()", "C", "U", "object"))
-                    //    ex.Message.Contains("'MemberClassWithUDClassConstraint<T>.Method_ReturnsU<U>()'"))
-                    return 0;
+                threwRuntimeBinderException = true;
             }
-
-            return 1;
+            Assert.True(threwRuntimeBinderException);
         }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass041.genclass041
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass041.genclass041;
-    // <Title> Tests generic class generic method used in explicit operator.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        public class InnerTest1
+        
+        [Fact]
+        public static void ForeachExpression()
         {
-            public int field;
-            public static explicit operator InnerTest2(InnerTest1 t1)
+            dynamic d = new GenericClass<string>();
+            List<string> list = new List<string>() { null, string.Empty, "Test" };
+            List<string> list2 = new List<string>();
+            foreach (string s in d.Method_ReturnsDynamic(null, 0, list, d))
             {
-                dynamic dy = new MemberClass<InnerTest1>();
-                return new InnerTest2()
-                {
-                    field = (int)dy.Method_ReturnsU<int>(t1.field + 1)
-                }
-
-                ;
+                list2.Add(s);
             }
-        }
 
-        public class InnerTest2
-        {
-            public int field;
+            Assert.Equal(new List<string>() { null, string.Empty, "Test" }, list2);
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody13()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic d = new GenericClass<string>();
+            Assert.Null(d.Method_ReturnsT(1.11f, string.Empty, 1L));
         }
 
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass<InnerTest2>();
-            InnerTest2 result1 = (InnerTest2)((InnerTest1)dy.Method_ReturnsDynamic<InnerTest1>(new InnerTest2()
-            {
-                field = 0
-            }
-
-            , new InnerTest1()
-            {
-                field = 10
-            }
-
-            , 0)); //explicit
-            return (result1.field == 11) ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass003a.genclass003a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass003a.genclass003a;
-    // <Title> Tests generic class generic method used in implicitly-typed variable initializer.</Title>
-    // <Description>
-    // Type inference.
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private static dynamic s_mc = new MemberClass<string>();
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody14()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic u = "Test";
+            dynamic v = 10;
+            dynamic d = new GenericClass<long>();
+            long result = d.Method_ReturnsT(out u, ref v);
+            Assert.Equal(0, result);
+            Assert.Null(u);
+            Assert.Equal(10, v);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void StaticMethodBody15()
         {
-            try
-            {
-                var loc = s_mc.Method_ReturnsU(null);
-            }
-            catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-            {
-                if (ErrorVerifier.Verify(ErrorMessageId.CantInferMethTypeArgs, e.Message, "MemberClass<string>.Method_ReturnsU<U>(string)"))
-                    return 0;
-            }
+            dynamic d1 = new GenericClass<string>();
+            dynamic d2 = "Test2";
+            dynamic d3 = "Test3";
+            string result = d1.Method_ReturnsDynamicConstraint(null, d2, new EmptyClass(), d3);
+            Assert.Equal("Test2", result);
+            Assert.Equal("Test3", d3);
+        }
 
-            return 1;
+        [Fact]
+        public static void StaticMethodBody16()
+        {
+            dynamic d = new GenericClass<string>();
+            GenericMethodGenericClassTests t = new GenericMethodGenericClassTests();
+            Assert.Throws<RuntimeBinderException>(() => d.Method_ReturnsTNegConstraint(t));
+        }
+
+        [Fact]
+        public static void StaticMethodBody17()
+        {
+            dynamic d = new GenericClass<string>.NestedGenericClass<int>();
+            int u = 10;
+            string v = "Test";
+            string result = d.Method_ReturnsT(out u, ref v);
+            Assert.Equal(0, u);
+            Assert.Equal("Test", v);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public static void StaticMethodBody18()
+        {
+            dynamic d1 = new GenericClass<string>.NestedGenericClass<string>();
+            dynamic dy = "Me";
+            dynamic result = d1.Method_ReturnsDynamic(null, "Test", 10, dy);
+            Assert.Equal(10, result);
         }
     }
-    //</Code>
-}
 
+    public class ClassWithImplicitlyTypedVariableInitializer
+    {
+        private static dynamic s_d = new GenericClass<string>();
 
+        [Fact]
+        public static void ImplicitlyTypedVariableInitializer()
+        {
+            var result = (int)s_d.Method_ReturnsU<int>(null);
+            Assert.Equal(0, result);
+        }
+    }
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass007a.genclass007a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass007a.genclass007a;
-    // <Title> Tests generic class generic method used in implicit operator.</Title>
-    // <Description>
-    // Type inference.
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
+    public class ClassWithImplicitOperator1
     {
         public class InnerTest1
         {
             public int field;
             public static implicit operator InnerTest2(InnerTest1 t1)
             {
-                dynamic dy = new MemberClass<InnerTest1>();
+                dynamic dy = new GenericClass<InnerTest1>();
                 return new InnerTest2()
                 {
-                    field = dy.Method_ReturnsU(t1.field + 1)
-                }
-
-                ;
+                    field = (int)dy.Method_ReturnsU<int>(t1.field + 1)
+                };
             }
         }
 
@@ -1904,559 +593,80 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ImplicitOperator()
         {
-            Assert.Equal(0, MainMethod());
-        }
+            dynamic d = new GenericClass<InnerTest2>();
+            InnerTest2 result1 = (InnerTest1)d.Method_ReturnsDynamic<InnerTest1>(
+                new InnerTest2() { field = 0 },
+                new InnerTest1() { field = 10 },
+                0);
 
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass<InnerTest2>();
-            InnerTest2 result1 = dy.Method_ReturnsDynamic(new InnerTest2()
-            {
-                field = 0
-            }
-
-            , new InnerTest1()
-            {
-                field = 10
-            }
-
-            , 0); //implicit
-            return (result1.field == 11) ? 0 : 1;
+            Assert.Equal(11, result1.field);
         }
     }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass008a.genclass008a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass008a.genclass008a;
-    // <Title> Tests generic class generic method used in foreach expression.</Title>
-    // <Description>
-    // Type inference.
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-
-    public class Test
+    public class ClassWithVolatileMembers
     {
-        [Fact]
-        public static void DynamicCSharpRunTest()
+        private dynamic _mc = new GenericClass<string>.NestedGenericClass<string>();
+        private dynamic _dy = "Me";
+        private volatile dynamic _field;
+        public ClassWithVolatileMembers()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>();
-            List<string> list = new List<string>()
-            {
-            null, string.Empty, "Test"
-            }
-
-            ;
-            List<string> list2 = new List<string>();
-            foreach (string s in mc.Method_ReturnsDynamic(null, 0, list, mc))
-            {
-                list2.Add(s);
-            }
-
-            if (list2.Count == 3 && list2[0] == null && list2[1] == string.Empty && list2[2] == "Test")
-            {
-                return 0;
-            }
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass010a.genclass010a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass010a.genclass010a;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // Type inference.
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>();
-            if (mc.Method_ReturnsT(1.11f, string.Empty, 1L) == null)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass011a.genclass011a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass011a.genclass011a;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // Type inference.
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test : I
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<int>();
-            I i = new Test();
-            dynamic d = i;
-            if (mc.Method_ReturnsT(d) == 0)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass011b.genclass011b
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass011b.genclass011b;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // Type inference.
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test : I
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<int>();
-            dynamic d = new Test();
-            if (mc.Method_ReturnsT<I>(d) == 0)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass012a.genclass012a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass012a.genclass012a;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // Type inference
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic u = "Test";
-            dynamic v = 10;
-            dynamic mc = new MemberClass<long>();
-            long result = mc.Method_ReturnsT(out u, ref v);
-            if (result == 0 && u == null && v == 10)
-            {
-                return 0;
-            }
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass016a.genclass016a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass016a.genclass016a;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // Type inference
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(13,9\).*CS0414</Expects>
-    using System;
-
-    public class Test
-    {
-        private int _field;
-        public Test()
-        {
-            _field = 10;
+            _field = _mc.Method_ReturnsDynamic(null, "Test", _dy);
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>();
-            Test result = null;
-            result = mc.Method_ReturnsUConstraint(result);
-            if (result == null)
-                return 0;
-            else
-                return 1;
+            ClassWithVolatileMembers t = new ClassWithVolatileMembers();
+            Assert.Equal("Test", (string)t._field);
         }
     }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass019a.genclass019a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass019a.genclass019a;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // Type inference
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
+    public class ClassWithTwoNestedClasses
     {
+        public class NestedClass1 : ClassWithTwoNestedClasses { }
+        public class NestedClass2 : ClassWithTwoNestedClasses { }
+
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody1()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>();
-            dynamic mc2 = "Test2";
-            dynamic mc3 = "Test3";
-            string result = mc.Method_ReturnsDynamicConstraint(null, mc2, new C(), mc3);
-            if (result == "Test2" && mc3 == "Test3")
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass023a.genclass023a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass023a.genclass023a;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // Negative: dynamic type would not satisfy the constraints. Type inference
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>();
-            Test t = new Test();
-            try
-            {
-                string result = mc.Method_ReturnsTNegConstraint(t); // not bind to any method.
-            }
-            catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-            {
-                if (ErrorVerifier.Verify(ErrorMessageId.ValConstraintNotSatisfied, e.Message, "MemberClass<T>.Method_ReturnsTNegConstraint<U>(U)", "U", "Test"))
-                    return 0;
-            }
-
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass027a.genclass027a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass027a.genclass027a;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>Type inference
-    //           out/ref need exact match
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>.NestedMemberClass<int>();
-            int u = 10;
-            string v = "Test";
-            string result = mc.Method_ReturnsT(out u, ref v);
-            if (u == 0 && v == "Test" && result == null)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass029a.genclass029a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass029a.genclass029a;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // Type inference
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass<string>.NestedMemberClass<string>();
-            dynamic dy = "Me";
-            dynamic result = mc.Method_ReturnsDynamic(null, "Test", 10, dy);
-            if (result == 10)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass035a.genclass035a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass035a.genclass035a;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // Type inference
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private int _field;
-        public Test()
-        {
-            _field = 10;
-        }
-
-        public class InnerTest : Test
-        {
-            public InnerTest()
-            {
-                _field = 11;
-            }
+            dynamic d = new GenericClassWithAnotherTypeConstraint<NestedClass1, ClassWithTwoNestedClasses>();
+            NestedClass1 result = (NestedClass1)d.Method_ReturnsDynamic<NestedClass2>(0, new ClassWithTwoNestedClasses(), new NestedClass2());
+            Assert.Null(result);
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody2()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClassWithNewConstraint<Test>();
-            Test t = new InnerTest()
-            {
-                _field = 0
-            }
-
-            ;
-            Test result = mc.Method_ReturnsDynamic(t, t);
-            if (result._field == 10)
-                return 0;
-            else
-                return 1;
+            dynamic d = new GenericClassWithAnotherTypeConstraint<NestedClass1, ClassWithTwoNestedClasses>();
+            NestedClass1 result = (NestedClass1)d.Method_ReturnsDynamic(0, new ClassWithTwoNestedClasses(), new NestedClass2());
+            Assert.Null(result);
         }
     }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass037a.genclass037a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass037a.genclass037a;
-    // <Title> Tests generic class generic method used in static method body.</Title>
-    // <Description>
-    // Type inference
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
+    public class ClassWithEmptyBaseClass : EmptyClass
     {
-        public class InnerTest : Test
-        {
-        }
-
-        public class InnerTest2 : Test
-        {
-        }
-
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClassWithAnotherTypeConstraint<InnerTest, Test>();
-            InnerTest result = (InnerTest)mc.Method_ReturnsDynamic(0, new Test(), new InnerTest2());
-            if (result == null)
-                return 0;
-            else
-                return 1;
+            dynamic d = new GenericClassWithUDClassConstraint<EmptyClass>();
+            Assert.Throws<RuntimeBinderException>(() => d.Method_ReturnsU<dynamic>());
         }
     }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass041a.genclass041a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclassgenmeth.genclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.genclass.genclass041a.genclass041a;
-    // <Title> Tests generic class generic method used in explicit operator.</Title>
-    // <Description>
-    // Type inference
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
+    public class ClassWithExplicitOperator2
     {
         public class InnerTest1
         {
             public int field;
             public static explicit operator InnerTest2(InnerTest1 t1)
             {
-                dynamic dy = new MemberClass<InnerTest1>();
+                dynamic dy = new GenericClass<InnerTest1>();
                 return new InnerTest2()
                 {
-                    field = dy.Method_ReturnsU(t1.field + 1)
-                }
-
-                ;
+                    field = (int)dy.Method_ReturnsU<int>(t1.field + 1)
+                };
             }
         }
 
@@ -2466,27 +676,219 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ExplicitOperator()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass<InnerTest2>();
-            InnerTest2 result1 = (InnerTest2)((InnerTest1)dy.Method_ReturnsDynamic(new InnerTest2()
-            {
-                field = 0
-            }
-
-            , new InnerTest1()
-            {
-                field = 10
-            }
-
-            , 0)); //explicit
-            return (result1.field == 11) ? 0 : 1;
+            dynamic d = new GenericClass<InnerTest2>();
+            InnerTest2 result1 = (InnerTest2)((InnerTest1)d.Method_ReturnsDynamic<InnerTest1>(
+            new InnerTest2() { field = 0 },
+            new InnerTest1() { field = 10 },
+            0)); //explicit
+            Assert.Equal(11, result1.field);
         }
     }
-    //</Code>
+
+    public class ClassWithImplicitOperator2
+    {
+        public class InnerTest1
+        {
+            public int field;
+            public static implicit operator InnerTest2(InnerTest1 t1)
+            {
+                dynamic dy = new GenericClass<InnerTest1>();
+                return new InnerTest2() { field = dy.Method_ReturnsU(t1.field + 1) };
+            }
+        }
+
+        public class InnerTest2
+        {
+            public int field;
+        }
+
+        [Fact]
+        public static void ImplicitOperator()
+        {
+            dynamic d = new GenericClass<InnerTest2>();
+            InnerTest2 result = d.Method_ReturnsDynamic(
+                new InnerTest2() { field = 0 },
+                new InnerTest1() { field = 10 },
+                0); // implicit;
+
+            Assert.Equal(11, result.field);
+        }
+    }
+
+    public class ClassWithEmptyInterface : EmptyInterface
+    {
+        [Fact]
+        public static void StaticMethodBody1()
+        {
+            dynamic d = new GenericClass<int>();
+            Assert.Equal(0, (int)d.Method_ReturnsT<EmptyInterface>(new ClassWithEmptyInterface()));
+        }
+
+        [Fact]
+        public static void StaticMethodBody2()
+        {
+            dynamic d1 = new GenericClass<int>();
+            EmptyInterface i = new ClassWithEmptyInterface();
+            dynamic d2 = i;
+            Assert.Equal(0, d1.Method_ReturnsT(d2));
+        }
+
+        [Fact]
+        public static void StaticMethodBody3()
+        {
+            dynamic mc = new GenericClass<int>();
+            dynamic d = new ClassWithEmptyInterface();
+            Assert.Equal(0, mc.Method_ReturnsT<EmptyInterface>(d));
+        }
+    }
+
+    public class ClassWithSinglePrivateField
+    {
+        private int _field;
+        public ClassWithSinglePrivateField()
+        {
+            _field = 10;
+        }
+
+        [Fact]
+        public static void StaticMethodBody1()
+        {
+            dynamic d = new GenericClass<string>();
+            Assert.Throws<RuntimeBinderException>(() => (ClassWithSinglePrivateField)d.Method_ReturnsUConstraint<ClassWithSinglePrivateField>(null));
+        }
+
+        [Fact]
+        public static void StaticMethodBody2()
+        {
+            dynamic d = new GenericClass<string>();
+            ClassWithSinglePrivateField result = null;
+            result = d.Method_ReturnsUConstraint(result);
+            Assert.Null(result);
+        }
+    }
+
+    public class ClassWithSimpleInternalFieldAndNestedClass
+    {
+        internal int _field;
+        public ClassWithSimpleInternalFieldAndNestedClass()
+        {
+            _field = 10;
+        }
+
+        public class NestedClass : ClassWithSimpleInternalFieldAndNestedClass
+        {
+            public NestedClass()
+            {
+                _field = 11;
+            }
+        }
+
+        [Fact]
+        public static void StaticMethodBody1()
+        {
+            dynamic d = new GenericClass<string>();
+            ClassWithSimpleInternalFieldAndNestedClass result = (ClassWithSimpleInternalFieldAndNestedClass)d.Method_ReturnsUConstraint<ClassWithSimpleInternalFieldAndNestedClass, NestedClass>(null, new NestedClass() { _field = 0 });
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public static void StaticMethodBody2()
+        {
+            dynamic d = new GenericClassWithNewConstraint<ClassWithSimpleInternalFieldAndNestedClass>();
+            var t = new NestedClass() { _field = 0 };
+            ClassWithSimpleInternalFieldAndNestedClass result = (ClassWithSimpleInternalFieldAndNestedClass)d.Method_ReturnsDynamic<NestedClass>(t, t);
+            Assert.Equal(10, result._field);
+        }
+
+        [Fact]
+        public static void StaticMethodBody3()
+        {
+            dynamic mc = new GenericClassWithNewConstraint<ClassWithSimpleInternalFieldAndNestedClass>();
+            ClassWithSimpleInternalFieldAndNestedClass t = new NestedClass() { _field = 0 };
+            ClassWithSimpleInternalFieldAndNestedClass result = mc.Method_ReturnsDynamic(t, t);
+            Assert.Equal(10, result._field);
+        }
+    }
+
+    public class ClassWithSimpleInternalFieldAndEmptyNestedClass
+    {
+        internal int Field;
+        public class NestedClass : ClassWithSimpleInternalFieldAndEmptyNestedClass { }
+
+        [Fact]
+        public static void StaticMethodBody1()
+        {
+            decimal dec = 10M;
+            dynamic d = new GenericClass<ClassWithSimpleInternalFieldAndEmptyNestedClass>();
+            ClassWithSimpleInternalFieldAndEmptyNestedClass mc2 = new ClassWithSimpleInternalFieldAndEmptyNestedClass() { Field = 2 };
+            dynamic dy2 = mc2;
+            ClassWithSimpleInternalFieldAndEmptyNestedClass mc3 = new NestedClass() { Field = 3 };
+
+            float result = (float)d.Method_ReturnsFloatConstraint<ClassWithSimpleInternalFieldAndEmptyNestedClass, NestedClass>(mc2, dy2, mc3, ref dec);
+            Assert.Equal(3M, dec);
+            Assert.Equal(3.4f, result);
+        }
+
+        [Fact]
+        public static void StaticMethodBody2()
+        {
+            dynamic mc = new GenericClass<ClassWithSimpleInternalFieldAndEmptyNestedClass>();
+            ClassWithSimpleInternalFieldAndEmptyNestedClass mc2 = new ClassWithSimpleInternalFieldAndEmptyNestedClass() { Field = 2 };
+            dynamic dy2 = mc2;
+            ClassWithSimpleInternalFieldAndEmptyNestedClass mc3 = new NestedClass() { Field = 3 };
+            string result = (string)mc.Method_ReturnsStringConstraint<ClassWithSimpleInternalFieldAndEmptyNestedClass, NestedClass>(mc2, dy2, mc3);
+            Assert.Equal(string.Empty, result);
+        }
+    }
+
+    public class ClassWithSimpleInternalFieldEmptyNestedClassAndEmptyInterface : EmptyInterface
+    {
+        internal int Field;
+        public class NestedClass : ClassWithSimpleInternalFieldEmptyNestedClassAndEmptyInterface { }
+
+        [Fact]
+        public static void StaticMethodBody()
+        {
+            dynamic mc = new GenericClass<ClassWithSimpleInternalFieldEmptyNestedClassAndEmptyInterface>();
+            ClassWithSimpleInternalFieldEmptyNestedClassAndEmptyInterface mc2 = new ClassWithSimpleInternalFieldEmptyNestedClassAndEmptyInterface() { Field = 2 };
+            dynamic dy2 = mc2;
+
+            ClassWithSimpleInternalFieldEmptyNestedClassAndEmptyInterface mc3 = new NestedClass() { Field = 3 };
+            dynamic dy3 = mc3;
+            decimal dec = 3;
+            decimal result = (decimal)mc.Method_ReturnsFloatNegConstraint<ClassWithSimpleInternalFieldEmptyNestedClassAndEmptyInterface, NestedClass>(dy2, dy2, dy3, ref dec);
+            Assert.Equal(3.4M, result);
+        }
+    }
+    
+    public class ClasWithExplicitOperator2
+    {
+        public class InnerTest1
+        {
+            public int field;
+            public static explicit operator InnerTest2(InnerTest1 t1)
+            {
+                dynamic dy = new GenericClass<InnerTest1>();
+                return new InnerTest2() { field = dy.Method_ReturnsU(t1.field + 1) };
+            }
+        }
+
+        public class InnerTest2
+        {
+            public int field;
+        }
+
+        [Fact]
+        public static void ExplicitOperator()
+        {
+            dynamic dy = new GenericClass<InnerTest2>();
+            InnerTest2 result = (InnerTest2)((InnerTest1)dy.Method_ReturnsDynamic(
+                new InnerTest2() { field = 0 },
+                new InnerTest1() { field = 10 },
+                0)); //explicit
+            Assert.Equal(11, result.field);
+        }
+    }
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.method.genmethod.regclass.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.method.genmethod.regclass.cs
@@ -2,35 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Collections;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth
+namespace Dynamic.RegularClass.GenericMethod.Tests
 {
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass001.regclass001;
-    using System;
-    using System.Collections.Generic;
+    public class EmptyClass { }
 
-    public class C
+    public interface EmptyInterface { }
+
+    public class NonGenericClass
     {
-    }
+        public T Method_ReturnsT<T>() => default(T);
 
-    public interface I
-    {
-    }
-
-    public class MemberClass
-    {
-        #region Instance methods
-        public T Method_ReturnsT<T>()
-        {
-            return default(T);
-        }
-
-        public T Method_ReturnsT<T>(T t)
-        {
-            return t;
-        }
+        public T Method_ReturnsT<T>(T t) => t;
 
         public T Method_ReturnsT<T, U>(out T t)
         {
@@ -44,30 +35,15 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
             return t;
         }
 
-        public T Method_ReturnsT<T>(params T[] t)
-        {
-            return default(T);
-        }
+        public T Method_ReturnsT<T>(params T[] t) => default(T);
 
-        public int M<T>(T t) where T : IEnumerable<T>
-        {
-            return 3;
-        }
+        public int M<T>(T t) where T : IEnumerable<T> => 3;
 
-        public T Method_ReturnsT<T, U>(params U[] d)
-        {
-            return default(T);
-        }
+        public T Method_ReturnsT<T, U>(params U[] d) => default(T);
 
-        public T Method_ReturnsT<T, U>(float x, T t, U u)
-        {
-            return default(T);
-        }
+        public T Method_ReturnsT<T, U>(float x, T t, U u) => default(T);
 
-        public T Method_ReturnsT<T, U>(U u)
-        {
-            return default(T);
-        }
+        public T Method_ReturnsT<T, U>(U u) => default(T);
 
         public T Method_ReturnsT<T, U, V>(out U u, ref V v)
         {
@@ -75,20 +51,11 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
             return default(T);
         }
 
-        public int Method_ReturnsInt<T>(T t)
-        {
-            return 1;
-        }
+        public int Method_ReturnsInt<T>(T t) => 1;
 
-        public string Method_ReturnsString<T, U>(T t, U u)
-        {
-            return "foo";
-        }
+        public string Method_ReturnsString<T, U>(T t, U u) => "foo";
 
-        public float Method_ReturnsFloat<T, U, V>(T t, dynamic d, U u)
-        {
-            return 3.4f;
-        }
+        public float Method_ReturnsFloat<T, U, V>(T t, dynamic d, U u) => 3.4f;
 
         public float Method_ReturnsFloat<T, U, V>(T t, dynamic d, U u, ref decimal dec)
         {
@@ -96,22 +63,12 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
             return 3.4f;
         }
 
-        public dynamic Method_ReturnsDynamic<T>(T t)
-        {
-            return t;
-        }
+        public dynamic Method_ReturnsDynamic<T>(T t) => t;
 
-        public dynamic Method_ReturnsDynamic<T, U>(T t, U u, dynamic d)
-        {
-            return u;
-        }
+        public dynamic Method_ReturnsDynamic<T, U>(T t, U u, dynamic d) => u;
 
-        public dynamic Method_ReturnsDynamic<T, U, V>(T t, U u, V v, dynamic d)
-        {
-            return v;
-        }
-
-        #region Constraints on methods that have a new type parameter
+        public dynamic Method_ReturnsDynamic<T, U, V>(T t, U u, V v, dynamic d) => v;
+        
         public U Method_ReturnsUConstraint<U>(U u) where U : class
         {
             return null;
@@ -150,7 +107,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
 
         //These are negative methods... you should not be able to call them with the dynamic type because the dynamic type would not satisfy the constraints
         //you cannot call this like: Method_ReturnsUConstraint<dynamic>(d); because object does not derive from C
-        public U Method_ReturnsUNegConstraint<U>(U u) where U : C
+        public U Method_ReturnsUNegConstraint<U>(U u) where U : EmptyClass
         {
             return null;
         }
@@ -160,25 +117,17 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
             return default(T);
         }
 
-        public float Method_ReturnsFloatNegConstraint<T, U, V>(T t, dynamic d, U u, ref decimal dec) where V : U where U : I
+        public float Method_ReturnsFloatNegConstraint<T, U, V>(T t, dynamic d, U u, ref decimal dec) where V : U where U : EmptyInterface
         {
             dec = 3m;
             return 3.4f;
         }
-
-        #endregion
-        #region Nested class
-        public class NestedMemberClass<U>
+        
+        public class NestedGenericClass<U>
         {
-            public U Method_ReturnsU(U t)
-            {
-                return default(U);
-            }
+            public U Method_ReturnsU(U t) => default(U);
 
-            public U Method_ReturnsT(params U[] d)
-            {
-                return default(U);
-            }
+            public U Method_ReturnsT(params U[] d) => default(U);
 
             public U Method_ReturnsT<V>(out U u, ref V v)
             {
@@ -186,20 +135,11 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
                 return default(U);
             }
 
-            public dynamic Method_ReturnsDynamic(U t, U u, dynamic d)
-            {
-                return u;
-            }
+            public dynamic Method_ReturnsDynamic(U t, U u, dynamic d) => u;
 
-            public dynamic Method_ReturnsDynamic<V>(U t, U u, V v, dynamic d)
-            {
-                return v;
-            }
+            public dynamic Method_ReturnsDynamic<V>(U t, U u, V v, dynamic d) => v;
 
-            public decimal Method_ReturnsDecimal<V>(U t, dynamic d, U u)
-            {
-                return 3.4m;
-            }
+            public decimal Method_ReturnsDecimal<V>(U t, dynamic d, U u) => 3.4m;
 
             public byte Method_ReturnsByte<V>(U t, dynamic d, U u, ref double dec)
             {
@@ -207,387 +147,268 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
                 return 4;
             }
         }
-        #endregion
-        #endregion
     }
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass001.regclass001
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass001.regclass001;
-    // <Title> Tests regular class generic method used in regular method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
+    public class RegularClassGenericMethodTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public void RegularMethodBody()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic d = new NonGenericClass();
+            Assert.False((bool)d.Method_ReturnsT<bool>());
         }
 
-        public static int MainMethod()
-        {
-            Test t = new Test();
-            if (t.TestMethod())
-                return 1;
-            return 0;
-        }
+        private static dynamic s_mc = new NonGenericClass();
+        public int _loc = (int)s_mc.Method_ReturnsT<int, string>(string.Empty, null, "abc");
 
-        public bool TestMethod()
-        {
-            dynamic mc = new MemberClass();
-            return (bool)mc.Method_ReturnsT<bool>();
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass002.regclass002
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass002.regclass002;
-    // <Title> Tests regular class generic method used in variable initializer.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private static dynamic s_mc = new MemberClass();
-        private int _loc = (int)s_mc.Method_ReturnsT<int, string>(string.Empty, null, "abc");
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void VariableInitializer()
         {
-            Assert.Equal(0, MainMethod());
+            RegularClassGenericMethodTests t = new RegularClassGenericMethodTests();
+            Assert.Equal(0, t._loc);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void VariableNamedDynamic()
         {
-            Test t = new Test();
-            if (t._loc != 0)
-                return 1;
-            return 0;
+            int i = 1;
+            dynamic dynamic = new NonGenericClass();
+            int result = dynamic.Method_ReturnsT<int>(ref i);
+            Assert.Equal(0, i);
+            Assert.Equal(0, result);
+        }
+
+        public T TestMethod<T>(T t)
+        {
+            dynamic d = new NonGenericClass();
+            return (T)d.Method_ReturnsT<T>(t, t, t);
+        }
+
+        [Fact]
+        public void RegularMethodBody2()
+        {
+            RegularClassGenericMethodTests t1 = new RegularClassGenericMethodTests();
+            Assert.Equal(0, t1.TestMethod(1L));
+        }
+
+        [Fact]
+        public static void ImplicitlyTypedVariableInitializer1()
+        {
+            dynamic d = new NonGenericClass();
+            string u = string.Empty;
+            string v = string.Empty;
+            var result = (int)d.Method_ReturnsT<int, string, string>(out u, ref v);
+            Assert.Equal(0, result);
+            Assert.Null(u);
+            Assert.Equal(string.Empty, v);
+        }
+
+        [Fact]
+        public static void ImplicitlyTypedVariableIntializer2()
+        {
+            dynamic mc = new NonGenericClass();
+            var tc = new
+            {
+                A1 = (int)mc.Method_ReturnsInt<int>(0),
+                A2 = (string)mc.Method_ReturnsString<int, int>(1, 2)
+            };
+            Assert.Equal(1, tc.A1);
+            Assert.Equal("foo", tc.A2);
+        }
+
+        [Fact]
+        public static void Operator()
+        {
+            dynamic d = new NonGenericClass();
+            int result = (int)d.Method_ReturnsDynamic<int>(7) % (int)d.Method_ReturnsDynamic<int>(5);
+            Assert.Equal(99, (int)d.Method_ReturnsDynamic<int>(99));
+            Assert.Equal(2, result);
+        }
+
+        [Fact]
+        public static void NullCoalescingOperator()
+        {
+            dynamic d = new NonGenericClass();
+            string result = (string)d.Method_ReturnsDynamic<int, string>(10, null, d) ?? string.Empty;
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public static void QueryExpression()
+        {
+            var list = new List<string>() { null, "b", null, "a" };
+            dynamic d = new NonGenericClass();
+            string a = "a";
+            dynamic da = a;
+            var result = list.Where(p => p == (string)d.Method_ReturnsDynamic<string, int, string>(null, 10, a, da)).ToList();
+            Assert.Equal(new List<string>() { "a" }, result);
+        }
+
+        [Fact]
+        public static void ShortCircuitBooleanExpression()
+        {
+            dynamic d = new NonGenericClass.NestedGenericClass<string>();
+            int loopCount = 0;
+            while ((int)d.Method_ReturnsDynamic<int>(null, null, loopCount, d) < 10)
+            {
+                loopCount++;
+            }
+            Assert.Equal(10, loopCount);
+
+        }
+
+        [Fact]
+        public static void StaticMethodBody1()
+        {
+            dynamic d = new NonGenericClass();
+            var result = (object)d.Method_ReturnsUConstraint<RegularClassGenericMethodTests>(new RegularClassGenericMethodTests());
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public static void StaticMethodBody2()
+        {
+            dynamic d = new NonGenericClass();
+            dynamic t = new RegularClassGenericMethodTests();
+            Assert.Throws<RuntimeBinderException>(() => d.Method_ReturnsUNegConstraint<RegularClassGenericMethodTests>(t));
+        }
+
+        [Fact]
+        public static void StaticMethodBody3()
+        {
+            dynamic dy = new NonGenericClass();
+            EmptyBaseClass mt = new EmptyBaseClass();
+            dynamic d = mt;
+            decimal dec = 0M;
+            Assert.Throws<RuntimeBinderException>(() => (float)dy.Method_ReturnsFloatNegConstraint<RegularClassGenericMethodTests, dynamic, EmptySubClass>(null, d, d, ref dec));
+        }
+
+        [Fact]
+        public static void StaticMethodBody4()
+        {
+            dynamic d = new NonGenericClass.NestedGenericClass<string>();
+            string result = (string)d.Method_ReturnsU("0");
+            Assert.Null(result);
         }
     }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass003.regclass003
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass003.regclass003;
-    // <Title> Tests regular class generic method used in indexer body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections.Generic;
-
-    public class Test
+    public class ClassWithIndexer
     {
         private Dictionary<int, string> _dic = new Dictionary<int, string>();
-        private MemberClass _mc = new MemberClass();
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            if (TestSet() == 0 && TestGet() == 0)
-                return 0;
-            else
-                return 1;
-        }
-
-        private static int TestSet()
-        {
-            Test t = new Test();
-            t[0] = "Test0";
-            t[1] = null;
-            t[2] = "Test2";
-            if (t._dic[0] == "Test0" && t._dic[1] == null && t._dic[2] == "Test2")
-                return 0;
-            else
-                return 1;
-        }
-
-        private static int TestGet()
-        {
-            Test t = new Test();
-            t._dic[2] = "Test0";
-            t._dic[1] = null;
-            t._dic[0] = "Test2";
-            if (t[2] == "Test0" && t[1] == null && t[0] == "Test2")
-                return 0;
-            else
-                return 1;
-        }
+        private NonGenericClass _mc = new NonGenericClass();
 
         public string this[int i]
         {
             set
             {
-                dynamic dy = _mc;
-                _dic.Add((int)dy.Method_ReturnsT(i), value);
+                dynamic d = _mc;
+                _dic.Add((int)d.Method_ReturnsT(i), value);
             }
 
             get
             {
-                dynamic dy = _mc;
-                return _dic[(int)dy.Method_ReturnsT(i)];
+                dynamic d = _mc;
+                return _dic[(int)d.Method_ReturnsT(i)];
             }
         }
+
+        [Fact]
+        public void Indexer_Get()
+        {
+            ClassWithIndexer t = new ClassWithIndexer();
+            t._dic[2] = "Test0";
+            t._dic[1] = null;
+            t._dic[0] = "Test2";
+            Assert.Equal("Test0", t[2]);
+            Assert.Null(t[1]);
+            Assert.Equal("Test2", t[0]);
+        }
+
+        [Fact]
+        public static void Indexer_Set()
+        {
+            ClassWithIndexer t = new ClassWithIndexer();
+            t[0] = "Test0";
+            t[1] = null;
+            t[2] = "Test2";
+            Assert.Equal("Test0", t._dic[0]);
+            Assert.Null(t._dic[1]);
+            Assert.Equal("Test2", t._dic[2]);
+        }
     }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass004.regclass004
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass004.regclass004;
-    // <Title> Tests regular class generic method used in static constructor.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
+    public class ClassWithStaticFields
     {
         private static int s_field = 10;
         private static int s_result = -1;
-        public Test()
+        public ClassWithStaticFields()
         {
-            dynamic dy = new MemberClass();
+            dynamic d = new NonGenericClass();
             string s = "Foo";
-            Test.s_result = dy.Method_ReturnsT<int, int, string>(out s_field, ref s);
+            s_result = d.Method_ReturnsT<int, int, string>(out s_field, ref s);
         }
 
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            Test t = new Test();
-            if (Test.s_field == 0 && Test.s_result == 0)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass005.regclass005
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass005.regclass005;
-    // <Title> Tests regular class generic method used in variable named dynamic.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            int i = 1;
-            dynamic dynamic = new MemberClass();
-            int result = dynamic.Method_ReturnsT<int>(ref i);
-            if (i == 0 && result == 0)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass006.regclass006
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass006.regclass006;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticConstructor()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            Test t1 = new Test();
-            return t1.TestMethod<long>(1L) == 0 ? 0 : 1;
-        }
-
-        public T TestMethod<T>(T t)
-        {
-            dynamic dy = new MemberClass();
-            return (T)dy.Method_ReturnsT<T>(t, t, t);
+            ClassWithStaticFields t = new ClassWithStaticFields();
+            Assert.Equal(0, s_field);
+            Assert.Equal(0, s_result);
         }
     }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass008.regclass008
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass008.regclass008;
-    // <Title> Tests regular class generic method used in method body of method with conditional attribute.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
+    public class ClassWithConditionalAttribute
     {
         private static int s_result = 0;
+
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public void ConditionalAttribute()
         {
-            Assert.Equal(0, MainMethod());
+            ClassWithConditionalAttribute c = new ClassWithConditionalAttribute();
+            c.TestMethod();
+            Assert.Equal(0, s_result);
         }
 
-        public static int MainMethod()
-        {
-            Test t1 = new Test();
-            t1.TestMethod();
-            return s_result;
-        }
-
-        [System.Diagnostics.Conditional("c1")]
+        [Conditional("c1")]
         public void TestMethod()
         {
-            dynamic dy = new MemberClass();
-            s_result = (int)dy.Method_ReturnsT<int, string>(null) + 1;
+            dynamic d = new NonGenericClass();
+            s_result = (int)d.Method_ReturnsT<int, string>(null) + 1;
         }
     }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass009.regclass009
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass009.regclass009;
-    // <Title> Tests regular class generic method used in arguments to method invocation.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-
-    public class Test
+    public class ClassWithNestedClasses
     {
-        public class InnerTest : IEnumerable<InnerTest>
+        public class NestedClass : IEnumerable<NestedClass>
         {
             public int Field;
-            #region IEnumerable<InnerTest> Members
-            public IEnumerator<InnerTest> GetEnumerator()
+            public IEnumerator<NestedClass> GetEnumerator()
             {
-                return new InnerTestEnumerator();
+                return new NestedEnumerator();
             }
 
-            #endregion
-            #region IEnumerable Members
             IEnumerator IEnumerable.GetEnumerator()
             {
-                return new InnerTestEnumerator();
+                return new NestedEnumerator();
             }
-            #endregion
         }
 
-        public class InnerTestEnumerator : IEnumerator<InnerTest>, IEnumerator
+        public class NestedEnumerator : IEnumerator<NestedClass>, IEnumerator
         {
-            private InnerTest[] _list = new InnerTest[]
+            private NestedClass[] _list = new NestedClass[]
             {
-            new InnerTest()
-            {
-            Field = 0
-            }
+                new NestedClass() { Field = 0 },
+                new NestedClass() { Field = 1 },
+                null
+            };
 
-            , new InnerTest()
-            {
-            Field = 1
-            }
-
-            , null
-            }
-
-            ;
             private int _index = -1;
-            #region IEnumerator<InnerTest> Members
-            public InnerTest Current
-            {
-                get
-                {
-                    return _list[_index];
-                }
-            }
 
-            #endregion
-            #region IDisposable Members
-            public void Dispose()
-            {
-                // Empty.
-            }
+            public NestedClass Current => _list[_index];
 
-            #endregion
-            #region IEnumerator Members
-            object IEnumerator.Current
-            {
-                get
-                {
-                    return _list[_index];
-                }
-            }
+            public void Dispose() { }
+
+            object IEnumerator.Current => _list[_index];
 
             public bool MoveNext()
             {
@@ -595,816 +416,180 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
                 return _index >= _list.Length ? false : true;
             }
 
-            public void Reset()
-            {
-                _index = -1;
-            }
-            #endregion
+            public void Reset() => _index = -1;
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ArgumentsToMethodInvocation()
         {
-            Assert.Equal(0, MainMethod());
+            ClassWithNestedClasses t = new ClassWithNestedClasses();
+            dynamic mc = new NonGenericClass();
+            int result = t.Method((int)mc.M<NestedClass>(new NestedClass()));
+            Assert.Equal(3, result);
         }
 
-        public static int MainMethod()
-        {
-            Test t = new Test();
-            dynamic mc = new MemberClass();
-            int result = t.Method((int)mc.M<InnerTest>(new InnerTest()));
-            return result == 3 ? 0 : 1;
-        }
-
-        public int Method(int value)
-        {
-            return value;
-        }
+        public int Method(int value) => value;
     }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass010.regclass010
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass010.regclass010;
-    // <Title> Tests regular class generic method used in implicitly-typed variable initializer.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
-            string u = string.Empty;
-            string v = string.Empty;
-            var result = (int)mc.Method_ReturnsT<int, string, string>(out u, ref v);
-            if (result == 0 && u == null && v == string.Empty)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass011.regclass011
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass011.regclass011;
-    // <Title> Tests regular class generic method used in implicitly-typed variable initializer.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
-            var tc = new
-            {
-                A1 = (int)mc.Method_ReturnsInt<int>(0),
-                A2 = (string)mc.Method_ReturnsString<int, int>(1, 2)
-            }
-
-            ;
-            if (tc != null && tc.A1 == 1 && tc.A2 == "foo")
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass012.regclass012
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass012.regclass012;
-    // <Title> Tests regular class generic method used in property-set body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
+    public class ClassWithSetProperty
     {
         private float _field;
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            Test t = new Test();
-            t.TestProperty = 1.1f;
-            if (t.TestProperty == 3.4f)
-                return 0;
-            return 1;
-        }
-
         public float TestProperty
         {
             set
             {
-                dynamic mc = new MemberClass();
+                dynamic mc = new NonGenericClass();
                 dynamic mv = value;
                 _field = (float)mc.Method_ReturnsFloat<float, string, string>(value, mv, null);
             }
+            get { return _field; }
+        }
 
-            get
-            {
-                return _field;
-            }
+        [Fact]
+        public static void PropertySetBody()
+        {
+            ClassWithSetProperty t = new ClassWithSetProperty();
+            t.TestProperty = 1.1f;
+            Assert.Equal(3.4f, t.TestProperty);
         }
     }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass013.regclass013
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass013.regclass013;
-    // <Title> Tests regular class generic method used in constructor.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
+    public class ClassWithConstructor
     {
         private float _filed;
         private decimal _dec;
-        public Test()
+        public ClassWithConstructor()
         {
-            dynamic mc = new MemberClass();
+            dynamic mc = new NonGenericClass();
             _filed = mc.Method_ReturnsFloat<string, long, int>(null, mc, 1L, ref _dec);
         }
 
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            Test t = new Test();
-            if (t._filed == 3.4f && t._dec == 3M)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass014.regclass014
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass014.regclass014;
-    // <Title> Tests regular class generic method used in operator.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Constructor()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
-            int result = (int)mc.Method_ReturnsDynamic<int>(7) % (int)mc.Method_ReturnsDynamic<int>(5);
-            if ((int)mc.Method_ReturnsDynamic<int>(99) != 99)
-                return 1;
-            if (result == 2)
-                return 0;
-            return 1;
+            ClassWithConstructor t = new ClassWithConstructor();
+            Assert.Equal(3.4f, t._filed);
+            Assert.Equal(3M, t._dec);
         }
     }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass015.regclass015
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass015.regclass015;
-    // <Title> Tests regular class generic method used in null coalescing operator.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
-            string result = (string)mc.Method_ReturnsDynamic<int, string>(10, null, mc) ?? string.Empty;
-            if (result == string.Empty)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass016.regclass016
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass016.regclass016;
-    // <Title> Tests regular class generic method used in query expression.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Linq;
-    using System.Collections.Generic;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            var list = new List<string>()
-            {
-            null, "b", null, "a"
-            }
-
-            ;
-            dynamic mc = new MemberClass();
-            string a = "a";
-            dynamic da = a;
-            var result = list.Where(p => p == (string)mc.Method_ReturnsDynamic<string, int, string>(null, 10, a, da)).ToList();
-            if (result.Count == 1 && result[0] == "a")
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass017.regclass017
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass017.regclass017;
-    // <Title> Tests regular class generic method used in short-circuit boolean expression.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Linq;
-    using System.Collections.Generic;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass.NestedMemberClass<string>();
-            int loopCount = 0;
-            while ((int)dy.Method_ReturnsDynamic<int>(null, null, loopCount, dy) < 10)
-            {
-                loopCount++;
-            }
-
-            return loopCount - 10;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass018.regclass018
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass018.regclass018;
-    // <Title> Tests regular class generic method used in destructor.</Title>
-    // <Description>
-    // On IA64 the GC.WaitForPendingFinalizers() does not actually work...
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Runtime.CompilerServices;
-
-    public class Test
+    public class ClassWithDeconstructor
     {
         private static string s_field;
         public static object locker = new object();
-        ~Test()
+        ~ClassWithDeconstructor()
         {
             lock (locker)
             {
-                dynamic mc = new MemberClass.NestedMemberClass<Test>();
-                s_field = mc.Method_ReturnsDynamic<string>(null, null, "Test", mc);
+                dynamic d = new NonGenericClass.NestedGenericClass<ClassWithDeconstructor>();
+                s_field = d.Method_ReturnsDynamic<string>(null, null, "Test", d);
             }
         }
 
-        public void Foo()
-        {
-        }
+        public void Foo() { }
 
-        private static int Verify()
+        private static void Verify()
         {
-            lock (Test.locker)
+            lock (locker)
             {
-                if (Test.s_field != "Test")
-                {
-                    return 1;
-                }
+                Assert.Equal("Test", s_field);
             }
-
-            return 0;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void RequireLifetimesEnded()
         {
-            Test t = new Test();
-            Test.s_field = "Field";
+            ClassWithDeconstructor t = new ClassWithDeconstructor();
+            s_field = "Field";
             t.Foo();
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
+        public static void Deconstructor()
         {
             RequireLifetimesEnded();
             GC.Collect();
             GC.WaitForPendingFinalizers();
             // If move the code in Verify() to here, the finalizer will only be executed after exited Main
-            return Verify();
+            Verify();
         }
     }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass019.regclass019
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass019.regclass019;
-    // <Title> Tests regular class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
-            var result = (object)dy.Method_ReturnsUConstraint<Test>(new Test());
-            return result == null ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass020.regclass020
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass020.regclass020;
-    // <Title> Tests regular class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
+    public class ClassWithRegularField
     {
         private int _field;
-        public Test()
+        public ClassWithRegularField()
         {
             _field = 10;
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody1()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
-            var result = (Test)dy.Method_ReturnsUConstraint<int, Test>(4);
-            if (result != null && result._field == 10)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass021.regclass021
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass021.regclass021;
-    // <Title> Tests regular class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private int _field;
-        public Test()
-        {
-            _field = 10;
-        }
-
-        public class InnerTest : Test
-        {
-            public InnerTest()
-            {
-                _field = 11;
-            }
+            dynamic d = new NonGenericClass();
+            var result = (ClassWithRegularField)d.Method_ReturnsUConstraint<int, ClassWithRegularField>(4);
+            Assert.Equal(10, result._field);
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody2()
         {
-            Assert.Equal(0, MainMethod());
-        }
+            dynamic d = new NonGenericClass();
+            dynamic result = d.Method_ReturnsDynamicConstraint<int, ClassWithRegularField>(1, new ClassWithRegularField() { _field = 0 }, d);
 
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
-            var result = (Test)dy.Method_ReturnsUConstraint<string, Test, InnerTest>(null, new InnerTest()
-            {
-                _field = 0
-            }
-
-            );
-            if (result.GetType() == typeof(InnerTest) && result._field == 11)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass022.regclass022
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass022.regclass022;
-    // <Title> Tests regular class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private int _field;
-        public Test()
-        {
-            _field = 10;
+            Assert.Equal(10, ((ClassWithRegularField)result)._field);
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody3()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
-            dynamic result = dy.Method_ReturnsDynamicConstraint<int, Test>(1, new Test()
-            {
-                _field = 0
-            }
-
-            , dy);
-            if (((Test)result)._field == 10)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass023.regclass023
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass023.regclass023;
-    // <Title> Tests regular class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(12,9\).*CS0414</Expects>
-    using System;
-
-    public class Test
-    {
-        private int _field;
-        public Test()
-        {
-            _field = 10;
-        }
-
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
+            dynamic d = new NonGenericClass();
             dynamic s = "Test";
-            dynamic result = dy.Method_ReturnsDynamicConstraint<string, string, string>((string)s, (string)s, (string)s, s);
-            if (((string)result) == "Test")
-                return 0;
-            return 1;
+            dynamic result = d.Method_ReturnsDynamicConstraint<string, string, string>((string)s, (string)s, (string)s, s);
+            Assert.Equal("Test", (string)result);
         }
     }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass024.regclass024
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass024.regclass024;
-    // <Title> Tests regular class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(12,9\).*CS0414</Expects>
-    using System;
-
-    public class Test
+    public class ClassWithNestedClass
     {
         private int _field;
-        public Test()
+        public ClassWithNestedClass()
         {
             _field = 10;
         }
 
-        public class InnerTest : Test
+        public class NestedClass : ClassWithNestedClass
         {
-            public InnerTest()
+            public NestedClass()
             {
                 _field = 11;
             }
         }
 
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
-            Test t = new Test();
-            dynamic it = new InnerTest();
-            decimal dec = 0M;
-            float result = (float)dy.Method_ReturnsFloatConstraint<Test, Test, InnerTest>(t, it, t, ref dec);
-            if (result == 3.4f && dec == 3M)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass025.regclass025
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass025.regclass025;
-    // <Title> Tests regular class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody1()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic d = new NonGenericClass();
+            var result = (ClassWithNestedClass)d.Method_ReturnsUConstraint<string, ClassWithNestedClass, NestedClass>(null, new NestedClass() { _field = 0 });
+
+            Assert.IsType<NestedClass>(result);
+            Assert.Equal(11, result._field);
         }
 
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
-            dynamic t = new Test();
-            try
-            {
-                dynamic result = dy.Method_ReturnsUNegConstraint<Test>(t);
-            }
-            catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-            {
-                if (ErrorVerifier.Verify(ErrorMessageId.GenericConstraintNotSatisfiedRefType, e.Message, "MemberClass.Method_ReturnsUNegConstraint<U>(U)", "C", "U", "Test"))
-                    return 0;
-            }
-
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass027.regclass027
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass027.regclass027;
-    // <Title> Tests regular class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
-            MyTest mt = new MyTest();
-            dynamic d = mt;
-            decimal dec = 0M;
-            try
-            {
-                float result = (float)dy.Method_ReturnsFloatNegConstraint<Test, dynamic, DerivedMyTest>(null, d, d, ref dec);
-            }
-            catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-            {
-                if (!ErrorVerifier.Verify(ErrorMessageId.GenericConstraintNotSatisfiedRefType, e.Message, "MemberClass.Method_ReturnsFloatNegConstraint<T,U,V>(T, object, U, ref decimal)", "I", "U", "object"))
-                    return 1;
-            }
-
-            return 0;
-        }
-    }
-
-    public class MyTest : I
-    {
-    }
-
-    public class DerivedMyTest : MyTest
-    {
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass028.regclass028
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclassgenmeth.regclassgenmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmethod.regclass.regclass028.regclass028;
-    // <Title> Tests regular class generic method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody2()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass.NestedMemberClass<string>();
-            string result = (string)dy.Method_ReturnsU("0");
-            if (result == null)
-                return 0;
-            return 1;
+            dynamic d = new NonGenericClass();
+            ClassWithNestedClass t = new ClassWithNestedClass();
+            dynamic it = new NestedClass();
+            decimal dec = 0M;
+            float result = (float)d.Method_ReturnsFloatConstraint<ClassWithNestedClass, ClassWithNestedClass, NestedClass>(t, it, t, ref dec);
+            Assert.Equal(3M, dec);
+            Assert.Equal(3.4f, result);
         }
     }
-    //</Code>
+
+    public class EmptyBaseClass : EmptyInterface { }
+
+    public class EmptySubClass : EmptyBaseClass { }
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.method.regmethod.genclass.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.method.regmethod.genclass.cs
@@ -2,22 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth
+namespace Dynamic.GenericClass.RegularMethod.Tests
 {
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass001.genclass001;
-    using System;
-    using System.Collections.Generic;
+    public class EmptyClass { }
 
-    public class C
-    {
-    }
-
-    public interface I
-    {
-    }
+    public interface EmptyInterface { }
 
     public class MyClass
     {
@@ -36,23 +30,13 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
         Third = 3
     }
 
-    public class MemberClass<T>
+    public class GenericClass<T>
     {
-        #region Instance methods
-        public bool Method_ReturnBool()
-        {
-            return false;
-        }
+        public bool Method_ReturnBool() => false;
 
-        public T Method_ReturnsT()
-        {
-            return default(T);
-        }
+        public T Method_ReturnsT() => default(T);
 
-        public T Method_ReturnsT(T t)
-        {
-            return t;
-        }
+        public T Method_ReturnsT(T t) => t;
 
         public T Method_ReturnsT(out T t)
         {
@@ -66,25 +50,13 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             return t;
         }
 
-        public T Method_ReturnsT(params T[] t)
-        {
-            return default(T);
-        }
+        public T Method_ReturnsT(params T[] t) => default(T);
 
-        public T Method_ReturnsT(float x, T t)
-        {
-            return default(T);
-        }
+        public T Method_ReturnsT(float x, T t) => default(T);
 
-        public int Method_ReturnsInt(T t)
-        {
-            return 1;
-        }
+        public int Method_ReturnsInt(T t) => 1;
 
-        public float Method_ReturnsFloat(T t, dynamic d)
-        {
-            return 3.4f;
-        }
+        public float Method_ReturnsFloat(T t, dynamic d) => 3.4f;
 
         public float Method_ReturnsFloat(T t, dynamic d, ref decimal dec)
         {
@@ -92,841 +64,306 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             return 3.4f;
         }
 
-        public dynamic Method_ReturnsDynamic(T t)
-        {
-            return t;
-        }
+        public dynamic Method_ReturnsDynamic(T t) => t;
 
-        public dynamic Method_ReturnsDynamic(T t, dynamic d)
-        {
-            return t;
-        }
+        public dynamic Method_ReturnsDynamic(T t, dynamic d) => t;
 
-        public dynamic Method_ReturnsDynamic(T t, int x, dynamic d)
-        {
-            return t;
-        }
+        public dynamic Method_ReturnsDynamic(T t, int x, dynamic d) => t;
 
-        // Multiple params
-        // Constraints
-        // Nesting
-        #endregion
-        #region Static methods
-        public static bool? StaticMethod_ReturnBoolNullable()
-        {
-            return (bool?)false;
-        }
-        #endregion
+        public static bool? StaticMethod_ReturnBoolNullable() => false;
     }
 
-    public class MemberClassMultipleParams<T, U, V>
+    public class GenericClassMultipleParams<T, U, V>
     {
-        public T Method_ReturnsT(V v, U u)
-        {
-            return default(T);
-        }
+        public T Method_ReturnsT(V v, U u) => default(T);
     }
 
-    public class MemberClassWithClassConstraint<T>
-        where T : class
+    public class GenericClassWithClassConstraint<T> where T : class
     {
-        public int Method_ReturnsInt()
-        {
-            return 1;
-        }
+        public int Method_ReturnsInt() => 1;
 
-        public T Method_ReturnsT(decimal dec, dynamic d)
-        {
-            return null;
-        }
+        public T Method_ReturnsT(decimal dec, dynamic d) => null;
     }
 
-    public class MemberClassWithNewConstraint<T>
-        where T : new()
+    public class GenericClassWithNewConstraint<T> where T : new()
     {
-        public T Method_ReturnsT()
-        {
-            return new T();
-        }
+        public T Method_ReturnsT() => new T();
 
-        public dynamic Method_ReturnsDynamic(T t)
-        {
-            return new T();
-        }
+        public dynamic Method_ReturnsDynamic(T t) => new T();
     }
 
-    public class MemberClassWithAnotherTypeConstraint<T, U>
-        where T : U
+    public class GenericClassWithAnotherTypeConstraint<T, U> where T : U
     {
-        public U Method_ReturnsU(dynamic d)
-        {
-            return default(U);
-        }
+        public U Method_ReturnsU(dynamic d) => default(U);
 
-        public dynamic Method_ReturnsDynamic(int x, U u, dynamic d)
-        {
-            return default(T);
-        }
+        public dynamic Method_ReturnsDynamic(int x, U u, dynamic d) => default(T);
     }
 
-    #region Negative tests - you should not be able to construct this with a dynamic object
-    public class MemberClassWithUDClassConstraint<T>
-        where T : C, new()
+    public class GenericClassWithUDClassConstraint<T> where T : EmptyClass, new()
     {
-        public C Method_ReturnsC()
-        {
-            return new T();
-        }
+        public EmptyClass Method_ReturnsC() => new T();
     }
 
-    public class MemberClassWithStructConstraint<T>
-        where T : struct
+    public class GenericClassWithStructConstraint<T> where T : struct
     {
-        public dynamic Method_ReturnsDynamic(int x)
-        {
-            return x;
-        }
+        public dynamic Method_ReturnsDynamic(int x) => x;
     }
 
-    public class MemberClassWithInterfaceConstraint<T>
-        where T : I
+    public class GenericClassWithInterfaceConstraint<T> where T : EmptyInterface
     {
-        public dynamic Method_ReturnsDynamic(int x, T v)
-        {
-            return default(T);
-        }
+        public dynamic Method_ReturnsDynamic(int x, T v) => default(T);
     }
-    #endregion
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass001.genclass001
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass001.genclass001;
-    // <Title> Tests generic class regular method used in regular method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
+    public class GenericClassRegularMethodTests
     {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public void RegularMethodBody()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic mc = new GenericClass<string>();
+            Assert.False((bool)mc.Method_ReturnBool());
         }
 
-        public static int MainMethod()
-        {
-            Test t = new Test();
-            if (t.TestMethod() == true)
-                return 1;
-            return 0;
-        }
-
-        public bool TestMethod()
-        {
-            dynamic mc = new MemberClass<string>();
-            return (bool)mc.Method_ReturnBool();
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass002.genclass002
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass002.genclass002;
-    // <Title> Tests generic class regular method used in arguments of method invocation.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ForLoop1()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            Test t = new Test();
-            dynamic mc1 = new MemberClass<int>();
-            int result1 = t.TestMethod((int)mc1.Method_ReturnsT());
-            dynamic mc2 = new MemberClass<string>();
-            int result2 = Test.TestMethod((string)mc2.Method_ReturnsT());
-            if (result1 == 0 && result2 == 0)
-                return 0;
-            else
-                return 1;
-        }
-
-        public int TestMethod(int i)
-        {
-            if (i == default(int))
-            {
-                return 0;
-            }
-            else
-            {
-                return 1;
-            }
-        }
-
-        public static int TestMethod(string s)
-        {
-            if (s == default(string))
-            {
-                return 0;
-            }
-            else
-            {
-                return 1;
-            }
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass003.genclass003
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass003.genclass003;
-    // <Title> Tests generic class regular method used in static variable.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private static dynamic s_mc = new MemberClass<string>();
-        private static float s_loc = (float)s_mc.Method_ReturnsFloat(null, 1);
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            if (s_loc != 3.4f)
-                return 1;
-            return 0;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass005.genclass005
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass005.genclass005;
-    // <Title> Tests generic class regular method used in unsafe.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    //using System;
-    //[TestClass]public class Test
-    //{
-    //[Test][Priority(Priority.Priority1)]public void DynamicCSharpRunTest(){Assert.AreEqual(0, MainMethod());} public static unsafe int MainMethod()
-    //{
-    //dynamic dy = new MemberClass<int>();
-    //int value = 1;
-    //int* valuePtr = &value;
-    //int result = dy.Method_ReturnsT(out *valuePtr);
-    //if (result == 0 && value == 0)
-    //return 0;
-    //return 1;
-    //}
-    //}
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass006.genclass006
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass006.genclass006;
-    // <Title> Tests generic class regular method used in generic method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            Test t = new Test();
-            string s1 = "";
-            string s2 = "";
-            string result = t.TestMethod<string>(ref s1, s2);
-            if (result == null && s1 == null)
-                return 0;
-            return 1;
-        }
-
-        public T TestMethod<T>(ref T t1, T t2)
-        {
-            dynamic mc = new MemberClass<T>();
-            return (T)mc.Method_ReturnsT(ref t1, t2);
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass008.genclass008
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass008.genclass008;
-    // <Title> Tests generic class regular method used in extension method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        public int Field = 10;
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            Test t = 1.ExReturnTest();
-            if (t.Field == 1)
-                return 0;
-            return 1;
-        }
-    }
-
-    static public class Extension
-    {
-        public static Test ExReturnTest(this int t)
-        {
-            dynamic dy = new MemberClass<int>();
-            float x = 3.3f;
-            int i = -1;
-            return new Test()
-            {
-                Field = t + (int)dy.Method_ReturnsT(x, i)
-            }
-
-            ;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass009.genclass009
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass009.genclass009;
-    // <Title> Tests generic class regular method used in for loop.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass<MyEnum>();
+            dynamic d = new GenericClass<MyEnum>();
             int result = 0;
-            for (int i = (int)dy.Method_ReturnsInt(MyEnum.Third); i < 10; i++)
+            for (int i = (int)d.Method_ReturnsInt(MyEnum.Third); i < 10; i++)
             {
-                result += (int)dy.Method_ReturnsInt((MyEnum)(i % 3 + 1));
+                result += (int)d.Method_ReturnsInt((MyEnum)(i % 3 + 1));
             }
-
-            if (result == 9)
-                return 0;
-            return 1;
+            Assert.Equal(9, result);
         }
-    } //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass009a.genclass009a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass009a.genclass009a;
-    // <Title> Tests generic class regular method used in for loop.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ForLoop2()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass<MyEnum>();
+            dynamic d = new GenericClass<MyEnum>();
             int result = 0;
-            for (int i = dy.Method_ReturnsInt(MyEnum.Third); i < 10; i++)
+            for (int i = d.Method_ReturnsInt(MyEnum.Third); i < 10; i++)
             {
-                result += dy.Method_ReturnsInt((MyEnum)(i % 3 + 1));
+                result += d.Method_ReturnsInt((MyEnum)(i % 3 + 1));
             }
-
-            if (result == 9)
-                return 0;
-            return 1;
-        }
-    } //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass010.genclass010
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass010.genclass010;
-    // <Title> Tests generic class regular method used in static constructor.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test : I
-    {
-        private static decimal s_dec = 0M;
-        private static float s_result = 0f;
-        static Test()
-        {
-            dynamic dy = new MemberClass<I>();
-            s_result = (float)dy.Method_ReturnsFloat(new Test(), dy, ref s_dec);
+            Assert.Equal(9, result);
         }
 
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            if (Test.s_dec == 3M && Test.s_result == 3.4f)
-                return 0;
-            return 1;
-        }
-    } //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass012.genclass012
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass012.genclass012;
-    // <Title> Tests generic class regular method used in lambda.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections.Generic;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void Lambda()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass<string>();
+            dynamic d = new GenericClass<string>();
             dynamic d1 = 3;
             dynamic d2 = "Test";
             Func<string, string, string> fun = (x, y) => (y + x.ToString());
-            string result = fun((string)dy.Method_ReturnsDynamic("foo", d1), (string)dy.Method_ReturnsDynamic("bar", d2));
-            if (result == "barfoo")
-                return 0;
-            return 1;
+            string result = fun((string)d.Method_ReturnsDynamic("foo", d1), (string)d.Method_ReturnsDynamic("bar", d2));
+            Assert.Equal("barfoo", result);
         }
-    } //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass013.genclass013
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass013.genclass013;
-    // <Title> Tests generic class regular method used in array initializer list.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections.Generic;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ArrayInitializer()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass<string>();
+            dynamic d = new GenericClass<string>();
             string[] array = new string[]
             {
-            (string)dy.Method_ReturnsDynamic(string.Empty, 1, dy), (string)dy.Method_ReturnsDynamic(null, 0, dy), (string)dy.Method_ReturnsDynamic("a", -1, dy)}
+                (string)d.Method_ReturnsDynamic(string.Empty, 1, d), (string)d.Method_ReturnsDynamic(null, 0, d), (string)d.Method_ReturnsDynamic("a", -1, d)
+            };
 
-            ;
-            if (array.Length == 3 && array[0] == string.Empty && array[1] == null && array[2] == "a")
-                return 0;
-            return 1;
+            Assert.Equal(new string[] { string.Empty, null, "a" }, array);
+
         }
-    } //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass014.genclass014
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass014.genclass014;
-    // <Title> Tests generic class regular method used in null coalescing operator.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections.Generic;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void NullCoalescingOperator()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic dy = GenericClass<string>.StaticMethod_ReturnBoolNullable();
+            Assert.False((bool?)dy ?? false);
         }
 
-        public static int MainMethod()
-        {
-            dynamic dy = MemberClass<string>.StaticMethod_ReturnBoolNullable();
-            if (!((bool?)dy ?? false))
-                return 0;
-            return 1;
-        }
-    } //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass015.genclass015
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass015.genclass015;
-    // <Title> Tests generic class regular method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections.Generic;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic d = new GenericClassMultipleParams<MyEnum, MyStruct, MyClass>();
+            MyEnum me = d.Method_ReturnsT(null, new MyStruct());
+            Assert.Equal(0, (int)me);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void TernaryOperatorExpression()
         {
-            dynamic dy = new MemberClassMultipleParams<MyEnum, MyStruct, MyClass>();
-            MyEnum me = dy.Method_ReturnsT(null, new MyStruct());
-            return (int)me;
+            dynamic d = new GenericClassWithClassConstraint<string>();
+            string result = (string)d.Method_ReturnsT(decimal.MaxValue, d) == null ? string.Empty : (string)d.Method_ReturnsT(decimal.MaxValue, d);
+            int ternaryResult = result == string.Empty ? 0 : 1;
+            Assert.Equal(0, ternaryResult);
         }
-    } //</Code>
-}
 
+        [Fact]
+        public static void LockExpression()
+        {
+            dynamic d = new GenericClassWithNewConstraint<EmptyClass>();
+            int result = 1;
+            lock (d.Method_ReturnsT())
+            {
+                result = 0;
+            }
+            Assert.Equal(0, result);
+        }
 
+        [Fact]
+        public static void SwitchStatementList()
+        {
+            dynamic d1 = new GenericClassWithNewConstraint<EmptyClass>();
+            dynamic d2 = new GenericClassWithAnotherTypeConstraint<int, int>();
+            EmptyClass result = new EmptyClass();
+            int result2 = -1;
+            switch ((int)d2.Method_ReturnsU(d1)) // 0
+            {
+                case 0:
+                    result = (EmptyClass)d1.Method_ReturnsDynamic(result); // called
+                    break;
+                default:
+                    result2 = (int)d2.Method_ReturnsDynamic(0, 0, d2); // not called
+                    break;
+            }
 
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass016.genclass016
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass016.genclass016;
-    // <Title> Tests generic class regular method used in query expression.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Linq;
-    using System.Collections.Generic;
+            Assert.IsType<EmptyClass>(result);
+            Assert.Equal(-1, result2);
+        }
+    }
 
-    public class Test
+    public class ClassWithRegularAndStaticMethods
     {
-        private class M
+        public int TestMethod(int i) => i == default(int) ? 0 : 1;
+        public static int TestMethod(string s) => s == null ? 0 : 1;
+
+        [Fact]
+        public static void ArgumentsOfMethodInvocation()
+        {
+            ClassWithRegularAndStaticMethods t = new ClassWithRegularAndStaticMethods();
+            dynamic mc1 = new GenericClass<int>();
+            int result1 = t.TestMethod((int)mc1.Method_ReturnsT());
+            dynamic mc2 = new GenericClass<string>();
+            int result2 = TestMethod((string)mc2.Method_ReturnsT());
+            Assert.Equal(0, result1);
+            Assert.Equal(0, result2);
+        }
+    }
+
+    public class ClassWithStaticVariables
+    {
+        private static dynamic s_mc = new GenericClass<string>();
+        private static float s_loc = (float)s_mc.Method_ReturnsFloat(null, 1);
+
+        [Fact]
+        public static void StaticVariableInitialization()
+        {
+            Assert.Equal(3.4f, s_loc);
+        }
+    }
+
+    public class ClassWithGenericMethod
+    {
+        public T TestMethod<T>(ref T t1, T t2)
+        {
+            dynamic d = new GenericClass<T>();
+            return (T)d.Method_ReturnsT(ref t1, t2);
+        }
+
+        [Fact]
+        public static void GenericMethodBody()
+        {
+            ClassWithGenericMethod t = new ClassWithGenericMethod();
+            string s1 = "";
+            string s2 = "";
+            string result = t.TestMethod(ref s1, s2);
+            Assert.Null(result);
+            Assert.Null(s1);
+        }
+    }
+
+    public static class Extension
+    {
+        public static ClassWithExtensionMethod ExReturnTest(this int t)
+        {
+            dynamic d = new GenericClass<int>();
+            float x = 3.3f;
+            int i = -1;
+            return new ClassWithExtensionMethod() { Field = t + (int)d.Method_ReturnsT(x, i) };
+        }
+    }
+
+    public class ClassWithExtensionMethod
+    {
+        public int Field = 10;
+
+        [Fact]
+        public static void ExtensionMethodBody()
+        {
+            ClassWithExtensionMethod t = 1.ExReturnTest();
+            Assert.Equal(1, t.Field);
+        }
+    }
+
+    public class ClassWithStaticConstructor : EmptyInterface
+    {
+        private static decimal s_dec = 0M;
+        private static float s_result = 0f;
+        static ClassWithStaticConstructor()
+        {
+            dynamic d = new GenericClass<EmptyInterface>();
+            s_result = (float)d.Method_ReturnsFloat(new ClassWithStaticConstructor(), d, ref s_dec);
+        }
+
+        [Fact]
+        public static void StaticConstructor()
+        {
+            Assert.Equal(3M, s_dec);
+            Assert.Equal(3.4f, s_result);
+        }
+    }
+
+    public class ClassWithNestedClass
+    {
+        private class NestedClass
         {
             public int Field1;
             public int Field2;
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public void QueryExpression()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClassWithClassConstraint<MyClass>();
-            var list = new List<M>()
+            dynamic dy = new GenericClassWithClassConstraint<MyClass>();
+            var list = new List<NestedClass>()
             {
-            new M()
-            {
-            Field1 = 1, Field2 = 2
-            }
-
-            , new M()
-            {
-            Field1 = 2, Field2 = 1
-            }
-            }
-
-            ;
-            return list.Any(p => p.Field1 == (int)dy.Method_ReturnsInt()) ? 0 : 1;
+                new NestedClass() { Field1 = 1, Field2 = 2 },
+                new NestedClass() { Field1 = 2, Field2 = 1 }
+            };
+            Assert.True(list.Any(p => p.Field1 == (int)dy.Method_ReturnsInt()));
         }
-    } //</Code>
-}
+    }
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass017.genclass017
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass017.genclass017;
-    // <Title> Tests generic class regular method used in ternary operator expression.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Linq;
-    using System.Collections.Generic;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClassWithClassConstraint<string>();
-            string result = (string)dy.Method_ReturnsT(decimal.MaxValue, dy) == null ? string.Empty : (string)dy.Method_ReturnsT(decimal.MaxValue, dy);
-            return result == string.Empty ? 0 : 1;
-        }
-    } //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass018.genclass018
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass018.genclass018;
-    // <Title> Tests generic class regular method used in lock expression.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Linq;
-    using System.Collections.Generic;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClassWithNewConstraint<C>();
-            int result = 1;
-            lock (dy.Method_ReturnsT())
-            {
-                result = 0;
-            }
-
-            return result;
-        }
-    } //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass019.genclass019
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclassregmeth.genclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.genclass019.genclass019;
-    // <Title> Tests generic class regular method used in switch section statement list.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Linq;
-    using System.Collections.Generic;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy1 = new MemberClassWithNewConstraint<C>();
-            dynamic dy2 = new MemberClassWithAnotherTypeConstraint<int, int>();
-            C result = new C();
-            int result2 = -1;
-            switch ((int)dy2.Method_ReturnsU(dy1)) // 0
-            {
-                case 0:
-                    result = (C)dy1.Method_ReturnsDynamic(result); // called
-                    break;
-                default:
-                    result2 = (int)dy2.Method_ReturnsDynamic(0, 0, dy2); // not called
-                    break;
-            }
-
-            return (result.GetType() == typeof(C) && result2 == -1) ? 0 : 1;
-        }
-    } //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.implicit01.implicit01
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.genclass.implicit01.implicit01;
-    // <Title> Tests generic class regular method used in regular method body.</Title>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections.Generic;
-
-    public class Ta
+    public class ClassWithStaticField
     {
         public static int i = 2;
     }
 
-    public class A<T>
+    public class GenericClassWithImplicitOperator<T>
     {
-        public static implicit operator A<List<string>>(A<T> x)
-        {
-            return new A<List<string>>();
-        }
+        public static implicit operator GenericClassWithImplicitOperator<List<string>>(GenericClassWithImplicitOperator<T> x) => new GenericClassWithImplicitOperator<List<string>>();
     }
 
-    public class B
+    public class ClassWithStaticMethodsWithImplicitOperator
     {
-        public static void Foo<T>(A<List<T>> x, string y)
-        {
-            Ta.i--;
-        }
+        public static void Foo<T>(GenericClassWithImplicitOperator<List<T>> x, string y) => ClassWithStaticField.i--;
 
-        public static void Foo<T>(object x, string y)
-        {
-            Ta.i++;
-        }
+        public static void Foo<T>(object x, string y) => ClassWithStaticField.i++;
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ImplicitOperator()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            var x = new A<Action<object>>();
+            var x = new GenericClassWithImplicitOperator<Action<object>>();
             Foo<string>(x, "");
             Foo<string>(x, (dynamic)"");
-            return Ta.i;
+            Assert.Equal(0, ClassWithStaticField.i);
         }
     }
 }

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.method.regmethod.regclass.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.method.regmethod.regclass.cs
@@ -2,19 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Xunit;
+using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
+using System.Collections.Generic;
+using System.IO;
+using System.Collections;
+using System.Linq;
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth
 {
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass001.regclass001;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Linq.Expressions;
-    using System.Reflection;
-
     public class MyClass
     {
         public int Field = 0;
@@ -34,16 +31,9 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
 
     public class MemberClass
     {
-        #region Instance methods
-        public bool Method_ReturnBool()
-        {
-            return false;
-        }
+        public bool Method_ReturnBool() => false;
 
-        public bool Method_ReturnBool(object o)
-        {
-            return o == null ? true : false;
-        }
+        public bool Method_ReturnBool(object o) => o == null ? true : false;
 
         public bool Method_ReturnBool(out byte? p1, ref ulong? p2, out int p3)
         {
@@ -53,31 +43,19 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             return false;
         }
 
-        public bool Method_ReturnBool(params object[] o)
-        {
-            return false;
-        }
+        public bool Method_ReturnBool(params object[] o) => false;
 
-        public bool? Method_ReturnBoolNullable()
-        {
-            return (bool?)false;
-        }
+        public bool? Method_ReturnBoolNullable() => false;
 
         public bool? Method_ReturnBoolNullable(MyEnum[] p1, out decimal?[] p2, params int?[] p3)
         {
             p2 = new decimal?[2];
-            return (bool?)true;
+            return true;
         }
 
-        public bool? Method_ReturnBoolNullable(params short?[] s)
-        {
-            return (bool?)false;
-        }
+        public bool? Method_ReturnBoolNullable(params short?[] s) => false;
 
-        public bool? Method_ReturnBoolNullable(short? s)
-        {
-            return s == null ? null : (bool?)true;
-        }
+        public bool? Method_ReturnBoolNullable(short? s) => s == null ? null : (bool?)true;
 
         public byte?[] Method_ReturnByteArrNullable()
         {
@@ -97,12 +75,8 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
 
         public byte?[] Method_ReturnByteArrNullable(out MyStruct? m)
         {
-            m = new MyStruct()
-            {
-                Number = 2
-            }
+            m = new MyStruct() { Number = 2 };
 
-            ;
             byte?[] arr = new byte?[10];
             for (byte i = 0; i < 10; i++)
                 arr[i] = (byte)m.Value.Number;
@@ -115,7 +89,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             p2 = null;
             byte?[] arr = new byte?[10];
             for (byte i = 0; i < 10; i++)
-                arr[i] = (byte)2;
+                arr[i] = 2;
             return arr;
         }
 
@@ -139,7 +113,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
         {
             byte[] arr = new byte[d.Length];
             for (byte i = 0; i < d.Length; i++)
-                arr[i] = (byte)5;
+                arr[i] = 5;
             return arr;
         }
 
@@ -164,15 +138,9 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             return arr2;
         }
 
-        public char Method_ReturnChar(MyStruct m)
-        {
-            return 's';
-        }
+        public char Method_ReturnChar(MyStruct m) =>'s';
 
-        public char Method_ReturnChar(params MyStruct[] m)
-        {
-            return 'b';
-        }
+        public char Method_ReturnChar(params MyStruct[] m) => 'b';
 
         public char Method_ReturnChar(ref MyStruct m)
         {
@@ -186,80 +154,43 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             return 'c';
         }
 
-        public char? Method_ReturnCharNullable()
-        {
-            return (char?)'a';
-        }
+        public char? Method_ReturnCharNullable() => 'a';
 
         public char? Method_ReturnCharNullable(decimal[] p1, ref object p2, ref char p3)
         {
-            p2 = new MyClass()
-            {
-                Field = 3
-            }
-
-            ;
+            p2 = new MyClass() { Field = 3 };
             p3 = 'b';
             return p3;
         }
 
-        public char? Method_ReturnCharNullable(MyClass m)
-        {
-            return (char?)m.ToString()[0];
-        }
+        public char? Method_ReturnCharNullable(MyClass m) => m.ToString()[0];
 
         public char? Method_ReturnCharNullable(out MyClass m)
         {
-            m = new MyClass()
-            {
-                Field = 5
-            }
-
-            ;
-            return (char?)m.ToString()[0];
+            m = new MyClass() { Field = 5 };
+            return m.ToString()[0];
         }
 
-        public char? Method_ReturnCharNullable(params MyClass[] m)
-        {
-            return (char?)'z';
-        }
+        public char? Method_ReturnCharNullable(params MyClass[] m) => 'z';
 
-        public decimal Method_ReturnDecimal()
-        {
-            return 1M;
-        }
+        public decimal Method_ReturnDecimal() => 1M;
 
-        public decimal Method_ReturnDecimal(int? i)
-        {
-            return (decimal)i;
-        }
+        public decimal Method_ReturnDecimal(int? i) => (decimal)i;
 
         public decimal Method_ReturnDecimal(out ulong p1, ref MyEnum p2, params char?[] p3)
         {
             p1 = (ulong)p3.Length;
             p2 = MyEnum.Third;
-            return (decimal)1;
+            return 1;
         }
 
-        public decimal Method_ReturnDecimal(params int?[] i)
-        {
-            return 1M;
-        }
+        public decimal Method_ReturnDecimal(params int?[] i) => 1M;
 
-        public decimal? Method_ReturnDecimalNullable()
-        {
-            return (decimal?)1M;
-        }
+        public decimal? Method_ReturnDecimalNullable() => 1M;
 
-        public decimal? Method_ReturnDecimalNullable(int i)
-        {
-            return (decimal?)i;
-        }
+        public decimal? Method_ReturnDecimalNullable(int i) => i;
 
-        public decimal? Method_ReturnDecimalNullable(params int[] i)
-        {
-            return (decimal?)1M;
-        }
+        public decimal? Method_ReturnDecimalNullable(params int[] i) => 1M;
 
         public decimal? Method_ReturnDecimalNullable(ref int? p1, ref short? p2, out MyStruct[] p3)
         {
@@ -275,10 +206,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             return x;
         }
 
-        public dynamic Method_ReturnDynamic(ref int x)
-        {
-            return x;
-        }
+        public dynamic Method_ReturnDynamic(ref int x) => x;
 
         public dynamic Method_ReturnDynamic(out float x)
         {
@@ -286,153 +214,65 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             return x;
         }
 
-        public dynamic Method_ReturnDynamic(params dynamic[] d)
-        {
-            return d.Length;
-        }
+        public dynamic Method_ReturnDynamic(params dynamic[] d) => d.Length;
 
-        public dynamic Method_ReturnDynamic(dynamic d, int x, ref dynamic e)
-        {
-            return x;
-        }
+        public dynamic Method_ReturnDynamic(dynamic d, int x, ref dynamic e) => x;
 
-        public float Method_ReturnFloat()
-        {
-            return 3.4534f;
-        }
+        public float Method_ReturnFloat() => 3.4534f;
 
-        public float Method_ReturnFloat(int x)
-        {
-            return (float)x;
-        }
+        public float Method_ReturnFloat(int x) => x;
 
-        public float Method_ReturnFloat(params float[] p1)
-        {
-            return p1[0];
-        }
+        public float Method_ReturnFloat(params float[] p1) => p1[0];
 
         public float Method_ReturnFloat(ref float p1, out float p2, params float[] p3)
         {
             p1 = 0.000003f;
             p2 = 2342424;
-            return (float)p3.Length;
+            return p3.Length;
         }
 
-        public float? Method_ReturnFloatNullable()
-        {
-            return 3.4534f;
-        }
+        public float? Method_ReturnFloatNullable() => 3.4534f;
 
-        public float? Method_ReturnFloatNullable(int x)
-        {
-            return (float?)x;
-        }
+        public float? Method_ReturnFloatNullable(int x) => x;
 
-        public float? Method_ReturnFloatNullable(params float[] p1)
-        {
-            return p1[0];
-        }
+        public float? Method_ReturnFloatNullable(params float[] p1) => p1[0];
 
         public float? Method_ReturnFloatNullable(ref float? p1, out float p2, params float?[] p3)
         {
             p1 = 0.000003f;
             p2 = 2342424;
-            return (float)p3.Length;
+            return p3.Length;
         }
 
-        public float?[] Method_ReturnFloatArrNullable()
-        {
-            return new float?[]
-            {
-            3.4534f
-            }
+        public float?[] Method_ReturnFloatArrNullable() => new float?[] { 3.4534f };
 
-            ;
-        }
+        public float?[] Method_ReturnFloatArrNullable(int x) => new float?[] { x };
 
-        public float?[] Method_ReturnFloatArrNullable(int x)
-        {
-            return new float?[]
-            {
-            x
-            }
-
-            ;
-        }
-
-        public float?[] Method_ReturnFloatArrNullable(params float[] p1)
-        {
-            return new float?[]
-            {
-            p1[0]
-            }
-
-            ;
-        }
+        public float?[] Method_ReturnFloatArrNullable(params float[] p1) => new float?[] { p1[0] };
 
         public float?[] Method_ReturnFloatArrNullable(ref float p1, out float p2, params float[] p3)
         {
             p1 = 0.000003f;
             p2 = 2342424;
-            return new float?[]
-            {
-            p3.Length
-            }
-
-            ;
+            return new float?[] { p3.Length };
         }
 
-        public float[] Method_ReturnFloatArr()
-        {
-            return new float[]
-            {
-            3.4534f
-            }
+        public float[] Method_ReturnFloatArr() => new float[] { 3.4534f };
 
-            ;
-        }
+        public float[] Method_ReturnFloatArr(int x) => new float[] { x };
 
-        public float[] Method_ReturnFloatArr(int x)
-        {
-            return new float[]
-            {
-            x
-            }
-
-            ;
-        }
-
-        public float[] Method_ReturnFloatArr(params float[] p1)
-        {
-            return new float[]
-            {
-            p1[0]
-            }
-
-            ;
-        }
+        public float[] Method_ReturnFloatArr(params float[] p1) => new float[] { p1[0] };
 
         public float[] Method_ReturnFloatArr(ref float p1, out float p2, params float[] p3)
         {
             p1 = 0.000003f;
             p2 = 2342424;
-            return new float[]
-            {
-            p3.Length
-            }
-
-            ;
+            return new float[] { p3.Length };
         }
 
-        public int Method_ReturnInt(decimal[] p1, char[] p2, byte p3)
-        {
-            return 5;
-        }
+        public int Method_ReturnInt(decimal[] p1, char[] p2, byte p3) => 5;
 
-        public int Method_ReturnInt(params string[] s)
-        {
-            return 1;
-        }
+        public int Method_ReturnInt(params string[] s) => 1;
 
         public int Method_ReturnInt(ref string s)
         {
@@ -440,37 +280,20 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             return s.Length;
         }
 
-        public int Method_ReturnInt(string s)
-        {
-            return s.Length;
-        }
+        public int Method_ReturnInt(string s) => s.Length;
 
-        public int? Method_ReturnIntNullable()
-        {
-            return (int?)1;
-        }
+        public int? Method_ReturnIntNullable() => 1;
 
-        public int? Method_ReturnIntNullable(bool b)
-        {
-            return null;
-        }
+        public int? Method_ReturnIntNullable(bool b) => null;
 
         public int? Method_ReturnIntNullable(out MyClass p1, ref decimal p2, char p3)
         {
-            p1 = new MyClass()
-            {
-                Field = 3
-            }
-
-            ;
+            p1 = new MyClass() { Field = 3 };
             p2 = 3m;
             return p3;
         }
 
-        public int? Method_ReturnIntNullable(params bool[] b)
-        {
-            return (int?)1;
-        }
+        public int? Method_ReturnIntNullable(params bool[] b) => 1;
 
         public int? Method_ReturnIntNullable(ref bool b)
         {
@@ -478,43 +301,26 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             return b == true ? (int?)1 : null;
         }
 
-        public MyClass Method_ReturnMyClass()
-        {
-            MyClass m = new MyClass();
-            m.Field = 1;
-            return m;
-        }
+        public MyClass Method_ReturnMyClass() => new MyClass() { Field = 1 };
 
         public MyClass Method_ReturnMyClass(out int? p1, short? p2, out byte p3)
         {
             p1 = 2;
             p3 = 3;
-            MyClass m = new MyClass();
-            m.Field = (int)p2;
+            MyClass m = new MyClass() { Field = (int)p2 };
             return m;
         }
 
         public MyClass Method_ReturnMyClass(out ulong l)
         {
             l = 3;
-            MyClass m = new MyClass();
-            m.Field = (int)l;
+            MyClass m = new MyClass() { Field = (int)l };
             return m;
         }
 
-        public MyClass Method_ReturnMyClass(params MyStruct[] arr)
-        {
-            MyClass m = new MyClass();
-            m.Field = 1;
-            return m;
-        }
+        public MyClass Method_ReturnMyClass(params MyStruct[] arr) => new MyClass() { Field = 1 };
 
-        public MyClass Method_ReturnMyClass(ulong l)
-        {
-            MyClass m = new MyClass();
-            m.Field = (int)l;
-            return m;
-        }
+        public MyClass Method_ReturnMyClass(ulong l) => new MyClass() { Field = (int)l };
 
         public MyClass Method_ReturnMyClass_Throw()
         {
@@ -536,165 +342,70 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             throw new ArithmeticException("Test exception");
         }
 
-        public MyEnum Method_ReturnMyEnum()
-        {
-            MyEnum m = MyEnum.First;
-            return m;
-        }
+        public MyEnum Method_ReturnMyEnum() => MyEnum.First;
 
         public MyEnum Method_ReturnMyEnum(out bool[] p1, int[] p2, out bool? p3)
         {
-            p1 = new bool[2];
-            p1[0] = true;
-            p1[1] = false;
+            p1 = new bool[] { true, false };
             p3 = null;
             MyEnum m = new MyEnum();
             m = MyEnum.First;
-            return m;
+            return MyEnum.First;
         }
 
-        public MyEnum Method_ReturnMyEnum(params short[] s)
-        {
-            MyEnum m = MyEnum.Second;
-            return m;
-        }
+        public MyEnum Method_ReturnMyEnum(params short[] s) => MyEnum.Second;
 
-        public MyEnum Method_ReturnMyEnum(short s)
-        {
-            MyEnum m = new MyEnum();
-            m = (MyEnum)s;
-            return m;
-        }
+        public MyEnum Method_ReturnMyEnum(short s) => (MyEnum)s;
 
-        public MyEnum? Method_ReturnMyEnumNullable()
-        {
-            MyEnum m = new MyEnum();
-            m = MyEnum.First;
-            return m;
-        }
+        public MyEnum? Method_ReturnMyEnumNullable() => MyEnum.First;
 
-        public MyEnum? Method_ReturnMyEnumNullable(int[] arr)
-        {
-            MyEnum m = MyEnum.Second;
-            return m;
-        }
+        public MyEnum? Method_ReturnMyEnumNullable(int[] arr) => MyEnum.Second;
 
-        public MyEnum? Method_ReturnMyEnumNullable(params MyClass[] d)
-        {
-            MyEnum m = new MyEnum();
-            m = MyEnum.Third;
-            return m;
-        }
+        public MyEnum? Method_ReturnMyEnumNullable(params MyClass[] d) => MyEnum.Third;
 
         public MyEnum? Method_ReturnMyEnumNullable(ref bool[] p1, bool p2, out short[] p3)
         {
             p1 = new bool[2];
             p3 = new short[3];
-            MyEnum m = new MyEnum();
-            m = MyEnum.First;
-            return m;
+            return MyEnum.First;
         }
 
-        public MyStruct Method_ReturnMyStruct()
-        {
-            MyStruct m = new MyStruct();
-            m.Number = 3;
-            return m;
-        }
+        public MyStruct Method_ReturnMyStruct() => new MyStruct() { Number = 3 };
 
-        public MyStruct Method_ReturnMyStruct(params string[] s)
-        {
-            MyStruct m = new MyStruct();
-            m.Number = 3;
-            return m;
-        }
+        public MyStruct Method_ReturnMyStruct(params string[] s) => new MyStruct() { Number = 3 };
 
         public MyStruct Method_ReturnMyStruct(short p1, out bool p2, params MyClass[] p3)
         {
             p2 = false;
-            MyStruct m = new MyStruct();
-            m.Number = p3.Length;
-            return m;
+            return new MyStruct() { Number = p3.Length };
         }
 
-        public MyStruct Method_ReturnMyStruct(string s)
-        {
-            MyStruct m = new MyStruct();
-            m.Number = s.Length;
-            return m;
-        }
+        public MyStruct Method_ReturnMyStruct(string s) => new MyStruct { Number = s.Length };
 
-        public MyStruct? Method_ReturnMyStructNullable()
-        {
-            MyStruct? m = new MyStruct()
-            {
-                Number = 3
-            }
+        public MyStruct? Method_ReturnMyStructNullable() => new MyStruct() { Number = 3 };
 
-            ;
-            return m;
-        }
-
-        public MyStruct? Method_ReturnMyStructNullable(object o)
-        {
-            MyStruct? m = new MyStruct()
-            {
-                Number = 3
-            }
-
-            ;
-            return m;
-        }
+        public MyStruct? Method_ReturnMyStructNullable(object o) => new MyStruct() { Number = 3 };
 
         public MyStruct? Method_ReturnMyStructNullable(out byte? p1, out string[] p2, params ulong[] p3)
         {
             p1 = 3;
             p2 = new string[3];
-            MyStruct? m = new MyStruct()
-            {
-                Number = p3.Length
-            }
-
-            ;
-            return m;
+            return new MyStruct() { Number = p3.Length };
         }
 
-        public MyStruct? Method_ReturnMyStructNullable(params object[] o)
-        {
-            MyStruct? m = new MyStruct()
-            {
-                Number = o.Length
-            }
+        public MyStruct? Method_ReturnMyStructNullable(params object[] o) => new MyStruct() { Number = o.Length };
 
-            ;
-            return m;
-        }
+        public object Method_ReturnObject() => null;
 
-        public object Method_ReturnObject()
-        {
-            return null;
-        }
-
-        public object Method_ReturnObject(byte?[] arr)
-        {
-            return null;
-        }
+        public object Method_ReturnObject(byte?[] arr) => null;
 
         public object Method_ReturnObject(MyEnum[] p1, int p2, ref char?[] p3)
         {
-            p3 = new char?[]
-            {
-            'a', 'b'
-            }
-
-            ;
+            p3 = new char?[] { 'a', 'b' };
             return null;
         }
 
-        public object Method_ReturnObject(params bool?[] b)
-        {
-            return null;
-        }
+        public object Method_ReturnObject(params bool?[] b) => null;
 
         public short Method_ReturnShort_Throw()
         {
@@ -748,20 +459,11 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             throw new ArgumentException("Test message", nameof(d));
         }
 
-        public sbyte Method_ReturnSbyte(int x, dynamic d, short s, decimal dd, MyClass c, float f, short? ss)
-        {
-            return 1;
-        }
+        public sbyte Method_ReturnSbyte(int x, dynamic d, short s, decimal dd, MyClass c, float f, short? ss) => 1;
 
-        public string Method_ReturnString()
-        {
-            return "string";
-        }
+        public string Method_ReturnString() => "string";
 
-        public string Method_ReturnString(char c)
-        {
-            return c.ToString();
-        }
+        public string Method_ReturnString(char c) => c.ToString();
 
         public string Method_ReturnString(out ulong?[] p1, out byte[] p2, out int?[] p3)
         {
@@ -771,10 +473,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             return "c";
         }
 
-        public string Method_ReturnString(params char[] c)
-        {
-            return "string";
-        }
+        public string Method_ReturnString(params char[] c) => "string";
 
         public string[] Method_ReturnStringArr()
         {
@@ -811,12 +510,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
 
         public string[] Method_ReturnStringArr(short?[] p1, ref MyStruct p2, out MyStruct[] p3)
         {
-            p2 = new MyStruct()
-            {
-                Number = 3
-            }
-
-            ;
+            p2 = new MyStruct() { Number = 3 };
             p3 = new MyStruct[2];
             p3[0].Number = 1;
             p3[1].Number = 2;
@@ -826,15 +520,9 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             return arr;
         }
 
-        public ulong Method_ReturnUlong()
-        {
-            return 1L;
-        }
+        public ulong Method_ReturnUlong() => 1L;
 
-        public ulong Method_ReturnUlong(MyClass m)
-        {
-            return (ulong)m.ToString().Length;
-        }
+        public ulong Method_ReturnUlong(MyClass m) => (ulong)m.ToString().Length;
 
         public ulong Method_ReturnUlong(out MyClass m)
         {
@@ -842,28 +530,17 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             return (ulong)m.ToString().Length;
         }
 
-        public ulong Method_ReturnUlong(params MyClass[] m)
-        {
-            return 1L;
-        }
+        public ulong Method_ReturnUlong(params MyClass[] m) => 1L;
 
         public ulong Method_ReturnUlong(ref ulong?[] p1, out MyStruct p2, ref byte?[] p3)
         {
             p1[0] = 3;
-            p2 = new MyStruct()
-            {
-                Number = 3
-            }
-
-            ;
+            p2 = new MyStruct() { Number = 3 };
             p3[0] = 1;
             return 1;
         }
 
-        public ulong? Method_ReturnUlongNullable()
-        {
-            return (ulong?)1L;
-        }
+        public ulong? Method_ReturnUlongNullable() => 1L;
 
         public ulong? Method_ReturnUlongNullable(long c)
         {
@@ -878,945 +555,252 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             return 1L;
         }
 
-        public ulong? Method_ReturnUlongNullable(params char?[] c)
-        {
-            return (ulong?)1L;
-        }
+        public ulong? Method_ReturnUlongNullable(params char?[] c) => 1L;
 
-        public void Method_ReturnVoid()
-        {
-            return;
-        }
+        public void Method_ReturnVoid() { }
 
-        public void Method_ReturnVoid(MyStruct[] arr)
-        {
-            return;
-        }
+        public void Method_ReturnVoid(MyStruct[] arr) { }
 
-        public void Method_ReturnVoid(params ulong[] l)
-        {
-            return;
-        }
+        public void Method_ReturnVoid(params ulong[] l) { }
 
         public void Method_ReturnVoid(ref object[] p1, out bool?[] p2, ref MyClass[] p3)
         {
             p1 = null;
             p3 = null;
-            p2 = new bool?[1];
-            p2[0] = false;
+            p2 = new bool?[] { false };
             return;
         }
 
-        #endregion
-        #region Static methods
-        public static bool StaticMethod_ReturnBool()
-        {
-            return false;
-        }
-        #endregion
+        public static bool StaticMethod_ReturnBool() => false;
     }
 }
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass001.regclass001
+namespace Dynamic.RegularClass.RegularMethod.Tests
 {
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass001.regclass001;
-    // <Title> Tests regular class regular method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
+    public class RegularClassRegularMethodTests
     {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            if (Test.TestMethod(new object()) == true)
-                return 1;
-            return 0;
-        }
-
         public static bool TestMethod(object o)
         {
-            dynamic mc = new MemberClass();
-            return (bool)mc.Method_ReturnBool(o, null);
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass002.regclass002
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass002.regclass002;
-    // <Title> Tests regular class regular method used in extension method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            Test t = new Test();
-            if (t.TestMethod())
-                return 1;
-            return 0;
-        }
-    }
-
-    static public class Extension
-    {
-        public static bool TestMethod(this Test t)
-        {
-            dynamic mc = new MemberClass();
-            return mc.Method_ReturnBoolNullable();
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass003.regclass003
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass003.regclass003;
-    // <Title> Tests regular class regular method used in member initializer of object initializer.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        public class TestClass
-        {
-            public MyStruct ms;
-            public bool? BoolProperty
-            {
-                get;
-                set;
-            }
-
-            public byte[] ByteArray;
+            dynamic d = new MemberClass();
+            return (bool)d.Method_ReturnBool(o, null);
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody1()
         {
-            Assert.Equal(0, MainMethod());
+            Assert.False(TestMethod(new object()));
         }
 
-        public static int MainMethod()
-        {
-            MemberClass mc = new MemberClass();
-            dynamic dy = mc;
-            TestClass tc = new TestClass
-            {
-                ms = dy.Method_ReturnMyStruct(),
-                BoolProperty = dy.Method_ReturnBoolNullable((short?)3),
-                ByteArray = dy.Method_ReturnByteArr(0, 1, 2, 3, 4)
-            }
-
-            ;
-            if (tc != null && tc.ms.Number == 3 && tc.BoolProperty == true && tc.ByteArray.Length == 5)
-            {
-                for (byte i = 0; i < 5; i++)
-                {
-                    if (tc.ByteArray[i] != i)
-                        return 1;
-                }
-
-                return 0;
-            }
-
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass004.regclass004
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass004.regclass004;
-    // <Title> Tests regular class regular method used in property-get body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ExtensionMethodBody()
         {
-            Assert.Equal(0, MainMethod());
+            RegularClassRegularMethodTests t = new RegularClassRegularMethodTests();
+            Assert.False(t.TestMethod());
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void CollectionIntializer()
         {
-            MyClass myClass = new Test().MyClass;
-            if (myClass.Field != 1)
-                return 1;
-            return 0;
-        }
-
-        public MyClass MyClass
-        {
-            get
-            {
-                dynamic mc = new MemberClass();
-                return (MyClass)mc.Method_ReturnMyClass();
-            }
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass005.regclass005
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass005.regclass005;
-    // <Title> Tests regular class regular method used in collection initializer.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections.Generic;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
+            dynamic d = new MemberClass();
             object p2 = null;
             char p3 = 'a';
-            decimal[] dec = new decimal[]
-            {
-            1
-            }
+            decimal[] dec = new decimal[] { 1 };
+            var list = new List<char?> { (char?)d.Method_ReturnCharNullable(), (char?)d.Method_ReturnCharNullable(dec, ref p2, ref p3) };
 
-            ;
-            var list = new List<char?>
-            {
-            (char ? )mc.Method_ReturnCharNullable(), (char ? )mc.Method_ReturnCharNullable(dec, ref p2, ref p3)}
-
-            ;
-            if (list.Count == 2 && p2.GetType() == typeof(MyClass) && ((MyClass)p2).Field == 3 && p3 == 'b' && list[0] == 'a' && list[1] == 'b')
-                return 0;
-            return 1;
+            Assert.Equal(new List<char?> { 'a', 'b' }, list);
+            Assert.Equal('b', p3);
+            Assert.IsType<MyClass>(p2);
+            Assert.Equal(3, ((MyClass)p2).Field);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass006.regclass006
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass006.regclass006;
-    // <Title> Tests regular class regular method used in checked expression.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections.Generic;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void CheckedExpression()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
+            dynamic d = new MemberClass();
             string s = "a";
-            int m1 = checked((int)mc.Method_ReturnInt(null, null) + 1);
-            int m2 = unchecked((int)mc.Method_ReturnInt(s) + int.MaxValue);
-            if (m1 == 2 && m2 == -2147483648)
-                return 0;
-            return 1;
+            int m1 = checked((int)d.Method_ReturnInt(null, null) + 1);
+            int m2 = unchecked((int)d.Method_ReturnInt(s) + int.MaxValue);
+            Assert.Equal(2, m1);
+            Assert.Equal(-2147483648, m2);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass007.regclass007
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass007.regclass007;
-    // <Title> Tests regular class regular method used in try/catch/finally.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    //<Expects Status=warning>\(24,36\).*CS0168</Expects>
-    using System;
-    using System.Collections.Generic;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
+        public static void TryCatchFinally()
         {
             int? result1 = null;
             decimal result2 = 0;
-            dynamic dy = new MemberClass();
+            dynamic d = new MemberClass();
             try
             {
-                dy.Method_ReturnMyClass_Throw();
+                d.Method_ReturnMyClass_Throw();
             }
             catch (ArithmeticException e)
             {
-                result1 = (int?)dy.Method_ReturnIntNullable();
+                result1 = (int?)d.Method_ReturnIntNullable();
             }
             finally
             {
-                result2 = (decimal)dy.Method_ReturnDecimal();
+                result2 = (decimal)d.Method_ReturnDecimal();
             }
 
-            return (result1.Value == result2) ? 0 : 1;
+            Assert.Equal(result2, result1.Value);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass008.regclass008
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass008.regclass008;
-    // <Title> Tests regular class regular method used in this-argument of extension method.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ThisArgumentOfExtensionMethod()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic d = new MemberClass();
+            Assert.Equal(6, ((int)d.Method_ReturnInt(null, new char[] { 'a' }, 0)).ExPlus());
         }
 
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
-            if (((int)dy.Method_ReturnInt(null, new char[]
-            {
-            'a'
-            }
-
-            , 0)).ExPlus() != 6)
-                return 1;
-            return 0;
-        }
-    }
-
-    static public class Extension
-    {
-        public static int ExPlus(this object i)
-        {
-            if (i.GetType() == typeof(int))
-            {
-                int result = (int)i;
-                return ++result;
-            }
-            else
-                throw new ArgumentException();
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass009.regclass009
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass009.regclass009;
-    // <Title> Tests regular class regular method used in throw expression.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ThrowExpression()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
+            dynamic d = new MemberClass();
+            bool testSucceeded = false;
             try
             {
-                throw new ArithmeticException((string)mc.Method_ReturnString());
+                throw new ArithmeticException((string)d.Method_ReturnString());
             }
             catch (ArithmeticException e)
             {
-                if (e.Message == "string")
-                    return 0;
+                testSucceeded = e.Message == "string";
             }
-
-            return 1;
+            Assert.True(testSucceeded);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass010.regclass010
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass010.regclass010;
-    // <Title> Tests regular class regular method used in using expression.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-    using System.Text;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UsingExpression()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
+            dynamic d = new MemberClass();
             string result = null;
-            using (MemoryStream sm = new MemoryStream())
+            using (MemoryStream memoryStream = new MemoryStream())
             {
-                using (StreamWriter sw = new StreamWriter(sm))
+                using (StreamWriter streamWriter = new StreamWriter(memoryStream))
                 {
-                    sw.WriteLine(mc.Method_ReturnString('a'));
-                    sw.Flush();
-                    sm.Position = 0;
-                    using (StreamReader sr = new StreamReader(sm, (bool)mc.Method_ReturnBool()))
+                    streamWriter.WriteLine(d.Method_ReturnString('a'));
+                    streamWriter.Flush();
+                    memoryStream.Position = 0;
+                    using (StreamReader sr = new StreamReader(memoryStream, (bool)d.Method_ReturnBool()))
                     {
                         result = sr.ReadToEnd();
                     }
                 }
             }
 
-            if (result.ToString().Trim() == "a")
-                return 0;
-            return 1;
+            Assert.Equal("a", result.Trim());
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass011.regclass011
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass011.regclass011;
-    // <Title> Tests regular class regular method used in lock expression.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private static object s_locker;
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void LockExpression()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
+            dynamic d = new MemberClass();
             dynamic result = true;
-            lock (s_locker = mc.Method_ReturnString(new char[]
-            {
-            'a', 'b'
-            }
-
-            ))
+            object locker;
+            lock (locker = d.Method_ReturnString(new char[] { 'a', 'b' }))
             {
                 result = MemberClass.StaticMethod_ReturnBool();
             }
-
-            if (!(bool)result)
-                return 0;
-            return 1;
+            Assert.False((bool)result);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass012.regclass012
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass012.regclass012;
-    // <Title> Tests regular class regular method used in the for loop.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-    using System.Text;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ForLoop1()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
+            dynamic d = new MemberClass();
             sbyte result = 0;
-            for (ulong i = (ulong)mc.Method_ReturnUlong(); i < (ulong)mc.Method_ReturnUlong(new MyClass()); i++)
+            for (ulong i = (ulong)d.Method_ReturnUlong(); i < (ulong)d.Method_ReturnUlong(new MyClass()); i++)
             {
-                result += (sbyte)mc.Method_ReturnSbyte((int)i, mc, (short)i, (decimal)i, new MyClass(), (float)i, (short?)i);
+                result += (sbyte)d.Method_ReturnSbyte((int)i, d, (short)i, (decimal)i, new MyClass(), (float)i, (short?)i);
             }
-
-            if (result == 119) // length of full name of MyClass.
-                return 0;
-            return 1;
+            Assert.Equal(119, result); // length of full name of MyClass.
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass012a.regclass012a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass012a.regclass012a;
-    // <Title> Tests regular class regular method used in the for loop.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-    using System.Text;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ForLoop2()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
+            dynamic d1 = new MemberClass();
             sbyte result = 0;
-            dynamic d = new MyClass();
-            for (ulong i = mc.Method_ReturnUlong(); i < mc.Method_ReturnUlong(d); i++)
+            dynamic d2 = new MyClass();
+            for (ulong i = d1.Method_ReturnUlong(); i < d1.Method_ReturnUlong(d2); i++)
             {
-                result += mc.Method_ReturnSbyte((int)i, mc, (short)i, (decimal)i, d, (float)i, (short?)i);
+                result += d1.Method_ReturnSbyte((int)i, d1, (short)i, (decimal)i, d2, (float)i, (short?)i);
             }
-
-            if (result == 119)
-                return 0;
-            return 1;
+            Assert.Equal(119, result); // length of full name of MyClass.
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass015.regclass015
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass015.regclass015;
-    // <Title> Tests regular class regular method used in the default section statement list.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-    using System.Text;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void DefaultSwitchStatement()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
+            dynamic d = new MemberClass();
             char c = '0';
             switch (c)
             {
                 case '1':
                     break;
                 default:
-                    c = (char)mc.Method_ReturnChar(new MyStruct[]
-                    {
-                    new MyStruct()
-                    {
-                    Number = 0
-                    }
-
-                    , new MyStruct()
-                    {
-                    Number = 1
-                    }
-                    }
-
-                    );
+                    c = (char)d.Method_ReturnChar(new MyStruct[] { new MyStruct() { Number = 0 }, new MyStruct() { Number = 1 } });
                     break;
             }
-
-            if (c == 'b')
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass018.regclass018
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass018.regclass018;
-    // <Title> Tests regular class regular method used in iterator that calls to a lambda expression.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections;
-
-    public class Test
-    {
-        private static dynamic s_mc = new MemberClass();
-
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            Assert.Equal('b', c);
         }
 
-        public static int MainMethod()
-        {
-            decimal index = 0;
-            dynamic dy = new Test();
-            foreach (decimal i in (IEnumerable)dy.Increment(0, 10))
-            {
-                if (i != index++)
-                    return 1;
-            }
-
-            return 0;
-        }
-
-        public IEnumerable Increment(int number, decimal max)
-        {
-            while (number < max)
-            {
-                Func<int?, decimal> func = (int? x) => (decimal)s_mc.Method_ReturnDecimal(x);
-                yield return func(number++);
-            }
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass019.regclass019
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass019.regclass019;
-    // <Title> Tests regular class regular method used in object initializer inside a collection initializer.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-
-    public class Test
-    {
-        private MyClass _myclass = null;
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void TryCatchFinally_TwoDynamicParameters()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
-            List<Test> list = new List<Test>()
-            {
-            new Test()
-            {
-            _myclass = mc.Method_ReturnMyClass(11)}
-            }
-
-            ;
-            if (list.Count == 1 && list[0]._myclass.Field == 11)
-                return 0;
-            else
-                return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass020.regclass020
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass020.regclass020;
-    // <Title> Tests regular class regular method used in try/catch/finally.</Title>
-    // <Description>
-    // try/catch/finally that uses an anonymous method and refer two dynamic parameters.
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
+            dynamic d = new MemberClass();
             int result = -1;
             try
             {
                 Func<short, short, short, short> func = delegate (short x, short y, short z)
                 {
-                    return (short)mc.Method_ReturnShort_Throw((MyEnum)mc.Method_ReturnMyEnum(), mc.Method_ReturnMyEnum(x, (short)y), mc.Method_ReturnMyEnum((short)z));
-                }
-
-                ;
+                    return (short)d.Method_ReturnShort_Throw((MyEnum)d.Method_ReturnMyEnum(), d.Method_ReturnMyEnum(x, (short)y), d.Method_ReturnMyEnum((short)z));
+                };
                 result = func(1, 2, 3);
-                return 1;
             }
             catch (ArithmeticException e)
             {
-                if (e.Message != "Test message")
-                    return 1;
+                Assert.Equal("Test message", e.Message);
             }
             finally
             {
-                result = (short)mc.Method_ReturnUlong(new MyClass()) - 1;
+                result = (short)d.Method_ReturnUlong(new MyClass()) - 1;
             }
 
-            return result == 119 ? 0 : 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass021.regclass021
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass021.regclass021;
-    // <Title> Tests regular class regular method used in anonymous type.</Title>
-    // <Description>
-    // anonymous type inside a query expression that introduces dynamic variables.
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Linq;
-    using System.Collections;
-    using System.Collections.Generic;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            Assert.Equal(119, result);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void AnonymousType_InsideQueryExpression_IntroducesDynamicVariables()
         {
-            List<int> list = new List<int>()
-            {
-            0, 4, 1, 6, 4, 4, 5
-            }
-
-            ;
+            List<int> list = new List<int>() { 0, 4, 1, 6, 4, 4, 5 };
             string s = "test";
-            dynamic mc = new MemberClass();
-            var result = list.Where(p => p == (int)mc.Method_ReturnInt(ref s)).Select(p => new
+            dynamic d = new MemberClass();
+            var result = list.Where(p => p == (int)d.Method_ReturnInt(ref s)).Select(p => new
             {
-                A = mc.Method_ReturnDecimalNullable(p)
-            }
+                A = d.Method_ReturnDecimalNullable(p)
+            }).ToList();
+            Assert.Equal("TEST", s);
+            Assert.Equal(3, result.Count);
 
-            ).ToList();
-            if (s == "TEST" && result.Count == 3)
+            foreach (var m in result)
             {
-                foreach (var m in result)
-                {
-                    if ((decimal)m.A == 4 && m.A.GetType() == typeof(decimal?))
-                        return 0;
-                }
-
-                return 0;
+                Assert.Equal(4, (decimal)m.A);
             }
-
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass022.regclass022
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass022.regclass022;
-    // <Title> Tests regular class regular method used in foreach.</Title>
-    // <Description>
-    // foreach inside a using statement that uses the dynamic introduced by the using statement.
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void Foreach_InsideUsingStatement_UsingDynamicIntroducedByTheUsingStatement()
         {
-            int[] array = new int[]
-            {
-            1, 2
-            }
+            int[] array = new int[] { 1, 2 };
+            MemoryStream ms = new MemoryStream(new byte[] { 84, 101, 115, 116 });
 
-            ;
-            MemoryStream ms = new MemoryStream(new byte[]
-            {
-            84, 101, 115, 116
-            }
-
-            ); //Test
-            dynamic mc = new MemberClass();
+            dynamic d = new MemberClass();
             string result = string.Empty;
             byte? p1 = null;
             ulong? p2 = 0;
             int p3 = 10;
-            using (dynamic sr = new StreamReader(ms, (bool)mc.Method_ReturnBool(out p1, ref p2, out p3)))
+            using (dynamic sr = new StreamReader(ms, (bool)d.Method_ReturnBool(out p1, ref p2, out p3)))
             {
                 foreach (int s in array)
                 {
@@ -1825,980 +809,152 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
                     result += m + s.ToString();
                 }
             }
-
-            //Test1Test2
-            if (p1 == 3 && p2 == null && p3 == 1 && result == "Test1Test2")
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass023.regclass023
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass023.regclass023;
-    // <Title> Tests regular class regular method used static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            Assert.Equal((byte)3, p1);
+            Assert.Null(p2);
+            Assert.Equal(1, p3);
+            Assert.Equal("Test1Test2", result);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void StaticMethodBody2()
         {
-            dynamic mc = new MemberClass();
+            dynamic d = new MemberClass();
             decimal?[] p2 = null;
-            var result = (bool?)mc.Method_ReturnBoolNullable(null, out p2, null, 0);
-            if (p2 != null && p2.Length == 2 && result.Value == true)
-                return 0;
-            return 1;
+            var result = (bool?)d.Method_ReturnBoolNullable(null, out p2, null, 0);
+            Assert.Equal(2, p2.Length);
+            Assert.True(result.Value);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass024.regclass024
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass024.regclass024;
-    // <Title> Tests regular class regular method used static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody3()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
+            dynamic d = new MemberClass();
             short? p = null;
-            var result = (bool?)mc.Method_ReturnBoolNullable(p);
-            bool ret = (null == result);
+            var result = (bool?)d.Method_ReturnBoolNullable(p);
+            Assert.Null(result);
             p = 0;
-            result = (bool?)mc.Method_ReturnBoolNullable(p);
-            ret &= (true == result.Value);
-            return ret ? 0 : 1;
+            result = (bool?)d.Method_ReturnBoolNullable(p);
+            Assert.True(result);
         }
-    }
-    //</Code>
-}
 
+        private static void IsEqual(byte?[] input)
+        {
+            Assert.Equal(new byte?[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }, input);
+        }
 
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass025.regclass025
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass025.regclass025;
-    // <Title> Tests regular class regular method used in method argument.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void MethodArgument_Regular()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic d = new MemberClass();
+            IsEqual((byte?[])d.Method_ReturnByteArrNullable());
         }
 
-        public static int MainMethod()
+        private static void IsEqual<T>(byte?[] input)
         {
-            dynamic mc = new MemberClass();
-            bool reuslt = IsEqual((byte?[])mc.Method_ReturnByteArrNullable());
-            if (reuslt)
-                return 0;
-            return 1;
+            Assert.Equal(new byte?[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }, input);
         }
 
-        private static bool IsEqual(byte?[] input)
-        {
-            if (input == null && input.Length != 10)
-            {
-                return false;
-            }
-
-            for (byte i = 0; i < 10; i++)
-                if (input[i].Value != i)
-                    return false;
-            return true;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass026.regclass026
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass026.regclass026;
-    // <Title> Tests regular class regular method used in generic method argument.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void MethodArgument_Generic()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic d = new MemberClass();
+            IsEqual<RegularClassRegularMethodTests>((byte?[])d.Method_ReturnByteArrNullable(new MyStruct?[] { new MyStruct() { Number = 10 } }));
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void StaticMethodBody4()
         {
-            dynamic mc = new MemberClass();
-            bool reuslt = IsEqual<Test>((byte?[])mc.Method_ReturnByteArrNullable(new MyStruct?[]
-            {
-            new MyStruct()
-            {
-            Number = 10
-            }
-            }
+            dynamic d = new MemberClass();
+            MyStruct? m = new MyStruct { Number = 10 };
 
-            ));
-            if (reuslt)
-                return 0;
-            return 1;
+            byte?[] result = (byte?[])d.Method_ReturnByteArrNullable(out m);
+            Assert.Equal(2, m.Value.Number);
+            Assert.Equal(new byte?[] { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 }, result);
         }
 
-        private static bool IsEqual<T>(byte?[] input)
+        public static void StaticGenericMethod<T>()
         {
-            if (input == null && input.Length != 10)
-            {
-                return false;
-            }
-
-            for (byte i = 0; i < 10; i++)
-                if (input[i].Value != i)
-                    return false;
-            return true;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass027.regclass027
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass027.regclass027;
-    // <Title> Tests regular class regular method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
-            MyStruct? m = new MyStruct
-            {
-                Number = 10
-            }
-
-            ;
-            byte?[] result = (byte?[])mc.Method_ReturnByteArrNullable(out m);
-            if (m.Value.Number != 2 || result.Length != 10)
-                return 1;
-            for (byte i = 0; i < 10; i++)
-                if (result[i].Value != 2)
-                    return 1;
-            return 0;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass028.regclass028
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass028.regclass028;
-    // <Title> Tests regular class regular method used in static generic method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            return TestMethod<MyEnum>();
-        }
-
-        private static int TestMethod<T>()
-        {
-            dynamic mc = new MemberClass();
+            dynamic d = new MemberClass();
             string p1 = null;
             ulong? p2 = 20;
             byte?[] p3 = null;
-            byte?[] result = (byte?[])mc.Method_ReturnByteArrNullable(out p1, ref p2, ref p3);
-            if (p1 != "one" || p2 != null || result.Length != 10)
-                return 1;
-            for (byte i = 0; i < 10; i++)
-                if (result[i].Value != (byte)2)
-                    return 1;
-            return 0;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass029.regclass029
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass029.regclass029;
-    // <Title> Tests regular class regular method used in delegate invoke argument.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private delegate bool MyDec(byte?[] input);
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
-            MyDec dec = IsEqual;
-            bool reuslt = dec((byte?[])mc.Method_ReturnByteArrNullable(null, null, null));
-            if (reuslt)
-                return 0;
-            return 1;
-        }
-
-        private static bool IsEqual(byte?[] input)
-        {
-            if (input == null && input.Length != 10)
-            {
-                return false;
-            }
-
-            for (byte i = 0; i < 10; i++)
-                if (input[i].Value != i)
-                    return false;
-            return true;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass030.regclass030
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass030.regclass030;
-    // <Title> Tests regular class regular method used in constructor</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private byte[] _field;
-        public Test()
-        {
-            dynamic mc = new MemberClass();
-            _field = (byte[])mc.Method_ReturnByteArr();
+            byte?[] result = (byte?[])d.Method_ReturnByteArrNullable(out p1, ref p2, ref p3);
+            Assert.Equal("one", p1);
+            Assert.Null(p2);
+            Assert.Equal(new byte?[] { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 }, result);
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody_Generic()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            Test t = new Test();
-            if (t._field == null && t._field.Length != 10)
-            {
-                return 1;
-            }
-
-            for (byte i = 0; i < 10; i++)
-                if (t._field[i] != i)
-                    return 1;
-            return 0;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass031.regclass031
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass031.regclass031;
-    // <Title> Tests regular class regular method used in field initializer out of constructor</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private dynamic _mc = new MemberClass();
-        private byte[] _field;
-        public Test()
-        {
-            _field = (byte[])_mc.Method_ReturnByteArr(new MyClass[]
-            {
-            null, null, new MyClass()}
-
-            );
+            StaticGenericMethod<MyEnum>();
         }
 
         [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            Test t = new Test();
-            if (t._field == null && t._field.Length != 3)
-            {
-                return 1;
-            }
-
-            for (byte i = 0; i < 3; i++)
-                if (t._field[i] != 5)
-                    return 1;
-            return 0;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass032.regclass032
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass032.regclass032;
-    // <Title> Tests regular class regular method used in static field initializer out of static constructor</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private static dynamic s_mc = new MemberClass();
-        private static short?[] s_p1 = null;
-        private static bool?[] s_p2 = new bool?[1];
-        private static MyEnum s_p3 = default(MyEnum);
-        private static byte[] s_field = (byte[])s_mc.Method_ReturnByteArr(out s_p1, ref s_p2, ref s_p3);
-        static Test()
-        {
-        }
-
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            if (s_p1.Length != 2 || s_p1[0] != 1 || s_p1[1] != null)
-                return 1;
-            if (s_p2.Length != 1 || s_p2[0] != null)
-                return 1;
-            if (s_p3 != MyEnum.Third)
-                return 1;
-            if (s_field.Length != 2 || s_field[0] != 1 || s_field[1] != 0)
-                return 1;
-            return 0;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass034.regclass034
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass034.regclass034;
-    // <Title> Tests regular class regular method used in implicitly-typed array initializer</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
+        public static void ImplicitlyTypedArrayInitializer1()
         {
             string p1 = "Test";
-            dynamic mc = new MemberClass();
-            var array = new char[]
-            {
-            (char)mc.Method_ReturnChar(ref p1, null, null), (char)mc.Method_ReturnChar(ref p1, 1, null)}
-
-            ;
-            if (p1 == "test" && array.Length == 2 && array[0] == 'c' && array[1] == 'c')
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass035.regclass035
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass035.regclass035;
-    // <Title> Tests regular class regular method used in == operator</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            dynamic d = new MemberClass();
+            var array = new char[] { (char)d.Method_ReturnChar(ref p1, null, null), (char)d.Method_ReturnChar(ref p1, 1, null) };
+            Assert.Equal("test", p1);
+            Assert.Equal(new char[] { 'c', 'c' }, array);
         }
 
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
-            MyClass myclass = new MyClass()
-            {
-                Field = 10
-            }
-
-            ;
-            bool b = ((char)mc.Method_ReturnCharNullable(myclass) == (char)mc.Method_ReturnCharNullable(out myclass));
-            if (myclass.Field == 5 && b)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass036.regclass036
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass036.regclass036;
-    // <Title> Tests regular class regular method used in + operator</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private decimal _field;
-
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            ulong p1 = 0;
-            MyEnum p2 = MyEnum.Second;
-            dynamic mc = new MemberClass();
-            Test t1 = new Test()
-            {
-                _field = (decimal)mc.Method_ReturnDecimal(out p1, ref p2, null, 'a')
-            }
-
-            ;
-            Test t2 = new Test()
-            {
-                _field = (decimal)mc.Method_ReturnDecimal(null, null, 0)
-            }
-
-            ;
-            Test t3 = t1 + t2;
-            if (p1 != 2 || p2 != MyEnum.Third || t1._field != 1M || t2._field != 1M || t3._field != 2M)
-                return 1;
-            return 0;
-        }
-
-        public static Test operator +(Test t1, Test t2)
-        {
-            return new Test()
-            {
-                _field = t1._field + t2._field
-            }
-
-            ;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass037.regclass037
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass037.regclass037;
-    // <Title> Tests regular class regular method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void EqualsOperator1()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic d = new MemberClass();
+            MyClass myClass = new MyClass() { Field = 10 };
+            bool b = ((char)d.Method_ReturnCharNullable(myClass) == (char)d.Method_ReturnCharNullable(out myClass));
+            Assert.True(b);
+            Assert.Equal(5, myClass.Field);
         }
 
-        public static int MainMethod()
-        {
-            MyClass myclass0 = new MyClass()
-            {
-                Field = 0
-            }
-
-            ;
-            dynamic myclass1 = new MyClass()
-            {
-                Field = 1
-            }
-
-            ;
-            MyClass myclass2 = new MyClass()
-            {
-                Field = 2
-            }
-
-            ;
-            dynamic mc = new MemberClass();
-            string s = ((object)mc.Method_ReturnCharNullable(new MyClass[]
-            {
-            myclass0, (MyClass)myclass1, myclass2
-            }
-
-            )).ToString();
-            if (s == "z")
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass038.regclass038
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass038.regclass038;
-    // <Title> Tests regular class regular method used in % operator.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private decimal? _field;
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody5()
         {
-            Assert.Equal(0, MainMethod());
+            MyClass myclass0 = new MyClass() { Field = 0 };
+            dynamic myclass1 = new MyClass() { Field = 1 };
+            MyClass myclass2 = new MyClass() { Field = 2 };
+            dynamic d = new MemberClass();
+
+            string s = ((object)d.Method_ReturnCharNullable(new MyClass[] { myclass0, (MyClass)myclass1, myclass2 })).ToString();
+            Assert.Equal("z", s);
         }
 
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
-            Test t1 = new Test()
-            {
-                _field = (decimal?)mc.Method_ReturnDecimalNullable()
-            }
-
-            ;
-            Test t2 = new Test()
-            {
-                _field = (decimal?)mc.Method_ReturnDecimal(1, -1, 0)
-            }
-
-            ;
-            Test t3 = t1 % t2;
-            if (t1._field != 1M || t2._field != 1M || t3._field != 0M)
-                return 1;
-            return 0;
-        }
-
-        public static Test operator %(Test t1, Test t2)
-        {
-            return new Test()
-            {
-                _field = t1._field % t2._field
-            }
-
-            ;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass039.regclass039
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass039.regclass039;
-    // <Title> Tests regular class regular method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
+        [Fact]
+        public static void StaticMethodBody6()
         {
             int? p1 = 10;
             short? p2 = 20;
             MyStruct[] p3 = new MyStruct[1];
-            dynamic mc = new MemberClass();
-            decimal s = (decimal)mc.Method_ReturnDecimalNullable(ref p1, ref p2, out p3);
-            if (p1 != null || p2 != null || p3.Length != 2 || s != 3M)
-                return 1;
-            return 0;
+            dynamic d = new MemberClass();
+
+            decimal s = (decimal)d.Method_ReturnDecimalNullable(ref p1, ref p2, out p3);
+            Assert.Null(p1);
+            Assert.Null(p2);
+            Assert.Equal(2, p3.Length);
+            Assert.Equal(3M, s);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass040.regclass040
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass040.regclass040;
-    // <Title> Tests regular class regular method used in object initializer inside a collection initializer.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections.Generic;
-
-    public class Test
-    {
-        private float _field;
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void LockBlock()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            int myInt = 345;
-            dynamic mc = new MemberClass();
-            List<Test> list = new List<Test>()
-            {
-            new Test()
-            {
-            _field = (float)mc.Method_ReturnFloat()}
-
-            , new Test()
-            {
-            _field = (float)mc.Method_ReturnFloat(myInt)}
-            }
-
-            ;
-            if (list.Count == 2 && list[0]._field == 3.4534f && list[1]._field == 345f)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass041.regclass041
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass041.regclass041;
-    // <Title> Tests regular class regular method used in static property-set body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private static float s_field;
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            Test.MyProp = 10f;
-            if (Test.MyProp != 10f)
-                return 1;
-            return 0;
-        }
-
-        public static float MyProp
-        {
-            get
-            {
-                return s_field;
-            }
-
-            set
-            {
-                float myFloat = 3f;
-                dynamic mc = new MemberClass();
-                s_field = (float)mc.Method_ReturnFloat(value, myFloat, 34.5f);
-            }
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass042.regclass042
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass042.regclass042;
-    // <Title> Tests regular class regular method used in static property-get body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private static float s_p1;
-        private static float s_p2;
-
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            float result = Test.MyProp;
-            if (result == 3 && s_p1 == 0.000003f && s_p2 == 2342424)
-                return 0;
-            return 1;
-        }
-
-        public static float MyProp
-        {
-            get
-            {
-                float myFloat = 3f;
-                dynamic mc = new MemberClass();
-                return (float)mc.Method_ReturnFloat(ref s_p1, out s_p2, s_p1, s_p2, myFloat);
-            }
-
-            set
-            {
-            }
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass043.regclass043
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass043.regclass043;
-    // <Title> Tests regular class regular method used in lock block.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
+            dynamic d = new MemberClass();
             int input = int.MinValue;
             float? result;
-            lock (mc.Method_ReturnFloatNullable())
+            lock (d.Method_ReturnFloatNullable())
             {
-                result = (float?)mc.Method_ReturnFloatNullable(input);
+                result = (float?)d.Method_ReturnFloatNullable(input);
             }
 
-            if (result.Value == int.MinValue)
-                return 0;
-            return 1;
+            Assert.Equal(int.MinValue, result);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass044.regclass044
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass044.regclass044;
-    // <Title> Tests regular class regular method used in the for loop body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ForLoopBody()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            float[] array1 = new float[]
-            {
-            1f, 24.333f, 3.44f
-            }
-
-            ;
+            float[] array1 = new float[] { 1f, 24.333f, 3.44f };
             float?[] array2 = new float?[3];
             for (int i = 0; i < array1.Length; i++)
             {
@@ -2806,643 +962,176 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
                 array2[i] = dy.Method_ReturnFloatNullable(array1[i], array1[0], array1[1], array1[2]);
             }
 
-            if (array1[0] == array2[0] && array1[1] == array2[1] && array1[2] == array2[2])
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass045.regclass045
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass045.regclass045;
-    // <Title> Tests regular class regular method used in variable named dynamic.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            Assert.Equal(new float?[] { array1[0], array1[1], array1[2] }, array2);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void VariableNamedDynamic()
         {
             float? p1 = null;
             float p2 = 1.234f;
             float? myFloat = null;
             dynamic dynamic = new MemberClass();
+
             float? result = (float?)dynamic.Method_ReturnFloatNullable(ref p1, out p2, p1, p2, myFloat);
-            if (result == 3f && p1 == 0.000003f && p2 == 2342424)
-                return 0;
-            return 1;
+            Assert.Equal(3f, result);
+            Assert.Equal(0.000003f, p1);
+            Assert.Equal(2342424, p2);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass046.regclass046
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass046.regclass046;
-    // <Title> Tests regular class regular method used in foreach expression.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections.Generic;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ForeachExpression1()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
+            dynamic d = new MemberClass();
             List<float?> list = new List<float?>();
-            foreach (var f in (float?[])mc.Method_ReturnFloatArrNullable())
+            foreach (var f in (float?[])d.Method_ReturnFloatArrNullable())
             {
                 list.Add(f);
             }
-
-            if (list.Count == 1 && list[0] == 3.4534f)
-                return 0;
-            return 1;
+            Assert.Equal(new List<float?> { 3.4534f }, list);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass047.regclass047
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass047.regclass047;
-    // <Title> Tests regular class regular method used in >= operator.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void GreaterThanOperator()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
+            dynamic d = new MemberClass();
             int intValue = 10;
             float floatValue = 9.9f;
-            bool result = ((float?[])mc.Method_ReturnFloatArrNullable(intValue))[0] >= ((float?[])mc.Method_ReturnFloatArrNullable(floatValue, intValue))[0];
-            if (result)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass048.regclass048
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass048.regclass048;
-    // <Title> Tests regular class regular method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            Assert.True(((float?[])d.Method_ReturnFloatArrNullable(intValue))[0] >= ((float?[])d.Method_ReturnFloatArrNullable(floatValue, intValue))[0]);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void StaticMethodBody7()
         {
             float p1 = 1f;
             float p2 = 2f;
             float myFloat = 0.111f;
             dynamic dynamic = new MemberClass();
             float?[] result = (float?[])dynamic.Method_ReturnFloatArrNullable(ref p1, out p2, p2, myFloat);
-            if (result.Length == 1 && result[0] == 2 && p1 == 0.000003f && p2 == 2342424)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass049.regclass049
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass049.regclass049;
-    // <Title> Tests regular class regular method used in static generic method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            Assert.Equal(new float?[] { 2f }, result);
+            Assert.Equal(0.000003f, p1);
+            Assert.Equal(2342424, p2);
         }
 
-        public static int MainMethod()
-        {
-            return Test.TestMethod<int, Test>();
-        }
-
-        private static int TestMethod<U, V>()
+        private static void StaticGenericMethodWithwoParametersT<U, V>()
         {
             dynamic dy = new MemberClass();
             float[] result = (float[])dy.Method_ReturnFloatArr();
-            if (result.Length == 1 && result[0] == 3.4534f)
-                return 0;
-            return 1;
+            Assert.Equal(new float[] { 3.4534f }, result);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass050.regclass050
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass050.regclass050;
-    // <Title> Tests regular class regular method used in do/while expression.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody_GenericMethod_TwoParameters()
         {
-            Assert.Equal(0, MainMethod());
+            StaticGenericMethodWithwoParametersT<int, RegularClassRegularMethodTests>();
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void DoWhleExpression()
         {
-            dynamic dy = new MemberClass();
+            dynamic d = new MemberClass();
             int value = 0;
             do
             {
                 ;
             }
-            while (((float[])dy.Method_ReturnFloatArr(value++))[0] < 10);
-            if (value == 11)
-                return 0;
-            return 1;
+            while (((float[])d.Method_ReturnFloatArr(value++))[0] < 10);
+            Assert.Equal(11, value);
         }
-    }
-    //</Code>
-}
 
+        private void RegularGenericMethod<T>(float value1, float value2, float value3)
+        {
+            dynamic d = new MemberClass();
+            float[] result = (float[])d.Method_ReturnFloatArr(value1, value2, value3);
+            Assert.Equal(new float[] { value1 }, result);
+        }
 
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass051.regclass051
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass051.regclass051;
-    // <Title> Tests regular class regular method used in generic method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void RegularMethodBody_GenericMethod()
         {
-            Assert.Equal(0, MainMethod());
+            RegularClassRegularMethodTests t = new RegularClassRegularMethodTests();
+            t.RegularGenericMethod<RegularClassRegularMethodTests>(float.MaxValue, float.NegativeInfinity, float.PositiveInfinity);
         }
 
-        public static int MainMethod()
-        {
-            return new Test().TestMethod<Test>(float.MaxValue, float.NegativeInfinity, float.PositiveInfinity);
-        }
-
-        private int TestMethod<T>(float value1, float value2, float value3)
-        {
-            dynamic dy = new MemberClass();
-            //This is also bad.... the same issue as 044...
-            float[] result = (float[])dy.Method_ReturnFloatArr(value1, value2, value3);
-            if (result.Length == 1 && result[0] == value1)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass052.regclass052
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass052.regclass052;
-    // <Title> Tests regular class regular method used in regular method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            float p1 = 1f;
-            float p2 = 2f;
-            int result = new Test().TestMethod(ref p1, out p2, p1, p2);
-            if (result == 0 && p1 == 0.000003f && p2 == 2342424)
-                return 0;
-            return 1;
-        }
-
-        private int TestMethod(ref float p1, out float p2, params float[] p3)
+        private void RegularMethod(ref float p1, out float p2, params float[] p3)
         {
             dynamic dy = new MemberClass();
             float[] result = (float[])dy.Method_ReturnFloatArr(ref p1, out p2, p3);
-            if (result.Length == 1 && result[0] == 2)
-                return 0;
-            return 1;
+            Assert.Equal(new float[] { 2 }, result);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass053.regclass053
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass053.regclass053;
-    // <Title> Tests regular class regular method used in argument of extension method.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void RegularMethodBody()
         {
-            Assert.Equal(0, MainMethod());
+            float p1 = 1f;
+            float p2 = 2f;
+            new RegularClassRegularMethodTests().RegularMethod(ref p1, out p2, p1, p2);
+            Assert.Equal(0.000003f, p1);
+            Assert.Equal(2342424, p2);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void ArgumentOfExtensionMethod()
         {
-            dynamic dy = new MemberClass();
-            bool result = ((int?)dy.Method_ReturnIntNullable(true)).IsNull();
-            if (result)
-                return 0;
-            return 1;
-        }
-    }
-
-    static public class Extension
-    {
-        public static bool IsNull(this int? value)
-        {
-            return value == null;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass054.regclass054
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass054.regclass054;
-    // <Title> Tests regular class regular method used in argument of regular method.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            dynamic d = new MemberClass();
+            Assert.True(((int?)d.Method_ReturnIntNullable(true)).IsNull());
         }
 
-        public static int MainMethod()
+        public void RegularMethod_NullableInt(int? value)
         {
-            dynamic dy = new MemberClass();
+            Assert.Equal('a', value);
+        }
+
+        [Fact]
+        public static void RegularMethodArgument()
+        {
+            dynamic d = new MemberClass();
             MyClass myclass = new MyClass();
             decimal p2 = -1M;
             char p3 = 'a';
-            bool result = new Test().TestMethod((int?)dy.Method_ReturnIntNullable(out myclass, ref p2, p3));
-            if (result)
-                return 0;
-            return 1;
+            new RegularClassRegularMethodTests().RegularMethod_NullableInt((int?)d.Method_ReturnIntNullable(out myclass, ref p2, p3));
         }
 
-        public bool TestMethod(int? value)
+        public static void StaticMethod_NullableInt(int? value)
         {
-            if (value.Value == (int)'a')
-                return true;
-            return false;
+            Assert.Equal(1, value);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass055.regclass055
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass055.regclass055;
-    // <Title> Tests regular class regular method used in argument of static regular method.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodArgument()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
+            dynamic d = new MemberClass();
             bool value = true;
-            bool result = Test.TestMethod((int?)dy.Method_ReturnIntNullable(true, false, value));
-            if (result)
-                return 0;
-            return 1;
+            StaticMethod_NullableInt((int?)d.Method_ReturnIntNullable(true, false, value));
         }
-
-        public static bool TestMethod(int? value)
-        {
-            if (value.Value == 1)
-                return true;
-            return false;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass056.regclass056
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass056.regclass056;
-    // <Title> Tests regular class regular method used in argument of static generic method.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         
-        public static void DynamicCSharpRunTest()
+        public static void StaticGenericMethod_NullableInt<T>(int? value)
         {
-            Assert.Equal(0, MainMethod());
+            Assert.Equal(1, value);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void StaticMethodArgument_Generic()
         {
-            dynamic dy = new MemberClass();
+            dynamic d = new MemberClass();
             bool value = false;
-            bool result = Test.TestMethod<bool>((int?)dy.Method_ReturnIntNullable(ref value));
-            if (result && value)
-                return 0;
-            return 1;
+            StaticGenericMethod_NullableInt<bool>((int?)d.Method_ReturnIntNullable(ref value));
+            Assert.True(value);
         }
 
-        public static bool TestMethod<T>(int? value)
-        {
-            if (value.Value == 1)
-                return true;
-            return false;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass057.regclass057
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass057.regclass057;
-    // <Title> Tests regular class regular method used in unsafe static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        private static int? s_p1 = null;
-        private static short? s_p2 = 2;
-        private static byte s_p3 = 0;
-
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
-            bool result = Test.TestMethod((MyClass)dy.Method_ReturnMyClass(out s_p1, s_p2, out s_p3));
-            if (result && s_p1 == 2 && s_p3 == 3)
-                return 0;
-            return 1;
-        }
-
-        private static bool TestMethod(MyClass mc)
-        {
-            return mc.Field == 2;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass058.regclass058
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass058.regclass058;
-    // <Title> Tests regular class regular method used in unsafe regular method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody8()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic d = new MemberClass();
+            dynamic myS = new MyStruct() { Number = 10 };
+            MyClass result = (MyClass)d.Method_ReturnMyClass(new MyStruct(), (MyStruct)myS);
+            Assert.Equal(1, result.Field);
         }
 
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
-            ulong value = int.MaxValue;
-            bool result = new Test().TestMethod((MyClass)dy.Method_ReturnMyClass(value), (int)value);
-            if (result)
-                return 0;
-            return 1;
-        }
-
-        private bool TestMethod(MyClass mc, int value)
-        {
-            return mc.Field == value;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass059.regclass059
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass059.regclass059;
-    // <Title> Tests regular class regular method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void TryExpression1()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
-            dynamic myS = new MyStruct()
-            {
-                Number = 10
-            }
-
-            ;
-            MyClass result = (MyClass)dy.Method_ReturnMyClass(new MyStruct(), (MyStruct)myS);
-            if (result.Field == 1)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass060.regclass060
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass060.regclass060;
-    // <Title> Tests regular class regular method used in try expression.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
+            bool testSucceeded = false;
             try
             {
                 dynamic dy = new MemberClass();
@@ -3452,52 +1141,18 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             }
             catch (ArgumentException ae)
             {
-                if (ae.Message.Contains("Test exception"))
-                    return 0;
+                testSucceeded = ae.Message.Contains("Test exception");
             }
-
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass061.regclass061
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass061.regclass061;
-    // <Title> Tests regular class regular method used in try expression.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            Assert.True(testSucceeded);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void TryExpression2()
         {
-            MyClass p1 = new MyClass()
-            {
-                Field = 1
-            }
+            MyClass p1 = new MyClass() { Field = 1 };
+            decimal?[] p2 = new decimal?[] { null };
 
-            ;
-            decimal?[] p2 = new decimal?[]
-            {
-            null
-            }
-
-            ;
+            bool testSucceeded = false;
             MyEnum p3 = MyEnum.Third;
             try
             {
@@ -3506,642 +1161,188 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             }
             catch (ArgumentException ae)
             {
-                if (ae.Message.Contains("Test exception") && p1.Field == 1 && p2.Length == 1 && p2[0] == null)
-                    return 0;
+                testSucceeded = ae.Message.Contains("Test exception");
+                Assert.Equal(1, p1.Field);
+                Assert.Equal(new decimal?[] { null }, p2);
             }
-
-            return 1;
+            Assert.True(testSucceeded);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass062.regclass062
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass062.regclass062;
-    // <Title> Tests regular class regular method used in while body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
+        public static void WhileBody()
         {
             bool value = true;
+            bool testSucceeded = false;
             try
             {
-                dynamic dy = new MemberClass();
+                dynamic d = new MemberClass();
                 while (value)
                 {
-                    MyClass mc = dy.Method_ReturnMyClass_Throw(new byte?[0]);
+                    MyClass mc = d.Method_ReturnMyClass_Throw(new byte?[0]);
                 }
             }
             catch (ArithmeticException ae)
             {
-                if (ae.Message == ("Test exception"))
-                    return 0;
+                testSucceeded = ae.Message == ("Test exception");
             }
-
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass063.regclass063
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass063.regclass063;
-    // <Title> Tests regular class regular method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            Assert.True(testSucceeded);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void StaticMethodBody9()
         {
             bool[] p1 = null;
             int[] p2 = new int[2];
             bool? p3 = true;
-            dynamic dy = new MemberClass();
-            MyEnum result = dy.Method_ReturnMyEnum(out p1, p2, out p3);
-            if (p1.Length == 2 && p1[0] == true && p1[1] == false && p3 == null && result == MyEnum.First)
-                return 0;
-            return 1;
+            dynamic d = new MemberClass();
+            MyEnum result = d.Method_ReturnMyEnum(out p1, p2, out p3);
+            Assert.Equal(new bool[] { true, false }, p1);
+            Assert.Null(p3);
+            Assert.Equal(MyEnum.First, result);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass064.regclass064
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass064.regclass064;
-    // <Title> Tests regular class regular method used in for loop-initializer.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ForLoopInitializer()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
+            dynamic d = new MemberClass();
             int index = 0;
             int expected = 1;
-            for (int i = (int)dy.Method_ReturnMyEnumNullable(); i <= (int)dy.Method_ReturnMyEnumNullable(new int[0]); i++)
+            for (int i = (int)d.Method_ReturnMyEnumNullable(); i <= (int)d.Method_ReturnMyEnumNullable(new int[0]); i++)
             {
-                if (i != expected)
-                {
-                    return 1;
-                }
+                Assert.Equal(expected, i);
                 expected++;
-
                 index = i;
             }
-
-            if (index == 2)
-                return 0;
-            return 1;
+            Assert.Equal(2, index);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass065.regclass065
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass065.regclass065;
-    // <Title> Tests regular class regular method used in while body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void DoWhileBody1()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
+            dynamic d = new MemberClass();
             int result = 0;
             int index = 0;
             do
             {
-                result += (int)dy.Method_ReturnMyEnumNullable(new MyClass[0]);
+                result += (int)d.Method_ReturnMyEnumNullable(new MyClass[0]);
             }
             while (index++ < 2);
-            if (result == 9)
-                return 0;
-            return 1;
+            Assert.Equal(9, result);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass065a.regclass065a
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass065a.regclass065a;
-    // <Title> Tests regular class regular method used in while body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void DoWhileBody2()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
+            dynamic d = new MemberClass();
             dynamic result = 0;
             dynamic index = 0;
             do
             {
-                result += ((MyEnum?)dy.Method_ReturnMyEnumNullable(new MyClass[0])).Value.GetHashCode();
+                result += ((MyEnum?)d.Method_ReturnMyEnumNullable(new MyClass[0])).Value.GetHashCode();
             }
             while (index++ < 2);
-            if (result == 9)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass066.regclass066
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass066.regclass066;
-    // <Title> Tests regular class regular method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            Assert.Equal(9, result);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void StaticMethodBody10()
         {
             bool[] p1 = null;
             bool p2 = false;
             short[] p3 = null;
             dynamic dy = new MemberClass();
             MyEnum result = (MyEnum)dy.Method_ReturnMyEnumNullable(ref p1, p2, out p3);
-            if (p1.Length == 2 && p3.Length == 3 && result == MyEnum.First)
-                return 0;
-            return 1;
+            Assert.Equal(2, p1.Length);
+            Assert.Equal(3, p3.Length);
+            Assert.Equal(MyEnum.First, result);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass067.regclass067
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass067.regclass067;
-    // <Title> Tests regular class regular method used in foreach body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections.Generic;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ForeachBody()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            string[] forLoop = new string[]
-            {
-            null, string.Empty, "Test"
-            }
-
-            ;
+            string[] forLoop = new string[] { null, string.Empty, "Test" };
             List<MyStruct> list = new List<MyStruct>();
             foreach (string s in forLoop)
             {
-                dynamic dy = new MemberClass();
-                MyStruct result = (MyStruct)dy.Method_ReturnMyStruct(s, forLoop[0]);
+                dynamic d = new MemberClass();
+                MyStruct result = (MyStruct)d.Method_ReturnMyStruct(s, forLoop[0]);
                 list.Add(result);
             }
-
-            if (list.Count == 3 && list[0].Number == 3 && list[1].Number == 3 && list[2].Number == 3)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass068.regclass068
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass068.regclass068;
-    // <Title> Tests regular class regular method used static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections.Generic;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            Assert.Equal(3, list.Count);
+            Assert.Equal(3, list[0].Number);
+            Assert.Equal(3, list[1].Number);
+            Assert.Equal(3, list[2].Number);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void StaticMethodBody11()
         {
             short p1 = 0;
             bool p2 = true;
-            MyClass[] p3 = new MyClass[]
-            {
-            null, null
-            }
-
-            ;
-            dynamic dy = new MemberClass();
-            MyStruct result = (MyStruct)dy.Method_ReturnMyStruct(p1, out p2, p3);
-            if (p2 == false && result.Number == 2)
-                return 0;
-            return 1;
+            MyClass[] p3 = new MyClass[] { null, null };
+            dynamic d = new MemberClass();
+            MyStruct result = (MyStruct)d.Method_ReturnMyStruct(p1, out p2, p3);
+            Assert.False(p2);
+            Assert.Equal(2, result.Number);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass069.regclass069
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass069.regclass069;
-    // <Title> Tests regular class regular method used in indexer-set.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections.Generic;
-
-    public class Test
-    {
-        private Dictionary<int, MyStruct> _dic = new Dictionary<int, MyStruct>();
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void DynamicMethodCall()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic d = new MemberClass();
+            MyStruct? result = (MyStruct?)d.Method_ReturnMyStructNullable((object)d.Method_ReturnMyStructNullable());
+            Assert.Equal(3, result.Value.Number);
         }
 
-        public static int MainMethod()
-        {
-            Test t = new Test();
-            t[string.Empty] = new MyStruct()
-            {
-                Number = 10
-            }
-
-            ;
-            t["a"] = new MyStruct()
-            {
-                Number = -1
-            }
-
-            ;
-            if (t._dic.Count == 2 && t._dic[0].Number == 0 && t._dic[1].Number == 1)
-                return 0;
-            return 1;
-        }
-
-        public MyStruct this[string i]
-        {
-            set
-            {
-                dynamic dy = new MemberClass();
-                _dic.Add(i.Length, (MyStruct)dy.Method_ReturnMyStruct(i));
-            }
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass070.regclass070
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass070.regclass070;
-    // <Title> Tests regular class regular method used in dynamic method call.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
-            MyStruct? result = (MyStruct?)dy.Method_ReturnMyStructNullable((object)dy.Method_ReturnMyStructNullable());
-            if (result.Value.Number == 3)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass071.regclass071
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass071.regclass071;
-    // <Title> Tests regular class regular method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
+        public static void StaticMethodBody12()
         {
             byte? p1 = null;
             string[] p2 = new string[2];
-            dynamic dy = new MemberClass();
-            MyStruct? result = (MyStruct?)dy.Method_ReturnMyStructNullable(out p1, out p2, ulong.MaxValue, ulong.MinValue);
-            if (p1 == 3 && p2.Length == 3 && result.Value.Number == 2)
-                return 0;
-            return 1;
+            dynamic d = new MemberClass();
+            MyStruct? result = (MyStruct?)d.Method_ReturnMyStructNullable(out p1, out p2, ulong.MaxValue, ulong.MinValue);
+            Assert.Equal((byte)3, p1);
+            Assert.Equal(3, p2.Length);
+            Assert.Equal(2, result.Value.Number);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass072.regclass072
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass072.regclass072;
-    // <Title> Tests regular class regular method used in static method body and parameter contains dynamic.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody13()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
+            dynamic d = new MemberClass();
             dynamic intdy = 1;
             dynamic enumdy = MyEnum.First;
-            MyStruct? result = (MyStruct?)dy.Method_ReturnMyStructNullable((object)dy, (object)intdy, (object)enumdy);
-            if (result.Value.Number == 3)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass073.regclass073
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass073.regclass073;
-    // <Title> Tests regular class regular method used in array initializer list.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            MyStruct? result = (MyStruct?)d.Method_ReturnMyStructNullable((object)d, (object)intdy, (object)enumdy);
+            Assert.Equal(3, result.Value.Number);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void ArrayInitializerList()
         {
-            dynamic dy = new MemberClass();
-            MyEnum[] p1 = new MyEnum[]
-            {
-            MyEnum.First, default (MyEnum)}
-
-            ;
+            dynamic d = new MemberClass();
+            MyEnum[] p1 = new MyEnum[] { MyEnum.First, default(MyEnum) };
             char?[] p3 = new char?[3];
             object[] result = new object[]
             {
-            dy.Method_ReturnObject(), dy.Method_ReturnObject(new byte ? [0]), dy.Method_ReturnObject(p1, -1, ref p3), dy.Method_ReturnObject(new bool ? [4])}
+                d.Method_ReturnObject(),
+                d.Method_ReturnObject(new byte ? [0]),
+                d.Method_ReturnObject(p1, -1, ref p3),
+                d.Method_ReturnObject(new bool ? [4])
+            };
 
-            ;
-            if (result.Length == 4 && result[0] == null && result[1] == null && result[2] == null && result[3] == null && p3[0] == 'a' && p3[1] == 'b')
-                return 0;
-            return 1;
+            Assert.Equal(new object[] { null, null, null, null }, result);
+            Assert.Equal(new char?[] { 'a', 'b' }, p3);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass074.regclass074
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass074.regclass074;
-    // <Title> Tests regular class regular method used in iterator and throw exception.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.Collections;
-
-    public class Test
-    {
-        private dynamic _mc = new MemberClass();
         [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            Test t = new Test();
-            try
-            {
-                foreach (short i in t.Increment(0))
-                {
-                    // never here.
-                    return 1;
-                }
-            }
-            catch (ArithmeticException ae)
-            {
-                if (ae.Message == "Test message")
-                    return 0;
-            }
-
-            return 1;
-        }
-
-        public IEnumerable Increment(int number)
-        {
-            while (number < 5)
-            {
-                number++;
-                yield return _mc.Method_ReturnShort_Throw();
-            }
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass076.regclass076
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass076.regclass076;
-    // <Title> Tests regular class regular method used in for and throw exception.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
+        public static void ForThrowsException()
         {
             var mc = new MemberClass();
             int index = 0;
             char? p1 = 'a';
             string[] p2 = new string[2];
             short[] p3 = new short[3];
+            bool testSucceeded = false;
             try
             {
                 for (int i = 0; i < 10; i++)
@@ -4152,248 +1353,67 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             }
             catch (ArgumentException ae)
             {
-                if (ae.Message.Contains("Test message") && index == 0 && p1 == 'a' && p2.Length == 2)
-                    return 0;
+                testSucceeded = ae.Message.Contains("Test message");
+                Assert.Equal(0, index);
+                Assert.Equal('a', p1);
+                Assert.Equal(2, p2.Length);
             }
-
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass077.regclass077
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass077.regclass077;
-    // <Title> Tests regular class regular method used in constructor and throw exception.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-
-    public class A
-    {
-        public A()
-        {
-            dynamic mc = new MemberClass();
-            Test.result = (short)mc.Method_ReturnShort_Throw(out Test.m);
-        }
-    }
-
-    public class Test
-    {
-        public static MyEnum m = MyEnum.First;
-        public static short result = -1;
-        public Test()
-        {
+            Assert.True(testSucceeded);
         }
 
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            try
-            {
-                A t = new A(); //exception
-            }
-            catch (ArgumentException ae)
-            {
-                if (ae.Message.Contains("Test message") && m == MyEnum.Second && result == -1)
-                    return 0;
-            }
-
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass078.regclass078
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass078.regclass078;
-    // <Title> Tests regular class regular method used in using block and throw exception.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void UsingBlockThrowsException()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
+            bool testSucceeed = false;
             try
             {
                 using (MemoryStream ms = new MemoryStream())
                 {
-                    dynamic dy = new MemberClass();
-                    short? result = (short?)dy.Method_ReturnShort_ThrowNullable(); //exception
+                    dynamic d = new MemberClass();
+                    short? result = (short?)d.Method_ReturnShort_ThrowNullable(); //exception
                 }
             }
             catch (ArithmeticException ae)
             {
-                if (ae.Message == "Test message")
-                    return 0;
+                testSucceeed = ae.Message == "Test message";
             }
-
-            return 1;
+            Assert.True(testSucceeed);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass079.regclass079
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass079.regclass079;
-    // <Title> Tests regular class regular method used in lock block and throw exception.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
-        private static object s_locker = new object();
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void LockBlockThrowsException()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
+            object locker = new object();
+            bool testSucceeded = false;
             try
             {
-                lock (s_locker)
+                lock (locker)
                 {
                     decimal? dec = 123M;
-                    dynamic dy = new MemberClass();
-                    short? result = (short?)dy.Method_ReturnShort_ThrowNullable(dec); //exception
+                    dynamic d = new MemberClass();
+                    short? result = (short?)d.Method_ReturnShort_ThrowNullable(dec); //exception
                 }
             }
             catch (ArgumentException ae)
             {
-                if (ae.Message.Contains("Test message"))
-                    return 0;
+                testSucceeded = ae.Message.Contains("Test message");
             }
-
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass080.regclass080
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass080.regclass080;
-    // <Title> Tests regular class regular method used in do/while block and throw exception.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
-        private char? _p1 = null;
-        private int[] _p2 = new int[2];
-        private bool?[] _p3 = new bool?[6];
-
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            Assert.True(testSucceeded);
         }
 
-        public static int MainMethod()
-        {
-            try
-            {
-                do
-                {
-                    Test t = new Test();
-                    dynamic dy = new MemberClass();
-                    short? result = (short?)dy.Method_ReturnShort_ThrowNullable(out t._p1, t._p2, t._p3); //exception
-                }
-                while (true);
-            }
-            catch (ArgumentException ae)
-            {
-                if (ae.Message.Contains("Test message"))
-                    return 0;
-            }
-
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass081.regclass081
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass081.regclass081;
-    // <Title> Tests regular class regular method used in switch section and throw exception.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void SwitchSectionThrowsException()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
+            bool testSucceeded = false;
             try
             {
                 int a = 0;
-                dynamic dy = new MemberClass();
+                dynamic d = new MemberClass();
                 short? result = null;
                 switch (a)
                 {
                     case 0:
-                        result = (short?)dy.Method_ReturnShort_ThrowNullable(null, 2M, null); //exception
+                        result = (short?)d.Method_ReturnShort_ThrowNullable(null, 2M, null); //exception
                         break;
                     default:
                         break;
@@ -4401,42 +1421,16 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             }
             catch (ArithmeticException ae)
             {
-                if (ae.Message.Contains("Test message"))
-                    return 0;
+                testSucceeded = ae.Message.Contains("Test message");
             }
-
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass082.regclass082
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass082.regclass082;
-    // <Title> Tests regular class regular method used in switch section and throw exception.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            Assert.True(testSucceeded);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void SwitchSectionThrowsException2()
         {
             decimal? d = 0M;
+            bool testSucceeded = false;
             try
             {
                 string a = "a";
@@ -4453,322 +1447,57 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             }
             catch (ArgumentException ae)
             {
-                if (ae.Message.Contains("Test message") && d == 3M)
-                    return 0;
+                testSucceeded = ae.Message.Contains("Test message");
+                Assert.Equal(3M, d);
             }
-
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass083.regclass083
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass083.regclass083;
-    // <Title> Tests regular class regular method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            Assert.True(testSucceeded);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void StaticMethodBody14()
         {
             ulong?[] p1 = new ulong?[0];
             byte[] p2 = new byte[0];
             int?[] p3 = null;
-            dynamic dy = new MemberClass();
-            string result = (string)dy.Method_ReturnString(out p1, out p2, out p3);
-            if (p1.Length == 2 && p2.Length == 2 && p3.Length == 3 && result == "c")
-                return 0;
-            return 1;
+            dynamic d = new MemberClass();
+
+            string result = (string)d.Method_ReturnString(out p1, out p2, out p3);
+            Assert.Equal(2, p1.Length);
+            Assert.Equal(2, p2.Length);
+            Assert.Equal(3, p3.Length);
+            Assert.Equal("c", result);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass084.regclass084
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass084.regclass084;
-    // <Title> Tests regular class regular method used in foreach.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void ForeachExpression2()
         {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic dy = new MemberClass();
+            dynamic d = new MemberClass();
             int index = 0;
-            foreach (var s in (string[])dy.Method_ReturnStringArr())
+            foreach (var s in (string[])d.Method_ReturnStringArr())
             {
                 index++;
             }
-
-            if (index == 10)
-                return 0;
-            return 1;
+            Assert.Equal(10, index);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass085.regclass085
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass085.regclass085;
-    // <Title> Tests regular class regular method used in static field init.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
-        private static dynamic s_dy = new MemberClass();
-        private static string[] s_result = (string[])s_dy.Method_ReturnStringArr(MyEnum.First);
         [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            if (s_result.Length == 10)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass086.regclass086
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass086.regclass086;
-    // <Title> Tests regular class regular method used in field init.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
-        private static dynamic s_dy = new MemberClass();
-        private string[] _result = (string[])s_dy.Method_ReturnStringArr(MyEnum.First, MyEnum.Second, MyEnum.Third);
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            Test t = new Test();
-            if (t._result.Length == 10)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass087.regclass087
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass087.regclass087;
-    // <Title> Tests regular class regular method used in static constructor.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
-        private static string[] s_result;
-        private static MyEnum? s_m = MyEnum.Third;
-        static Test()
-        {
-            dynamic dy = new MemberClass();
-            s_result = (string[])dy.Method_ReturnStringArr(ref s_m);
-        }
-
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            if (Test.s_result.Length == 10 && Test.s_m == null)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass088.regclass088
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass088.regclass088;
-    // <Title> Tests regular class regular method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
+        public static void StaticMethodBody15()
         {
             short?[] p1 = null;
-            MyStruct p2 = new MyStruct()
-            {
-                Number = 10
-            }
+            MyStruct p2 = new MyStruct() { Number = 10 };
+            MyStruct[] p3 = new MyStruct[] { p2 };
 
-            ;
-            MyStruct[] p3 = new MyStruct[]
-            {
-            p2
-            }
-
-            ;
-            dynamic mc = new MemberClass();
-            string[] result = (string[])mc.Method_ReturnStringArr(p1, ref p2, out p3);
-            if (p2.Number == 3 && p3.Length == 2 && p3[0].Number == 1 && p3[1].Number == 2 && result.Length == 10)
-                return 0;
-            return 1;
+            dynamic d = new MemberClass();
+            string[] result = (string[])d.Method_ReturnStringArr(p1, ref p2, out p3);
+            Assert.Equal(3, p2.Number);
+            Assert.Equal(2, p3.Length);
+            Assert.Equal(1, p3[0].Number);
+            Assert.Equal(2, p3[1].Number);
+            Assert.Equal(10, result.Length);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass089.regclass089
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass089.regclass089;
-    // <Title> Tests regular class regular method used in object initializer.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
-        private long _field1;
-        private long? _field2;
         [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            MyClass p1 = new MyClass();
-            dynamic mc = new MemberClass();
-            Test t = new Test()
-            {
-                _field1 = (long)mc.Method_ReturnUlong(p1),
-                _field2 = (long?)mc.Method_ReturnUlongNullable()
-            }
-
-            ;
-            if (p1.Field == 0 && t._field1 == p1.ToString().Length && t._field2 == 1L)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass090.regclass090
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass090.regclass090;
-    // <Title> Tests regular class regular method used in implicitly-typed array initializer.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
+        public static void ImplicitlyTypedArrayInitializer2()
         {
             dynamic mc = new MemberClass();
             object[] p1 = null;
@@ -4776,201 +1505,580 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmetho
             decimal? p3 = null;
             var result = new long?[]
             {
-            (long ? )mc.Method_ReturnUlongNullable(0), (long ? )mc.Method_ReturnUlongNullable(out p1, out p2, out p3), (long ? )mc.Method_ReturnUlongNullable('a', 'b', null)}
+                (long ? )mc.Method_ReturnUlongNullable(0),
+                (long ? )mc.Method_ReturnUlongNullable(out p1, out p2, out p3),
+                (long ? )mc.Method_ReturnUlongNullable('a', 'b', null)
+            };
 
-            ;
-            if (result.Length == 3 && result[0] == 1L && result[1] == 1L && result[2] == 1L && p1.Length == 2 && p2.Length == 2 && p3 == 4M)
-                return 0;
-            return 1;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass091.regclass091
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass091.regclass091;
-    // <Title> Tests regular class regular method used in == operator.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
+            Assert.Equal(new long?[] { 1L, 1L, 1L }, result);
+            Assert.Equal(2, p1.Length);
+            Assert.Equal(2, p2.Length);
+            Assert.Equal(4M, p3);
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void EqualsOperator2()
         {
-            dynamic mc = new MemberClass();
-            MyClass[] m = new MyClass[]
-            {
-            null, null, new MyClass()}
-
-            ;
+            dynamic d = new MemberClass();
+            MyClass[] m = new MyClass[] { null, null, new MyClass() };
             ulong?[] p1 = new ulong?[4];
             MyStruct p2 = new MyStruct();
             byte?[] p3 = new byte?[1];
-            var result = (ulong)mc.Method_ReturnUlong(m) == (ulong)mc.Method_ReturnUlong(ref p1, out p2, ref p3);
-            if (result && p1[0] == 3 && p2.Number == 3 && p3[0] == 1)
-                return 0;
-            return 1;
+
+            var result = (ulong)d.Method_ReturnUlong(m) == (ulong)d.Method_ReturnUlong(ref p1, out p2, ref p3);
+            Assert.True(result);
+            Assert.Equal((ulong)3, p1[0]);
+            Assert.Equal(3, p2.Number);
+            Assert.Equal((byte)1, p3[0]);
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass092.regclass092
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass092.regclass092;
-    // <Title> Tests regular class regular void method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
+        public static void StaticMethodBody16()
         {
-            Assert.Equal(0, MainMethod());
+            dynamic d = new MemberClass();
+            d.Method_ReturnVoid();
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void StaticMethodBody17()
         {
             dynamic mc = new MemberClass();
-            mc.Method_ReturnVoid();
-            return 0;
+            mc.Method_ReturnVoid(new MyStruct[] { new MyStruct(), new MyStruct() { Number = -1 } });
         }
-    }
-    //</Code>
-}
 
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass093.regclass093
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass093.regclass093;
-    // <Title> Tests regular class regular void method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
         [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
-        {
-            dynamic mc = new MemberClass();
-            mc.Method_ReturnVoid(new MyStruct[]
-            {
-            new MyStruct(), new MyStruct()
-            {
-            Number = -1
-            }
-            }
-
-            );
-            return 0;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass094.regclass094
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass094.regclass094;
-    // <Title> Tests regular class regular void method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
-        [Fact]
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
-        }
-
-        public static int MainMethod()
+        public static void StaticMethodBody18()
         {
             dynamic mc = new MemberClass();
             mc.Method_ReturnVoid(1UL, 2UL);
-            return 0;
-        }
-    }
-    //</Code>
-}
-
-
-
-namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass095.regclass095
-{
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclassregmeth.regclassregmeth;
-    using ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.regmethod.regclass.regclass095.regclass095;
-    // <Title> Tests regular class regular void method used in static method body.</Title>
-    // <Description>
-    // </Description>
-    // <RelatedBugs></RelatedBugs>
-    //<Expects Status=success></Expects>
-    // <Code>
-    using System;
-    using System.IO;
-
-    public class Test
-    {
-        
-        public static void DynamicCSharpRunTest()
-        {
-            Assert.Equal(0, MainMethod());
         }
 
-        public static int MainMethod()
+        [Fact]
+        public static void StaticMethodBody19()
         {
             object[] p1 = new object[7];
             bool?[] p2 = new bool?[0];
             MyClass[] p3 = new MyClass[3];
             dynamic mc = new MemberClass();
             mc.Method_ReturnVoid(ref p1, out p2, ref p3);
-            if (p1 == null && p2.Length == 1 && p2[0] == false && p3 == null)
-                return 0;
-            return 1;
+            Assert.Null(p1);
+            Assert.Equal(new bool?[] { false }, p2);
+            Assert.Null(p3);
         }
     }
-    //</Code>
+
+    public static class Extension
+    {
+        public static bool TestMethod(this RegularClassRegularMethodTests t)
+        {
+            dynamic d = new MemberClass();
+            return d.Method_ReturnBoolNullable();
+        }
+
+        public static int ExPlus(this object i)
+        {
+            if (i.GetType() == typeof(int))
+            {
+                int result = (int)i;
+                return ++result;
+            }
+            else
+                throw new ArgumentException();
+        }
+
+        public static bool IsNull(this int? value) => value == null;
+    }
+    
+    public class ClassWithNestedClass
+    {
+        public class NestedClass
+        {
+            public MyStruct ms;
+            public bool? BoolProperty { get; set; }
+
+            public byte[] ByteArray;
+        }
+
+        [Fact]
+        public static void MemberInitializerOfObjectIntializer()
+        {
+            MemberClass mc = new MemberClass();
+            dynamic d = mc;
+            NestedClass tc = new NestedClass
+            {
+                ms = d.Method_ReturnMyStruct(),
+                BoolProperty = d.Method_ReturnBoolNullable((short?)3),
+                ByteArray = d.Method_ReturnByteArr(0, 1, 2, 3, 4)
+            };
+
+            Assert.Equal(3, tc.ms.Number);
+            Assert.True(tc.BoolProperty);
+            Assert.Equal(new byte[] { 0, 1, 2, 3, 4 }, tc.ByteArray);
+        }
+    }
+
+    public class ClassWithGetProperty
+    {
+        public MyClass MyClass
+        {
+            get
+            {
+                dynamic mc = new MemberClass();
+                return (MyClass)mc.Method_ReturnMyClass();
+            }
+        }
+
+        [Fact]
+        public static void PropertyGetBody()
+        {
+            ClassWithGetProperty t = new ClassWithGetProperty();
+            Assert.Equal(1, t.MyClass.Field);
+        }
+    }
+
+    public class ClassWithIteratorCallingLambdaExpression
+    {
+        private static dynamic s_mc = new MemberClass();
+        public IEnumerable Increment(int number, decimal max)
+        {
+            while (number < max)
+            {
+                Func<int?, decimal> func = (int? x) => (decimal)s_mc.Method_ReturnDecimal(x);
+                yield return func(number++);
+            }
+        }
+
+        [Fact]
+        public static void LamdaExpression()
+        {
+            decimal index = 0;
+            dynamic d = new ClassWithIteratorCallingLambdaExpression();
+            foreach (decimal i in (IEnumerable)d.Increment(0, 10))
+            {
+                Assert.Equal(index++, i);
+            }
+        }
+    }
+
+    public class ClassWithObjectInitializerInsideCollectionIntializer1
+    {
+        private MyClass _myclass = null;
+
+        [Fact]
+        public static void ObjectInitializerInsideCollectionInitializer()
+        {
+            dynamic mc = new MemberClass();
+            List<ClassWithObjectInitializerInsideCollectionIntializer1> list = new List<ClassWithObjectInitializerInsideCollectionIntializer1>()
+            {
+                new ClassWithObjectInitializerInsideCollectionIntializer1() { _myclass = mc.Method_ReturnMyClass(11) }
+            };
+
+            Assert.Equal(1, list.Count);
+            Assert.Equal(11, list[0]._myclass.Field);
+        }
+    }
+
+    public class ClassWithDelegate
+    {
+        private delegate void MyDec(byte?[] input);
+        private static void IsEqual(byte?[] input)
+        {
+            Assert.Equal(new byte?[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }, input);
+        }
+
+        [Fact]
+        public static void DelegateInvokeArgument()
+        {
+            dynamic mc = new MemberClass();
+            MyDec dec = IsEqual;
+            dec((byte?[])mc.Method_ReturnByteArrNullable(null, null, null));
+        }
+    } 
+
+    public class ClassWithConstructor
+    {
+        private byte[] _field;
+        public ClassWithConstructor()
+        {
+            dynamic mc = new MemberClass();
+            _field = (byte[])mc.Method_ReturnByteArr();
+        }
+
+        [Fact]
+        public static void Constructor()
+        {
+            ClassWithConstructor t = new ClassWithConstructor();
+            Assert.Equal(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }, t._field);
+        }
+    }
+
+    public class ClassWithFieldInitializerOutOfConstructor
+    {
+        private dynamic _d = new MemberClass();
+        private byte[] _field;
+        public ClassWithFieldInitializerOutOfConstructor()
+        {
+            _field = (byte[])_d.Method_ReturnByteArr(new MyClass[] { null, null, new MyClass() });
+        }
+
+        [Fact]
+        public static void FieldInitializerOutOfConstructor()
+        {
+            ClassWithFieldInitializerOutOfConstructor t = new ClassWithFieldInitializerOutOfConstructor();
+            Assert.Equal(new byte[] { 5, 5, 5 }, t._field);
+        }
+    }
+
+    public class ClassWithStaticFieldInitializerOutOfStaticConstructor
+    {
+        private static dynamic s_d = new MemberClass();
+        private static short?[] s_p1 = null;
+        private static bool?[] s_p2 = new bool?[1];
+        private static MyEnum s_p3 = default(MyEnum);
+        private static byte[] s_field = (byte[])s_d.Method_ReturnByteArr(out s_p1, ref s_p2, ref s_p3);
+        static ClassWithStaticFieldInitializerOutOfStaticConstructor() { }
+
+        [Fact]
+        public static void FieldInitializerOutOfStaticConstructor()
+        {
+            Assert.Equal(new short?[] { 1, null }, s_p1);
+            Assert.Equal(new bool?[] { null }, s_p2);
+            Assert.Equal(MyEnum.Third, s_p3);
+            Assert.Equal(new byte[] { 1, 0 }, s_field);
+        }
+    }
+
+    public class ClassWithAddOperator
+    {
+        private decimal _field;
+        public static ClassWithAddOperator operator +(ClassWithAddOperator t1, ClassWithAddOperator t2)
+        {
+            return new ClassWithAddOperator() { _field = t1._field + t2._field };
+        }
+
+        [Fact]
+        public static void PlusOperator()
+        {
+            ulong p1 = 0;
+            MyEnum p2 = MyEnum.Second;
+            dynamic mc = new MemberClass();
+            ClassWithAddOperator t1 = new ClassWithAddOperator() { _field = (decimal)mc.Method_ReturnDecimal(out p1, ref p2, null, 'a') };
+            ClassWithAddOperator t2 = new ClassWithAddOperator() { _field = (decimal)mc.Method_ReturnDecimal(null, null, 0) };
+
+            ClassWithAddOperator t3 = t1 + t2;
+            Assert.Equal((ulong)2, p1);
+            Assert.Equal(MyEnum.Third, p2);
+
+            Assert.Equal(1M, t1._field);
+            Assert.Equal(1M, t2._field);
+            Assert.Equal(2M, t3._field);
+        }
+    }
+
+    public class ClassWithModuloOperator
+    {
+        private decimal? _field;
+        public static ClassWithModuloOperator operator %(ClassWithModuloOperator t1, ClassWithModuloOperator t2)
+        {
+            return new ClassWithModuloOperator() { _field = t1._field % t2._field };
+        }
+
+        [Fact]
+        public static void ModuloOperator()
+        {
+            dynamic d = new MemberClass();
+            ClassWithModuloOperator t1 = new ClassWithModuloOperator() { _field = (decimal?)d.Method_ReturnDecimalNullable() };
+            ClassWithModuloOperator t2 = new ClassWithModuloOperator() { _field = (decimal?)d.Method_ReturnDecimal(1, -1, 0) };
+
+            ClassWithModuloOperator t3 = t1 % t2;
+            Assert.Equal(1M, t1._field);
+            Assert.Equal(1M, t2._field);
+            Assert.Equal(0M, t3._field);
+        }
+    }
+
+    public class ClassWithObjectInitializerInsideCollectionIntializer2
+    {
+        private float _field;
+
+        [Fact]
+        public static void ObjectInitializerInsideCollectionIntializer()
+        {
+            int myInt = 345;
+            dynamic d = new MemberClass();
+            List<ClassWithObjectInitializerInsideCollectionIntializer2> list = new List<ClassWithObjectInitializerInsideCollectionIntializer2>()
+            {
+                new ClassWithObjectInitializerInsideCollectionIntializer2() { _field = (float)d.Method_ReturnFloat() },
+                new ClassWithObjectInitializerInsideCollectionIntializer2(){ _field = (float)d.Method_ReturnFloat(myInt)}
+            };
+            Assert.Equal(2, list.Count);
+            Assert.Equal(3.4534f, list[0]._field);
+            Assert.Equal(345f, list[1]._field);
+        }
+    }
+
+    public class ClassWithStaticSetProperty
+    {
+        private static float s_field;
+        public static float MyProp
+        {
+            get { return s_field; }
+            set
+            {
+                float myFloat = 3f;
+                dynamic mc = new MemberClass();
+                s_field = (float)mc.Method_ReturnFloat(value, myFloat, 34.5f);
+            }
+        }
+
+        [Fact]
+        public static void StaticPropertySetBody()
+        {
+            MyProp = 10f;
+            Assert.Equal(10f, MyProp);
+        }
+    }
+
+    public class ClassWithStaticGetProperty
+    {
+        private static float s_p1;
+        private static float s_p2;
+        public static float MyProp
+        {
+            get
+            {
+                float myFloat = 3f;
+                dynamic mc = new MemberClass();
+                return (float)mc.Method_ReturnFloat(ref s_p1, out s_p2, s_p1, s_p2, myFloat);
+            }
+            set { }
+        }
+
+        [Fact]
+        public static void StaticPropertyGetBody()
+        {
+            float result = ClassWithStaticGetProperty.MyProp;
+            Assert.Equal(3, result);
+            Assert.Equal(0.000003f, s_p1);
+            Assert.Equal(2342424, s_p2);
+        }
+    }
+
+    public class ClassWithUnsafeStaticMethod
+    {
+        private static int? s_p1 = null;
+        private static short? s_p2 = 2;
+        private static byte s_p3 = 0;
+
+        private static void TestMethod(MyClass mc)
+        {
+            Assert.Equal(2, mc.Field);
+        }
+
+        [Fact]
+        public static void StaticMethodBody_Unsafe()
+        {
+            dynamic d = new MemberClass();
+            TestMethod((MyClass)d.Method_ReturnMyClass(out s_p1, s_p2, out s_p3));
+            Assert.Equal(2, s_p1);
+            Assert.Equal(3, s_p3);
+        }
+    }
+
+    public class ClassWithUnsafeRegularMethod
+    {
+        private void TestMethod(MyClass mc, int value)
+        {
+            Assert.Equal(value, mc.Field);
+        }
+
+        [Fact]
+        public static void RegularMethodBody_Unsafe()
+        {
+            dynamic dy = new MemberClass();
+            ulong value = int.MaxValue;
+            new ClassWithUnsafeRegularMethod().TestMethod((MyClass)dy.Method_ReturnMyClass(value), (int)value);
+        }
+    }
+
+    public class ClassWithSetIndexer
+    {
+        private Dictionary<int, MyStruct> _dic = new Dictionary<int, MyStruct>();
+
+        [Fact]
+        public static void IndexerSetBody()
+        {
+            ClassWithSetIndexer t = new ClassWithSetIndexer();
+            t[string.Empty] = new MyStruct() { Number = 10 };
+            t["a"] = new MyStruct() { Number = -1 };
+
+            Assert.Equal(2, t._dic.Count);
+            Assert.Equal(0, t._dic[0].Number);
+            Assert.Equal(1, t._dic[1].Number);
+        }
+
+        public MyStruct this[string i]
+        {
+            set
+            {
+                dynamic d = new MemberClass();
+                _dic.Add(i.Length, (MyStruct)d.Method_ReturnMyStruct(i));
+            }
+        }
+    }
+
+    public class ClassWithIteratorThrowingException
+    {
+        private dynamic _d = new MemberClass();
+
+        public IEnumerable Increment(int number)
+        {
+            while (number < 5)
+            {
+                number++;
+                yield return _d.Method_ReturnShort_Throw();
+            }
+        }
+
+        [Fact]
+        public static void IteratorThrowingException()
+        {
+            ClassWithIteratorThrowingException t = new ClassWithIteratorThrowingException();
+            bool testSucceeded = false;
+            try
+            {
+                foreach (short i in t.Increment(0)) { }
+            }
+            catch (ArithmeticException ae)
+            {
+                testSucceeded = ae.Message == "Test message";
+            }
+            Assert.True(testSucceeded);
+        }
+    }
+
+    public class ClassWithConstructorThrowsException
+    {
+        public ClassWithConstructorThrowsException()
+        {
+            dynamic d = new MemberClass();
+            ClassInitializingClassThatThrowsException.result = (short)d.Method_ReturnShort_Throw(out ClassInitializingClassThatThrowsException.m);
+        }
+    }
+
+    public class ClassInitializingClassThatThrowsException
+    {
+        public static MyEnum m = MyEnum.First;
+        public static short result = -1;
+        public ClassInitializingClassThatThrowsException() { }
+
+        [Fact]
+        public static void ConstructorThrowsException()
+        {
+            bool testSucceeded = false;
+            try
+            {
+                ClassWithConstructorThrowsException t = new ClassWithConstructorThrowsException(); //exception
+            }
+            catch (ArgumentException ae)
+            {
+                testSucceeded = ae.Message.Contains("Test message");
+                Assert.Equal(MyEnum.Second, m);
+                Assert.Equal(-1, result);
+            }
+            Assert.True(testSucceeded);
+        }
+    }
+
+    public class ClassWithDoWhileThrowingException
+    {
+        private char? _p1 = null;
+        private int[] _p2 = new int[2];
+        private bool?[] _p3 = new bool?[6];
+
+        [Fact]
+        public static void MainMethod()
+        {
+            bool testSucceeded = false;
+            try
+            {
+                do
+                {
+                    ClassWithDoWhileThrowingException t = new ClassWithDoWhileThrowingException();
+                    dynamic dy = new MemberClass();
+                    short? result = (short?)dy.Method_ReturnShort_ThrowNullable(out t._p1, t._p2, t._p3); //exception
+                }
+                while (true);
+            }
+            catch (ArgumentException ae)
+            {
+                testSucceeded = ae.Message.Contains("Test message");
+            }
+            Assert.True(testSucceeded);
+        }
+    }
+
+    public class ClassWithStaticFieldInitializer
+    {
+        private static dynamic s_dy = new MemberClass();
+        private static string[] s_result = (string[])s_dy.Method_ReturnStringArr(MyEnum.First);
+
+        [Fact]
+        public static void StaticFieldInitializer()
+        {
+            Assert.Equal(10, s_result.Length);
+        }
+    }
+
+    public class ClassWithFieldInitializer
+    {
+        private static dynamic s_dy = new MemberClass();
+        private string[] _result = (string[])s_dy.Method_ReturnStringArr(MyEnum.First, MyEnum.Second, MyEnum.Third);
+
+        [Fact]
+        public static void FieldInitializer()
+        {
+            ClassWithFieldInitializer t = new ClassWithFieldInitializer();
+            Assert.Equal(10, t._result.Length);
+        }
+    }
+
+    public class ClassWithStaticConstructor
+    {
+        private static string[] s_result;
+        private static MyEnum? s_m = MyEnum.Third;
+        static ClassWithStaticConstructor()
+        {
+            dynamic d = new MemberClass();
+            s_result = (string[])d.Method_ReturnStringArr(ref s_m);
+        }
+
+        [Fact]
+        public static void StaticConstructor()
+        {
+            Assert.Equal(10, s_result.Length);
+            Assert.Null(s_m);
+        }
+    }
+
+    public class ClassWithObjectInitializer
+    {
+        private long _field1;
+        private long? _field2;
+
+        [Fact]
+        public static void ObjectInitializer()
+        {
+            MyClass p1 = new MyClass();
+            dynamic mc = new MemberClass();
+            ClassWithObjectInitializer t = new ClassWithObjectInitializer()
+            {
+                _field1 = (long)mc.Method_ReturnUlong(p1),
+                _field2 = (long?)mc.Method_ReturnUlongNullable()
+            };
+            Assert.Equal(0, p1.Field);
+            Assert.Equal(p1.ToString().Length, t._field1);
+            Assert.Equal(1L, t._field2);
+        }
+    }
 }


### PR DESCRIPTION
- Consolidate common test data
- Rename tests to make sense
- Extract common code
- Deobfuscate some tests
Contributes to #3133, #915, #516

/cc @VSadov @stephentoub